### PR TITLE
fix(test): reset cwd before test_expect_success for t10300 stability

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -124,7 +124,7 @@ t1022-read-tree-partial-clone	t1	yes	1	1	0	true	ok	0
 t10220-reset-soft-commit	t1	yes	34	0	0	false		0
 t10230-cherry-pick-range	t1	yes	31	0	0	false		0
 t10240-diff-cached-rename	t1	yes	34	0	0	false		0
-t10300-for-each-ref-count-pattern	t1	yes	36	0	0	false		0
+t10300-for-each-ref-count-pattern	t1	yes	36	36	0	true	ok	0
 t10310-show-ref-quiet-hash	t1	yes	33	0	0	false		0
 t10320-update-ref-verify-old	t1	yes	31	0	0	false		0
 t10330-symbolic-ref-short	t1	yes	30	0	0	false		0
@@ -154,7 +154,7 @@ t10530-add-verbose-dry-run	t1	yes	32	0	0	false		0
 t10540-rm-ignore-unmatch	t1	yes	31	0	0	false		0
 t10550-mv-verbose-dry-run	t1	yes	28	0	0	false		0
 t10560-switch-create-detach	t1	yes	28	0	0	false		0
-t10570-restore-worktree-only	t1	yes	28	0	0	false		0
+t10570-restore-worktree-only	t1	yes	28	27	1	false	ok	0
 t10580-reset-path-mixed	t1	yes	25	0	0	false		0
 t1060-object-corruption	t1	yes	17	0	0	false	ok	1
 t1060-object-types	t1	yes	35	0	0	false		0
@@ -276,7 +276,7 @@ t12110-rm-force-recursive	t1	yes	35	0	0	false		0
 t12120-mv-verbose-dryrun	t1	yes	33	0	0	false		0
 t12130-switch-create-force	t1	yes	33	0	0	false		0
 t12160-cherry-pick-conflict-resolve	t1	yes	34	0	0	false		0
-t12170-for-each-ref-count-limit	t1	yes	33	0	0	false		0
+t12170-for-each-ref-count-limit	t1	yes	33	33	0	true	ok	0
 t12180-show-ref-hash-abbrev	t1	yes	33	0	0	false		0
 t12190-update-ref-deref-symref	t1	yes	35	0	0	false		0
 t12200-check-ignore-pathname	t1	yes	30	0	0	false		0

--- a/docs/index.html
+++ b/docs/index.html
@@ -56,14 +56,14 @@ h2 { font-size: 1.1rem; margin-bottom: 1rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit test dashboard</h1>
-<p class="sub">Generated 2026-04-07 09:16 UTC · cdc0f3a · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated 2026-04-07 09:29 UTC · 349432c · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <div class="cards">
   <div class="card"><div class="n">1,440</div><div class="lbl">Test files (in scope)</div></div>
-  <div class="card accent"><div class="n">233</div><div class="lbl">Files fully passing</div></div>
+  <div class="card accent"><div class="n">235</div><div class="lbl">Files fully passing</div></div>
   <div class="card"><div class="n">43,483</div><div class="lbl">Tests (total)</div></div>
-  <div class="card accent"><div class="n">9,815</div><div class="lbl">Tests passed</div></div>
-  <div class="card"><div class="n">22.6%</div><div class="lbl">Tests passing</div></div>
+  <div class="card accent"><div class="n">9,911</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n">22.8%</div><div class="lbl">Tests passing</div></div>
   <div class="card"><div class="n">164</div><div class="lbl">Manually skipped files</div></div>
 </div>
 
@@ -82,11 +82,11 @@ h2 { font-size: 1.1rem; margin-bottom: 1rem; color: #f0f6fc; }
     <a class="group-card" href="testfiles.html?group=t1">
       <div class="group-head">
         <span class="group-id">t1</span>
-        <span class="group-meta">22/371 files · 771/11,880 tests</span>
+        <span class="group-meta">24/371 files · 867/11,880 tests</span>
       </div>
       <p class="group-desc">Basic commands concerning the database</p>
-      <div class="bar-bg"><div class="bar-fg" style="width:6.5%"></div></div>
-      <div class="group-pct">6.5%</div>
+      <div class="bar-bg"><div class="bar-fg" style="width:7.3%"></div></div>
+      <div class="group-pct">7.3%</div>
     </a>
     <a class="group-card" href="testfiles.html?group=t2">
       <div class="group-head">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -83,13 +83,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · 2026-04-07 09:16 UTC · cdc0f3a</p>
+<p class="sub"><a href="index.html">Dashboard</a> · 2026-04-07 09:29 UTC · 349432c</p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,440</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,483</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">9,815</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">22.6%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">9,911</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">22.8%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -1376,14 +1376,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="36" data-passed="0">
+<tr class="" data-group="t1" data-tests="36" data-passed="36">
   <td class="mono">t10300-for-each-ref-count-pattern</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">36</td>
-  <td class="right">0</td>
-  <td class="right"></td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="right">36</td>
+  <td class="right">ok</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="33" data-passed="0">
@@ -1676,14 +1676,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="28" data-passed="0">
+<tr class="" data-group="t1" data-tests="28" data-passed="27">
   <td class="mono">t10570-restore-worktree-only</td>
   <td>t1</td>
   <td></td>
   <td class="right">28</td>
-  <td class="right">0</td>
-  <td class="right"></td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="right">27</td>
+  <td class="right">ok</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:96.4%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="25" data-passed="0">
@@ -2896,14 +2896,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="33" data-passed="0">
+<tr class="" data-group="t1" data-tests="33" data-passed="33">
   <td class="mono">t12170-for-each-ref-count-limit</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">33</td>
-  <td class="right">0</td>
-  <td class="right"></td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="right">33</td>
+  <td class="right">ok</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="33" data-passed="0">

--- a/tests/test-lib-tap.sh
+++ b/tests/test-lib-tap.sh
@@ -106,6 +106,7 @@ test_expect_success() {
 	_test_eval_result=0
 	_test_eval_inner() {
 		set -e
+		cd "$TRASH_DIRECTORY" || exit 1
 		eval "$1"
 	}
 	_twf_cmd=""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t10300-for-each-ref-count-pattern` failed because the setup block ends with `cd repo`, leaving the shell’s cwd inside the nested repository. Later tests run `cd repo` again from that cwd, which fails (`repo/repo` does not exist).

## Change

In `tests/test-lib-tap.sh`, `test_expect_success` now `cd`s to `$TRASH_DIRECTORY` before evaluating each test body (same idea as `test_expect_failure`, which already ran in a subshell starting from trash).

## Verification

- `./scripts/run-tests.sh t10300-for-each-ref-count-pattern.sh` — **36/36**
- `./scripts/run-tests.sh t12170-for-each-ref-count-limit.sh` — **33/33** (sanity)
- `cargo test -p grit-lib --lib` — **98 passed**

Harness also refreshed `data/test-files.csv` and dashboard HTML for the t10300 run.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3b0c8ce-12ca-45a1-9d87-04a33409aef8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3b0c8ce-12ca-45a1-9d87-04a33409aef8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

