### PR TITLE
fix: make t10890-cherry-pick-message pass (switch -c via checkout)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -106,7 +106,7 @@ t1011-read-tree-sparse-checkout	t1	yes	23	12	11	false	ok	0
 t10110-ls-files-pathspec-filter	t1	yes	37	37	0	true	ok	0
 t1012-read-tree-df	t1	yes	5	5	0	true	ok	0
 t10120-config-unset-all	t1	yes	33	33	0	true	ok	0
-t1013-read-tree-submodule	t1	yes	68	2	56	false	ok	0
+t1013-read-tree-submodule	t1	yes	58	2	56	false	ok	0
 t10130-init-bare-reinit	t1	yes	32	32	0	true	ok	0
 t1014-read-tree-confusing	t1	yes	28	27	1	false	ok	0
 t10140-branch-show-current	t1	yes	32	32	0	true	ok	0
@@ -156,7 +156,7 @@ t10550-mv-verbose-dry-run	t1	yes	28	28	0	true	ok	0
 t10560-switch-create-detach	t1	yes	28	6	22	false	ok	0
 t10570-restore-worktree-only	t1	yes	28	28	0	true	ok	0
 t10580-reset-path-mixed	t1	yes	25	25	0	true	ok	0
-t1060-object-corruption	t1	yes	17	12	4	false	ok	1
+t1060-object-corruption	t1	yes	16	12	4	false	ok	1
 t1060-object-types	t1	yes	35	35	0	true	ok	0
 t10600-for-each-ref-exclude	t1	yes	35	35	0	true	ok	0
 t10610-show-ref-dereference-extra	t1	yes	40	40	0	true	ok	0
@@ -186,12 +186,12 @@ t10850-mv-multi-source	t1	yes	30	30	0	true	ok	0
 t10860-switch-force-create	t1	yes	30	11	19	false	ok	0
 t10870-restore-head-source	t1	yes	31	31	0	true	ok	0
 t10880-reset-hard-soft-path	t1	yes	31	31	0	true	ok	0
-t10890-cherry-pick-message	t1	yes	30	29	1	false	ok	0
+t10890-cherry-pick-message	t1	yes	30	30	0	true	ok	0
 t1090-sparse-checkout-scope	t1	yes	7	3	4	false	ok	0
 t10900-for-each-ref-pattern-sort	t1	yes	34	34	0	true	ok	0
-t1091-sparse-checkout-builtin	t1	yes	77	9	67	false	ok	1
+t1091-sparse-checkout-builtin	t1	yes	76	9	67	false	ok	1
 t10910-show-ref-tags-branches	t1	yes	35	35	0	true	ok	0
-t1092-sparse-checkout-compatibility	t1	yes	106	1	103	false	ok	3
+t1092-sparse-checkout-compatibility	t1	yes	104	1	103	false	ok	3
 t10920-update-ref-create-delete	t1	yes	29	29	0	true	ok	0
 t10930-symbolic-ref-read-write	t1	yes	29	28	1	false	ok	0
 t10940-check-ignore-dir-pattern	t1	yes	35	35	0	true	ok	0
@@ -367,7 +367,7 @@ t1307-config-blob	t1	yes	13	11	2	false	ok	0
 t13070-for-each-ref-points-at	t1	yes	32	18	14	false	ok	0
 t1308-config-set	t1	yes	39	12	27	false	ok	0
 t13080-show-ref-loose-packed	t1	yes	31	18	13	false	ok	0
-t1309-early-config	t1	yes	10	1	7	false	ok	2
+t1309-early-config	t1	yes	8	1	7	false	ok	2
 t1310-config-default	t1	yes	5	5	0	true	ok	0
 t1311-config-optional	t1	yes	3	3	0	true	ok	0
 t13120-diff-no-index-dir-file	t1	yes	37	36	1	false	ok	0
@@ -410,7 +410,7 @@ t1406-submodule-ref-store	t1	yes	15	8	7	false	ok	0
 t1407-worktree-ref-store	t1	skip	4	1	3	false	ok	0
 t1408-packed-refs	t1	yes	3	3	0	true	ok	0
 t1409-avoid-packing-refs	t1	yes	0	0	0	false	ok	0
-t1410-reflog	t1	yes	41	6	34	false	ok	1
+t1410-reflog	t1	yes	40	6	34	false	ok	1
 t1411-reflog-show	t1	yes	17	8	9	false	ok	0
 t1412-reflog-loop	t1	yes	3	0	3	false	ok	0
 t1413-reflog-detach	t1	yes	7	7	0	true	ok	0
@@ -424,7 +424,7 @@ t1420-lost-found	t1	yes	2	2	0	true	ok	0
 t1421-reflog-write	t1	yes	10	5	5	false	ok	0
 t1422-show-ref-exists	t1	yes	0	0	0	false	timeout	0
 t1423-ref-backend	t1	skip	9	0	0	false	ok	0
