### PR TITLE
chore: refresh harness for t9010-branch-list-sort (26/26 passing)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1390,7 +1390,7 @@ t9000-init-default-branch	t9	yes	24	0	0	false		0
 t9001-send-email	t9	yes	200	0	0	false	ok	1
 t9002-column	t9	yes	16	16	0	true	ok	0
 t9003-help-autocorrect	t9	yes	10	1	9	false	ok	0
-t9010-branch-list-sort	t9	yes	26	0	0	false		0
+t9010-branch-list-sort	t9	yes	26	26	0	true	ok	0
 t9020-tag-list-contains	t9	yes	28	0	0	false		0
 t9030-commit-tree-parents	t9	yes	25	0	0	false		0
 t9040-hash-object-types	t9	yes	28	0	0	false		0

--- a/docs/index.html
+++ b/docs/index.html
@@ -56,14 +56,14 @@ h2 { font-size: 1.1rem; margin-bottom: 1rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit test dashboard</h1>
-<p class="sub">Generated 2026-04-07 09:31 UTC · e9ad750 · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated 2026-04-07 10:58 UTC · 3736637 · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <div class="cards">
   <div class="card"><div class="n">1,440</div><div class="lbl">Test files (in scope)</div></div>
-  <div class="card accent"><div class="n">234</div><div class="lbl">Files fully passing</div></div>
+  <div class="card accent"><div class="n">239</div><div class="lbl">Files fully passing</div></div>
   <div class="card"><div class="n">43,483</div><div class="lbl">Tests (total)</div></div>
-  <div class="card accent"><div class="n">9,820</div><div class="lbl">Tests passed</div></div>
-  <div class="card"><div class="n">22.6%</div><div class="lbl">Tests passing</div></div>
+  <div class="card accent"><div class="n">10,005</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n">23.0%</div><div class="lbl">Tests passing</div></div>
   <div class="card"><div class="n">164</div><div class="lbl">Manually skipped files</div></div>
 </div>
 
@@ -82,11 +82,11 @@ h2 { font-size: 1.1rem; margin-bottom: 1rem; color: #f0f6fc; }
     <a class="group-card" href="testfiles.html?group=t1">
       <div class="group-head">
         <span class="group-id">t1</span>
-        <span class="group-meta">23/371 files · 776/11,880 tests</span>
+        <span class="group-meta">27/371 files · 935/11,880 tests</span>
       </div>
       <p class="group-desc">Basic commands concerning the database</p>
-      <div class="bar-bg"><div class="bar-fg" style="width:6.5%"></div></div>
-      <div class="group-pct">6.5%</div>
+      <div class="bar-bg"><div class="bar-fg" style="width:7.9%"></div></div>
+      <div class="group-pct">7.9%</div>
     </a>
     <a class="group-card" href="testfiles.html?group=t2">
       <div class="group-head">
@@ -154,11 +154,11 @@ h2 { font-size: 1.1rem; margin-bottom: 1rem; color: #f0f6fc; }
     <a class="group-card" href="testfiles.html?group=t9">
       <div class="group-head">
         <span class="group-id">t9</span>
-        <span class="group-meta">2/92 files · 61/3,149 tests</span>
+        <span class="group-meta">3/92 files · 87/3,149 tests</span>
       </div>
       <p class="group-desc">Git tools</p>
-      <div class="bar-bg"><div class="bar-fg" style="width:1.9%"></div></div>
-      <div class="group-pct">1.9%</div>
+      <div class="bar-bg"><div class="bar-fg" style="width:2.8%"></div></div>
+      <div class="group-pct">2.8%</div>
     </a>
 </body>
 </html>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -83,13 +83,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · 2026-04-07 09:31 UTC · e9ad750</p>
+<p class="sub"><a href="index.html">Dashboard</a> · 2026-04-07 10:58 UTC · 3736637</p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,440</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,483</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">9,820</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">22.6%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">10,005</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">23.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -976,14 +976,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="32" data-passed="0">
+<tr class="" data-group="t1" data-tests="32" data-passed="32">
   <td class="mono">t10000-for-each-ref-merged</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">32</td>
-  <td class="right">0</td>
-  <td class="right"></td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="right">32</td>
+  <td class="right">ok</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="29" data-passed="0">
@@ -1356,14 +1356,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="31" data-passed="0">
+<tr class="" data-group="t1" data-tests="31" data-passed="31">
   <td class="mono">t10230-cherry-pick-range</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">31</td>
-  <td class="right">0</td>
-  <td class="right"></td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="right">31</td>
+  <td class="right">ok</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="0">
@@ -1376,14 +1376,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="36" data-passed="0">
+<tr class="" data-group="t1" data-tests="36" data-passed="36">
   <td class="mono">t10300-for-each-ref-count-pattern</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">36</td>
-  <td class="right">0</td>
-  <td class="right"></td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="right">36</td>
+  <td class="right">ok</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="33" data-passed="0">
@@ -1676,14 +1676,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="28" data-passed="0">
+<tr class="" data-group="t1" data-tests="28" data-passed="27">
   <td class="mono">t10570-restore-worktree-only</td>
   <td>t1</td>
   <td></td>
   <td class="right">28</td>
-  <td class="right">0</td>
-  <td class="right"></td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="right">27</td>
+  <td class="right">ok</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:96.4%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="25" data-passed="0">
@@ -2896,14 +2896,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="33" data-passed="0">
+<tr class="" data-group="t1" data-tests="33" data-passed="33">
   <td class="mono">t12170-for-each-ref-count-limit</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">33</td>
-  <td class="right">0</td>
-  <td class="right"></td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="right">33</td>
+  <td class="right">ok</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="33" data-passed="0">
@@ -14036,14 +14036,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:10.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t9" data-tests="26" data-passed="0">
+<tr class="" data-group="t9" data-tests="26" data-passed="26">
   <td class="mono">t9010-branch-list-sort</td>
   <td>t9</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">26</td>
-  <td class="right">0</td>
-  <td class="right"></td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="right">26</td>
+  <td class="right">ok</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t9" data-tests="28" data-passed="0">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t9010-branch-list-sort.sh` already passes against the current `grit` implementation (26/26). This change only refreshes harness artifacts after running `./scripts/run-tests.sh t9010-branch-list-sort.sh`.

## Verification

```bash
./scripts/run-tests.sh t9010-branch-list-sort.sh
```

## Files

- `data/test-files.csv` — updated row for `t9010-branch-list-sort` (pass counts, `ok`)
- `docs/index.html`, `docs/testfiles.html` — regenerated dashboards
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1916b39c-1861-45db-be4b-5b7aaf74c14f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1916b39c-1861-45db-be4b-5b7aaf74c14f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

