### PR TITLE
fix: make t10750-status-deleted-renamed fully pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -174,7 +174,7 @@ t10710-ls-files-deduplicate	t1	yes	36	36	0	true	ok	0
 t10720-diff-stat-summary	t1	yes	38	38	0	true	ok	0
 t10730-diff-tree-recursive-stat	t1	yes	37	37	0	true	ok	0
 t10740-diff-index-name-status	t1	yes	43	43	0	true	ok	0
-t10750-status-deleted-renamed	t1	yes	40	39	1	false	ok	0
+t10750-status-deleted-renamed	t1	yes	40	40	0	true	ok	0
 t10780-config-rename-section	t1	yes	33	33	0	true	ok	0
 t10790-init-reinit-structure	t1	yes	33	33	0	true	ok	0
 t10800-branch-merged-contains	t1	yes	32	32	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-07T18:35:51+00:00" class="gen-time" title="2026-04-07 18:35 UTC">2026-04-07 18:35 UTC</time> · <a href="https://github.com/schacon/grit/commit/8e6206b63f4b0d1f35380cf73402a859da397fe4" style="color:#58a6ff">8e6206b</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-07T18:55:27+00:00" class="gen-time" title="2026-04-07 18:55 UTC">2026-04-07 18:55 UTC</time> · <a href="https://github.com/schacon/grit/commit/c4cba7b1ae55f2209b2d44d6fc52192d29b24e95" style="color:#58a6ff">c4cba7b</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,413</div>
+      <div class="summary-big-val">29,414</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>599 files fully passing</span>
+    <span>600 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -190,7 +190,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">234/368 files · 8 skipped · 10,499/12,224 tests</span>
+        <span class="group-meta">235/368 files · 8 skipped · 10,500/12,224 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-green" style="width:85.9%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T18:35:51+00:00" class="gen-time" title="2026-04-07 18:35 UTC">2026-04-07 18:35 UTC</time> · <a href="https://github.com/schacon/grit/commit/8e6206b63f4b0d1f35380cf73402a859da397fe4" style="color:#58a6ff">8e6206b</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T18:55:27+00:00" class="gen-time" title="2026-04-07 18:55 UTC">2026-04-07 18:55 UTC</time> · <a href="https://github.com/schacon/grit/commit/c4cba7b1ae55f2209b2d44d6fc52192d29b24e95" style="color:#58a6ff">c4cba7b</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,739</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,413</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,414</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">67.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1877,14 +1877,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="40" data-passed="39">
+<tr class="" data-group="t1" data-tests="40" data-passed="40">
   <td class="mono">t10750-status-deleted-renamed</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">40</td>
-  <td class="right">39</td>
+  <td class="right">40</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:97.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="33" data-passed="33">

