### PR TITLE
chore: set up Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,3 +83,12 @@ run-tests.sh → data/file-results.tsv (source of truth)
 - Create stub/partial test files (use full upstream tests)
 - Skip tests by adding `SKIP` prereqs (fix the code instead)
 - Run `cargo build` in worktrees (build in main repo, copy binary)
+
+## Cursor Cloud specific instructions
+
+- **Rust toolchain**: The pre-installed Rust may be outdated. The update script runs `rustup update stable && rustup default stable` to ensure the latest stable toolchain is available, since newer workspace dependencies (e.g. `time-core`) require edition 2024 support (Rust ≥ 1.85).
+- **No external services**: Grit is a pure CLI tool with no databases, containers, or network services. Build and test entirely via Cargo and the Bash test runner.
+- **Unit tests**: Run `cargo test -p grit-lib --lib` (95 tests). The `grit-rs` crate has no lib target; use `cargo test --workspace` to run everything.
+- **Integration tests**: Use `./scripts/run-tests.sh <test-file>` (see TESTING.md). Many tests are expected to fail — Grit is a work-in-progress.
+- **Lint**: `cargo check -p grit-rs 2>&1 | grep warning` — there are 2 pre-existing unused-variable warnings in `grit/src/commands/add.rs`.
+- **Binary location**: After `cargo build --release`, the binary is at `target/release/grit`. The test harness expects this path.

--- a/grit/src/commands/rebase.rs
+++ b/grit/src/commands/rebase.rs
@@ -86,6 +86,10 @@ pub struct Args {
     #[arg(long = "no-fork-point")]
     pub no_fork_point: bool,
 
+    /// Be verbose.
+    #[arg(short = 'v', long = "verbose")]
+    pub verbose: bool,
+
     /// Branch to rebase (checkout first, then rebase onto upstream).
     #[arg(value_name = "BRANCH")]
     pub branch: Option<String>,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cursor Cloud development environment for the Grit codebase.

### Changes

- **Fix build**: Added missing `verbose` field to `rebase::Args` struct in `grit/src/commands/rebase.rs` — the field was referenced in `pull.rs` but absent from the struct, causing a compilation error on `main`.
- **Cloud instructions**: Added `## Cursor Cloud specific instructions` section to `AGENTS.md` with toolchain, testing, and lint guidance for future cloud agents.

### Validation

All checks pass in the cloud environment:

[dev_environment_validation.log](https://cursor.com/agents/bc-257ad028-fcc1-4744-95e9-18b33fc15bb2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdev_environment_validation.log)

| Check | Result |
|-------|--------|
| `cargo build --release` | Compiles successfully (2 pre-existing warnings) |
| `cargo test --workspace` | 95 unit tests + 2 doc-tests pass |
| `./scripts/run-tests.sh t0000-basic.sh` | 26/92 (expected — WIP project) |
| `grit init/add/commit/log/status` | All work correctly |


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-257ad028-fcc1-4744-95e9-18b33fc15bb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-257ad028-fcc1-4744-95e9-18b33fc15bb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

