### PR TITLE
t9740 check-ref-format normalize — harness refresh

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1543,7 +1543,7 @@ t9700-perl-git	t9	yes	3	2	1	false	ok	0
 t9710-show-ref-hash-abbrev	t9	yes	38	35	3	false	ok	0
 t9720-update-ref-create-verify	t9	yes	32	22	10	false	ok	0
 t9730-symbolic-ref-head	t9	yes	31	25	6	false	ok	0
-t9740-check-ref-format-normalize	t9	yes	51	27	24	false	ok	0
+t9740-check-ref-format-normalize	t9	yes	51	51	0	true	ok	0
 t9750-merge-base-octopus	t9	yes	35	32	3	false	ok	0
 t9760-hash-object-blob-tree	t9	yes	32	30	2	false	ok	0
 t9770-cat-file-type-size	t9	yes	32	28	4	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,16 +141,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-07T18:35:51+00:00" class="gen-time" title="2026-04-07 18:35 UTC">2026-04-07 18:35 UTC</time> · <a href="https://github.com/schacon/grit/commit/8e6206b63f4b0d1f35380cf73402a859da397fe4" style="color:#58a6ff">8e6206b</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-07T18:46:34+00:00" class="gen-time" title="2026-04-07 18:46 UTC">2026-04-07 18:46 UTC</time> · <a href="https://github.com/schacon/grit/commit/c4cba7b1ae55f2209b2d44d6fc52192d29b24e95" style="color:#58a6ff">c4cba7b</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">67.2%</div>
+      <div class="summary-big-val pct-blue">67.3%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,413</div>
+      <div class="summary-big-val">29,437</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -159,12 +159,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:67.2%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:67.3%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>599 files fully passing</span>
+    <span>600 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -278,11 +278,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t9</span>
         <span class="group-desc">Git tools</span>
-        <span class="group-meta">38/90 files · 127 skipped · 2,245/2,851 tests</span>
+        <span class="group-meta">39/90 files · 127 skipped · 2,269/2,851 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:78.7%"></div></div>
-        <span class="group-pct pct-blue">78.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:79.6%"></div></div>
+        <span class="group-pct pct-blue">79.6%</span>
       </div>
     </a>
 

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,13 +84,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T18:35:51+00:00" class="gen-time" title="2026-04-07 18:35 UTC">2026-04-07 18:35 UTC</time> · <a href="https://github.com/schacon/grit/commit/8e6206b63f4b0d1f35380cf73402a859da397fe4" style="color:#58a6ff">8e6206b</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T18:46:34+00:00" class="gen-time" title="2026-04-07 18:46 UTC">2026-04-07 18:46 UTC</time> · <a href="https://github.com/schacon/grit/commit/c4cba7b1ae55f2209b2d44d6fc52192d29b24e95" style="color:#58a6ff">c4cba7b</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,739</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,413</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">67.2%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,437</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">67.3%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -15567,14 +15567,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:80.6%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t9" data-tests="51" data-passed="27">
+<tr class="" data-group="t9" data-tests="51" data-passed="51">
   <td class="mono">t9740-check-ref-format-normalize</td>
   <td>t9</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">51</td>
-  <td class="right">27</td>
+  <td class="right">51</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:52.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t9" data-tests="35" data-passed="32">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`tests/t9740-check-ref-format-normalize.sh` already passes **51/51** against current `grit check-ref-format` (validation, `--normalize`, `--allow-onelevel`, `--refspec-pattern`, `--branch`, and cross-checks with `/usr/bin/git`).

This change records the harness run in `data/test-files.csv` and regenerates the dashboards.

## Verification

```bash
./scripts/run-tests.sh t9740-check-ref-format-normalize.sh
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f97ecc1-a4ad-48a4-bb6c-1a32093c158f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f97ecc1-a4ad-48a4-bb6c-1a32093c158f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