--- a/grit/src/commands/status.rs
+++ b/grit/src/commands/status.rs
@@ -486,7 +486,30 @@ fn format_short(
     for path in &paths {
         let x = staged_map.get(path).copied().unwrap_or(' ');
         let y = unstaged_map.get(path).copied().unwrap_or(' ');
-        write!(out, "{x}{y} {path}{terminator}")?;
+        write!(out, "{x}{y} ")?;
+        let rename_or_copy = staged.iter().chain(unstaged.iter()).find(|e| {
+            e.path() == path.as_str()
+                && (e.status == DiffStatus::Renamed || e.status == DiffStatus::Copied)
+        });
+        if let Some(e) = rename_or_copy {
+            let old_p = e.old_path.as_deref().unwrap_or("");
+            let new_p = e.new_path.as_deref().unwrap_or("");
+            if args.null_terminated {
+                // Match git: current path (destination) first, then source, each NUL-terminated.
+                write!(out, "{new_p}\0")?;
+                if !old_p.is_empty() {
+                    write!(out, "{old_p}\0")?;
+                }
+            } else if !old_p.is_empty() && !new_p.is_empty() {
+                writeln!(out, "{old_p} -> {new_p}")?;
+            } else {
+                writeln!(out, "{}", e.path())?;
+            }
+        } else if args.null_terminated {
+            write!(out, "{path}\0")?;
+        } else {
+            writeln!(out, "{path}")?;
+        }
     }
 
     for path in untracked {

--- a/logs/2026-04-07_t10750-status-deleted-renamed.md
+++ b/logs/2026-04-07_t10750-status-deleted-renamed.md
@@ -1,0 +1,21 @@
+# t10750-status-deleted-renamed
+
+## Goal
+
+Make `tests/t10750-status-deleted-renamed.sh` pass (40/40).
+
+## Failure
+
+Test 12 (`status -s shows old and new filename`) failed: after `grit mv alpha.txt renamed.txt`, `grit status -s` printed `R  renamed.txt` only. Git prints `R  alpha.txt -> renamed.txt` (and porcelain v1 short format matches).
+
+## Fix
+
+In `grit/src/commands/status.rs`, `format_short` now:
+
+- For `Renamed` / `Copied` entries, prints `old -> new` when not `-z`.
+- For `-z`, prints destination path then source path, each NUL-terminated, after `XY `, matching `wt_shortstatus_status` in Git’s `wt-status.c`.
+
+## Verification
+
+- `./scripts/run-tests.sh t10750-status-deleted-renamed.sh` → 40/40
+- `cargo test -p grit-lib --lib` → pass

--- a/progress.md
+++ b/progress.md
@@ -6,13 +6,14 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |    85 |
+| Completed   |    86 |
 | In progress |     0 |
-| Remaining   |   682 |
+| Remaining   |   681 |
 | **Total**   |   767 |
 
 ## Recently completed
 
+- `t10750-status-deleted-renamed` — 40/40 tests pass (short/porcelain `-s` output now prints `old -> new` for renames/copies; `-z` uses Git’s NUL-separated `new\0old\0` path layout after the XY prefix)
 - `t11290-update-ref-atomic-batch` — 33/33 tests pass (`test_must_fail` in `test-lib-tap.sh` now accepts absolute paths to `git`/`grit`/`scalar`, so `test_must_fail "$GUST_BIN"` and `test_must_fail "$REAL_GIT"` work under the harness)
 - `t1092-sparse-checkout-compatibility` — in progress (~39/106 passing): sparse index (`sdir`), expand/collapse, `sparse-checkout` CLI flags, `ls-files --sparse`, status sparse banner, index write finalization across commands; see `logs/2026-04-07_sparse-index-t1092-progress.md`
 - `t0450-txt-doc-vs-help` — 548/548 tests pass (`-h` synopsis generated from vendored `git/Documentation/*.adoc` at build time; harness sets `GIT_SOURCE_DIR`; trimmed `adoc-help-mismatches` to builtins Grit does not ship)

--- a/t1-plan.md
+++ b/t1-plan.md
@@ -38,7 +38,7 @@
 - [ ] t10650-merge-file-zdiff3.sh
 - [ ] t10670-cat-file-commit-tree.sh
 - [ ] t10740-diff-index-name-status.sh
-- [ ] t10750-status-deleted-renamed.sh
+- [x] t10750-status-deleted-renamed.sh
 - [ ] t10780-config-rename-section.sh
 - [ ] t10790-init-reinit-structure.sh                                                                   - [ ] t10800-branch-merged-contains.sh
 - [ ] t10810-tag-sort-contains.sh

--- a/test-results.md
+++ b/test-results.md
@@ -2,6 +2,7 @@
 
 **Updated:** 2026-04-07
 
+- `./scripts/run-tests.sh t10750-status-deleted-renamed.sh`: 40/40 passing (short status shows `old -> new` for renames; `-z` emits NUL-separated new then old path).
 - `./scripts/run-tests.sh t11290-update-ref-atomic-batch.sh`: 33/33 passing (harness `test_must_fail` now allows absolute `git`/`grit`/`scalar` paths).
 - Test pipeline: `data/test-files.csv` + `scripts/generate-dashboard-from-test-files.py`; `./scripts/run-tests.sh` updates CSV and `docs/index.html` / `docs/testfiles.html`. `cargo test -p grit-lib --lib`: 102/102 passing (2026-04-07).
 - `./scripts/run-tests.sh t1092-sparse-checkout-compatibility.sh`: 39/106 passing (65 failing; 2 `test_expect_failure`); sparse-index plumbing in progress.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`grit status -s` / porcelain short format only showed the destination path for renames (e.g. `R  renamed.txt`), so `t10750-status-deleted-renamed` failed test 12 which expects both names like Git (`R  alpha.txt -> renamed.txt`).

## Changes

- **`format_short` in `grit/src/commands/status.rs`**: For `Renamed` / `Copied` entries, print `old -> new` when not using `-z`. With `-z`, emit the destination path then the source path, each NUL-terminated, after the `XY ` prefix (aligned with Git’s `wt_shortstatus_status` in `wt-status.c`).
- **Tracking**: `t1-plan.md`, `progress.md`, `test-results.md`, `logs/2026-04-07_t10750-status-deleted-renamed.md`.
- **Harness**: refreshed `data/test-files.csv` and dashboards via `./scripts/run-tests.sh t10750-status-deleted-renamed.sh`.

## Verification

- `./scripts/run-tests.sh t10750-status-deleted-renamed.sh`: **40/40**
- `cargo test -p grit-lib --lib`: **102/102**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93c7eb07-d15e-4cff-a073-8dd0db274b10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93c7eb07-d15e-4cff-a073-8dd0db274b10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

