### PR TITLE
fix(tests): EXPENSIVE prereq for t0095-bloom (GIT_TEST_LONG)

### DIFF
--- a/logs/2026-04-07-t0095-bloom-expensive-prereq.md
+++ b/logs/2026-04-07-t0095-bloom-expensive-prereq.md
@@ -1,0 +1,14 @@
+# t0095-bloom — EXPENSIVE prerequisite
+
+## Issue
+
+`t0095-bloom.sh` test 11 (`get bloom filter for commit with 513 changes`) is tagged `EXPENSIVE`. Upstream Git defines that prerequisite as “enabled when `GIT_TEST_LONG` is set”. Our simplified `tests/test-lib.sh` never registered `EXPENSIVE`, so `test_have_prereq` always failed and the subtest was skipped as “missing EXPENSIVE” even with `GIT_TEST_LONG=1`.
+
+## Change
+
+Added `test_lazy_prereq EXPENSIVE` matching `git/t/test-lib.sh` so expensive subtests can run when `GIT_TEST_LONG` is exported.
+
+## Verification
+
+- `GIT_TEST_LONG=1 bash tests/t0095-bloom.sh` — all 11 tests pass (11th runs, does not skip).
+- `./scripts/run-tests.sh t0095-bloom.sh` — still reports ok (default run skips expensive case by design).

--- a/tests/test-lib.sh
+++ b/tests/test-lib.sh
@@ -818,6 +818,9 @@ test_lazy_prereq () {
 	fi
 }
 
+# Matches git/t/test-lib.sh: subtests tagged EXPENSIVE run when GIT_TEST_LONG is set.
+test_lazy_prereq EXPENSIVE 'test -n "$GIT_TEST_LONG"'
+
 # write_script FILE [INTERPRETER] — write a script from stdin
 write_script () {
 	{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Grit test harness never registered the `EXPENSIVE` prerequisite, so `t0095-bloom.sh` subtest 11 was always skipped as `missing EXPENSIVE`, even when `GIT_TEST_LONG=1`.

This adds `test_lazy_prereq EXPENSIVE` to match [upstream `git/t/test-lib.sh`](https://github.com/git/git/blob/master/t/test-lib.sh): expensive subtests run when `GIT_TEST_LONG` is set.

## Verification

- `GIT_TEST_LONG=1 bash tests/t0095-bloom.sh` — all 11 tests pass (11th runs).
- `./scripts/run-tests.sh t0095-bloom.sh` — still green (default harness run skips expensive cases by design).
- `cargo test -p grit-lib --lib`

## Notes

Bloom implementation in `grit` was already correct; the gap was harness parity with upstream Git for the `EXPENSIVE` tag.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3165f1ab-dcbd-4859-9625-f5277499633e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3165f1ab-dcbd-4859-9625-f5277499633e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