-t1430-bad-ref-name	t1	yes	42	6	34	false	ok	2
+t1430-bad-ref-name	t1	yes	40	6	34	false	ok	2
 t1450-fsck	t1	skip	74	0	0	false	ok	0
 t1450-fsck-basic	t1	yes	31	31	0	true	ok	0
 t1450-fsck-flags	t1	yes	10	8	2	false	ok	0
@@ -450,7 +450,7 @@ t1512-rev-parse-disambiguation	t1	yes	0	0	0	false	ok	3
 t1513-rev-parse-prefix	t1	yes	11	11	0	true	ok	0
 t1514-rev-parse-push	t1	yes	9	4	5	false	ok	0
 t1515-rev-parse-outside-repo	t1	yes	4	4	0	true	ok	0
-t1517-outside-repo	t1	yes	193	92	89	false	ok	0
+t1517-outside-repo	t1	yes	181	92	89	false	ok	0
 t1600-index	t1	yes	7	5	2	false	ok	0
 t1601-index-bogus	t1	yes	4	4	0	true	ok	0
 t1700-split-index	t1	yes	29	3	26	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-07T14:57:13+00:00" class="gen-time" title="2026-04-07 14:57 UTC">2026-04-07 14:57 UTC</time> · <a href="https://github.com/schacon/grit/commit/fa570e1d579803d70354ac4fd5f821c38df49c3f" style="color:#58a6ff">fa570e1</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-07T16:58:20+00:00" class="gen-time" title="2026-04-07 16:58 UTC">2026-04-07 16:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/409ef10d3bbbea7f4b57c12c168572f2f6703360" style="color:#58a6ff">409ef10</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,11 +150,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,335</div>
+      <div class="summary-big-val">29,336</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">43,735</div>
+      <div class="summary-big-val">43,704</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>598 files fully passing</span>
+    <span>599 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -190,11 +190,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">233/368 files · 8 skipped · 10,421/12,220 tests</span>
+        <span class="group-meta">234/368 files · 8 skipped · 10,422/12,189 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:85.3%"></div></div>
-        <span class="group-pct pct-green">85.3%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:85.5%"></div></div>
+        <span class="group-pct pct-green">85.5%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t2">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T14:57:13+00:00" class="gen-time" title="2026-04-07 14:57 UTC">2026-04-07 14:57 UTC</time> · <a href="https://github.com/schacon/grit/commit/fa570e1d579803d70354ac4fd5f821c38df49c3f" style="color:#58a6ff">fa570e1</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T16:58:20+00:00" class="gen-time" title="2026-04-07 16:58 UTC">2026-04-07 16:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/409ef10d3bbbea7f4b57c12c168572f2f6703360" style="color:#58a6ff">409ef10</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">43,735</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,335</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n" id="sum-tests">43,704</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,336</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">67.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1197,14 +1197,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="68" data-passed="2">
+<tr class="" data-group="t1" data-tests="58" data-passed="2">
   <td class="mono">t1013-read-tree-submodule</td>
   <td>t1</td>
   <td></td>
-  <td class="right">68</td>
+  <td class="right">58</td>
   <td class="right">2</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:2.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:3.4%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="32" data-passed="32">
@@ -1697,14 +1697,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="17" data-passed="12">
+<tr class="" data-group="t1" data-tests="16" data-passed="12">
   <td class="mono">t1060-object-corruption</td>
   <td>t1</td>
   <td></td>
-  <td class="right">17</td>
+  <td class="right">16</td>
   <td class="right">12</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.6%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:75.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
 <tr class="" data-group="t1" data-tests="35" data-passed="35">
@@ -1997,14 +1997,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="30" data-passed="29">
+<tr class="" data-group="t1" data-tests="30" data-passed="30">
   <td class="mono">t10890-cherry-pick-message</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">30</td>
-  <td class="right">29</td>
+  <td class="right">30</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:96.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="7" data-passed="3">
@@ -2027,14 +2027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="77" data-passed="9">
+<tr class="" data-group="t1" data-tests="76" data-passed="9">
   <td class="mono">t1091-sparse-checkout-builtin</td>
   <td>t1</td>
   <td></td>
-  <td class="right">77</td>
+  <td class="right">76</td>
   <td class="right">9</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:11.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:11.8%"></div></div></td>
   <td class="right small">1</td>
 </tr>
 <tr class="" data-group="t1" data-tests="35" data-passed="35">
@@ -2047,14 +2047,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="106" data-passed="1">
+<tr class="" data-group="t1" data-tests="104" data-passed="1">
   <td class="mono">t1092-sparse-checkout-compatibility</td>
   <td>t1</td>
   <td></td>
-  <td class="right">106</td>
+  <td class="right">104</td>
   <td class="right">1</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:1.0%"></div></div></td>
   <td class="right small">3</td>
 </tr>
 <tr class="" data-group="t1" data-tests="29" data-passed="29">
@@ -3807,14 +3807,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:58.1%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="10" data-passed="1">
+<tr class="" data-group="t1" data-tests="8" data-passed="1">
   <td class="mono">t1309-early-config</td>
   <td>t1</td>
   <td></td>
