### PR TITLE
fix(test): reset trash cwd before test_expect_success (t10000 pass)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -84,7 +84,7 @@ t0612-reftable-jgit-compatibility	t0	skip	4	0	0	false	ok	0
 t0613-reftable-write-options	t0	skip	11	0	11	false	ok	0
 t0614-reftable-fsck	t0	skip	7	1	6	false	ok	0
 t1000-read-tree-m-3way	t1	yes	39	0	0	false	ok	0
-t10000-for-each-ref-merged	t1	yes	32	0	0	false		0
+t10000-for-each-ref-merged	t1	yes	32	32	0	true	ok	0
 t1001-read-tree-m-2way	t1	yes	29	0	0	false	ok	0
 t10010-show-ref-dereference	t1	yes	37	0	0	false		0
 t1002-read-tree-m-u-2way	t1	yes	22	8	14	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -56,13 +56,13 @@ h2 { font-size: 1.1rem; margin-bottom: 1rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit test dashboard</h1>
-<p class="sub">Generated 2026-04-07 09:16 UTC · cdc0f3a · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated 2026-04-07 09:29 UTC · 349432c · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <div class="cards">
   <div class="card"><div class="n">1,440</div><div class="lbl">Test files (in scope)</div></div>
-  <div class="card accent"><div class="n">233</div><div class="lbl">Files fully passing</div></div>
+  <div class="card accent"><div class="n">234</div><div class="lbl">Files fully passing</div></div>
   <div class="card"><div class="n">43,483</div><div class="lbl">Tests (total)</div></div>
-  <div class="card accent"><div class="n">9,815</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n">9,847</div><div class="lbl">Tests passed</div></div>
   <div class="card"><div class="n">22.6%</div><div class="lbl">Tests passing</div></div>
   <div class="card"><div class="n">164</div><div class="lbl">Manually skipped files</div></div>
 </div>
@@ -82,11 +82,11 @@ h2 { font-size: 1.1rem; margin-bottom: 1rem; color: #f0f6fc; }
     <a class="group-card" href="testfiles.html?group=t1">
       <div class="group-head">
         <span class="group-id">t1</span>
-        <span class="group-meta">22/371 files · 771/11,880 tests</span>
+        <span class="group-meta">23/371 files · 803/11,880 tests</span>
       </div>
       <p class="group-desc">Basic commands concerning the database</p>
-      <div class="bar-bg"><div class="bar-fg" style="width:6.5%"></div></div>
-      <div class="group-pct">6.5%</div>
+      <div class="bar-bg"><div class="bar-fg" style="width:6.8%"></div></div>
+      <div class="group-pct">6.8%</div>
     </a>
     <a class="group-card" href="testfiles.html?group=t2">
       <div class="group-head">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -83,12 +83,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · 2026-04-07 09:16 UTC · cdc0f3a</p>
+<p class="sub"><a href="index.html">Dashboard</a> · 2026-04-07 09:29 UTC · 349432c</p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,440</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,483</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">9,815</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">9,847</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">22.6%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -976,14 +976,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="32" data-passed="0">
+<tr class="" data-group="t1" data-tests="32" data-passed="32">
   <td class="mono">t10000-for-each-ref-merged</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">32</td>
-  <td class="right">0</td>
-  <td class="right"></td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="right">32</td>
+  <td class="right">ok</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="29" data-passed="0">

--- a/logs/2026-04-07-t10000-for-each-ref-merged.md
+++ b/logs/2026-04-07-t10000-for-each-ref-merged.md
@@ -1,0 +1,17 @@
+# t10000-for-each-ref-merged
+
+## Issue
+
+All 31/32 failures were `cd: repo: No such file or directory`. The TAP harness runs
+each `test_expect_success` block in the same shell. The setup test ends with
+`cd repo`, so the next test’s `cd repo` looked for `trash.../repo/repo`.
+
+## Fix
+
+In `tests/test-lib-tap.sh`, `cd "$TRASH_DIRECTORY"` before evaluating each
+`test_expect_success` block (matches upstream assumption that cwd is trash root).
+
+## Verification
+
+- `bash tests/t10000-for-each-ref-merged.sh` — 32/32 pass
+- `./scripts/run-tests.sh t10000-for-each-ref-merged.sh` — 32/32 pass

--- a/tests/test-lib-tap.sh
+++ b/tests/test-lib-tap.sh
@@ -110,6 +110,12 @@ test_expect_success() {
 	}
 	_twf_cmd=""
 	test -z "$verbose" || say "expecting success of $TEST_NUMBER.$test_count '$description': $commands"
+	# Each block assumes cwd is the trash root (like upstream git tests). A prior
+	# block may have left the shell in a subdirectory (e.g. setup ends in `repo/`).
+	if test -n "$TRASH_DIRECTORY"
+	then
+		cd "$TRASH_DIRECTORY" || exit 1
+	fi
 	_test_eval_inner "$commands" </dev/null 2>&1 || _test_eval_result=$?
 	result=$_test_eval_result
 	set +e


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t10000-for-each-ref-merged` failed because the TAP harness runs each `test_expect_success` block in the **same shell**. The setup test ends with `cd repo`, so subsequent tests’ `cd repo` tried to enter `repo/repo`.

## Change

Before evaluating each `test_expect_success` body, `cd` to `$TRASH_DIRECTORY` so relative paths match upstream Git test expectations (cwd = trash root).

## Verification

- `./scripts/run-tests.sh t10000-for-each-ref-merged.sh` — 32/32 pass
- `cargo test -p grit-lib --lib` — pass

No Rust behavior changes; `for-each-ref --merged` logic was already correct.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa26c17b-ccf0-46cb-b2bf-960c88f707e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa26c17b-ccf0-46cb-b2bf-960c88f707e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

