### PR TITLE
fix(test): run test_expect_success from trash directory (t10460)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -141,7 +141,7 @@ t10430-diff-tree-commit-range	t1	yes	33	0	0	false		0
 t10440-diff-index-exit-code	t1	yes	36	0	0	false		0
 t10450-status-porcelain-staged	t1	yes	35	0	0	false		0
 t10460-log-format-author-committer	t1	yes	31	0	0	false		0
-t10460-status-ahead-behind	t1	yes	5	0	0	false		0
+t10460-status-ahead-behind	t1	yes	5	5	0	true	ok	0
 t10480-config-list-file	t1	yes	34	0	0	false		0
 t10490-init-quiet-branch	t1	yes	32	0	0	false		0
 t1050-large	t1	yes	29	13	16	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -56,13 +56,13 @@ h2 { font-size: 1.1rem; margin-bottom: 1rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit test dashboard</h1>
-<p class="sub">Generated 2026-04-07 09:16 UTC · cdc0f3a · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated 2026-04-07 09:31 UTC · e9ad750 · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <div class="cards">
   <div class="card"><div class="n">1,440</div><div class="lbl">Test files (in scope)</div></div>
-  <div class="card accent"><div class="n">233</div><div class="lbl">Files fully passing</div></div>
+  <div class="card accent"><div class="n">234</div><div class="lbl">Files fully passing</div></div>
   <div class="card"><div class="n">43,483</div><div class="lbl">Tests (total)</div></div>
-  <div class="card accent"><div class="n">9,815</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n">9,820</div><div class="lbl">Tests passed</div></div>
   <div class="card"><div class="n">22.6%</div><div class="lbl">Tests passing</div></div>
   <div class="card"><div class="n">164</div><div class="lbl">Manually skipped files</div></div>
 </div>
@@ -82,7 +82,7 @@ h2 { font-size: 1.1rem; margin-bottom: 1rem; color: #f0f6fc; }
     <a class="group-card" href="testfiles.html?group=t1">
       <div class="group-head">
         <span class="group-id">t1</span>
-        <span class="group-meta">22/371 files · 771/11,880 tests</span>
+        <span class="group-meta">23/371 files · 776/11,880 tests</span>
       </div>
       <p class="group-desc">Basic commands concerning the database</p>
       <div class="bar-bg"><div class="bar-fg" style="width:6.5%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -83,12 +83,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · 2026-04-07 09:16 UTC · cdc0f3a</p>
+<p class="sub"><a href="index.html">Dashboard</a> · 2026-04-07 09:31 UTC · e9ad750</p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,440</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,483</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">9,815</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">9,820</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">22.6%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1546,14 +1546,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="5" data-passed="0">
+<tr class="" data-group="t1" data-tests="5" data-passed="5">
   <td class="mono">t10460-status-ahead-behind</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">5</td>
-  <td class="right">0</td>
-  <td class="right"></td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="right">5</td>
+  <td class="right">ok</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="0">

--- a/logs/2026-04-07_t10460-status-ahead-behind.md
+++ b/logs/2026-04-07_t10460-status-ahead-behind.md
@@ -1,0 +1,14 @@
+# t10460-status-ahead-behind
+
+## Issue
+
+`t10460-status-ahead-behind.sh` failed 4/5: `cd local` / `cd upstream` failed because `test_expect_success` in `tests/test-lib-tap.sh` evaluated test bodies in the shell’s current directory. After setup left cwd in `local/`, later tests could not `cd local` from there.
+
+## Fix
+
+Match upstream Git behavior: each `test_expect_success` body starts in `$TRASH_DIRECTORY`, sourcing `.test-exports` when present (same as `test_expect_failure`).
+
+## Verification
+
+- `GUST_BIN=... bash tests/t10460-status-ahead-behind.sh` — all 5 pass
+- `./scripts/run-tests.sh t10460-status-ahead-behind.sh` — 5/5

--- a/tests/test-lib-tap.sh
+++ b/tests/test-lib-tap.sh
@@ -106,6 +106,8 @@ test_expect_success() {
 	_test_eval_result=0
 	_test_eval_inner() {
 		set -e
+		cd "$TRASH_DIRECTORY" || exit 1
+		test -f "$TRASH_DIRECTORY/.test-exports" && . "$TRASH_DIRECTORY/.test-exports"
 		eval "$1"
 	}
 	_twf_cmd=""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t10460-status-ahead-behind` failed because `test_expect_success` in our TAP harness evaluated test bodies in whatever cwd the previous test left behind. After the setup test ended in `local/`, later tests could not `cd local` or `cd upstream`.

## Change

In `tests/test-lib-tap.sh`, each `test_expect_success` body now:

1. `cd` to `$TRASH_DIRECTORY`
2. Sources `$TRASH_DIRECTORY/.test-exports` when present (same pattern as `test_expect_failure`)

This matches upstream Git’s behavior where every test case starts from the trash directory.

## Verification

- `./scripts/run-tests.sh t10460-status-ahead-behind.sh` — **5/5** pass

## Note

`data/test-files.csv` and dashboard HTML were refreshed by the harness run.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86eff127-fe73-4b38-91ad-a737090a124c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86eff127-fe73-4b38-91ad-a737090a124c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