-  <td class="right">10</td>
+  <td class="right">8</td>
   <td class="right">1</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:10.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:12.5%"></div></div></td>
   <td class="right small">2</td>
 </tr>
 <tr class="" data-group="t1" data-tests="5" data-passed="5">
@@ -4237,14 +4237,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="41" data-passed="6">
+<tr class="" data-group="t1" data-tests="40" data-passed="6">
   <td class="mono">t1410-reflog</td>
   <td>t1</td>
   <td></td>
-  <td class="right">41</td>
+  <td class="right">40</td>
   <td class="right">6</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:14.6%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:15.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
 <tr class="" data-group="t1" data-tests="17" data-passed="8">
@@ -4377,14 +4377,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="42" data-passed="6">
+<tr class="" data-group="t1" data-tests="40" data-passed="6">
   <td class="mono">t1430-bad-ref-name</td>
   <td>t1</td>
   <td></td>
-  <td class="right">42</td>
+  <td class="right">40</td>
   <td class="right">6</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:14.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:15.0%"></div></div></td>
   <td class="right small">2</td>
 </tr>
 <tr class="row-skip" data-group="t1" data-tests="74" data-passed="0">
@@ -4637,14 +4637,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="193" data-passed="92">
+<tr class="" data-group="t1" data-tests="181" data-passed="92">
   <td class="mono">t1517-outside-repo</td>
   <td>t1</td>
   <td></td>
-  <td class="right">193</td>
+  <td class="right">181</td>
   <td class="right">92</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:47.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="7" data-passed="5">

--- a/grit/src/commands/checkout.rs
+++ b/grit/src/commands/checkout.rs
@@ -234,19 +234,25 @@ pub fn run(mut args: Args) -> Result<()> {
 
     // Post-process rest: extract -b/-B/--new-branch/--force-new-branch that
     // appeared after a positional arg (e.g. `checkout <rev> -b <branch>`).
+    // Also accept `git switch` spellings: -c/--create and -C/--force-create
+    // (switch delegates here with those flags in `rest`).
     // clap's trailing_var_arg consumes these as raw strings when allow_hyphen_values=true.
     {
         let mut new_rest: Vec<String> = Vec::new();
         let mut i = 0;
         while i < args.rest.len() {
             let s = &args.rest[i];
-            if (s == "-b" || s == "--new-branch" || s == "-B" || s == "--force-new-branch")
+            let is_force_create =
+                s == "-B" || s == "--force-new-branch" || s == "-C" || s == "--force-create";
+            let is_create =
+                s == "-b" || s == "--new-branch" || s == "-c" || s == "--create" || is_force_create;
+            if is_create
                 && args.new_branch.is_none()
                 && args.force_branch.is_none()
                 && i + 1 < args.rest.len()
             {
                 let bname = args.rest[i + 1].clone();
-                if s == "-B" || s == "--force-new-branch" {
+                if is_force_create {
                     args.force_branch = Some(bname);
                 } else {
                     args.new_branch = Some(bname);

--- a/logs/2026-04-07_t10890-switch-create-checkout.md
+++ b/logs/2026-04-07_t10890-switch-create-checkout.md
@@ -1,0 +1,18 @@
+# t10890-cherry-pick-message
+
+## Failure
+
+Test 26 `cherry-pick works on a freshly created branch` runs
+`grit switch -c pick-target <initial_oid>`. `switch` delegates to `checkout` with
+`rest = ["-c", "pick-target", "<oid>"]`. Checkout only peeled `-b`/`-B` from
+`rest`, so `-c` was treated as a revision and failed with `unknown revision: '-c'`.
+
+## Fix
+
+Extend checkout’s post-processing of `rest` to recognize `git switch` spellings:
+`-c`/`--create` → same as `-b`, and `-C`/`--force-create` → same as `-B`.
+
+## Verification
+
+- `./scripts/run-tests.sh t10890-cherry-pick-message.sh` → 30/30 pass
+- `cargo test -p grit-lib --lib` → pass


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t10890-cherry-pick-message` failed on **test 26** (`grit switch -c pick-target <oid>`) because `switch` forwards `-c` in the trailing argument list to `checkout`, and `checkout` only peeled `-b`/`-B` from `rest`. The first token `-c` was therefore interpreted as a revision.

## Change

In `checkout`’s post-processing of `rest`, also recognize `git switch` spellings:

- `-c` / `--create` → same handling as `-b`
- `-C` / `--force-create` → same handling as `-B`

## Verification

- `./scripts/run-tests.sh t10890-cherry-pick-message.sh` → **30/30** pass
- `cargo test -p grit-lib --lib` → pass

Dashboard rows in `data/test-files.csv` / `docs/*.html` updated by the harness run.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5727c9f-8987-4af6-b7b3-bc19f9d7135e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5727c9f-8987-4af6-b7b3-bc19f9d7135e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

