### PR TITLE
Sparse index groundwork for t1092 (39/106 passing)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -164,7 +164,7 @@ commit → check it off → move on.
 - [ ] `t1510-repo-setup` ██░░░░░░░░░░░░░░░░░░ 12/109 (97 left) — Tests of cwd/prefix/worktree/gitdir setup in all cases
 
 - [ ] `t1517-outside-repo` █████████░░░░░░░░░░░ 97/195 (98 left) — check random commands outside repo
-- [ ] `t1092-sparse-checkout-compatibility` ░░░░░░░░░░░░░░░░░░░░ 3/106 (103 left) — compare full workdir to sparse workdir
+- [~] `t1092-sparse-checkout-compatibility` ░░░░░░░░░░░░░░░░░░░░ 39/106 (67 left) — compare full workdir to sparse workdir
 - [x] `t0450-txt-doc-vs-help` ████████████████████ 548/548 — assert (unbuilt) Documentation/*.adoc and -h output
 
 

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -106,7 +106,7 @@ t1011-read-tree-sparse-checkout	t1	yes	23	12	11	false	ok	0
 t10110-ls-files-pathspec-filter	t1	yes	37	37	0	true	ok	0
 t1012-read-tree-df	t1	yes	5	5	0	true	ok	0
 t10120-config-unset-all	t1	yes	33	33	0	true	ok	0
-t1013-read-tree-submodule	t1	yes	68	2	56	false	ok	0
+t1013-read-tree-submodule	t1	yes	58	2	56	false	ok	0
 t10130-init-bare-reinit	t1	yes	32	32	0	true	ok	0
 t1014-read-tree-confusing	t1	yes	28	27	1	false	ok	0
 t10140-branch-show-current	t1	yes	32	32	0	true	ok	0
@@ -156,7 +156,7 @@ t10550-mv-verbose-dry-run	t1	yes	28	28	0	true	ok	0
 t10560-switch-create-detach	t1	yes	28	6	22	false	ok	0
 t10570-restore-worktree-only	t1	yes	28	28	0	true	ok	0
 t10580-reset-path-mixed	t1	yes	25	25	0	true	ok	0
-t1060-object-corruption	t1	yes	17	12	4	false	ok	1
+t1060-object-corruption	t1	yes	16	12	4	false	ok	1
 t1060-object-types	t1	yes	35	35	0	true	ok	0
 t10600-for-each-ref-exclude	t1	yes	35	35	0	true	ok	0
 t10610-show-ref-dereference-extra	t1	yes	40	40	0	true	ok	0
@@ -189,9 +189,9 @@ t10880-reset-hard-soft-path	t1	yes	31	31	0	true	ok	0
 t10890-cherry-pick-message	t1	yes	30	29	1	false	ok	0
 t1090-sparse-checkout-scope	t1	yes	7	3	4	false	ok	0
 t10900-for-each-ref-pattern-sort	t1	yes	34	34	0	true	ok	0
-t1091-sparse-checkout-builtin	t1	yes	77	9	67	false	ok	1
+t1091-sparse-checkout-builtin	t1	yes	76	9	67	false	ok	1
 t10910-show-ref-tags-branches	t1	yes	35	35	0	true	ok	0
-t1092-sparse-checkout-compatibility	t1	yes	106	1	103	false	ok	3
+t1092-sparse-checkout-compatibility	t1	yes	106	39	65	false	ok	3
 t10920-update-ref-create-delete	t1	yes	29	29	0	true	ok	0
 t10930-symbolic-ref-read-write	t1	yes	29	28	1	false	ok	0
 t10940-check-ignore-dir-pattern	t1	yes	35	35	0	true	ok	0
@@ -367,7 +367,7 @@ t1307-config-blob	t1	yes	13	11	2	false	ok	0
 t13070-for-each-ref-points-at	t1	yes	32	18	14	false	ok	0
 t1308-config-set	t1	yes	39	12	27	false	ok	0
 t13080-show-ref-loose-packed	t1	yes	31	18	13	false	ok	0
-t1309-early-config	t1	yes	10	1	7	false	ok	2
+t1309-early-config	t1	yes	8	1	7	false	ok	2
 t1310-config-default	t1	yes	5	5	0	true	ok	0
 t1311-config-optional	t1	yes	3	3	0	true	ok	0
 t13120-diff-no-index-dir-file	t1	yes	37	36	1	false	ok	0
@@ -410,7 +410,7 @@ t1406-submodule-ref-store	t1	yes	15	8	7	false	ok	0
 t1407-worktree-ref-store	t1	skip	4	1	3	false	ok	0
 t1408-packed-refs	t1	yes	3	3	0	true	ok	0
 t1409-avoid-packing-refs	t1	yes	0	0	0	false	ok	0
-t1410-reflog	t1	yes	41	6	34	false	ok	1
+t1410-reflog	t1	yes	40	6	34	false	ok	1
 t1411-reflog-show	t1	yes	17	8	9	false	ok	0
 t1412-reflog-loop	t1	yes	3	0	3	false	ok	0
 t1413-reflog-detach	t1	yes	7	7	0	true	ok	0
@@ -424,7 +424,7 @@ t1420-lost-found	t1	yes	2	2	0	true	ok	0
 t1421-reflog-write	t1	yes	10	5	5	false	ok	0
 t1422-show-ref-exists	t1	yes	0	0	0	false	timeout	0
 t1423-ref-backend	t1	skip	9	0	0	false	ok	0
-t1430-bad-ref-name	t1	yes	42	6	34	false	ok	2
+t1430-bad-ref-name	t1	yes	40	6	34	false	ok	2
 t1450-fsck	t1	skip	74	0	0	false	ok	0
 t1450-fsck-basic	t1	yes	31	31	0	true	ok	0
 t1450-fsck-flags	t1	yes	10	8	2	false	ok	0
@@ -450,7 +450,7 @@ t1512-rev-parse-disambiguation	t1	yes	0	0	0	false	ok	3
 t1513-rev-parse-prefix	t1	yes	11	11	0	true	ok	0
 t1514-rev-parse-push	t1	yes	9	4	5	false	ok	0
 t1515-rev-parse-outside-repo	t1	yes	4	4	0	true	ok	0
-t1517-outside-repo	t1	yes	193	92	89	false	ok	0
+t1517-outside-repo	t1	yes	181	92	89	false	ok	0
 t1600-index	t1	yes	7	5	2	false	ok	0
 t1601-index-bogus	t1	yes	4	4	0	true	ok	0
 t1700-split-index	t1	yes	29	3	26	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,25 +141,25 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-07T14:57:13+00:00" class="gen-time" title="2026-04-07 14:57 UTC">2026-04-07 14:57 UTC</time> · <a href="https://github.com/schacon/grit/commit/fa570e1d579803d70354ac4fd5f821c38df49c3f" style="color:#58a6ff">fa570e1</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-07T17:56:53+00:00" class="gen-time" title="2026-04-07 17:56 UTC">2026-04-07 17:56 UTC</time> · <a href="https://github.com/schacon/grit/commit/409ef10d3bbbea7f4b57c12c168572f2f6703360" style="color:#58a6ff">409ef10</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">67.1%</div>
+      <div class="summary-big-val pct-blue">67.2%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,335</div>
+      <div class="summary-big-val">29,373</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">43,735</div>
+      <div class="summary-big-val">43,706</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:67.1%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:67.2%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
@@ -190,11 +190,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">233/368 files · 8 skipped · 10,421/12,220 tests</span>
+        <span class="group-meta">233/368 files · 8 skipped · 10,459/12,191 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:85.3%"></div></div>
-        <span class="group-pct pct-green">85.3%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:85.8%"></div></div>
+        <span class="group-pct pct-green">85.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t2">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,13 +84,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T14:57:13+00:00" class="gen-time" title="2026-04-07 14:57 UTC">2026-04-07 14:57 UTC</time> · <a href="https://github.com/schacon/grit/commit/fa570e1d579803d70354ac4fd5f821c38df49c3f" style="color:#58a6ff">fa570e1</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T17:56:53+00:00" class="gen-time" title="2026-04-07 17:56 UTC">2026-04-07 17:56 UTC</time> · <a href="https://github.com/schacon/grit/commit/409ef10d3bbbea7f4b57c12c168572f2f6703360" style="color:#58a6ff">409ef10</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">43,735</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,335</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">67.1%</div><div class="lbl">Pass rate</div></div>
+  <div class="card"><div class="n" id="sum-tests">43,706</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,373</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">67.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -1197,14 +1197,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="68" data-passed="2">
+<tr class="" data-group="t1" data-tests="58" data-passed="2">
   <td class="mono">t1013-read-tree-submodule</td>
   <td>t1</td>
   <td></td>
-  <td class="right">68</td>
+  <td class="right">58</td>
   <td class="right">2</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:2.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:3.4%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="32" data-passed="32">
@@ -1697,14 +1697,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="17" data-passed="12">
+<tr class="" data-group="t1" data-tests="16" data-passed="12">
   <td class="mono">t1060-object-corruption</td>
   <td>t1</td>
   <td></td>
-  <td class="right">17</td>
+  <td class="right">16</td>
   <td class="right">12</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.6%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:75.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
 <tr class="" data-group="t1" data-tests="35" data-passed="35">
@@ -2027,14 +2027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="77" data-passed="9">
+<tr class="" data-group="t1" data-tests="76" data-passed="9">
   <td class="mono">t1091-sparse-checkout-builtin</td>
   <td>t1</td>
   <td></td>
-  <td class="right">77</td>
+  <td class="right">76</td>
   <td class="right">9</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:11.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:11.8%"></div></div></td>
   <td class="right small">1</td>
 </tr>
 <tr class="" data-group="t1" data-tests="35" data-passed="35">
@@ -2047,14 +2047,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="106" data-passed="1">
+<tr class="" data-group="t1" data-tests="106" data-passed="39">
   <td class="mono">t1092-sparse-checkout-compatibility</td>
   <td>t1</td>
   <td></td>
   <td class="right">106</td>
-  <td class="right">1</td>
+  <td class="right">39</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:36.8%"></div></div></td>
   <td class="right small">3</td>
 </tr>
 <tr class="" data-group="t1" data-tests="29" data-passed="29">
@@ -3807,14 +3807,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:58.1%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="10" data-passed="1">
+<tr class="" data-group="t1" data-tests="8" data-passed="1">
   <td class="mono">t1309-early-config</td>
   <td>t1</td>
   <td></td>
-  <td class="right">10</td>
+  <td class="right">8</td>
   <td class="right">1</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:10.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:12.5%"></div></div></td>
   <td class="right small">2</td>
 </tr>
 <tr class="" data-group="t1" data-tests="5" data-passed="5">
@@ -4237,14 +4237,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="41" data-passed="6">
+<tr class="" data-group="t1" data-tests="40" data-passed="6">
   <td class="mono">t1410-reflog</td>
   <td>t1</td>
   <td></td>
-  <td class="right">41</td>
+  <td class="right">40</td>
   <td class="right">6</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:14.6%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:15.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
 <tr class="" data-group="t1" data-tests="17" data-passed="8">
@@ -4377,14 +4377,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="42" data-passed="6">
+<tr class="" data-group="t1" data-tests="40" data-passed="6">
   <td class="mono">t1430-bad-ref-name</td>
   <td>t1</td>
   <td></td>
-  <td class="right">42</td>
+  <td class="right">40</td>
   <td class="right">6</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:14.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:15.0%"></div></div></td>
   <td class="right small">2</td>
 </tr>
 <tr class="row-skip" data-group="t1" data-tests="74" data-passed="0">
@@ -4637,14 +4637,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="193" data-passed="92">
+<tr class="" data-group="t1" data-tests="181" data-passed="92">
   <td class="mono">t1517-outside-repo</td>
   <td>t1</td>
   <td></td>
-  <td class="right">193</td>
+  <td class="right">181</td>
   <td class="right">92</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:47.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="7" data-passed="5">

--- a/grit-lib/src/index.rs
+++ b/grit-lib/src/index.rs
@@ -15,6 +15,7 @@
 //! See `Documentation/technical/index-format.txt` in the Git source tree for
 //! the authoritative format specification.
 
+use std::collections::BTreeSet;
 use std::fs;
 use std::io::{self, Write};
 use std::path::Path;
@@ -23,7 +24,8 @@ use sha1::{Digest, Sha1};
 
 use crate::config::ConfigSet;
 use crate::error::{Error, Result};
-use crate::objects::ObjectId;
+use crate::objects::{parse_tree, ObjectId, ObjectKind};
+use crate::odb::Odb;
 
 /// File mode for a regular (non-executable) file.
 pub const MODE_REGULAR: u32 = 0o100644;
@@ -35,6 +37,9 @@ pub const MODE_SYMLINK: u32 = 0o120000;
 pub const MODE_GITLINK: u32 = 0o160000;
 /// File mode for a directory (tree) entry — only used in tree objects, not index.
 pub const MODE_TREE: u32 = 0o040000;
+
+/// Git index extension signature `sdir` (sparse directory entries present).
+const INDEX_EXT_SPARSE_DIRECTORIES: u32 = u32::from_be_bytes(*b"sdir");
 
 /// A single entry in the Git index.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -132,6 +137,12 @@ impl IndexEntry {
             }
         }
     }
+
+    /// Sparse-index placeholder: tree mode, stage 0, and `SKIP_WORKTREE` set.
+    #[must_use]
+    pub fn is_sparse_directory_placeholder(&self) -> bool {
+        self.mode == MODE_TREE && self.stage() == 0 && self.skip_worktree()
+    }
 }
 
 /// The in-memory representation of the Git index file.
@@ -141,6 +152,23 @@ pub struct Index {
     pub version: u32,
     /// Index entries, sorted by (path, stage).
     pub entries: Vec<IndexEntry>,
+    /// When true, the on-disk index includes the `sdir` extension (sparse index).
+    pub sparse_directories: bool,
+}
+
+/// Options for loading an index from disk.
+#[derive(Debug, Clone, Copy)]
+pub struct IndexLoadOptions {
+    /// If the index contains sparse directory placeholders, expand them to full file entries.
+    pub expand_sparse_directories: bool,
+}
+
+impl Default for IndexLoadOptions {
+    fn default() -> Self {
+        Self {
+            expand_sparse_directories: true,
+        }
+    }
 }
 
 /// Default index version when `GIT_INDEX_VERSION` is unset or invalid.
@@ -183,6 +211,7 @@ impl Index {
         Self {
             version,
             entries: Vec::new(),
+            sparse_directories: false,
         }
     }
 
@@ -198,6 +227,7 @@ impl Index {
             return Self {
                 version: v,
                 entries: Vec::new(),
+                sparse_directories: false,
             };
         }
         // Config index.version
@@ -207,6 +237,7 @@ impl Index {
                     return Self {
                         version: v,
                         entries: Vec::new(),
+                        sparse_directories: false,
                     };
                 }
             }
@@ -218,6 +249,7 @@ impl Index {
             return Self {
                 version: INDEX_FORMAT_DEFAULT,
                 entries: Vec::new(),
+                sparse_directories: false,
             };
         }
         // feature.manyFiles implies version 4
@@ -228,16 +260,18 @@ impl Index {
                 return Self {
                     version: 4,
                     entries: Vec::new(),
+                    sparse_directories: false,
                 };
             }
         }
         Self {
             version: 2,
             entries: Vec::new(),
+            sparse_directories: false,
         }
     }
 
-    /// Load an index from the given file path.
+    /// Load an index from the given file path without expanding sparse-directory placeholders.
     ///
     /// Returns an empty index if the file does not exist.
     ///
@@ -247,9 +281,181 @@ impl Index {
     pub fn load(path: &Path) -> Result<Self> {
         match fs::read(path) {
             Ok(data) => Self::parse(&data),
-            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(Self::new()),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(Self {
+                sparse_directories: false,
+                ..Self::new()
+            }),
             Err(e) => Err(Error::Io(e)),
         }
+    }
+
+    /// Load an index and expand sparse-directory placeholders using the object database.
+    ///
+    /// After a successful return, [`Index::sparse_directories`] is cleared and every
+    /// placeholder is replaced by the blob entries from the referenced tree.
+    pub fn load_expand_sparse(path: &Path, odb: &Odb) -> Result<Self> {
+        let mut idx = Self::load(path)?;
+        idx.expand_sparse_directory_placeholders(odb)?;
+        Ok(idx)
+    }
+
+    /// Like [`Index::load_expand_sparse`], but treats a missing index or Git's
+    /// `"file too short"` placeholder as an empty index.
+    pub fn load_expand_sparse_optional(path: &Path, odb: &Odb) -> Result<Self> {
+        let mut idx = match fs::read(path) {
+            Ok(data) => Self::parse(&data).or_else(|e| match e {
+                Error::IndexError(msg) if msg == "file too short" => Ok(Self::new()),
+                other => Err(other),
+            })?,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Self::new(),
+            Err(e) => return Err(Error::Io(e)),
+        };
+        idx.expand_sparse_directory_placeholders(odb)?;
+        Ok(idx)
+    }
+
+    /// Returns true if the index contains sparse-index tree placeholders (`MODE_TREE` + skip-worktree).
+    #[must_use]
+    pub fn has_sparse_directory_placeholders(&self) -> bool {
+        self.entries
+            .iter()
+            .any(IndexEntry::is_sparse_directory_placeholder)
+    }
+
+    /// Replace sparse-directory placeholder entries with all blob paths from their trees.
+    ///
+    /// Each placeholder must reference a tree object. New entries are marked skip-worktree like Git's
+    /// expanded index, except we keep `sparse_directories` false in memory after expansion.
+    pub fn expand_sparse_directory_placeholders(&mut self, odb: &Odb) -> Result<()> {
+        if !self.has_sparse_directory_placeholders() {
+            return Ok(());
+        }
+        let mut out: Vec<IndexEntry> = Vec::with_capacity(self.entries.len());
+        for entry in self.entries.drain(..) {
+            if entry.is_sparse_directory_placeholder() {
+                let prefix = trim_trailing_slash_bytes(&entry.path);
+                let blobs = flatten_tree_blobs(odb, &entry.oid, prefix)?;
+                out.extend(blobs);
+            } else {
+                out.push(entry);
+            }
+        }
+        self.entries = out;
+        self.sparse_directories = false;
+        self.sort();
+        Ok(())
+    }
+
+    /// Collapse consecutive skip-worktree subtrees into sparse-directory placeholders when
+    /// `cone_mode` is true and each directory is outside the sparse cone.
+    ///
+    /// `head_tree` is the tree OID at `HEAD`. When `enable_sparse_index` is false, clears
+    /// [`Index::sparse_directories`] and returns without collapsing.
+    pub fn try_collapse_sparse_directories(
+        &mut self,
+        odb: &Odb,
+        head_tree: &ObjectId,
+        patterns: &[String],
+        cone_mode: bool,
+        enable_sparse_index: bool,
+    ) -> Result<()> {
+        if !enable_sparse_index || !cone_mode {
+            self.sparse_directories = false;
+            return Ok(());
+        }
+
+        let mut prefixes = BTreeSet::<Vec<u8>>::new();
+        for e in &self.entries {
+            if e.stage() != 0 || e.mode == MODE_TREE || !e.skip_worktree() {
+                continue;
+            }
+            collect_directory_prefixes(&e.path, &mut prefixes);
+        }
+
+        let mut collapsed_any = false;
+        // Deepest prefixes first so nested dirs collapse before parents.
+        let mut ordered: Vec<Vec<u8>> = prefixes.into_iter().collect();
+        ordered.sort_by_key(|p| std::cmp::Reverse(p.len()));
+
+        for pref in ordered {
+            let pref_str = String::from_utf8_lossy(&pref);
+            if directory_in_cone(&pref_str, patterns) {
+                continue;
+            }
+            let Some(subtree_oid) = tree_oid_for_prefix(odb, head_tree, &pref)? else {
+                continue;
+            };
+            let expected = collect_sparse_aware_expected_blobs(
+                odb,
+                &subtree_oid,
+                &pref,
+                patterns,
+                cone_mode,
+                &self.entries,
+            )?;
+            if expected.is_empty() {
+                continue;
+            }
+            let mut matched = Vec::new();
+            for e in &self.entries {
+                if e.stage() != 0 {
+                    continue;
+                }
+                if path_under_prefix(&e.path, &pref) && e.mode != MODE_TREE {
+                    matched.push(e.clone());
+                }
+            }
+            if matched.len() != expected.len() {
+                continue;
+            }
+            matched.sort_by(|a, b| a.path.cmp(&b.path));
+            let mut exp_sorted = expected;
+            exp_sorted.sort_by(|a, b| a.path.cmp(&b.path));
+            if !matched
+                .iter()
+                .zip(exp_sorted.iter())
+                .all(|(a, b)| a.path == b.path && a.oid == b.oid && a.mode == b.mode)
+            {
+                continue;
+            }
+            if !matched.iter().all(|e| e.skip_worktree()) {
+                continue;
+            }
+
+            let mut path_with_slash = pref.clone();
+            if !path_with_slash.ends_with(b"/") {
+                path_with_slash.push(b'/');
+            }
+            self.entries
+                .retain(|e| e.stage() != 0 || !path_under_prefix(&e.path, &pref));
+            let mut placeholder = IndexEntry {
+                ctime_sec: 0,
+                ctime_nsec: 0,
+                mtime_sec: 0,
+                mtime_nsec: 0,
+                dev: 0,
+                ino: 0,
+                mode: MODE_TREE,
+                uid: 0,
+                gid: 0,
+                size: 0,
+                oid: subtree_oid,
+                flags: path_with_slash.len().min(0xFFF) as u16,
+                flags_extended: Some(0),
+                path: path_with_slash,
+            };
+            placeholder.set_skip_worktree(true);
+            self.add_or_replace(placeholder);
+            collapsed_any = true;
+        }
+
+        if collapsed_any {
+            self.sort();
+            self.sparse_directories = true;
+        } else {
+            self.sparse_directories = false;
+        }
+        Ok(())
     }
 
     /// Parse index bytes (the whole file including trailing SHA-1).
@@ -303,7 +509,38 @@ impl Index {
             pos += consumed;
         }
 
-        Ok(Self { version, entries })
+        let mut sparse_directories = false;
+        while pos + 8 <= body.len() {
+            let sig = u32::from_be_bytes(
+                body[pos..pos + 4]
+                    .try_into()
+                    .map_err(|_| Error::IndexError("truncated extension sig".to_owned()))?,
+            );
+            let ext_sz = u32::from_be_bytes(
+                body[pos + 4..pos + 8]
+                    .try_into()
+                    .map_err(|_| Error::IndexError("truncated extension size".to_owned()))?,
+            ) as usize;
+            pos += 8;
+            if pos + ext_sz > body.len() {
+                return Err(Error::IndexError(
+                    "extension overruns index body".to_owned(),
+                ));
+            }
+            if sig == INDEX_EXT_SPARSE_DIRECTORIES {
+                sparse_directories = true;
+            }
+            pos += ext_sz;
+        }
+        if pos != body.len() {
+            return Err(Error::IndexError("junk after index extensions".to_owned()));
+        }
+
+        Ok(Self {
+            version,
+            entries,
+            sparse_directories,
+        })
     }
 
     /// Write the index to a file, computing and appending the trailing SHA-1.
@@ -397,6 +634,10 @@ impl Index {
         for entry in &self.entries {
             serialize_entry(entry, write_version, out);
         }
+        if self.sparse_directories {
+            out.extend_from_slice(&INDEX_EXT_SPARSE_DIRECTORIES.to_be_bytes());
+            out.extend_from_slice(&0u32.to_be_bytes());
+        }
         Ok(())
     }
 
@@ -463,6 +704,221 @@ impl Index {
             .iter_mut()
             .find(|e| e.path == path && e.stage() == stage)
     }
+}
+
+fn trim_trailing_slash_bytes(path: &[u8]) -> &[u8] {
+    path.strip_suffix(b"/").unwrap_or(path)
+}
+
+fn path_under_prefix(path: &[u8], prefix: &[u8]) -> bool {
+    if path == prefix {
+        return true;
+    }
+    if prefix.is_empty() {
+        return true;
+    }
+    path.len() > prefix.len() && path.starts_with(prefix) && path[prefix.len()] == b'/'
+}
+
+fn directory_in_cone(dir_path: &str, patterns: &[String]) -> bool {
+    for pattern in patterns {
+        let prefix = pattern.trim_end_matches('/');
+        if prefix.is_empty() {
+            continue;
+        }
+        if dir_path == prefix {
+            return true;
+        }
+        if dir_path.starts_with(prefix) && dir_path.as_bytes().get(prefix.len()) == Some(&b'/') {
+            return true;
+        }
+        if prefix.starts_with(dir_path) && prefix.as_bytes().get(dir_path.len()) == Some(&b'/') {
+            return true;
+        }
+    }
+    false
+}
+
+fn collect_directory_prefixes(path: &[u8], out: &mut BTreeSet<Vec<u8>>) {
+    for (i, &b) in path.iter().enumerate() {
+        if b == b'/' {
+            out.insert(path[..i].to_vec());
+        }
+    }
+}
+
+fn tree_oid_for_prefix(odb: &Odb, root_tree: &ObjectId, prefix: &[u8]) -> Result<Option<ObjectId>> {
+    if prefix.is_empty() {
+        return Ok(Some(*root_tree));
+    }
+    let pref_str = String::from_utf8_lossy(prefix);
+    let components: Vec<&str> = pref_str.split('/').filter(|c| !c.is_empty()).collect();
+    let mut current = *root_tree;
+    for comp in components {
+        let obj = odb.read(&current)?;
+        if obj.kind != ObjectKind::Tree {
+            return Ok(None);
+        }
+        let entries = parse_tree(&obj.data)?;
+        let mut next = None;
+        for e in entries {
+            if e.name == comp.as_bytes() {
+                if e.mode == MODE_TREE {
+                    next = Some(e.oid);
+                }
+                break;
+            }
+        }
+        current = match next {
+            Some(o) => o,
+            None => return Ok(None),
+        };
+    }
+    Ok(Some(current))
+}
+
+/// Build the list of blob index entries under `prefix` that match `HEAD` at `tree_oid`,
+/// treating existing sparse-directory placeholders in `entries` as opaque subtrees (like Git).
+fn collect_sparse_aware_expected_blobs(
+    odb: &Odb,
+    tree_oid: &ObjectId,
+    prefix: &[u8],
+    patterns: &[String],
+    cone_mode: bool,
+    entries: &[IndexEntry],
+) -> Result<Vec<IndexEntry>> {
+    let mut out = Vec::new();
+    walk_sparse_aware(
+        odb, tree_oid, prefix, patterns, cone_mode, entries, &mut out,
+    )?;
+    Ok(out)
+}
+
+fn walk_sparse_aware(
+    odb: &Odb,
+    tree_oid: &ObjectId,
+    prefix: &[u8],
+    patterns: &[String],
+    cone_mode: bool,
+    entries: &[IndexEntry],
+    out: &mut Vec<IndexEntry>,
+) -> Result<()> {
+    let obj = odb.read(tree_oid)?;
+    if obj.kind != ObjectKind::Tree {
+        return Err(Error::IndexError(format!("expected tree at {}", tree_oid)));
+    }
+    let tree_entries = parse_tree(&obj.data)?;
+    for te in tree_entries {
+        let path = if prefix.is_empty() {
+            te.name.clone()
+        } else {
+            let mut p = prefix.to_vec();
+            p.push(b'/');
+            p.extend_from_slice(&te.name);
+            p
+        };
+        if te.mode == MODE_TREE {
+            let path_slash = {
+                let mut p = path.clone();
+                p.push(b'/');
+                p
+            };
+            if entries.iter().any(|e| {
+                e.stage() == 0
+                    && e.is_sparse_directory_placeholder()
+                    && e.path == path_slash
+                    && e.oid == te.oid
+            }) {
+                continue;
+            }
+            walk_sparse_aware(odb, &te.oid, &path, patterns, cone_mode, entries, out)?;
+        } else {
+            let path_len = path.len().min(0xFFF) as u16;
+            let path_str = String::from_utf8_lossy(&path);
+            if cone_mode && path_matches_cone_sparse(&path_str, patterns) {
+                continue;
+            }
+            let mut e = IndexEntry {
+                ctime_sec: 0,
+                ctime_nsec: 0,
+                mtime_sec: 0,
+                mtime_nsec: 0,
+                dev: 0,
+                ino: 0,
+                mode: te.mode,
+                uid: 0,
+                gid: 0,
+                size: 0,
+                oid: te.oid,
+                flags: path_len,
+                flags_extended: Some(0),
+                path,
+            };
+            e.set_skip_worktree(true);
+            out.push(e);
+        }
+    }
+    Ok(())
+}
+
+fn path_matches_cone_sparse(path: &str, patterns: &[String]) -> bool {
+    if !path.contains('/') {
+        return true;
+    }
+    for pattern in patterns {
+        let prefix = pattern.trim_end_matches('/');
+        if path.starts_with(prefix) && path.as_bytes().get(prefix.len()) == Some(&b'/') {
+            return true;
+        }
+        if path == prefix {
+            return true;
+        }
+    }
+    false
+}
+
+fn flatten_tree_blobs(odb: &Odb, tree_oid: &ObjectId, prefix: &[u8]) -> Result<Vec<IndexEntry>> {
+    let obj = odb.read(tree_oid)?;
+    if obj.kind != ObjectKind::Tree {
+        return Err(Error::IndexError(format!("expected tree at {}", tree_oid)));
+    }
+    let entries = parse_tree(&obj.data)?;
+    let mut out = Vec::new();
+    for te in entries {
+        let path = if prefix.is_empty() {
+            te.name.clone()
+        } else {
+            let mut p = prefix.to_vec();
+            p.push(b'/');
+            p.extend_from_slice(&te.name);
+            p
+        };
+        if te.mode == MODE_TREE {
+            let sub = flatten_tree_blobs(odb, &te.oid, &path)?;
+            out.extend(sub);
+        } else {
+            let path_len = path.len().min(0xFFF) as u16;
+            let mut e = IndexEntry {
+                ctime_sec: 0,
+                ctime_nsec: 0,
+                mtime_sec: 0,
+                mtime_nsec: 0,
+                dev: 0,
+                ino: 0,
+                mode: te.mode,
+                uid: 0,
+                gid: 0,
+                size: 0,
+                oid: te.oid,
+                flags: path_len,
+                flags_extended: Some(0),
+                path,
+            };
+            e.set_skip_worktree(true);
+            out.push(e);
+        }
+    }
+    Ok(out)
 }
 
 fn lockfile_pid_enabled(index_path: &Path) -> bool {

--- a/grit-lib/src/repo.rs
+++ b/grit-lib/src/repo.rs
@@ -22,8 +22,25 @@ use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
+use crate::config::ConfigSet;
 use crate::error::{Error, Result};
+use crate::index::Index;
+use crate::objects::parse_commit;
 use crate::odb::Odb;
+use crate::state::resolve_head;
+
+fn read_sparse_checkout_patterns(git_dir: &Path) -> Vec<String> {
+    let path = git_dir.join("info").join("sparse-checkout");
+    let Ok(content) = fs::read_to_string(&path) else {
+        return Vec::new();
+    };
+    content
+        .lines()
+        .map(|l| l.trim())
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .map(String::from)
+        .collect()
+}
 
 /// A handle to an open Git repository.
 #[derive(Debug)]
@@ -192,6 +209,67 @@ impl Repository {
     #[must_use]
     pub fn index_path(&self) -> PathBuf {
         self.git_dir.join("index")
+    }
+
+    /// Load the index, expanding sparse-directory placeholders from the object database.
+    ///
+    /// Commands that operate on individual paths should use this instead of [`Index::load`].
+    pub fn load_index(&self) -> Result<Index> {
+        let path = self.index_path();
+        self.load_index_at(&path)
+    }
+
+    /// Like [`Repository::load_index`], but reads from an explicit index file path
+    /// (e.g. `GIT_INDEX_FILE` or a worktree-specific index).
+    pub fn load_index_at(&self, path: &std::path::Path) -> Result<Index> {
+        Index::load_expand_sparse_optional(path, &self.odb)
+    }
+
+    /// Write the index to the default path after optionally collapsing skip-worktree
+    /// subtrees into sparse-directory placeholders (when sparse index is enabled).
+    pub fn write_index(&self, index: &mut Index) -> Result<()> {
+        self.write_index_at(&self.index_path(), index)
+    }
+
+    /// Like [`Repository::write_index`], but writes to an explicit index file path.
+    pub fn write_index_at(&self, path: &std::path::Path, index: &mut Index) -> Result<()> {
+        self.finalize_sparse_index_if_needed(index)?;
+        index.write(path)
+    }
+
+    fn finalize_sparse_index_if_needed(&self, index: &mut Index) -> Result<()> {
+        let cfg = ConfigSet::load(Some(&self.git_dir), true).unwrap_or_default();
+        let sparse_enabled = cfg
+            .get("core.sparseCheckout")
+            .map(|v| v == "true")
+            .unwrap_or(false);
+        if !sparse_enabled {
+            index.sparse_directories = false;
+            return Ok(());
+        }
+        let cone = cfg
+            .get("core.sparseCheckoutCone")
+            .and_then(|v| v.parse::<bool>().ok())
+            .unwrap_or(true);
+        let sparse_ix = cfg
+            .get("index.sparse")
+            .map(|v| v == "true")
+            .unwrap_or(false);
+        let patterns = read_sparse_checkout_patterns(&self.git_dir);
+        let head = resolve_head(&self.git_dir)?;
+        let tree_oid = if let Some(oid) = head.oid() {
+            let obj = self.odb.read(oid)?;
+            let commit = parse_commit(&obj.data)?;
+            Some(commit.tree)
+        } else {
+            None
+        };
+        if let Some(t) = tree_oid {
+            index.try_collapse_sparse_directories(&self.odb, &t, &patterns, cone, sparse_ix)?;
+        } else {
+            index.sparse_directories = false;
+        }
+        Ok(())
     }
 
     /// Path to the `refs/` directory.

--- a/grit-lib/src/rev_parse.rs
+++ b/grit-lib/src/rev_parse.rs
@@ -997,8 +997,8 @@ fn resolve_index_path_at_stage(repo: &Repository, path: &str, stage: u8) -> Resu
     } else {
         repo.index_path()
     };
-    let index =
-        Index::load(&index_path).map_err(|_| Error::ObjectNotFound(format!(":{stage}:{path}")))?;
+    let index = Index::load_expand_sparse(&index_path, &repo.odb)
+        .map_err(|_| Error::ObjectNotFound(format!(":{stage}:{path}")))?;
     match index.get(path.as_bytes(), stage) {
         Some(entry) => Ok(entry.oid),
         None => Err(Error::ObjectNotFound(format!(":{stage}:{path}"))),

--- a/grit-lib/src/write_tree.rs
+++ b/grit-lib/src/write_tree.rs
@@ -24,7 +24,10 @@ pub fn write_tree_from_index(odb: &Odb, index: &Index, prefix: &str) -> Result<O
         .entries
         .iter()
         .filter(|entry| {
-            entry.stage() == 0 && !entry.intent_to_add() && entry.path.starts_with(prefix_bytes)
+            entry.stage() == 0
+                && !entry.intent_to_add()
+                && entry.mode != MODE_TREE
+                && entry.path.starts_with(prefix_bytes)
         })
         .collect();
     entries.sort_by(|a, b| a.path.cmp(&b.path).then_with(|| a.stage().cmp(&b.stage())));

--- a/grit/src/commands/add.rs
+++ b/grit/src/commands/add.rs
@@ -150,7 +150,7 @@ pub fn run(mut args: Args) -> Result<()> {
     let _cfg_ver = config.get("index.version");
     let _cfg_many = config.get("feature.manyFiles");
     let mut index = if idx_exists {
-        Index::load(&index_path)?
+        repo.load_index_at(&index_path)?
     } else {
         Index::new_with_config(
             config.get("index.version").as_deref(),
@@ -195,7 +195,7 @@ pub fn run(mut args: Args) -> Result<()> {
     // --chmod with no pathspecs: do nothing (don't error, just return)
     if args.chmod.is_some() && args.pathspec.is_empty() {
         if !args.dry_run {
-            write_index_or_lock_err(&index, &repo.index_path())?;
+            write_index_or_lock_err(&repo, &mut index, &repo.index_path())?;
         }
         return Ok(());
     }
@@ -225,6 +225,7 @@ pub fn run(mut args: Args) -> Result<()> {
     // --renormalize: re-apply clean conversion to tracked files
     if args.renormalize {
         return run_renormalize(
+            &repo,
             odb,
             &mut index,
             work_tree,
@@ -315,13 +316,13 @@ pub fn run(mut args: Args) -> Result<()> {
 
         if had_ignored {
             if !args.dry_run {
-                write_index_or_lock_err(&index, &repo.index_path())?;
+                write_index_or_lock_err(&repo, &mut index, &repo.index_path())?;
             }
             bail!("some ignored files could not be added");
         }
         if had_errors {
             if !args.dry_run {
-                write_index_or_lock_err(&index, &repo.index_path())?;
+                write_index_or_lock_err(&repo, &mut index, &repo.index_path())?;
             }
             if !add_cfg.ignore_errors {
                 bail!("adding files failed");
@@ -333,7 +334,7 @@ pub fn run(mut args: Args) -> Result<()> {
     }
 
     if !args.dry_run {
-        write_index_or_lock_err(&index, &repo.index_path())?;
+        write_index_or_lock_err(&repo, &mut index, &repo.index_path())?;
     }
 
     Ok(())
@@ -425,7 +426,7 @@ fn run_refresh(
     }
 
     if !args.dry_run {
-        write_index_or_lock_err(index, &repo.index_path())?;
+        write_index_or_lock_err(repo, index, &repo.index_path())?;
     }
 
     Ok(())
@@ -433,6 +434,7 @@ fn run_refresh(
 
 /// Re-apply clean conversion (CRLF normalization) to tracked files.
 fn run_renormalize(
+    repo: &Repository,
     odb: &Odb,
     index: &mut Index,
     work_tree: &Path,
@@ -491,8 +493,8 @@ fn run_renormalize(
     }
 
     if !args.dry_run {
-        let index_path = work_tree.join(".git/index");
-        write_index_or_lock_err(index, &index_path)?;
+        let index_path = repo.index_path();
+        write_index_or_lock_err(repo, index, &index_path)?;
     }
 
     Ok(())
@@ -1164,8 +1166,8 @@ fn is_unwritable_lock_error(err: &grit_lib::error::Error) -> bool {
     )
 }
 
-fn write_index_or_lock_err(index: &Index, index_path: &Path) -> Result<()> {
-    index.write(index_path).map_err(|e| {
+fn write_index_or_lock_err(repo: &Repository, index: &mut Index, index_path: &Path) -> Result<()> {
+    repo.write_index_at(index_path, index).map_err(|e| {
         if is_unwritable_lock_error(&e) {
             let mut msg = format!(
                 "Unable to create '{}': File exists.",

--- a/grit/src/commands/am.rs
+++ b/grit/src/commands/am.rs
@@ -16,7 +16,6 @@ use std::io::{self, Read, Write};
 use std::path::Path;
 
 use grit_lib::config::{parse_bool, ConfigSet};
-use grit_lib::error::Error as GritError;
 use grit_lib::index::Index;
 use grit_lib::objects::{parse_commit, serialize_commit, CommitData, ObjectId, ObjectKind};
 use grit_lib::repo::Repository;
@@ -1329,7 +1328,7 @@ fn stage_affected_files(repo: &Repository, affected_paths: &[String]) -> Result<
     }
 
     index.sort();
-    index.write(&repo.index_path())?;
+    repo.write_index(&mut index)?;
     Ok(())
 }
 
@@ -1524,7 +1523,7 @@ fn do_skip() -> Result<()> {
         let mut index = Index::new();
         index.entries = entries;
         index.sort();
-        index.write(&repo.index_path())?;
+        repo.write_index(&mut index)?;
 
         if let Some(wt) = &repo.work_tree {
             checkout_index_to_worktree(&repo, wt, &index)?;
@@ -1652,7 +1651,7 @@ fn do_abort() -> Result<()> {
         let mut index = Index::new();
         index.entries = entries;
         index.sort();
-        index.write(&repo.index_path())?;
+        repo.write_index(&mut index)?;
 
         if let Some(wt) = &repo.work_tree {
             checkout_index_to_worktree(&repo, wt, &index)?;
@@ -3203,12 +3202,7 @@ fn apply_hunks(old_content: &str, hunks: &[Hunk]) -> Result<String> {
 // ── Helpers ─────────────────────────────────────────────────────────
 
 fn load_index(repo: &Repository) -> Result<Index> {
-    let index_path = repo.index_path();
-    match Index::load(&index_path) {
-        Ok(idx) => Ok(idx),
-        Err(GritError::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => Ok(Index::new()),
-        Err(e) => Err(e.into()),
-    }
+    Ok(repo.load_index()?)
 }
 
 fn resolve_identity(config: &ConfigSet, kind: &str) -> Result<(String, String)> {

--- a/grit/src/commands/apply.rs
+++ b/grit/src/commands/apply.rs
@@ -1846,7 +1846,7 @@ pub fn run(args: Args) -> Result<()> {
 /// This implements `git apply --build-fake-ancestor=<file>` behavior.
 fn build_fake_ancestor_file(patches: &[FilePatch], args: &Args, out_path: &Path) -> Result<()> {
     let repo = Repository::discover(None).context("not a git repository")?;
-    let current_index = Index::load(&repo.index_path()).unwrap_or_else(|_| Index::new());
+    let current_index = repo.load_index().unwrap_or_else(|_| Index::new());
     let mut fake = Index::new();
 
     for fp in patches {
@@ -1919,7 +1919,7 @@ impl ApplyCrlfContext {
     fn load() -> Option<Self> {
         let repo = Repository::discover(None).ok()?;
         let work_tree = repo.work_tree.clone()?;
-        let index = Index::load(&repo.index_path()).unwrap_or_else(|_| Index::new());
+        let index = repo.load_index().unwrap_or_else(|_| Index::new());
         let config = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
         let conv = crlf::ConversionConfig::from_config(&config);
         Some(Self {
@@ -1973,7 +1973,7 @@ impl ApplyCrlfContext {
 /// Verify that working tree files match the index (required for --index mode).
 fn verify_worktree_matches_index(patches: &[FilePatch], args: &Args) -> Result<()> {
     let repo = Repository::discover(None).context("not a git repository")?;
-    let index = match Index::load(&repo.index_path()) {
+    let index = match repo.load_index() {
         Ok(idx) => idx,
         Err(_) => return Ok(()),
     };
@@ -2575,7 +2575,7 @@ fn apply_to_worktree(
 /// Apply patches to the index only (--cached).
 fn apply_to_index(patches: &[FilePatch], args: &Args, ws_mode: ApplyWhitespaceMode) -> Result<()> {
     let repo = Repository::discover(None).context("not a git repository")?;
-    let mut index = match Index::load(&repo.index_path()) {
+    let mut index = match repo.load_index() {
         Ok(idx) => idx,
         Err(_) => Index::new(),
     };
@@ -2772,7 +2772,7 @@ fn apply_to_index(patches: &[FilePatch], args: &Args, ws_mode: ApplyWhitespaceMo
         index.add_or_replace(entry);
     }
 
-    index.write(&repo.index_path())?;
+    repo.write_index(&mut index)?;
     Ok(())
 }
 
@@ -2790,7 +2790,7 @@ fn apply_intent_to_add_entries(patches: &[FilePatch], args: &Args) -> Result<()>
         Ok(repo) => repo,
         Err(_) => return Ok(()),
     };
-    let mut index = match Index::load(&repo.index_path()) {
+    let mut index = match repo.load_index() {
         Ok(idx) => idx,
         Err(_) => Index::new(),
     };
@@ -2848,7 +2848,7 @@ fn apply_intent_to_add_entries(patches: &[FilePatch], args: &Args) -> Result<()>
         index.add_or_replace(entry);
     }
 
-    index.write(&repo.index_path())?;
+    repo.write_index(&mut index)?;
     Ok(())
 }
 

--- a/grit/src/commands/blame.rs
+++ b/grit/src/commands/blame.rs
@@ -7,7 +7,6 @@ use grit_lib::crlf::{
     convert_to_git, get_file_attrs, load_gitattributes, load_gitattributes_from_index,
     ConversionConfig, GitAttributes,
 };
-use grit_lib::index::Index;
 use grit_lib::objects::{parse_commit, parse_tree, CommitData, ObjectId, ObjectKind};
 use grit_lib::odb::Odb;
 use grit_lib::repo::Repository;
@@ -331,7 +330,7 @@ fn load_attr_rules(repo: &Repository) -> GitAttributes {
         }
     }
 
-    if let Ok(index) = Index::load(&repo.index_path()) {
+    if let Ok(index) = repo.load_index() {
         return load_gitattributes_from_index(&index, &repo.odb);
     }
 
@@ -347,7 +346,7 @@ fn load_diff_attr_rules(repo: &Repository) -> Vec<DiffAttrRule> {
     }
 
     if rules.is_empty() {
-        if let Ok(index) = Index::load(&repo.index_path()) {
+        if let Ok(index) = repo.load_index() {
             if let Some(entry) = index.get(b".gitattributes", 0) {
                 if let Ok(obj) = repo.odb.read(&entry.oid) {
                     if let Ok(content) = String::from_utf8(obj.data) {
@@ -1816,8 +1815,8 @@ pub fn run(args: Args) -> Result<()> {
 
 /// Read file content from index conflict stages (for blame during merge conflicts).
 fn read_from_index_conflict(repo: &Repository, odb: &Odb, file_path: &str) -> Result<String> {
-    use grit_lib::index::Index;
-    let index = Index::load(&repo.index_path()).context("loading index")?;
+    
+    let index = repo.load_index().context("loading index")?;
     let path_bytes = file_path.as_bytes();
     // Find the highest-stage entry for this path (prefer stage 3, then 2, then 1)
     let mut best: Option<&grit_lib::index::IndexEntry> = None;

--- a/grit/src/commands/check_attr.rs
+++ b/grit/src/commands/check_attr.rs
@@ -9,7 +9,6 @@ use grit_lib::attributes::{
     quote_path_for_check_attr, resolve_attr_treeish, resolve_tree_oid, ParsedGitAttributes,
 };
 use grit_lib::config::ConfigSet;
-use grit_lib::index::Index;
 use grit_lib::repo::Repository;
 use std::io::{self, BufRead, Write};
 use std::path::{Path, PathBuf};
@@ -114,7 +113,7 @@ fn load_parsed_for_run(repo: &Repository, args: &Args) -> Result<ParsedGitAttrib
             .ok()
             .map(PathBuf::from)
             .unwrap_or_else(|| repo.index_path());
-        let index = Index::load(&index_path).context("read index")?;
+        let index = repo.load_index_at(&index_path).context("read index")?;
         let wt = repo.work_tree.as_deref().unwrap_or_else(|| Path::new("."));
         return load_gitattributes_from_index(&index, &repo.odb, wt).context("index attributes");
     }
@@ -164,7 +163,7 @@ pub fn run(args: Args) -> Result<()> {
         .ok()
         .map(PathBuf::from)
         .unwrap_or_else(|| repo.index_path());
-    let index_cached = Index::load(&index_path).ok();
+    let index_cached = repo.load_index_at(&index_path).ok();
 
     for raw_path in &paths {
         let rel = if repo.work_tree.is_some() {

--- a/grit/src/commands/check_ignore.rs
+++ b/grit/src/commands/check_ignore.rs
@@ -43,7 +43,7 @@ fn run_inner(args: Args) -> Result<()> {
     let index = if parsed.no_index {
         None
     } else {
-        Some(Index::load(&repo.index_path()).context("failed to read index")?)
+        Some(repo.load_index().context("failed to read index")?)
     };
     let index_ref = index.as_ref();
 

--- a/grit/src/commands/checkout.rs
+++ b/grit/src/commands/checkout.rs
@@ -827,7 +827,7 @@ fn create_and_switch_branch(
     // Update working tree if start point differs from current HEAD, or if force,
     // or if the worktree is empty (e.g. after clone --no-checkout)
     let worktree_is_empty = if let Some(ref _wt) = repo.work_tree {
-        let old_idx = grit_lib::index::Index::load(&repo.index_path()).unwrap_or_default();
+        let old_idx = repo.load_index().unwrap_or_default();
         old_idx.entries.is_empty()
     } else {
         false
@@ -1003,7 +1003,7 @@ fn create_orphan_branch(repo: &Repository, name: &str, start_point: Option<&str>
     // If a start point is given, populate the index/worktree from it
     // But first check for local changes that would be overwritten
     if start_point.is_some() {
-        let index = Index::load(&repo.index_path()).unwrap_or_else(|_| Index::new());
+        let index = repo.load_index().unwrap_or_else(|_| Index::new());
         let work_tree = repo.work_tree.as_ref();
         if let Some(wt) = work_tree {
             let mut dirty_files = Vec::new();
@@ -1043,15 +1043,13 @@ fn create_orphan_branch(repo: &Repository, name: &str, start_point: Option<&str>
             .work_tree
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("not a work tree"))?;
-        let old_index = Index::load(&repo.index_path()).unwrap_or_else(|_| Index::new());
+        let old_index = repo.load_index().unwrap_or_else(|_| Index::new());
         let new_entries = tree_to_flat_entries(repo, &tree_oid, "")?;
         let mut new_index = Index::new();
         new_index.entries = new_entries;
         new_index.sort();
         checkout_index_to_worktree(repo, &old_index, &new_index, work_tree, true)?;
-        new_index
-            .write(&repo.index_path())
-            .context("writing index")?;
+        repo.write_index(&mut new_index).context("writing index")?;
     }
 
     // Point HEAD at the new branch (which doesn't exist yet = unborn)
@@ -1069,7 +1067,7 @@ fn force_reset_to_tree(repo: &Repository, target_tree: &ObjectId) -> Result<()> 
         None => bail!("this operation must be run in a work tree"),
     };
 
-    let old_index = Index::load(&repo.index_path()).unwrap_or_else(|_| Index::new());
+    let old_index = repo.load_index().unwrap_or_else(|_| Index::new());
     let new_entries = tree_to_flat_entries(repo, target_tree, "")?;
     let mut new_index = Index::new();
     new_index.entries = new_entries;
@@ -1089,9 +1087,7 @@ fn force_reset_to_tree(repo: &Repository, target_tree: &ObjectId) -> Result<()> 
         )?;
     }
 
-    new_index
-        .write(&repo.index_path())
-        .context("writing index")?;
+    repo.write_index(&mut new_index).context("writing index")?;
     Ok(())
 }
 
@@ -1146,7 +1142,8 @@ fn force_reset_to_head(repo: &Repository) -> Result<()> {
 
     // Write the new index
     let index_path = repo.index_path();
-    new_index.write(&index_path).context("writing index")?;
+    repo.write_index_at(&index_path, &mut new_index)
+        .context("writing index")?;
 
     // Print current branch/commit info
     match &head {
@@ -1220,7 +1217,7 @@ fn switch_to_tree(
     };
 
     let index_path = repo.index_path();
-    let old_index = Index::load(&index_path).context("loading index")?;
+    let old_index = repo.load_index_at(&index_path).context("loading index")?;
 
     // Build the new index from the target tree
     let new_entries = tree_to_flat_entries(repo, target_tree_oid, "")?;
@@ -1318,7 +1315,8 @@ fn switch_to_tree(
     }
 
     // Write the new index
-    new_index.write(&index_path).context("writing index")?;
+    repo.write_index_at(&index_path, &mut new_index)
+        .context("writing index")?;
 
     Ok(())
 }
@@ -1655,7 +1653,7 @@ fn checkout_paths(
         None => {
             // checkout -- <paths>: restore from index
             let index_path = repo.index_path();
-            let index = Index::load(&index_path).context("loading index")?;
+            let index = repo.load_index_at(&index_path).context("loading index")?;
 
             for path_str in paths {
                 let rel = resolve_pathspec(path_str, work_tree, &cwd);
@@ -1745,7 +1743,7 @@ fn checkout_paths(
             let tree_oid = commit_to_tree(repo, &source_oid)?;
 
             let index_path = repo.index_path();
-            let mut index = Index::load(&index_path).context("loading index")?;
+            let mut index = repo.load_index_at(&index_path).context("loading index")?;
             let mut index_modified = false;
 
             for path_str in paths {
@@ -1914,10 +1912,10 @@ fn checkout_paths(
                             remove_empty_parent_dirs(work_tree, &abs_path);
                         }
                         // Remove from index
-                        if let Ok(mut idx) = Index::load(&repo.index_path()) {
+                        if let Ok(mut idx) = repo.load_index() {
                             idx.entries
                                 .retain(|e| String::from_utf8_lossy(&e.path) != rel.as_str());
-                            let _ = idx.write(&repo.index_path());
+                            let _ = repo.write_index(&mut idx);
                         }
                         continue;
                     }
@@ -1977,7 +1975,8 @@ fn checkout_paths(
             }
 
             if index_modified {
-                index.write(&index_path).context("writing index")?;
+                repo.write_index_at(&index_path, &mut index)
+                    .context("writing index")?;
             }
         }
     }
@@ -2009,7 +2008,7 @@ pub(crate) fn checkout_patch(
 
     let cwd = std::env::current_dir().context("resolving cwd")?;
     let index_path = repo.index_path();
-    let index = Index::load(&index_path).context("loading index")?;
+    let index = repo.load_index_at(&index_path).context("loading index")?;
 
     // Determine which files to consider
     let filter_paths: Vec<String> = paths

--- a/grit/src/commands/checkout_index.rs
+++ b/grit/src/commands/checkout_index.rs
@@ -143,7 +143,7 @@ pub fn run(args: Args) -> Result<()> {
         .to_path_buf();
 
     let index_path = repo.index_path();
-    let mut index = Index::load(&index_path).context("loading index")?;
+    let mut index = repo.load_index_at(&index_path).context("loading index")?;
 
     let cwd = std::env::current_dir().context("resolving current directory")?;
 
@@ -248,7 +248,8 @@ pub fn run(args: Args) -> Result<()> {
     }
 
     if index_needs_write {
-        index.write(&index_path).context("writing index")?;
+        repo.write_index_at(&index_path, &mut index)
+            .context("writing index")?;
     }
 
     if has_errors || has_conflicts {

--- a/grit/src/commands/cherry_pick.rs
+++ b/grit/src/commands/cherry_pick.rs
@@ -13,7 +13,6 @@ use std::fs;
 use std::path::Path;
 
 use grit_lib::config::ConfigSet;
-use grit_lib::error::Error as GritError;
 use grit_lib::index::{Index, IndexEntry, MODE_EXECUTABLE, MODE_SYMLINK};
 use grit_lib::merge_file::{merge, MergeFavor, MergeInput};
 use grit_lib::objects::{
@@ -296,9 +295,7 @@ fn cherry_pick_one_commit(repo: &Repository, commit_oid: ObjectId, args: &Args) 
             let mut new_index = Index::new();
             new_index.entries = entries;
             new_index.sort();
-            new_index
-                .write(&repo.index_path())
-                .context("writing index")?;
+            repo.write_index(&mut new_index).context("writing index")?;
             if let Some(wt) = &repo.work_tree {
                 checkout_merged_index(repo, wt, &old_index, &new_index, &BTreeMap::new())?;
             }
@@ -370,7 +367,7 @@ fn cherry_pick_one_commit(repo: &Repository, commit_oid: ObjectId, args: &Args) 
     let theirs_entries = tree_to_map(tree_to_index_entries(repo, &commit_tree_oid, "")?);
 
     let (favor, ws_opts) = parse_strategy_options(&args.strategy_option);
-    let merge_result = three_way_merge_with_content(
+    let mut merge_result = three_way_merge_with_content(
         repo,
         &base_entries,
         &ours_entries,
@@ -397,9 +394,7 @@ fn cherry_pick_one_commit(repo: &Repository, commit_oid: ObjectId, args: &Args) 
     }
 
     let old_index = load_index(repo)?;
-    merge_result
-        .index
-        .write(&repo.index_path())
+    repo.write_index(&mut merge_result.index)
         .context("writing index")?;
 
     let work_tree = repo
@@ -598,7 +593,7 @@ fn do_abort() -> Result<()> {
         let mut index = Index::new();
         index.entries = entries;
         index.sort();
-        index.write(&repo.index_path())?;
+        repo.write_index(&mut index)?;
 
         if let Some(wt) = &repo.work_tree {
             checkout_merged_index(&repo, wt, &old_idx, &index, &BTreeMap::new())?;
@@ -635,7 +630,7 @@ fn do_skip(args: &Args) -> Result<()> {
         let mut new_index = Index::new();
         new_index.entries = entries;
         new_index.sort();
-        new_index.write(&repo.index_path())?;
+        repo.write_index(&mut new_index)?;
 
         if let Some(wt) = &repo.work_tree {
             checkout_merged_index(&repo, wt, &old_index, &new_index, &BTreeMap::new())?;
@@ -783,12 +778,7 @@ fn cleanup_cherry_pick_state(git_dir: &Path) {
 }
 
 fn load_index(repo: &Repository) -> Result<Index> {
-    let index_path = repo.index_path();
-    match Index::load(&index_path) {
-        Ok(idx) => Ok(idx),
-        Err(GritError::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => Ok(Index::new()),
-        Err(e) => Err(e.into()),
-    }
+    Ok(repo.load_index()?)
 }
 
 fn create_cherry_pick_commit(

--- a/grit/src/commands/clean.rs
+++ b/grit/src/commands/clean.rs
@@ -82,7 +82,7 @@ pub fn run(args: Args) -> Result<()> {
         bail!("-x and -X cannot be used together");
     }
 
-    let index = Index::load(&repo.index_path()).context("failed to read index")?;
+    let index = repo.load_index().context("failed to read index")?;
     let mut matcher =
         IgnoreMatcher::from_repository(&repo).context("failed to load ignore rules")?;
 

--- a/grit/src/commands/clone.rs
+++ b/grit/src/commands/clone.rs
@@ -1280,7 +1280,8 @@ fn write_index_from_tree(repo: &Repository, tree_oid: &ObjectId) -> Result<()> {
         &mut index,
         repo.work_tree.as_deref(),
     )?;
-    index.write(&index_path).context("writing index")?;
+    repo.write_index_at(&index_path, &mut index)
+        .context("writing index")?;
 
     Ok(())
 }

--- a/grit/src/commands/commit.rs
+++ b/grit/src/commands/commit.rs
@@ -222,7 +222,7 @@ pub fn run(args: Args) -> Result<()> {
     }
 
     // Load index
-    let index = match Index::load(&repo.index_path()) {
+    let index = match repo.load_index() {
         Ok(idx) => idx,
         Err(Error::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => Index::new(),
         Err(e) => return Err(e.into()),
@@ -733,7 +733,7 @@ fn walk_untracked(
 
 /// Stage specific files given as pathspec arguments to `commit`.
 fn stage_pathspec_files(repo: &Repository, work_tree: &Path, pathspecs: &[String]) -> Result<()> {
-    let mut index = match Index::load(&repo.index_path()) {
+    let mut index = match repo.load_index() {
         Ok(idx) => idx,
         Err(Error::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => Index::new(),
         Err(e) => return Err(e.into()),
@@ -783,13 +783,13 @@ fn stage_pathspec_files(repo: &Repository, work_tree: &Path, pathspecs: &[String
         }
     }
 
-    index.write(&repo.index_path())?;
+    repo.write_index(&mut index)?;
     Ok(())
 }
 
 /// Auto-stage tracked files (for `commit -a`).
 fn auto_stage_tracked(repo: &Repository, work_tree: &Path) -> Result<()> {
-    let mut index = match Index::load(&repo.index_path()) {
+    let mut index = match repo.load_index() {
         Ok(idx) => idx,
         Err(Error::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
         Err(e) => return Err(e.into()),
@@ -869,7 +869,7 @@ fn auto_stage_tracked(repo: &Repository, work_tree: &Path) -> Result<()> {
     }
 
     if changed {
-        index.write(&repo.index_path())?;
+        repo.write_index(&mut index)?;
     }
 
     Ok(())

--- a/grit/src/commands/describe.rs
+++ b/grit/src/commands/describe.rs
@@ -268,7 +268,7 @@ fn is_worktree_dirty(repo: &Repository) -> bool {
         Ok(h) => h,
         Err(_) => return true,
     };
-    let index = match Index::load(&repo.index_path()) {
+    let index = match repo.load_index() {
         Ok(idx) => idx,
         Err(Error::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => Index::new(),
         Err(_) => return true,

--- a/grit/src/commands/diagnose.rs
+++ b/grit/src/commands/diagnose.rs
@@ -7,7 +7,6 @@ use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::config::ConfigSet;
 use grit_lib::error::Error;
-use grit_lib::index::Index;
 use grit_lib::repo::Repository;
 use std::fs;
 use std::path::Path;
@@ -75,7 +74,7 @@ pub fn run(args: Args) -> Result<()> {
 
             // Index info
             report.push_str("[Index]\n");
-            match Index::load(&repo.index_path()) {
+            match repo.load_index() {
                 Ok(index) => {
                     let entries = &index.entries;
                     report.push_str(&format!("entries: {}\n", entries.len()));

--- a/grit/src/commands/diff.rs
+++ b/grit/src/commands/diff.rs
@@ -588,7 +588,7 @@ pub fn run(mut args: Args) -> Result<()> {
     let work_tree = repo.work_tree.as_deref();
 
     // Load index (empty if not found)
-    let index = match Index::load(&repo.index_path()) {
+    let index = match repo.load_index() {
         Ok(idx) => idx,
         Err(Error::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => Index::new(),
         Err(e) => return Err(e.into()),

--- a/grit/src/commands/diff_files.rs
+++ b/grit/src/commands/diff_files.rs
@@ -41,7 +41,7 @@ pub fn run(args: Args) -> Result<()> {
     };
 
     let index_path = effective_index_path(&repo)?;
-    let index = Index::load(&index_path).context("loading index")?;
+    let index = repo.load_index_at(&index_path).context("loading index")?;
 
     let changes = collect_changes(&repo, &index, &work_tree, &options)?;
 

--- a/grit/src/commands/diff_index.rs
+++ b/grit/src/commands/diff_index.rs
@@ -37,7 +37,7 @@ pub fn run(args: Args) -> Result<()> {
     collect_tree_entries(&repo, &tree_oid, "", &mut tree_map)?;
 
     let index_path = effective_index_path(&repo)?;
-    let index = Index::load(&index_path).context("loading index")?;
+    let index = repo.load_index_at(&index_path).context("loading index")?;
     let mut index_map = BTreeMap::new();
     for entry in &index.entries {
         if entry.stage() != 0 {
@@ -1321,7 +1321,7 @@ pub fn index_cached_differs_from_head(repo: &Repository) -> Result<bool> {
     let mut tree_map = BTreeMap::new();
     collect_tree_entries(repo, &tree_oid, "", &mut tree_map)?;
     let index_path = effective_index_path(repo)?;
-    let index = Index::load(&index_path).context("loading index")?;
+    let index = repo.load_index_at(&index_path).context("loading index")?;
     let mut index_map = BTreeMap::new();
     for entry in &index.entries {
         if entry.stage() != 0 {

--- a/grit/src/commands/difftool.rs
+++ b/grit/src/commands/difftool.rs
@@ -9,7 +9,6 @@ use clap::Args as ClapArgs;
 use grit_lib::config::ConfigSet;
 use grit_lib::diff::{diff_index_to_worktree, DiffEntry, DiffStatus};
 use grit_lib::error::Error;
-use grit_lib::index::Index;
 use grit_lib::repo::Repository;
 use std::fs;
 use std::io::{self, Write};
@@ -52,7 +51,7 @@ pub fn run(args: Args) -> Result<()> {
         .or_else(|| config.get("diff.tool"))
         .unwrap_or_else(|| "vimdiff".to_string());
 
-    let index = match Index::load(&repo.index_path()) {
+    let index = match repo.load_index() {
         Ok(idx) => idx,
         Err(Error::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => {
             return Ok(());

--- a/grit/src/commands/grep.rs
+++ b/grit/src/commands/grep.rs
@@ -7,7 +7,7 @@ use std::io::{self, Write};
 use std::path::Path;
 
 use grit_lib::config::ConfigSet;
-use grit_lib::index::{Index, MODE_GITLINK};
+use grit_lib::index::MODE_GITLINK;
 use grit_lib::objects::{parse_commit, parse_tree, ObjectKind};
 use grit_lib::refs::resolve_ref;
 use grit_lib::repo::Repository;
@@ -505,7 +505,7 @@ fn grep_cached(
     out: &mut (impl Write + ?Sized),
     all_match: bool,
 ) -> Result<bool> {
-    let index = Index::load(&repo.index_path()).context("loading index")?;
+    let index = repo.load_index().context("loading index")?;
     // Load diff attrs from index (for --cached, use index attrs) or worktree
     let diff_attrs = if let Some(ref wt) = repo.work_tree {
         // Try worktree first, fallback to index
@@ -638,7 +638,7 @@ fn grep_worktree(
         .as_deref()
         .ok_or_else(|| anyhow::anyhow!("cannot grep in bare repository"))?;
 
-    let index = Index::load(&repo.index_path()).context("loading index")?;
+    let index = repo.load_index().context("loading index")?;
     let diff_attrs = load_diff_attrs(work_tree);
     let mut seen = std::collections::HashSet::new();
     let mut found_any = false;
@@ -848,7 +848,7 @@ fn load_diff_attrs(work_tree: &Path) -> Vec<DiffAttrRule> {
 /// Load diff attribute rules from .gitattributes in the index.
 fn load_diff_attrs_from_index(repo: &Repository) -> Vec<DiffAttrRule> {
     let mut rules = Vec::new();
-    if let Ok(index) = Index::load(&repo.index_path()) {
+    if let Ok(index) = repo.load_index() {
         if let Some(entry) = index.entries.iter().find(|e| e.path == b".gitattributes") {
             if let Ok(obj) = repo.odb.read(&entry.oid) {
                 if let Ok(content) = String::from_utf8(obj.data) {

--- a/grit/src/commands/ls_files.rs
+++ b/grit/src/commands/ls_files.rs
@@ -8,7 +8,7 @@ use std::path::Component;
 use std::path::PathBuf;
 
 use grit_lib::ignore::IgnoreMatcher;
-use grit_lib::index::{Index, IndexEntry};
+use grit_lib::index::IndexEntry;
 use grit_lib::repo::Repository;
 
 /// Arguments for `grit ls-files`.
@@ -69,6 +69,10 @@ pub struct Args {
     /// Show verbose long format.
     #[arg(long)]
     pub long: bool,
+
+    /// Show sparse directory placeholders in the index (do not expand sparse index).
+    #[arg(long)]
+    pub sparse: bool,
 
     /// Format string for output (supports %(objectmode), %(objectname), %(stage), %(path)).
     #[arg(long)]
@@ -142,7 +146,11 @@ pub fn run(args: Args) -> Result<()> {
     };
     let cwd_prefix = cwd_prefix_bytes(work_tree, &cwd)?;
     let index_path = repo.index_path();
-    let index = Index::load(&index_path).context("loading index")?;
+    let index = if args.sparse {
+        grit_lib::index::Index::load(&index_path).context("loading index")?
+    } else {
+        repo.load_index_at(&index_path).context("loading index")?
+    };
 
     let stdout = io::stdout();
     let mut out = stdout.lock();

--- a/grit/src/commands/merge.rs
+++ b/grit/src/commands/merge.rs
@@ -499,7 +499,7 @@ fn merge_unborn(repo: &Repository, head: &HeadState, args: &Args) -> Result<()> 
     if let Some(ref wt) = repo.work_tree {
         checkout_entries(repo, wt, &index, None)?;
     }
-    index.write(&repo.index_path())?;
+    repo.write_index(&mut index)?;
 
     if !args.quiet {
         eprintln!("Updating to {}", &merge_oid.to_hex()[..7]);
@@ -544,7 +544,7 @@ fn do_fast_forward(
         remove_deleted_files(wt, &old_entries, &new_index)?;
         checkout_entries(repo, wt, &new_index, None)?;
     }
-    new_index.write(&repo.index_path())?;
+    repo.write_index(&mut new_index)?;
 
     if !args.quiet {
         println!(
@@ -923,7 +923,7 @@ fn do_real_merge(
     maybe_simulate_partial_clone_fetch(repo, &args.commits[0])?;
 
     // Merge trees
-    let merge_result = merge_trees(
+    let mut merge_result = merge_trees(
         repo,
         &base_entries,
         &ours_entries,
@@ -956,7 +956,7 @@ fn do_real_merge(
     }
 
     // Write index
-    merge_result.index.write(&repo.index_path())?;
+    repo.write_index(&mut merge_result.index)?;
 
     // Update working tree
     if let Some(ref wt) = repo.work_tree {
@@ -1020,7 +1020,7 @@ fn do_real_merge(
     }
 
     if args.squash {
-        return do_squash_from_merge(repo, &merge_result.index, head, head_oid, merge_oid, args);
+        return do_squash_from_merge(repo, merge_result.index, head, head_oid, merge_oid, args);
     }
 
     if args.no_commit {
@@ -1145,7 +1145,7 @@ fn bail_if_merge_would_overwrite_local_changes(
     let Some(work_tree) = repo.work_tree.as_deref() else {
         return Ok(());
     };
-    let current_index = Index::load(&repo.index_path())?;
+    let current_index = repo.load_index()?;
 
     let new_map: HashMap<&[u8], &IndexEntry> = new_index
         .entries
@@ -1466,7 +1466,7 @@ fn bail_if_merge_touches_present_skip_worktree(
     let Some(work_tree) = repo.work_tree.as_deref() else {
         return Ok(());
     };
-    let index = Index::load(&repo.index_path())?;
+    let index = repo.load_index()?;
 
     for entry in &index.entries {
         if entry.stage() != 0 || !entry.skip_worktree() {
@@ -1646,7 +1646,7 @@ fn do_octopus_merge(
             let mut orig_index = Index::new();
             orig_index.entries = orig_entries;
             orig_index.sort();
-            orig_index.write(&repo.index_path())?;
+            repo.write_index(&mut orig_index)?;
             if let Some(ref wt) = repo.work_tree {
                 checkout_entries(repo, wt, &orig_index, None)?;
             }
@@ -1667,7 +1667,7 @@ fn do_octopus_merge(
     let mut final_index = Index::new();
     final_index.entries = current_tree_entries;
     final_index.sort();
-    final_index.write(&repo.index_path())?;
+    repo.write_index(&mut final_index)?;
 
     if let Some(ref wt) = repo.work_tree {
         checkout_entries(repo, wt, &final_index, None)?;
@@ -1963,7 +1963,7 @@ fn do_strategy_theirs(
         remove_deleted_files(wt, &old_entries, &new_index)?;
         checkout_entries(repo, wt, &new_index, None)?;
     }
-    new_index.write(&repo.index_path())?;
+    repo.write_index(&mut new_index)?;
 
     if !args.quiet {
         let short = &commit_oid.to_hex()[..7];
@@ -2171,7 +2171,7 @@ fn do_squash(
     if let Some(ref wt) = repo.work_tree {
         checkout_entries(repo, wt, &new_index, None)?;
     }
-    new_index.write(&repo.index_path())?;
+    repo.write_index(&mut new_index)?;
 
     // Write SQUASH_MSG
     let msg = build_squash_msg(repo, head_oid, &[merge_oid])?;
@@ -2191,13 +2191,13 @@ fn do_squash(
 /// Squash from a three-way merge result.
 fn do_squash_from_merge(
     repo: &Repository,
-    index: &Index,
+    mut index: Index,
     _head: &HeadState,
     head_oid: ObjectId,
     merge_oid: ObjectId,
     args: &Args,
 ) -> Result<()> {
-    index.write(&repo.index_path())?;
+    repo.write_index(&mut index)?;
 
     let msg = build_squash_msg(repo, head_oid, &[merge_oid])?;
     fs::write(repo.git_dir.join("SQUASH_MSG"), &msg)?;
@@ -2239,7 +2239,7 @@ fn merge_abort() -> Result<()> {
     if let Some(ref wt) = repo.work_tree {
         checkout_entries(&repo, wt, &index, None)?;
     }
-    index.write(&repo.index_path())?;
+    repo.write_index(&mut index)?;
 
     // Clean up merge state files
     let _ = fs::remove_file(git_dir.join("MERGE_HEAD"));
@@ -2274,7 +2274,7 @@ fn merge_continue(message: Option<String>) -> Result<()> {
     }
 
     // Check that index has no unmerged entries
-    let index = match Index::load(&repo.index_path()) {
+    let index = match repo.load_index() {
         Ok(idx) => idx,
         Err(e) => bail!("cannot load index: {}", e),
     };
@@ -4395,7 +4395,7 @@ fn capture_dirty_tracked_entries(repo: &Repository) -> Result<Vec<AutoStashEntry
     let Some(work_tree) = repo.work_tree.as_deref() else {
         return Ok(Vec::new());
     };
-    let index = Index::load(&repo.index_path())?;
+    let index = repo.load_index()?;
     let mut entries = Vec::new();
     for entry in &index.entries {
         if entry.stage() != 0 {

--- a/grit/src/commands/merge_file.rs
+++ b/grit/src/commands/merge_file.rs
@@ -118,7 +118,7 @@ pub fn run_inner(args: Args) -> Result<i32> {
     let (current_bytes, base_bytes, other_bytes) = if args.object_id {
         let repo = Repository::discover(None).context("not a git repository")?;
         let index_path = repo.git_dir.join("index");
-        let index = Index::load(&index_path).context("reading index")?;
+        let index = repo.load_index_at(&index_path).context("reading index")?;
         let cb = resolve_object_id_content(&repo, &index, &current_str)?;
         let bb = resolve_object_id_content(&repo, &index, &base_str)?;
         let ob = resolve_object_id_content(&repo, &index, &other_str)?;

--- a/grit/src/commands/merge_index.rs
+++ b/grit/src/commands/merge_index.rs
@@ -9,7 +9,6 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::process::Command;
 
-use grit_lib::index::Index;
 use grit_lib::objects::ObjectId;
 use grit_lib::repo::Repository;
 
@@ -52,7 +51,7 @@ pub fn run(args: Args) -> Result<()> {
 
     let repo = Repository::discover(None)?;
     let index_path = effective_index_path(&repo)?;
-    let index = Index::load(&index_path).context("loading index")?;
+    let index = repo.load_index_at(&index_path).context("loading index")?;
 
     // Collect unmerged entries by path
     let mut unmerged: BTreeMap<Vec<u8>, UnmergedEntry> = BTreeMap::new();

--- a/grit/src/commands/merge_one_file.rs
+++ b/grit/src/commands/merge_one_file.rs
@@ -11,7 +11,7 @@ use clap::Args as ClapArgs;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use grit_lib::index::{Index, IndexEntry, MODE_REGULAR};
+use grit_lib::index::{IndexEntry, MODE_REGULAR};
 use grit_lib::merge_file::{merge, ConflictStyle, MergeFavor, MergeInput};
 use grit_lib::objects::{ObjectId, ObjectKind};
 use grit_lib::repo::Repository;
@@ -91,7 +91,7 @@ fn update_index_with_merged_blob(
     preferred_mode: u32,
 ) -> Result<()> {
     let index_path = effective_index_path(repo)?;
-    let mut index = Index::load(&index_path).context("loading index")?;
+    let mut index = repo.load_index_at(&index_path).context("loading index")?;
 
     let template = index
         .entries
@@ -127,7 +127,7 @@ fn update_index_with_merged_blob(
     merged_entry.flags &= 0x0FFF;
     index.entries.push(merged_entry);
     index.sort();
-    index.write(&index_path)?;
+    repo.write_index_at(&index_path, &mut index)?;
     Ok(())
 }
 
@@ -241,10 +241,10 @@ fn run_delete_merge_case(repo: &Repository, work_tree: &Path, args: &Args) -> Re
 
     if !ours_nonempty {
         let index_path = effective_index_path(repo)?;
-        let mut index = Index::load(&index_path).context("loading index")?;
+        let mut index = repo.load_index_at(&index_path).context("loading index")?;
         index.entries.retain(|e| e.path != path_bytes);
         index.sort();
-        index.write(&index_path)?;
+        repo.write_index_at(&index_path, &mut index)?;
         return Ok(());
     }
 
@@ -257,10 +257,10 @@ fn run_delete_merge_case(repo: &Repository, work_tree: &Path, args: &Args) -> Re
     }
 
     let index_path = effective_index_path(repo)?;
-    let mut index = Index::load(&index_path).context("loading index")?;
+    let mut index = repo.load_index_at(&index_path).context("loading index")?;
     index.entries.retain(|e| e.path != path_bytes);
     index.sort();
-    index.write(&index_path)?;
+    repo.write_index_at(&index_path, &mut index)?;
     Ok(())
 }
 

--- a/grit/src/commands/merge_recursive.rs
+++ b/grit/src/commands/merge_recursive.rs
@@ -46,7 +46,7 @@ pub fn run(args: Args) -> Result<()> {
 
     let their_name = positional[2].clone();
     let base_label = positional[0].clone();
-    let merge_result = merge_trees_for_replay(
+    let mut merge_result = merge_trees_for_replay(
         &repo,
         &base_entries,
         &ours_entries,
@@ -63,7 +63,7 @@ pub fn run(args: Args) -> Result<()> {
         MergeDirectoryRenamesMode::FromConfig,
     )?;
 
-    merge_result.index.write(&repo.index_path())?;
+    repo.write_index(&mut merge_result.index)?;
     if let Some(ref wt) = repo.work_tree {
         remove_deleted_files(wt, &ours_entries, &merge_result.index)?;
         checkout_entries(&repo, wt, &merge_result.index)?;

--- a/grit/src/commands/merge_resolve.rs
+++ b/grit/src/commands/merge_resolve.rs
@@ -2,7 +2,6 @@
 
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
-use grit_lib::index::Index;
 use grit_lib::repo::Repository;
 
 use crate::commands::{diff_index, merge_index, read_tree, update_index, write_tree};
@@ -38,7 +37,7 @@ pub fn run(args: Args) -> Result<()> {
         trees: vec![base, head, remote],
     })?;
 
-    let index = Index::load(&repo.index_path()).context("loading index")?;
+    let index = repo.load_index().context("loading index")?;
     if write_tree::write_tree_from_index(&repo.odb, &index, "", false).is_ok() {
         return Ok(());
     }

--- a/grit/src/commands/mergetool.rs
+++ b/grit/src/commands/mergetool.rs
@@ -7,7 +7,6 @@ use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::config::ConfigSet;
 use grit_lib::error::Error;
-use grit_lib::index::Index;
 use grit_lib::repo::Repository;
 use std::collections::BTreeSet;
 use std::fs;
@@ -46,7 +45,7 @@ pub fn run(args: Args) -> Result<()> {
         .or_else(|| config.get("merge.tool"))
         .unwrap_or_else(|| "vimdiff".to_string());
 
-    let index = match Index::load(&repo.index_path()) {
+    let index = match repo.load_index() {
         Ok(idx) => idx,
         Err(Error::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => {
             println!("No files need merging");

--- a/grit/src/commands/mv.rs
+++ b/grit/src/commands/mv.rs
@@ -68,7 +68,7 @@ pub fn run(args: Args) -> Result<()> {
         .as_deref()
         .ok_or_else(|| anyhow::anyhow!("this operation must be run in a work tree"))?;
 
-    let mut index = match Index::load(&repo.index_path()) {
+    let mut index = match repo.load_index() {
         Ok(idx) => idx,
         Err(Error::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => Index::new(),
         Err(e) => return Err(e.into()),
@@ -345,7 +345,7 @@ pub fn run(args: Args) -> Result<()> {
     }
 
     if !args.dry_run {
-        index.write(&repo.index_path())?;
+        repo.write_index(&mut index)?;
     }
 
     Ok(())

--- a/grit/src/commands/read_tree.rs
+++ b/grit/src/commands/read_tree.rs
@@ -8,7 +8,6 @@ use std::path::{Path, PathBuf};
 
 use grit_lib::config::ConfigSet;
 use grit_lib::crlf;
-use grit_lib::error::Error as GustError;
 use grit_lib::ignore::IgnoreMatcher;
 use grit_lib::index::{Index, IndexEntry, MODE_EXECUTABLE, MODE_SYMLINK};
 use grit_lib::objects::{parse_commit, parse_tree, ObjectId, ObjectKind};
@@ -189,9 +188,8 @@ pub fn run(args: Args) -> Result<()> {
     // Handle --empty: clear the index
     if args.empty {
         if !dry_run {
-            let empty_index = Index::new();
-            empty_index
-                .write(&index_path)
+            let mut empty_index = Index::new();
+            repo.write_index_at(&index_path, &mut empty_index)
                 .context("writing empty index")?;
         }
         return Ok(());
@@ -237,7 +235,7 @@ pub fn run(args: Args) -> Result<()> {
 
     if args.reset {
         // Reset mode is a hard replacement by the final tree argument.
-        let old_index = load_index_for_read_tree(&index_path).context("loading index")?;
+        let old_index = repo.load_index_at(&index_path).context("loading index")?;
         let mut new_index = Index::new();
         new_index.entries =
             tree_to_index_entries(&repo, &tree_oids[tree_oids.len() - 1], "", prot)?;
@@ -246,7 +244,8 @@ pub fn run(args: Args) -> Result<()> {
             checkout_index_entries(&repo, &old_index, &new_index)?;
         }
         if !dry_run {
-            new_index.write(&index_path).context("writing index")?;
+            repo.write_index_at(&index_path, &mut new_index)
+                .context("writing index")?;
         }
         if args.update && args.recurse_submodules && !dry_run {
             submodule_update_after_read_tree(&repo)?;
@@ -254,7 +253,7 @@ pub fn run(args: Args) -> Result<()> {
         return Ok(());
     }
 
-    let old_index = load_index_for_read_tree(&index_path).context("loading index")?;
+    let old_index = repo.load_index_at(&index_path).context("loading index")?;
     let mut new_index = old_index.clone();
 
     if let Some(prefix) = &args.prefix {
@@ -329,7 +328,8 @@ pub fn run(args: Args) -> Result<()> {
         checkout_index_entries(&repo, &old_index, &new_index)?;
     }
     if !dry_run {
-        new_index.write(&index_path).context("writing index")?;
+        repo.write_index_at(&index_path, &mut new_index)
+            .context("writing index")?;
     }
 
     if args.update && args.recurse_submodules && !dry_run {
@@ -1245,14 +1245,6 @@ fn effective_index_path(repo: &Repository) -> Result<PathBuf> {
         return Ok(cwd.join(p));
     }
     Ok(repo.index_path())
-}
-
-fn load_index_for_read_tree(path: &Path) -> Result<Index> {
-    match Index::load(path) {
-        Ok(index) => Ok(index),
-        Err(GustError::IndexError(msg)) if msg == "file too short" => Ok(Index::new()),
-        Err(err) => Err(err.into()),
-    }
 }
 
 fn maybe_write_trace_packet_done() {

--- a/grit/src/commands/rebase.rs
+++ b/grit/src/commands/rebase.rs
@@ -17,7 +17,6 @@ use std::fs;
 use std::path::Path;
 
 use grit_lib::config::ConfigSet;
-use grit_lib::error::Error as GritError;
 use grit_lib::index::{Index, IndexEntry, MODE_EXECUTABLE, MODE_SYMLINK};
 
 use grit_lib::merge_file::{merge, ConflictStyle, MergeInput};
@@ -273,7 +272,7 @@ fn do_rebase(args: Args) -> Result<()> {
             .work_tree
             .as_deref()
             .ok_or_else(|| anyhow::anyhow!("this operation must be run in a work tree"))?;
-        let idx = Index::load(&repo.index_path()).context("failed to read index")?;
+        let idx = repo.load_index().context("failed to read index")?;
         let head_tree = resolve_head(git_dir)?.oid().and_then(|oid| {
             let obj = repo.odb.read(oid).ok()?;
             parse_commit(&obj.data).ok().map(|c| c.tree)
@@ -623,13 +622,13 @@ fn cherry_pick_for_rebase(
         &theirs_entries,
         &conflict_ctx,
     )?;
-    let merged_index = merge_result.index;
+    let mut merged_index = merge_result.index;
 
     let has_conflicts = merged_index.entries.iter().any(|e| e.stage() != 0);
 
     // Write index
     let old_index = load_index(repo)?;
-    merged_index.write(&repo.index_path())?;
+    repo.write_index(&mut merged_index)?;
 
     // Update worktree
     if let Some(wt) = &repo.work_tree {
@@ -809,7 +808,7 @@ fn do_skip() -> Result<()> {
         index.entries = entries;
         index.sort();
         let old_index = load_index(&repo)?;
-        index.write(&repo.index_path())?;
+        repo.write_index(&mut index)?;
         if let Some(wt) = &repo.work_tree {
             checkout_merged_index(&repo, wt, &old_index, &index)?;
         }
@@ -869,7 +868,7 @@ fn do_abort() -> Result<()> {
     index.sort();
 
     let old_index = load_index(&repo)?;
-    index.write(&repo.index_path())?;
+    repo.write_index(&mut index)?;
 
     if let Some(wt) = &repo.work_tree {
         checkout_merged_index(&repo, wt, &old_index, &index)?;
@@ -923,12 +922,7 @@ fn cleanup_rebase_state(git_dir: &Path) {
 // ── Helpers (mirrored from revert.rs) ───────────────────────────────
 
 fn load_index(repo: &Repository) -> Result<Index> {
-    let index_path = repo.index_path();
-    match Index::load(&index_path) {
-        Ok(idx) => Ok(idx),
-        Err(GritError::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => Ok(Index::new()),
-        Err(e) => Err(e.into()),
-    }
+    Ok(repo.load_index()?)
 }
 
 fn resolve_identity(config: &ConfigSet, kind: &str) -> Result<(String, String)> {

--- a/grit/src/commands/rerere.rs
+++ b/grit/src/commands/rerere.rs
@@ -337,7 +337,7 @@ fn find_conflict_files(repo: &Repository) -> Result<Vec<String>> {
         return Ok(Vec::new());
     }
 
-    let index = grit_lib::index::Index::load(&index_path)?;
+    let index = repo.load_index_at(&index_path)?;
     let mut conflict_paths = Vec::new();
 
     for entry in &index.entries {
@@ -496,7 +496,7 @@ pub fn auto_rerere_worktree(repo: &Repository) -> Result<bool> {
     // Scan worktree for files with conflict markers
     let index_path = repo.git_dir.join("index");
     let index = if index_path.exists() {
-        grit_lib::index::Index::load(&index_path)?
+        repo.load_index_at(&index_path)?
     } else {
         return Ok(false);
     };

--- a/grit/src/commands/reset.rs
+++ b/grit/src/commands/reset.rs
@@ -273,7 +273,7 @@ fn reset_patch(repo: &Repository, _rest: &[String]) -> Result<()> {
 
     let head = resolve_head(&repo.git_dir)?;
     let index_path = repo.index_path();
-    let mut index = Index::load(&index_path).context("loading index")?;
+    let mut index = repo.load_index_at(&index_path).context("loading index")?;
 
     // Get HEAD tree entries (empty if unborn)
     let tree_entries = if let Some(oid) = head.oid() {
@@ -342,7 +342,8 @@ fn reset_patch(repo: &Repository, _rest: &[String]) -> Result<()> {
         }
     }
 
-    index.write(&index_path).context("writing index")?;
+    repo.write_index_at(&index_path, &mut index)
+        .context("writing index")?;
     Ok(())
 }
 
@@ -384,7 +385,7 @@ fn reset_paths(
     }
 
     let index_path = repo.index_path();
-    let mut index = Index::load(&index_path).context("loading index")?;
+    let mut index = repo.load_index_at(&index_path).context("loading index")?;
 
     for path_str in paths {
         let path_bytes = path_str.as_bytes().to_vec();
@@ -435,7 +436,8 @@ fn reset_paths(
         // If not in tree and no -N, path is removed from index (staged deletion).
     }
 
-    index.write(&index_path).context("writing index")?;
+    repo.write_index_at(&index_path, &mut index)
+        .context("writing index")?;
     Ok(())
 }
 
@@ -455,7 +457,7 @@ fn reset_commit(repo: &Repository, commit_spec: &str, mode: ResetMode, quiet: bo
             bail!("Cannot do a soft reset in the middle of a revert.");
         }
         let index_path = repo.index_path();
-        let index = Index::load(&index_path).context("loading index")?;
+        let index = repo.load_index_at(&index_path).context("loading index")?;
         if index.entries.iter().any(|e| e.stage() != 0) {
             bail!("Cannot do a soft reset in the middle of a merge.");
         }
@@ -473,22 +475,24 @@ fn reset_commit(repo: &Repository, commit_spec: &str, mode: ResetMode, quiet: bo
                 ResetMode::Mixed => {
                     // Mixed on unborn: clear the index
                     let index_path = repo.index_path();
-                    let new_index = Index::new();
-                    new_index.write(&index_path).context("writing index")?;
+                    let mut new_index = Index::new();
+                    repo.write_index_at(&index_path, &mut new_index)
+                        .context("writing index")?;
                     return Ok(());
                 }
                 ResetMode::Hard | ResetMode::Merge => {
                     // Unborn branch: reset --hard just clears the index and working tree
                     let index_path = repo.index_path();
-                    let old_index = match Index::load(&index_path) {
+                    let old_index = match repo.load_index_at(&index_path) {
                         Ok(idx) => idx,
                         Err(_) => Index::new(),
                     };
-                    let new_index = Index::new();
+                    let mut new_index = Index::new();
                     if let Some(_wt) = &repo.work_tree {
                         checkout_index_to_worktree(repo, &old_index, &mut new_index.clone())?;
                     }
-                    new_index.write(&index_path).context("writing index")?;
+                    repo.write_index_at(&index_path, &mut new_index)
+                        .context("writing index")?;
                     return Ok(());
                 }
                 ResetMode::Keep => {
@@ -537,7 +541,9 @@ fn reset_commit(repo: &Repository, commit_spec: &str, mode: ResetMode, quiet: bo
     let tree_entries = tree_to_flat_entries(repo, &tree_oid, "")?;
 
     let index_path = repo.index_path();
-    let old_index = Index::load(&index_path).context("loading old index")?;
+    let old_index = repo
+        .load_index_at(&index_path)
+        .context("loading old index")?;
     let mut new_index = Index::new();
     new_index.entries = tree_entries;
     new_index.sort();
@@ -598,7 +604,8 @@ fn reset_commit(repo: &Repository, commit_spec: &str, mode: ResetMode, quiet: bo
         }
     }
 
-    new_index.write(&index_path).context("writing index")?;
+    repo.write_index_at(&index_path, &mut new_index)
+        .context("writing index")?;
     Ok(())
 }
 
@@ -653,7 +660,7 @@ fn check_keep_safety(repo: &Repository, head: &HeadState, target_oid: &ObjectId)
     // Check if any of these changed paths have local modifications in the
     // working tree or index that differ from HEAD.
     let index_path = repo.index_path();
-    let index = Index::load(&index_path).context("loading index")?;
+    let index = repo.load_index_at(&index_path).context("loading index")?;
     let index_map: HashMap<Vec<u8>, &IndexEntry> = index
         .entries
         .iter()

--- a/grit/src/commands/restore.rs
+++ b/grit/src/commands/restore.rs
@@ -130,7 +130,7 @@ pub fn run(args: Args) -> Result<()> {
     let restore_worktree = args.worktree || !args.staged;
 
     let index_path = repo.index_path();
-    let mut index = Index::load(&index_path).context("loading index")?;
+    let mut index = repo.load_index_at(&index_path).context("loading index")?;
 
     let cwd = std::env::current_dir().context("resolving cwd")?;
 
@@ -232,7 +232,8 @@ pub fn run(args: Args) -> Result<()> {
     }
 
     if index_modified {
-        index.write(&index_path).context("writing index")?;
+        repo.write_index_at(&index_path, &mut index)
+            .context("writing index")?;
     }
 
     Ok(())

--- a/grit/src/commands/revert.rs
+++ b/grit/src/commands/revert.rs
@@ -18,7 +18,6 @@ use std::fs;
 use std::path::Path;
 
 use grit_lib::config::ConfigSet;
-use grit_lib::error::Error as GritError;
 use grit_lib::index::{Index, IndexEntry, MODE_EXECUTABLE, MODE_SYMLINK};
 use grit_lib::merge_file::{merge, MergeInput};
 use grit_lib::objects::{
@@ -259,7 +258,7 @@ fn revert_one_commit(
     let ours_entries = tree_to_map(tree_to_index_entries(repo, &head_tree_oid, "")?);
     let theirs_entries = tree_to_map(tree_to_index_entries(repo, &parent_tree_oid, "")?);
 
-    let merged_index =
+    let mut merged_index =
         three_way_merge_with_content(repo, &base_entries, &ours_entries, &theirs_entries)?;
 
     // Check for conflicts (any entry with stage != 0).
@@ -286,7 +285,8 @@ fn revert_one_commit(
 
     // Write index.
     let index_path = repo.index_path();
-    merged_index.write(&index_path).context("writing index")?;
+    repo.write_index_at(&index_path, &mut merged_index)
+        .context("writing index")?;
 
     // Update working tree.
     let work_tree = repo
@@ -444,7 +444,7 @@ fn do_abort() -> Result<()> {
         index.entries = entries;
         index.sort();
         let index_path = repo.index_path();
-        index.write(&index_path)?;
+        repo.write_index_at(&index_path, &mut index)?;
 
         if let Some(wt) = &repo.work_tree {
             checkout_merged_index(&repo, wt, &old_idx, &index)?;
@@ -479,12 +479,7 @@ fn cleanup_revert_state(git_dir: &Path) {
 }
 
 fn load_index(repo: &Repository) -> Result<Index> {
-    let index_path = repo.index_path();
-    match Index::load(&index_path) {
-        Ok(idx) => Ok(idx),
-        Err(GritError::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => Ok(Index::new()),
-        Err(e) => Err(e.into()),
-    }
+    Ok(repo.load_index()?)
 }
 
 fn create_revert_commit(

--- a/grit/src/commands/rm.rs
+++ b/grit/src/commands/rm.rs
@@ -145,7 +145,7 @@ pub fn run(mut args: Args) -> Result<()> {
         .and_then(|r| r.ok())
         .unwrap_or(true);
 
-    let mut index = match Index::load(&repo.index_path()) {
+    let mut index = match repo.load_index() {
         Ok(idx) => idx,
         Err(Error::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => Index::new(),
         Err(e) => return Err(e.into()),
@@ -342,7 +342,7 @@ pub fn run(mut args: Args) -> Result<()> {
     }
 
     if !args.dry_run && !to_remove.is_empty() {
-        index.write(&repo.index_path())?;
+        repo.write_index(&mut index)?;
     }
     if !args.dry_run && !args.cached && !removed_gitlinks.is_empty() {
         remove_submodule_config_sections(&repo.git_dir, &removed_gitlinks)?;

--- a/grit/src/commands/sparse_checkout.rs
+++ b/grit/src/commands/sparse_checkout.rs
@@ -4,10 +4,13 @@
 //! in the working tree. Patterns are stored in `.git/info/sparse-checkout`
 //! and controlled by `core.sparseCheckout` config.
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use clap::{Args as ClapArgs, Subcommand};
 use grit_lib::config::{ConfigFile, ConfigScope};
+use grit_lib::index::MODE_TREE;
+use grit_lib::objects::parse_commit;
 use grit_lib::repo::Repository;
+use grit_lib::state::resolve_head;
 use std::fs;
 use std::io::{self, Write};
 
@@ -22,17 +25,36 @@ pub struct Args {
 #[derive(Debug, Subcommand)]
 pub enum SparseCheckoutSubcommand {
     /// Initialize sparse checkout.
-    Init,
+    Init(InitArgs),
     /// Set sparse checkout patterns.
     Set(SetArgs),
     /// Add patterns to sparse checkout.
     Add(AddArgs),
     /// Reapply sparse checkout patterns.
-    Reapply,
+    Reapply(ReapplyArgs),
     /// List current sparse checkout patterns.
     List,
     /// Disable sparse checkout.
     Disable,
+}
+
+#[derive(Debug, ClapArgs)]
+pub struct InitArgs {
+    /// Use cone mode (directory-based) sparse checkout.
+    #[arg(long)]
+    pub cone: bool,
+
+    /// Use non-cone mode (pattern-based) sparse checkout.
+    #[arg(long = "no-cone")]
+    pub no_cone: bool,
+
+    /// Store the index in sparse form (sparse directory entries) when possible.
+    #[arg(long)]
+    pub sparse_index: bool,
+
+    /// Do not use a sparse index.
+    #[arg(long = "no-sparse-index")]
+    pub no_sparse_index: bool,
 }
 
 #[derive(Debug, ClapArgs)]
@@ -42,8 +64,20 @@ pub struct SetArgs {
     pub cone: bool,
 
     /// Use non-cone mode (pattern-based) sparse checkout.
-    #[arg(long = "no-cone", hide = true)]
+    #[arg(long = "no-cone")]
     pub no_cone: bool,
+
+    /// Store the index in sparse form when possible.
+    #[arg(long)]
+    pub sparse_index: bool,
+
+    /// Do not use a sparse index.
+    #[arg(long = "no-sparse-index")]
+    pub no_sparse_index: bool,
+
+    /// Skip validation that each pattern names an existing directory (cone mode).
+    #[arg(long = "skip-checks")]
+    pub skip_checks: bool,
 
     /// Patterns to include in sparse checkout.
     pub patterns: Vec<String>,
@@ -51,9 +85,32 @@ pub struct SetArgs {
 
 #[derive(Debug, ClapArgs)]
 pub struct AddArgs {
+    /// Skip validation that each pattern names an existing directory (cone mode).
+    #[arg(long = "skip-checks")]
+    pub skip_checks: bool,
+
     /// Patterns to add to sparse checkout.
     #[arg(required = true)]
     pub patterns: Vec<String>,
+}
+
+#[derive(Debug, ClapArgs)]
+pub struct ReapplyArgs {
+    /// Use cone mode (directory-based) sparse checkout.
+    #[arg(long)]
+    pub cone: bool,
+
+    /// Use non-cone mode (pattern-based) sparse checkout.
+    #[arg(long = "no-cone")]
+    pub no_cone: bool,
+
+    /// Store the index in sparse form when possible.
+    #[arg(long)]
+    pub sparse_index: bool,
+
+    /// Do not use a sparse index.
+    #[arg(long = "no-sparse-index")]
+    pub no_sparse_index: bool,
 }
 
 /// Run `grit sparse-checkout`.
@@ -61,44 +118,97 @@ pub fn run(args: Args) -> Result<()> {
     let repo = Repository::discover(None).context("not a git repository")?;
 
     match args.subcommand {
-        SparseCheckoutSubcommand::Init => cmd_init(&repo),
-        SparseCheckoutSubcommand::Set(set_args) => {
-            let cone = set_args.cone || !set_args.no_cone;
-            cmd_set(&repo, &set_args.patterns, cone)
-        }
-        SparseCheckoutSubcommand::Add(add_args) => cmd_add(&repo, &add_args.patterns),
-        SparseCheckoutSubcommand::Reapply => cmd_reapply(&repo),
+        SparseCheckoutSubcommand::Init(init_args) => cmd_init(&repo, &init_args),
+        SparseCheckoutSubcommand::Set(set_args) => cmd_set(&repo, &set_args),
+        SparseCheckoutSubcommand::Add(add_args) => cmd_add(&repo, &add_args),
+        SparseCheckoutSubcommand::Reapply(reapply_args) => cmd_reapply(&repo, &reapply_args),
         SparseCheckoutSubcommand::List => cmd_list(&repo),
         SparseCheckoutSubcommand::Disable => cmd_disable(&repo),
     }
 }
 
-/// Enable sparse checkout by setting `core.sparseCheckout = true`
-/// and creating the sparse-checkout file with a default `/*` pattern.
-fn cmd_init(repo: &Repository) -> Result<()> {
+fn tri_bool(cone: bool, no_cone: bool) -> Result<Option<bool>> {
+    match (cone, no_cone) {
+        (true, true) => bail!("cannot combine --cone and --no-cone"),
+        (true, false) => Ok(Some(true)),
+        (false, true) => Ok(Some(false)),
+        (false, false) => Ok(None),
+    }
+}
+
+fn tri_bool_sparse(sparse: bool, no_sparse: bool) -> Result<Option<bool>> {
+    match (sparse, no_sparse) {
+        (true, true) => bail!("cannot combine --sparse-index and --no-sparse-index"),
+        (true, false) => Ok(Some(true)),
+        (false, true) => Ok(Some(false)),
+        (false, false) => Ok(None),
+    }
+}
+
+fn cmd_init(repo: &Repository, args: &InitArgs) -> Result<()> {
+    let cone_opt = tri_bool(args.cone, args.no_cone)?;
+    let sparse_idx_opt = tri_bool_sparse(args.sparse_index, args.no_sparse_index)?;
+
+    let config = grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+    let was_sparse = config
+        .get("core.sparseCheckout")
+        .map(|v| v == "true")
+        .unwrap_or(false);
+    let prev_cone = config
+        .get("core.sparseCheckoutCone")
+        .and_then(|v| v.parse::<bool>().ok())
+        .unwrap_or(true);
+
+    let cone = match cone_opt {
+        Some(c) => c,
+        None if was_sparse => prev_cone,
+        None => true,
+    };
+
     set_sparse_config(repo, true)?;
+    set_cone_config(repo, cone)?;
+
+    if let Some(enable) = sparse_idx_opt {
+        set_sparse_index_config(repo, enable)?;
+    }
 
     let sc_path = sparse_checkout_path(repo);
-    // Create parent directory if needed
     if let Some(parent) = sc_path.parent() {
         fs::create_dir_all(parent).context("creating info directory")?;
     }
 
-    // Only write defaults if the file doesn't exist yet
     if !sc_path.exists() {
         fs::write(&sc_path, "/*\n").context("writing sparse-checkout file")?;
     }
 
+    let patterns = read_sparse_patterns(repo)?;
+    apply_sparse_patterns(repo, &patterns)?;
     Ok(())
 }
 
-/// Set the sparse checkout patterns, replacing any existing ones.
-fn cmd_set(repo: &Repository, patterns: &[String], cone: bool) -> Result<()> {
-    // Ensure sparse checkout is enabled
-    set_sparse_config(repo, true)?;
+fn cmd_set(repo: &Repository, args: &SetArgs) -> Result<()> {
+    let cone_opt = tri_bool(args.cone, args.no_cone)?;
+    let sparse_idx_opt = tri_bool_sparse(args.sparse_index, args.no_sparse_index)?;
 
-    // Set cone mode config
+    let config = grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+    let prev_cone = config
+        .get("core.sparseCheckoutCone")
+        .and_then(|v| v.parse::<bool>().ok())
+        .unwrap_or(true);
+
+    let cone = cone_opt.unwrap_or(prev_cone);
+
+    set_sparse_config(repo, true)?;
     set_cone_config(repo, cone)?;
+
+    if let Some(enable) = sparse_idx_opt {
+        set_sparse_index_config(repo, enable)?;
+    }
+
+    let patterns = args.patterns.clone();
+    if !args.skip_checks && cone {
+        validate_cone_patterns(repo, &patterns)?;
+    }
 
     let sc_path = sparse_checkout_path(repo);
     if let Some(parent) = sc_path.parent() {
@@ -106,23 +216,137 @@ fn cmd_set(repo: &Repository, patterns: &[String], cone: bool) -> Result<()> {
     }
 
     let mut content = String::new();
-    for pat in patterns {
+    for pat in &patterns {
         content.push_str(pat);
         content.push('\n');
     }
     fs::write(&sc_path, &content).context("writing sparse-checkout file")?;
 
-    // Apply sparse checkout patterns to the working tree
-    apply_sparse_patterns(repo, patterns)?;
-
+    apply_sparse_patterns(repo, &patterns)?;
     Ok(())
+}
+
+fn cmd_add(repo: &Repository, args: &AddArgs) -> Result<()> {
+    let config = grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true)?;
+    let sparse_enabled = config
+        .get("core.sparseCheckout")
+        .map(|v| v == "true")
+        .unwrap_or(false);
+    if !sparse_enabled {
+        bail!("no sparse-checkout to add to");
+    }
+
+    let cone = config
+        .get("core.sparseCheckoutCone")
+        .and_then(|v| v.parse::<bool>().ok())
+        .unwrap_or(true);
+
+    let mut patterns = read_sparse_patterns(repo)?;
+    if !args.skip_checks && cone {
+        validate_cone_patterns(repo, &args.patterns)?;
+    }
+    for pat in &args.patterns {
+        if !patterns.iter().any(|p| p == pat) {
+            patterns.push(pat.clone());
+        }
+    }
+
+    let sc_path = sparse_checkout_path(repo);
+    if let Some(parent) = sc_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let content: String = patterns.iter().map(|p| format!("{p}\n")).collect();
+    fs::write(&sc_path, &content)?;
+    apply_sparse_patterns(repo, &patterns)?;
+    Ok(())
+}
+
+fn cmd_reapply(repo: &Repository, args: &ReapplyArgs) -> Result<()> {
+    let cone_opt = tri_bool(args.cone, args.no_cone)?;
+    let sparse_idx_opt = tri_bool_sparse(args.sparse_index, args.no_sparse_index)?;
+
+    let config = grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true)?;
+    let sparse_enabled = config
+        .get("core.sparseCheckout")
+        .map(|v| v == "true")
+        .unwrap_or(false);
+    if !sparse_enabled {
+        bail!("must be in a sparse-checkout to reapply sparsity patterns");
+    }
+
+    if let Some(cone) = cone_opt {
+        set_cone_config(repo, cone)?;
+    }
+
+    if let Some(enable) = sparse_idx_opt {
+        set_sparse_index_config(repo, enable)?;
+    }
+
+    let patterns = read_sparse_patterns(repo)?;
+    apply_sparse_patterns(repo, &patterns)?;
+    Ok(())
+}
+
+fn read_sparse_patterns(repo: &Repository) -> Result<Vec<String>> {
+    let sc_path = sparse_checkout_path(repo);
+    if !sc_path.exists() {
+        return Ok(Vec::new());
+    }
+    let content = fs::read_to_string(&sc_path).context("reading sparse-checkout file")?;
+    Ok(content
+        .lines()
+        .map(|l| l.trim())
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .map(String::from)
+        .collect())
+}
+
+fn validate_cone_patterns(repo: &Repository, patterns: &[String]) -> Result<()> {
+    let index_path = repo.index_path();
+    let index =
+        grit_lib::index::Index::load(&index_path).context("reading index for validation")?;
+    for pat in patterns {
+        let p = pat.trim_end_matches('/');
+        if p.is_empty() {
+            continue;
+        }
+        if let Some(ce) = index.get(p.as_bytes(), 0) {
+            if ce.is_sparse_directory_placeholder() {
+                continue;
+            }
+            bail!(
+                "'{}' is not a directory; to treat it as a directory anyway, rerun with --skip-checks",
+                p
+            );
+        }
+        let with_slash = format!("{p}/");
+        if let Some(ce) = index.get(with_slash.as_bytes(), 0) {
+            if ce.is_sparse_directory_placeholder() {
+                continue;
+            }
+            bail!(
+                "'{}' is not a directory; to treat it as a directory anyway, rerun with --skip-checks",
+                p
+            );
+        }
+        // No exact index entry: allowed (Git treats as missing / directory prefix only).
+    }
+    Ok(())
+}
+
+fn head_tree_oid(repo: &Repository) -> Result<Option<grit_lib::objects::ObjectId>> {
+    let head = resolve_head(&repo.git_dir).context("reading HEAD")?;
+    let Some(commit_oid) = head.oid() else {
+        return Ok(None);
+    };
+    let obj = repo.odb.read(commit_oid).context("reading HEAD commit")?;
+    let commit = parse_commit(&obj.data).context("parsing HEAD commit")?;
+    Ok(Some(commit.tree))
 }
 
 /// Apply sparse checkout patterns: remove files from the working tree that
 /// don't match any pattern, and set skip-worktree bit in the index.
 fn apply_sparse_patterns(repo: &Repository, patterns: &[String]) -> Result<()> {
-    use grit_lib::index::Index;
-
     let work_tree = repo
         .work_tree
         .as_deref()
@@ -132,24 +356,28 @@ fn apply_sparse_patterns(repo: &Repository, patterns: &[String]) -> Result<()> {
         .get("core.sparseCheckoutCone")
         .and_then(|v| v.parse::<bool>().ok())
         .unwrap_or(true);
+    let sparse_index_enabled = config
+        .get("index.sparse")
+        .map(|v| v == "true")
+        .unwrap_or(false);
 
-    let index_path = repo.git_dir.join("index");
-    let mut index = Index::load(&index_path).context("reading index")?;
+    let index_path = repo.index_path();
+    let mut index = repo.load_index_at(&index_path).context("reading index")?;
 
-    // Promote to version 3 if needed (skip-worktree requires extended flags)
     if index.version < 3 {
         index.version = 3;
     }
 
     for entry in &mut index.entries {
+        if entry.mode == MODE_TREE {
+            continue;
+        }
         let path_str = String::from_utf8_lossy(&entry.path).to_string();
         let matches = path_matches_sparse_patterns(&path_str, patterns, cone_mode);
 
         if matches {
-            // File should be in the working tree
             if entry.skip_worktree() {
                 entry.set_skip_worktree(false);
-                // Restore the file if missing
                 let full_path = work_tree.join(&path_str);
                 if !full_path.exists() {
                     if let Some(parent) = full_path.parent() {
@@ -161,12 +389,10 @@ fn apply_sparse_patterns(repo: &Repository, patterns: &[String]) -> Result<()> {
                 }
             }
         } else {
-            // File should NOT be in the working tree — remove it
             entry.set_skip_worktree(true);
             let full_path = work_tree.join(&path_str);
             if full_path.exists() {
                 let _ = fs::remove_file(&full_path);
-                // Clean up empty parent directories
                 if let Some(parent) = full_path.parent() {
                     remove_empty_dirs_up_to(parent, work_tree);
                 }
@@ -174,15 +400,25 @@ fn apply_sparse_patterns(repo: &Repository, patterns: &[String]) -> Result<()> {
         }
     }
 
-    index.write(&index_path).context("writing index")?;
+    if let Some(tree_oid) = head_tree_oid(repo)? {
+        index.try_collapse_sparse_directories(
+            &repo.odb,
+            &tree_oid,
+            patterns,
+            cone_mode,
+            sparse_index_enabled,
+        )?;
+    } else {
+        index.sparse_directories = false;
+    }
+
+    repo.write_index_at(&index_path, &mut index)
+        .context("writing index")?;
     Ok(())
 }
 
-/// Check if a file path matches any of the sparse checkout patterns.
-/// Patterns are treated as directory prefixes (like git's cone mode).
 fn path_matches_sparse_patterns(path: &str, patterns: &[String], cone_mode: bool) -> bool {
     if cone_mode {
-        // Cone mode keeps top-level files and explicitly included directories.
         if !path.contains('/') {
             return true;
         }
@@ -199,8 +435,6 @@ fn path_matches_sparse_patterns(path: &str, patterns: &[String], cone_mode: bool
         return false;
     }
 
-    // Non-cone mode interprets sparse-checkout patterns in order, where later
-    // patterns override earlier ones and negated patterns remove matches.
     let mut included = false;
     for raw_pattern in patterns {
         let pattern = raw_pattern.trim();
@@ -232,13 +466,12 @@ fn path_matches_sparse_patterns(path: &str, patterns: &[String], cone_mode: bool
     included
 }
 
-/// Remove empty directories walking up from `dir` to `stop` (exclusive).
 fn remove_empty_dirs_up_to(dir: &std::path::Path, stop: &std::path::Path) {
     let mut current = dir.to_path_buf();
     while current != stop {
         if let Ok(mut entries) = fs::read_dir(&current) {
             if entries.next().is_some() {
-                break; // Not empty
+                break;
             }
             let _ = fs::remove_dir(&current);
         } else {
@@ -251,21 +484,18 @@ fn remove_empty_dirs_up_to(dir: &std::path::Path, stop: &std::path::Path) {
     }
 }
 
-/// List the current sparse checkout patterns.
 fn cmd_list(repo: &Repository) -> Result<()> {
-    // Check if sparse checkout is actually enabled
     let config = grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true)?;
     let sparse_enabled = config
         .get("core.sparseCheckout")
         .map(|v| v == "true")
         .unwrap_or(false);
     if !sparse_enabled {
-        anyhow::bail!("this worktree is not sparse");
+        bail!("this worktree is not sparse");
     }
 
     let sc_path = sparse_checkout_path(repo);
     if !sc_path.exists() {
-        // No sparse checkout file — nothing to list
         return Ok(());
     }
 
@@ -281,33 +511,31 @@ fn cmd_list(repo: &Repository) -> Result<()> {
     Ok(())
 }
 
-/// Disable sparse checkout by setting `core.sparseCheckout = false`
-/// and restoring all files to the working tree.
 fn cmd_disable(repo: &Repository) -> Result<()> {
-    use grit_lib::index::Index;
     set_sparse_config(repo, false)?;
+    set_sparse_index_config(repo, false)?;
 
-    // Restore all skip-worktree files to the working tree
     let work_tree = match repo.work_tree.as_deref() {
         Some(wt) => wt,
         None => return Ok(()),
     };
 
-    let index_path = repo.git_dir.join("index");
-    let mut index = Index::load(&index_path).context("reading index")?;
+    let index_path = repo.index_path();
+    let mut index = repo.load_index_at(&index_path).context("reading index")?;
 
-    // Ensure version 3 for extended flags
     if index.version < 3 {
         index.version = 3;
     }
 
     for entry in &mut index.entries {
+        if entry.mode == MODE_TREE {
+            continue;
+        }
         if entry.skip_worktree() {
             entry.set_skip_worktree(false);
             let path_str = String::from_utf8_lossy(&entry.path).to_string();
             let full_path = work_tree.join(&path_str);
             if !full_path.exists() {
-                // Restore file from the ODB
                 if let Some(parent) = full_path.parent() {
                     let _ = fs::create_dir_all(parent);
                 }
@@ -320,9 +548,10 @@ fn cmd_disable(repo: &Repository) -> Result<()> {
         }
     }
 
-    index.write(&index_path).context("writing index")?;
+    index.sparse_directories = false;
+    repo.write_index_at(&index_path, &mut index)
+        .context("writing index")?;
 
-    // Remove sparse-checkout file
     let sc_path = sparse_checkout_path(repo);
     let _ = fs::remove_file(&sc_path);
 
@@ -333,7 +562,6 @@ fn sparse_checkout_path(repo: &Repository) -> std::path::PathBuf {
     repo.git_dir.join("info").join("sparse-checkout")
 }
 
-/// Set `core.sparseCheckout` in the local repo config.
 fn set_sparse_config(repo: &Repository, enable: bool) -> Result<()> {
     let config_path = repo.git_dir.join("config");
     let mut config = if config_path.exists() {
@@ -349,7 +577,6 @@ fn set_sparse_config(repo: &Repository, enable: bool) -> Result<()> {
     Ok(())
 }
 
-/// Set `core.sparseCheckoutCone` in the local repo config.
 fn set_cone_config(repo: &Repository, cone: bool) -> Result<()> {
     let config_path = repo.git_dir.join("config");
     let mut config = if config_path.exists() {
@@ -365,47 +592,17 @@ fn set_cone_config(repo: &Repository, cone: bool) -> Result<()> {
     Ok(())
 }
 
-fn cmd_add(repo: &Repository, patterns: &[String]) -> Result<()> {
-    // Read existing patterns
-    let sc_path = sparse_checkout_path(repo);
-    let mut existing = if sc_path.exists() {
-        fs::read_to_string(&sc_path)
-            .context("reading sparse-checkout file")?
-            .lines()
-            .filter(|l| !l.is_empty())
-            .map(String::from)
-            .collect::<Vec<_>>()
+fn set_sparse_index_config(repo: &Repository, enable: bool) -> Result<()> {
+    let config_path = repo.git_dir.join("config");
+    let mut config = if config_path.exists() {
+        let content = fs::read_to_string(&config_path).context("reading repo config")?;
+        ConfigFile::parse(&config_path, &content, ConfigScope::Local)?
     } else {
-        Vec::new()
+        ConfigFile::parse(&config_path, "", ConfigScope::Local)?
     };
 
-    // Add new patterns
-    for pat in patterns {
-        if !existing.contains(pat) {
-            existing.push(pat.clone());
-        }
-    }
-
-    // Write back and apply
-    let content: String = existing.iter().map(|p| format!("{p}\n")).collect();
-    if let Some(parent) = sc_path.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    fs::write(&sc_path, &content)?;
-    apply_sparse_patterns(repo, &existing)?;
-    Ok(())
-}
-
-fn cmd_reapply(repo: &Repository) -> Result<()> {
-    let sc_path = sparse_checkout_path(repo);
-    if !sc_path.exists() {
-        anyhow::bail!("sparse-checkout is not initialized");
-    }
-    let patterns: Vec<String> = fs::read_to_string(&sc_path)?
-        .lines()
-        .filter(|l| !l.is_empty())
-        .map(String::from)
-        .collect();
-    apply_sparse_patterns(repo, &patterns)?;
+    let value = if enable { "true" } else { "false" };
+    config.set("index.sparse", value)?;
+    config.write().context("writing repo config")?;
     Ok(())
 }

--- a/grit/src/commands/stash.rs
+++ b/grit/src/commands/stash.rs
@@ -429,7 +429,7 @@ fn do_push(opts: PushOpts) -> Result<()> {
         .ok_or_else(|| anyhow::anyhow!("cannot stash on an unborn branch"))?;
 
     // Load index
-    let index = match Index::load(&repo.index_path()) {
+    let index = match repo.load_index() {
         Ok(idx) => idx,
         Err(Error::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => Index::new(),
         Err(e) => return Err(e.into()),
@@ -717,7 +717,7 @@ fn do_push_pathspec(
         }
     }
 
-    new_index.write(&repo.index_path())?;
+    repo.write_index(&mut new_index)?;
 
     if !opts.quiet {
         eprintln!("Saved working directory and index state {stash_msg}");
@@ -822,8 +822,8 @@ fn do_push_staged(
         }
     }
 
-    let new_index = build_index_from_tree(&repo.odb, &head_tree_entries)?;
-    new_index.write(&repo.index_path())?;
+    let mut new_index = build_index_from_tree(&repo.odb, &head_tree_entries)?;
+    repo.write_index(&mut new_index)?;
 
     if !opts.quiet {
         eprintln!("Saved working directory and index state {stash_msg}");
@@ -849,7 +849,7 @@ fn do_create(message: Option<String>) -> Result<()> {
         .oid()
         .ok_or_else(|| anyhow::anyhow!("cannot stash on an unborn branch"))?;
 
-    let index = match Index::load(&repo.index_path()) {
+    let index = match repo.load_index() {
         Ok(idx) => idx,
         Err(Error::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => Index::new(),
         Err(e) => return Err(e.into()),
@@ -1308,7 +1308,7 @@ fn apply_stash_impl(
     let index_commit_oid = &stash_commit.parents[1];
 
     // Load current index
-    let current_index = match Index::load(&repo.index_path()) {
+    let current_index = match repo.load_index() {
         Ok(idx) => idx,
         Err(Error::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => Index::new(),
         Err(e) => return Err(e.into()),
@@ -1640,7 +1640,7 @@ fn apply_stash_impl(
     if has_conflicts {
         new_index.sort();
     }
-    new_index.write(&repo.index_path())?;
+    repo.write_index(&mut new_index)?;
 
     // Apply untracked files if present (3rd parent)
     if stash_commit.parents.len() >= 3 {
@@ -2644,7 +2644,7 @@ fn reset_to_head(repo: &Repository, head_oid: &ObjectId, work_tree: &Path) -> Re
     let head_commit = parse_commit(&head_obj.data)?;
 
     let tree_entries = flatten_tree_full(&repo.odb, &head_commit.tree, "")?;
-    let new_index = build_index_from_tree(&repo.odb, &tree_entries)?;
+    let mut new_index = build_index_from_tree(&repo.odb, &tree_entries)?;
 
     // First pass: remove worktree files that are not in HEAD tree
     // (handles type changes like file→directory)
@@ -2682,7 +2682,7 @@ fn reset_to_head(repo: &Repository, head_oid: &ObjectId, work_tree: &Path) -> Re
         }
     }
 
-    new_index.write(&repo.index_path())?;
+    repo.write_index(&mut new_index)?;
     Ok(())
 }
 

--- a/grit/src/commands/status.rs
+++ b/grit/src/commands/status.rs
@@ -8,7 +8,7 @@ use grit_lib::config::{ConfigFile, ConfigScope, ConfigSet};
 use grit_lib::diff::{detect_renames, diff_index_to_tree, diff_index_to_worktree, DiffStatus};
 use grit_lib::error::Error;
 use grit_lib::ignore::IgnoreMatcher;
-use grit_lib::index::Index;
+use grit_lib::index::{Index, MODE_TREE};
 use grit_lib::objects::{parse_commit, ObjectId};
 use grit_lib::repo::Repository;
 use grit_lib::state::{detect_in_progress, resolve_head, HeadState};
@@ -173,12 +173,15 @@ pub fn run(mut args: Args) -> Result<()> {
         _ => "normal",
     };
 
-    // Load index
-    let index = match Index::load(&repo.index_path()) {
+    // Load index: remember sparse-index on disk, then expand placeholders for diffs.
+    let index_path = repo.index_path();
+    let mut index = match grit_lib::index::Index::load(&index_path) {
         Ok(idx) => idx,
         Err(Error::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => Index::new(),
         Err(e) => return Err(e.into()),
     };
+    let index_sparse_on_disk = index.sparse_directories;
+    let _ = index.expand_sparse_directory_placeholders(&repo.odb);
 
     // Get HEAD tree OID
     let head_tree = match head.oid() {
@@ -301,6 +304,8 @@ pub fn run(mut args: Args) -> Result<()> {
             &config,
             &args,
             &in_progress,
+            &index,
+            index_sparse_on_disk,
             &staged,
             &unstaged,
             &untracked,
@@ -491,6 +496,42 @@ fn format_short(
 /// Helper: write a line with optional comment prefix.
 /// Git's comment prefix behavior:
 ///   "# text" for normal text, "#" for empty lines, "#\tfile" for tab-indented lines.
+/// Message shown after in-progress state, matching `wt-status.c` sparse checkout hints.
+fn sparse_checkout_banner(
+    config: &ConfigSet,
+    expanded_index: &Index,
+    index_sparse_on_disk: bool,
+) -> Option<String> {
+    let sparse_enabled = config
+        .get("core.sparseCheckout")
+        .map(|v| v == "true")
+        .unwrap_or(false);
+    if !sparse_enabled || expanded_index.entries.is_empty() {
+        return None;
+    }
+    if index_sparse_on_disk {
+        return Some("You are in a sparse checkout.".to_owned());
+    }
+    let mut skip = 0usize;
+    let mut total = 0usize;
+    for e in &expanded_index.entries {
+        if e.stage() != 0 || e.mode == MODE_TREE {
+            continue;
+        }
+        total += 1;
+        if e.skip_worktree() {
+            skip += 1;
+        }
+    }
+    if total == 0 {
+        return None;
+    }
+    let pct = 100 - (100 * skip) / total;
+    Some(format!(
+        "You are in a sparse checkout with {pct}% of tracked files present."
+    ))
+}
+
 fn cpw(out: &mut impl Write, prefix: &str, line: &str) -> Result<()> {
     if prefix.is_empty() {
         writeln!(out, "{line}")?;
@@ -514,6 +555,8 @@ fn format_long(
     config: &ConfigSet,
     args: &Args,
     in_progress: &[grit_lib::state::InProgressOperation],
+    expanded_index: &Index,
+    index_sparse_on_disk: bool,
     staged: &[grit_lib::diff::DiffEntry],
     unstaged: &[grit_lib::diff::DiffEntry],
     untracked: &[String],
@@ -627,6 +670,12 @@ fn format_long(
         cpw(out, cp, "")?;
         cpw(out, cp, &format!("You are currently {}.", op.description()))?;
         cpw(out, cp, &format!("  ({})", op.hint()))?;
+    }
+
+    if let Some(msg) = sparse_checkout_banner(config, expanded_index, index_sparse_on_disk) {
+        cpw(out, cp, "")?;
+        cpw(out, cp, &msg)?;
+        cpw(out, cp, "")?;
     }
 
     // Track whether we've printed any section (to know if we need a separator)

--- a/grit/src/commands/submodule.rs
+++ b/grit/src/commands/submodule.rs
@@ -7,7 +7,6 @@ use crate::grit_exe;
 use anyhow::{bail, Context, Result};
 use clap::{Args as ClapArgs, Subcommand};
 use grit_lib::config::{ConfigFile, ConfigScope};
-use grit_lib::index::Index;
 use grit_lib::objects::{parse_commit, parse_tree, ObjectKind};
 use grit_lib::repo::Repository;
 use grit_lib::state::resolve_head;
@@ -231,7 +230,7 @@ fn parse_gitmodules_with_repo(
         fs::read_to_string(&gitmodules_path).context("failed to read .gitmodules")?
     } else if let Some(repo) = repo {
         // Fallback: read .gitmodules from the index (e.g. sparse checkout)
-        let index = Index::load(&repo.index_path()).context("failed to load index")?;
+        let index = repo.load_index().context("failed to load index")?;
         if let Some(ie) = index.get(b".gitmodules", 0) {
             let obj = repo
                 .odb

--- a/grit/src/commands/update_index.rs
+++ b/grit/src/commands/update_index.rs
@@ -258,7 +258,7 @@ fn paths_equal(expected: Option<&PathBuf>, actual: &str) -> bool {
 pub fn run(args: Args, raw_rest: &[String]) -> Result<()> {
     let repo = Repository::discover(None).context("not a git repository")?;
     let index_path = repo.index_path();
-    let mut index = Index::load(&index_path).context("loading index")?;
+    let mut index = repo.load_index_at(&index_path).context("loading index")?;
     let symlinks_enabled = core_symlinks_enabled(&repo);
 
     let work_tree = repo
@@ -282,12 +282,13 @@ pub fn run(args: Args, raw_rest: &[String]) -> Result<()> {
             println!("index-version: was {old_ver}, set to {ver}");
         }
         index.version = ver;
-        index.write(&index_path).context("writing index")?;
+        repo.write_index_at(&index_path, &mut index)
+            .context("writing index")?;
         return Ok(());
     }
 
     if args.index_info {
-        return run_index_info(&mut index, &index_path, &repo.odb);
+        return run_index_info(&repo, &mut index, &index_path);
     }
 
     if args.unresolve {
@@ -295,7 +296,8 @@ pub fn run(args: Args, raw_rest: &[String]) -> Result<()> {
         // Accept the flag silently so scripts that pass it don't hard-fail.
         // If paths are given, just succeed; real git re-creates stage 1/2/3 entries.
         eprintln!("warning: --unresolve is not yet fully implemented");
-        index.write(&index_path).context("writing index")?;
+        repo.write_index_at(&index_path, &mut index)
+            .context("writing index")?;
         return Ok(());
     }
 
@@ -760,7 +762,8 @@ pub fn run(args: Args, raw_rest: &[String]) -> Result<()> {
                 }
             }
         }
-        index.write(&index_path).context("writing index")?;
+        repo.write_index_at(&index_path, &mut index)
+            .context("writing index")?;
         if needs_update {
             std::process::exit(1);
         }
@@ -777,7 +780,8 @@ pub fn run(args: Args, raw_rest: &[String]) -> Result<()> {
             args.ignore_missing,
             args.ignore_submodules,
         )?;
-        index.write(&index_path).context("writing index")?;
+        repo.write_index_at(&index_path, &mut index)
+            .context("writing index")?;
         // -q (quiet) suppresses the error exit; otherwise exit 1 if files need updating
         if !uptodate && !args.quiet {
             std::process::exit(1);
@@ -785,12 +789,17 @@ pub fn run(args: Args, raw_rest: &[String]) -> Result<()> {
         return Ok(());
     }
 
-    index.write(&index_path).context("writing index")?;
+    repo.write_index_at(&index_path, &mut index)
+        .context("writing index")?;
     Ok(())
 }
 
 /// Process `--index-info` stdin: lines of `"<mode> <oid>\t<path>"`.
-fn run_index_info(index: &mut Index, index_path: &std::path::Path, _odb: &Odb) -> Result<()> {
+fn run_index_info(
+    repo: &grit_lib::repo::Repository,
+    index: &mut Index,
+    index_path: &std::path::Path,
+) -> Result<()> {
     let stdin = io::stdin();
     for line in stdin.lock().lines() {
         let line = line?;
@@ -867,7 +876,8 @@ fn run_index_info(index: &mut Index, index_path: &std::path::Path, _odb: &Odb) -
         index.add_or_replace(entry);
     }
 
-    index.write(index_path).context("writing index")?;
+    repo.write_index_at(index_path, index)
+        .context("writing index")?;
     Ok(())
 }
 
@@ -1126,12 +1136,13 @@ fn core_symlinks_enabled(repo: &Repository) -> bool {
 /// Non-CLI: `update-index -q --refresh` — refresh stat cache without exiting when entries are stale.
 pub fn run_refresh_quiet(repo: &Repository) -> Result<()> {
     let index_path = repo.index_path();
-    let mut index = Index::load(&index_path).context("loading index")?;
+    let mut index = repo.load_index_at(&index_path).context("loading index")?;
     let work_tree = repo
         .work_tree
         .as_deref()
         .ok_or_else(|| anyhow::anyhow!("cannot update-index in bare repository"))?;
     let (_uptodate, _) = refresh_index(&mut index, work_tree, &repo.odb, false, false, false)?;
-    index.write(&index_path).context("writing index")?;
+    repo.write_index_at(&index_path, &mut index)
+        .context("writing index")?;
     Ok(())
 }

--- a/grit/src/commands/worktree.rs
+++ b/grit/src/commands/worktree.rs
@@ -707,7 +707,7 @@ fn cmd_add(args: AddArgs) -> Result<()> {
         let commit_oid = commit_oid.ok_or_else(|| {
             anyhow::anyhow!("HEAD does not point to a valid commit; specify a branch")
         })?;
-        populate_worktree(&repo.odb, &common, &commit_oid, &wt_path, &wt_admin)?;
+        populate_worktree(&repo, &commit_oid, &wt_path, &wt_admin)?;
     }
 
     Ok(())
@@ -780,13 +780,13 @@ fn setup_unborn_worktree(
 
 /// Populate a worktree directory with files from a commit.
 fn populate_worktree(
-    odb: &grit_lib::odb::Odb,
-    _common_dir: &Path,
+    repo: &grit_lib::repo::Repository,
     commit_oid: &ObjectId,
     wt_path: &Path,
     admin_dir: &Path,
 ) -> Result<()> {
     use grit_lib::objects::parse_commit;
+    let odb = &repo.odb;
     // Read the commit to get its tree
     let obj = odb.read(commit_oid).context("reading commit")?;
     let commit = parse_commit(&obj.data).context("parsing commit")?;
@@ -799,7 +799,8 @@ fn populate_worktree(
     let index_path = admin_dir.join("index");
     let mut index = Index::new();
     add_worktree_tree_to_index(odb, &tree_oid, "", &mut index, Some(wt_path))?;
-    index.write(&index_path).context("writing worktree index")?;
+    repo.write_index_at(&index_path, &mut index)
+        .context("writing worktree index")?;
 
     Ok(())
 }
@@ -1299,7 +1300,7 @@ fn cmd_remove(args: RemoveArgs) -> Result<()> {
         // Load the linked worktree's index (stored in the admin directory)
         let index_path = admin.join("index");
         if index_path.exists() {
-            if let Ok(index) = grit_lib::index::Index::load(&index_path) {
+            if let Ok(index) = repo.load_index_at(&index_path) {
                 // Check for untracked files
                 if has_untracked_files(&wt_path, &index) {
                     bail!("worktree '{}' contains modified or untracked files; use --force to delete it", wt_path.display());

--- a/grit/src/commands/write_tree.rs
+++ b/grit/src/commands/write_tree.rs
@@ -23,7 +23,7 @@ pub struct Args {
 /// Run `grit write-tree`.
 pub fn run(args: Args) -> Result<()> {
     let repo = Repository::discover(None).context("not a git repository")?;
-    let index = Index::load(&repo.index_path()).context("loading index")?;
+    let index = repo.load_index().context("loading index")?;
 
     let prefix = args.prefix.as_deref().unwrap_or("");
     let oid = match write_tree_from_index(&repo.odb, &index, prefix, args.missing_ok)

--- a/logs/2026-04-07_sparse-index-t1092-progress.md
+++ b/logs/2026-04-07_sparse-index-t1092-progress.md
@@ -1,0 +1,21 @@
+# Sparse index / t1092 progress (2026-04-07)
+
+## Done
+
+- Index: parse/write `sdir` extension; sparse directory placeholders (`MODE_TREE` + skip-worktree); expand via ODB; collapse using cone patterns and nested sparse-dir awareness.
+- `Repository::load_index` / `load_index_at` expand placeholders; `write_index` / `write_index_at` re-collapse before write.
+- Wired most command paths to expanded load + finalized write (reset, checkout, add, merge, etc.).
+- `sparse-checkout`: `init`/`set`/`reapply`/`add` flags (`--cone`, `--no-cone`, `--sparse-index`, `--no-sparse-index`, `--skip-checks`); `index.sparse` config; collapse after apply.
+- `ls-files --sparse` reads on-disk index without expanding.
+- `status`: sparse-checkout banner (percentage vs sparse-index one-liner).
+- `write_tree_from_index`: ignore `MODE_TREE` entries.
+- `rev_parse` index path lookup uses expanded index.
+- Tests: `test_cmp_config` aligned with upstream Git (`git -C … config` + file compare); added `test_region` for trace2 checks in t1092.
+
+## Still failing
+
+- `./scripts/run-tests.sh t1092-sparse-checkout-compatibility.sh` — ~65 failures remain (2 expected `test_expect_failure`).
+
+## Next steps (for a follow-up)
+
+- Remaining t1092 failures likely need command-specific sparse behavior (blame outside cone, reset pathspecs, read-tree, submodule paths, etc.).

--- a/progress.md
+++ b/progress.md
@@ -6,13 +6,14 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |    84 |
-| In progress |     0 |
-| Remaining   |   683 |
+| Completed   |   217 |
+| In progress |     2 |
+| Remaining   |   548 |
 | **Total**   |   767 |
 
 ## Recently completed
 
+- `t1092-sparse-checkout-compatibility` — in progress (~39/106 passing): sparse index (`sdir`), expand/collapse, `sparse-checkout` CLI flags, `ls-files --sparse`, status sparse banner, index write finalization across commands; see `logs/2026-04-07_sparse-index-t1092-progress.md`
 - `t0450-txt-doc-vs-help` — 548/548 tests pass (`-h` synopsis generated from vendored `git/Documentation/*.adoc` at build time; harness sets `GIT_SOURCE_DIR`; trimmed `adoc-help-mismatches` to builtins Grit does not ship)
 - `t6426-merge-skip-unneeded-updates` — 13/13 tests pass (fixed merge output channels so successful merge-commit summaries no longer pollute stderr checks while keeping conflict diagnostics on stdout; expanded `tests/test-tool chmtime` compatibility so `--get` supports optional offset specs used by mtime assertions; merge tree orchestration now preserves pre-merge dirty worktree files by skipping checkout when index OIDs are unchanged and only refreshing paths whose index content changed; resolved rename/add handling to drop stale stage-0 entries, emit conflict-marker worktree content, and correctly keep the renamed-side blob as stage-3 in 1to1 rename+add-source cases)
 - `t6406-merge-attr` — 13/13 tests pass (merge core now honors gitattributes merge attributes: `-merge`/binary paths, `merge=union`, and custom `merge=<driver>` with `%O/%A/%B/%P/%S/%X/%Y` placeholder expansion and proper signal-failure handling; merge conflict marker size now respects `conflict-marker-size` with Git-compatible warning for invalid values; `checkout -m <path>` now reconstructs conflicted files from index stages and applies `conflict-marker-size`, enabling conflict re-materialization checks)
@@ -74,4 +75,4 @@
 
 ## What Remains
 
-684 test files still pending. See `plan.md` for the full prioritized list.
+550 test-tracked items still open (548 `[ ]` + 2 `[~]`). See `PLAN.md` for the full prioritized list.

--- a/test-results.md
+++ b/test-results.md
@@ -2,7 +2,9 @@
 
 **Updated:** 2026-04-07
 
-- Test pipeline: `data/test-files.csv` + `scripts/generate-dashboard-from-test-files.py`; `./scripts/run-tests.sh` updates CSV and `docs/index.html` / `docs/testfiles.html`. `cargo test -p grit-lib --lib`: 98/98 passing (2026-04-07).
+- Test pipeline: `data/test-files.csv` + `scripts/generate-dashboard-from-test-files.py`; `./scripts/run-tests.sh` updates CSV and `docs/index.html` / `docs/testfiles.html`. `cargo test -p grit-lib --lib`: 102/102 passing (2026-04-07).
+- `./scripts/run-tests.sh t1092-sparse-checkout-compatibility.sh`: 39/106 passing (65 failing; 2 `test_expect_failure`); sparse-index plumbing in progress.
+- `cargo test --workspace`: not run for this change set.
 
 **Updated:** 2026-04-06
 

--- a/tests/test-lib.sh
+++ b/tests/test-lib.sh
@@ -870,25 +870,53 @@ test_hook () {
 	write_script "$hook_dir/$1"
 }
 
-# test_cmp_config [--default DEFAULT] EXPECTED [KEY...]
-test_cmp_config () {
-	local default=""
-	if test "$1" = "--default"
+# Look for trace2 region enter/leave in a trace file (from GIT_TRACE2_EVENT).
+#	test_region [!] <category> <label> <tracefile>
+#
+# If the first parameter is !, the region must not appear.
+test_region () {
+	local expect_exit=0
+	if test "$1" = "!"
 	then
-		default="$2"
-		shift 2
+		expect_exit=1
+		shift
 	fi
-	local expect="$1"
-	shift
-	local actual
-	actual=$(git config "$@" 2>/dev/null) || actual="$default"
-	if test "$expect" = "$actual"
+
+	grep -e	'"region_enter".*"category":"'"$1"'","label":"'"$2"\" "$3"
+	exitcode=$?
+
+	if test $exitcode != $expect_exit
 	then
-		return 0
-	else
-		echo >&2 "test_cmp_config: expected '$expect', got '$actual'"
 		return 1
 	fi
+
+	grep -e	'"region_leave".*"category":"'"$1"'","label":"'"$2"\" "$3"
+	exitcode=$?
+
+	if test $exitcode != $expect_exit
+	then
+		return 1
+	fi
+
+	return 0
+}
+
+# Check that the given config key has the expected value.
+#
+#    test_cmp_config [-C <dir>] <expected-value>
+#                    [<git-config-options>...] <config-key>
+test_cmp_config () {
+	local GD &&
+	if test "$1" = "-C"
+	then
+		shift &&
+		GD="-C $1" &&
+		shift
+	fi &&
+	printf "%s\n" "$1" >expect.config &&
+	shift &&
+	git $GD config "$@" >actual.config &&
+	test_cmp expect.config actual.config
 }
 
 test_commit () {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements core **sparse index** behavior needed by `t1092-sparse-checkout-compatibility`: `sdir` extension on disk, sparse-directory placeholder entries (`MODE_TREE` + skip-worktree), ODB-backed expansion, and cone-aware collapse (including nested sparse dirs). Commands now load an **expanded** index for normal work and **re-collapse** before writing when sparse checkout + `index.sparse` apply.

Also extends **`sparse-checkout`** with Git-compatible flags (`--cone` / `--no-cone`, `--sparse-index` / `--no-sparse-index`, `--skip-checks`), adds **`ls-files --sparse`**, and prints the **sparse checkout status banner** (percentage vs sparse-index one-liner). **`write-tree`** ignores tree-mode index rows.

Harness fixes in `tests/test-lib.sh`: **`test_cmp_config`** matches upstream Git (`git -C … config` + file compare) and **`test_region`** for trace2 checks.

## Test status

- `cargo test -p grit-lib --lib`: **102/102** pass
- `./scripts/run-tests.sh t1092-sparse-checkout-compatibility.sh`: **39/106** pass (65 fail; 2 expected `test_expect_failure`)

## Follow-up

Remaining t1092 failures need more command-specific sparse behavior (e.g. blame outside cone, reset pathspecs, read-tree, submodules).

See `logs/2026-04-07_sparse-index-t1092-progress.md` for notes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7942b462-c1db-4f64-9058-ee3906733fdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7942b462-c1db-4f64-9058-ee3906733fdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

