### PR TITLE
fix(test): reset cwd before test_expect_success (t10410)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -135,7 +135,7 @@ t10370-cat-file-type-errors	t1	yes	37	0	0	false		0
 t10380-mktree-batch-missing	t1	yes	31	0	0	false		0
 t10390-write-tree-after-modify	t1	yes	32	0	0	false		0
 t10400-ls-tree-name-only-z	t1	yes	33	0	0	false		0
-t10410-ls-files-nul-output	t1	yes	31	0	0	false		0
+t10410-ls-files-nul-output	t1	yes	31	31	0	true	ok	0
 t10420-diff-stat-numstat	t1	yes	35	0	0	false		0
 t10430-diff-tree-commit-range	t1	yes	33	0	0	false		0
 t10440-diff-index-exit-code	t1	yes	36	0	0	false		0

--- a/docs/index.html
+++ b/docs/index.html
@@ -56,13 +56,13 @@ h2 { font-size: 1.1rem; margin-bottom: 1rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit test dashboard</h1>
-<p class="sub">Generated 2026-04-07 09:16 UTC · cdc0f3a · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated 2026-04-07 09:28 UTC · 349432c · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <div class="cards">
   <div class="card"><div class="n">1,440</div><div class="lbl">Test files (in scope)</div></div>
-  <div class="card accent"><div class="n">233</div><div class="lbl">Files fully passing</div></div>
+  <div class="card accent"><div class="n">234</div><div class="lbl">Files fully passing</div></div>
   <div class="card"><div class="n">43,483</div><div class="lbl">Tests (total)</div></div>
-  <div class="card accent"><div class="n">9,815</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n">9,846</div><div class="lbl">Tests passed</div></div>
   <div class="card"><div class="n">22.6%</div><div class="lbl">Tests passing</div></div>
   <div class="card"><div class="n">164</div><div class="lbl">Manually skipped files</div></div>
 </div>
@@ -82,11 +82,11 @@ h2 { font-size: 1.1rem; margin-bottom: 1rem; color: #f0f6fc; }
     <a class="group-card" href="testfiles.html?group=t1">
       <div class="group-head">
         <span class="group-id">t1</span>
-        <span class="group-meta">22/371 files · 771/11,880 tests</span>
+        <span class="group-meta">23/371 files · 802/11,880 tests</span>
       </div>
       <p class="group-desc">Basic commands concerning the database</p>
-      <div class="bar-bg"><div class="bar-fg" style="width:6.5%"></div></div>
-      <div class="group-pct">6.5%</div>
+      <div class="bar-bg"><div class="bar-fg" style="width:6.8%"></div></div>
+      <div class="group-pct">6.8%</div>
     </a>
     <a class="group-card" href="testfiles.html?group=t2">
       <div class="group-head">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -83,12 +83,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · 2026-04-07 09:16 UTC · cdc0f3a</p>
+<p class="sub"><a href="index.html">Dashboard</a> · 2026-04-07 09:28 UTC · 349432c</p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,440</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,483</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">9,815</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">9,846</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">22.6%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1486,14 +1486,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="31" data-passed="0">
+<tr class="" data-group="t1" data-tests="31" data-passed="31">
   <td class="mono">t10410-ls-files-nul-output</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">31</td>
-  <td class="right">0</td>
-  <td class="right"></td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="right">31</td>
+  <td class="right">ok</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="35" data-passed="0">

--- a/logs/2026-04-07-t10410-ls-files-nul-output.md
+++ b/logs/2026-04-07-t10410-ls-files-nul-output.md
@@ -1,0 +1,20 @@
+# t10410-ls-files-nul-output
+
+## Issue
+
+`t10410-ls-files-nul-output.sh` failed after the first test: `cd: repo: No such file or directory`.
+
+## Root cause
+
+`test_expect_success` in `tests/test-lib-tap.sh` evaluated each test block in the **same shell** as the previous test. Test 1 left cwd inside `repo/`, so test 2’s `cd repo` tried `repo/repo`.
+
+Upstream Git’s test library resets cwd to the trash directory before each test block.
+
+## Fix
+
+In `_test_eval_inner`, `cd "$TRASH_DIRECTORY"` before `eval` so every `test_expect_success` starts from the trash root.
+
+## Verification
+
+- `./scripts/run-tests.sh t10410-ls-files-nul-output.sh` — 31/31 pass.
+- `cargo test -p grit-lib --lib` — pass.

--- a/tests/test-lib-tap.sh
+++ b/tests/test-lib-tap.sh
@@ -106,6 +106,10 @@ test_expect_success() {
 	_test_eval_result=0
 	_test_eval_inner() {
 		set -e
+		# Match upstream git test-lib: each test starts from the trash directory.
+		# Otherwise a prior test's `cd repo` leaves the shell nested and breaks
+		# later blocks that run `cd repo && ...`.
+		cd "$TRASH_DIRECTORY" || exit 1
 		eval "$1"
 	}
 	_twf_cmd=""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t10410-ls-files-nul-output.sh` was failing because `test_expect_success` reused the same shell across tests. After the setup test ran `cd repo`, later blocks that run `cd repo && ...` tried to enter `repo/repo`.

## Change

In `tests/test-lib-tap.sh`, `_test_eval_inner` now runs `cd "$TRASH_DIRECTORY"` before evaluating each success test body, matching upstream Git’s test harness behavior.

## Verification

- `./scripts/run-tests.sh t10410-ls-files-nul-output.sh` — 31/31 pass
- `cargo test -p grit-lib --lib` — pass

Also updates harness artifacts: `data/test-files.csv`, `docs/index.html`, `docs/testfiles.html`, and adds `logs/2026-04-07-t10410-ls-files-nul-output.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3cfb9b1f-3eac-4b11-b3c2-faccf3a605c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3cfb9b1f-3eac-4b11-b3c2-faccf3a605c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

