### PR TITLE
feat: submodulePathConfig and t7425 submodule gitdir extension

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -191,7 +191,7 @@ t1090-sparse-checkout-scope	t1	yes	7	3	4	false	ok	0
 t10900-for-each-ref-pattern-sort	t1	yes	34	34	0	true	ok	0
 t1091-sparse-checkout-builtin	t1	yes	76	9	67	false	ok	1
 t10910-show-ref-tags-branches	t1	yes	35	35	0	true	ok	0
-t1092-sparse-checkout-compatibility	t1	yes	106	39	65	false	ok	3
+t1092-sparse-checkout-compatibility	t1	yes	104	39	65	false	ok	3
 t10920-update-ref-create-delete	t1	yes	29	29	0	true	ok	0
 t10930-symbolic-ref-read-write	t1	yes	29	28	1	false	ok	0
 t10940-check-ignore-dir-pattern	t1	yes	35	35	0	true	ok	0
@@ -1215,7 +1215,7 @@ t7421-submodule-summary-add	t7	yes	5	1	4	false	ok	0
 t7422-submodule-output	t7	yes	18	0	18	false	ok	0
 t7423-submodule-symlinks	t7	yes	6	3	3	false	ok	0
 t7424-submodule-mixed-ref-formats	t7	skip	14	3	11	false	ok	0
-t7425-submodule-gitdir-path-extension	t7	yes	23	4	19	false	ok	0
+t7425-submodule-gitdir-path-extension	t7	yes	23	23	0	true	ok	0
 t7426-submodule-get-default-remote	t7	yes	15	1	14	false	ok	0
 t7450-bad-git-dotfiles	t7	yes	50	7	43	false	ok	0
 t7500-commit-template-squash-signoff	t7	yes	57	20	37	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,27 +141,30 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-07T18:00:28+00:00" class="gen-time" title="2026-04-07 18:00 UTC">2026-04-07 18:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/cb98bd226560cc2a148584f4ebb1cab29255f5fb" style="color:#58a6ff">cb98bd2</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-07T19:00:59+00:00" class="gen-time" title="2026-04-07 19:00 UTC">2026-04-07 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/4ffd2df9a49744c0724e505d033e5ffef9d92526" style="color:#58a6ff">4ffd2df</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">67.2%</div>
+      <div class="summary-big-val pct-blue">67.3%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,375</div>      <div class="summary-big-lbl">Tests passed</div>
+      <div class="summary-big-val">29,432</div>
+      <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">43,741</div>      <div class="summary-big-lbl">Total tests</div>
+      <div class="summary-big-val">43,739</div>
+      <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:67.2%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:67.3%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>599 files fully passing</span>
+    <span>600 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -187,10 +190,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">234/368 files · 8 skipped · 10,461/12,226 tests</span>      </div>
+        <span class="group-meta">234/368 files · 8 skipped · 10,499/12,224 tests</span>
+      </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:85.6%"></div></div>
-        <span class="group-pct pct-green">85.6%</span>      </div>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:85.9%"></div></div>
+        <span class="group-pct pct-green">85.9%</span>
+      </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t2">
       <div class="group-line1">
@@ -251,11 +256,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">35/126 files · 11 skipped · 1,873/3,607 tests</span>
+        <span class="group-meta">36/126 files · 11 skipped · 1,892/3,607 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:51.9%"></div></div>
-        <span class="group-pct pct-orange">51.9%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:52.5%"></div></div>
+        <span class="group-pct pct-orange">52.5%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T18:00:28+00:00" class="gen-time" title="2026-04-07 18:00 UTC">2026-04-07 18:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/cb98bd226560cc2a148584f4ebb1cab29255f5fb" style="color:#58a6ff">cb98bd2</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T19:00:59+00:00" class="gen-time" title="2026-04-07 19:00 UTC">2026-04-07 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/4ffd2df9a49744c0724e505d033e5ffef9d92526" style="color:#58a6ff">4ffd2df</a></p>
+
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">43,741</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,375</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">67.2%</div><div class="lbl">Pass rate</div></div>
+  <div class="card"><div class="n" id="sum-tests">43,739</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,432</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">67.3%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -2046,14 +2047,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="106" data-passed="39">
+<tr class="" data-group="t1" data-tests="104" data-passed="39">
   <td class="mono">t1092-sparse-checkout-compatibility</td>
   <td>t1</td>
   <td></td>
-  <td class="right">106</td>
+  <td class="right">104</td>
   <td class="right">39</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:36.8%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:37.5%"></div></div></td>
   <td class="right small">3</td>
 </tr>
 <tr class="" data-group="t1" data-tests="29" data-passed="29">
@@ -12286,14 +12287,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="23" data-passed="4">
+<tr class="" data-group="t7" data-tests="23" data-passed="23">
   <td class="mono">t7425-submodule-gitdir-path-extension</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">23</td>
-  <td class="right">4</td>
+  <td class="right">23</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:17.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="15" data-passed="1">

--- a/grit-lib/src/lib.rs
+++ b/grit-lib/src/lib.rs
@@ -46,6 +46,7 @@ pub mod rev_list;
 pub mod rev_parse;
 pub mod state;
 pub mod stripspace;
+pub mod submodule_gitdir;
 pub mod tree_path_follow;
 #[cfg(unix)]
 pub mod unix_process;

--- a/grit-lib/src/repo.rs
+++ b/grit-lib/src/repo.rs
@@ -674,6 +674,7 @@ fn validate_repository_format(git_dir: &Path) -> Result<()> {
                 | "objectformat"
                 | "compatobjectformat"
                 | "refstorage"
+                | "submodulepathconfig"
         ) {
             continue;
         }
@@ -1079,6 +1080,28 @@ fn resolve_git_dir_env_path(git_dir: &Path) -> Result<PathBuf> {
         return parse_gitfile(&content, base);
     }
     Ok(git_dir.to_path_buf())
+}
+
+/// Resolves a work tree's `.git` path (directory or gitfile) to the real git directory.
+///
+/// # Errors
+///
+/// Returns [`Error::NotARepository`] when `.git` is missing, invalid, or the gitfile target is absent.
+pub fn resolve_dot_git(dot_git: &Path) -> Result<PathBuf> {
+    if dot_git.is_dir() {
+        return dot_git
+            .canonicalize()
+            .map_err(|_| Error::NotARepository(dot_git.display().to_string()));
+    }
+    if dot_git.is_file() {
+        let content =
+            fs::read_to_string(dot_git).map_err(|e| Error::NotARepository(e.to_string()))?;
+        let base = dot_git
+            .parent()
+            .ok_or_else(|| Error::NotARepository(dot_git.display().to_string()))?;
+        return parse_gitfile(&content, base);
+    }
+    Err(Error::NotARepository(dot_git.display().to_string()))
 }
 
 /// Parse a gitfile's `"gitdir: <path>"` line.

--- a/grit-lib/src/submodule_gitdir.rs
+++ b/grit-lib/src/submodule_gitdir.rs
@@ -1,0 +1,610 @@
+//! Submodule gitdir paths when `extensions.submodulePathConfig` is enabled.
+//!
+//! Mirrors Git's `create_default_gitdir_config` / `validate_submodule_git_dir` logic
+//! enough for upstream tests (encoded paths, nesting checks, conflict resolution).
+
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+use sha1::{Digest, Sha1};
+
+use crate::config::{ConfigFile, ConfigScope};
+use crate::error::{Error, Result};
+use crate::index::Index;
+use crate::objects::{ObjectId, ObjectKind};
+use crate::odb::Odb;
+
+/// Returns whether `extensions.submodulePathConfig` is enabled in `git_dir/config`.
+pub fn submodule_path_config_enabled(git_dir: &Path) -> bool {
+    let config_path = git_dir.join("config");
+    let Ok(content) = fs::read_to_string(&config_path) else {
+        return false;
+    };
+    let mut in_extensions = false;
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') {
+            in_extensions = trimmed.eq_ignore_ascii_case("[extensions]");
+            continue;
+        }
+        if in_extensions {
+            if let Some((k, v)) = trimmed.split_once('=') {
+                if k.trim().eq_ignore_ascii_case("submodulepathconfig") {
+                    return parse_bool(v.trim());
+                }
+            }
+        }
+    }
+    false
+}
+
+fn parse_bool(s: &str) -> bool {
+    matches!(s.to_ascii_lowercase().as_str(), "true" | "yes" | "on" | "1")
+}
+
+fn is_rfc3986_unreserved(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.' | b'~')
+}
+
+fn is_casefolding_rfc3986_unreserved(b: u8) -> bool {
+    matches!(b, b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~')
+}
+
+fn percent_encode(name: &str, pred: fn(u8) -> bool) -> String {
+    let mut out = String::new();
+    for &b in name.as_bytes() {
+        if pred(b) {
+            out.push(b as char);
+        } else {
+            out.push_str(&format!("%{:02x}", b));
+        }
+    }
+    out
+}
+
+/// Returns true if `path` looks like a git directory (`HEAD` and `objects/` exist).
+pub fn is_git_directory(path: &Path) -> bool {
+    path.join("HEAD").is_file() && path.join("objects").is_dir()
+}
+
+fn last_modules_segment(git_dir_abs: &Path) -> Option<String> {
+    let s = git_dir_abs.to_string_lossy();
+    let marker = "/modules/";
+    let mut p = 0usize;
+    let mut last_start = None;
+    while let Some(idx) = s[p..].find(marker) {
+        let start = p + idx + marker.len();
+        last_start = Some(start);
+        p = start + 1;
+    }
+    last_start.map(|start| s[start..].to_string())
+}
+
+fn path_inside_other_gitdir(git_dir: &Path, submodule_name: &str) -> bool {
+    let suffix = submodule_name.as_bytes();
+    let gd = git_dir.to_string_lossy();
+    let gd_bytes = gd.as_bytes();
+    if gd_bytes.len() <= suffix.len() {
+        return false;
+    }
+    let cut = gd_bytes.len() - suffix.len();
+    if gd_bytes[cut - 1] != b'/' {
+        return false;
+    }
+    if &gd_bytes[cut..] != suffix {
+        return false;
+    }
+    for i in cut..gd_bytes.len() {
+        if gd_bytes[i] == b'/' {
+            let prefix = Path::new(std::str::from_utf8(&gd_bytes[..i]).unwrap_or(""));
+            if is_git_directory(prefix) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn resolve_gitdir_value(work_tree: &Path, gitdir_cfg: &str) -> PathBuf {
+    let p = Path::new(gitdir_cfg.trim());
+    if p.is_absolute() {
+        p.to_path_buf()
+    } else {
+        work_tree.join(p)
+    }
+}
+
+fn canonical_abs(path: &Path) -> PathBuf {
+    fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn existing_gitdir_abs_paths(
+    work_tree: &Path,
+    cfg: &ConfigFile,
+    except_name: &str,
+) -> Result<HashSet<PathBuf>> {
+    let mut set = HashSet::new();
+    let suffix = ".gitdir";
+    for e in &cfg.entries {
+        if !e.key.starts_with("submodule.") || !e.key.ends_with(suffix) {
+            continue;
+        }
+        let inner = &e.key["submodule.".len()..e.key.len() - suffix.len()];
+        if inner == except_name {
+            continue;
+        }
+        if let Some(v) = e.value.as_deref() {
+            let abs = canonical_abs(&resolve_gitdir_value(work_tree, v));
+            set.insert(abs);
+        }
+    }
+    Ok(set)
+}
+
+fn gitdir_conflicts_with_existing(
+    work_tree: &Path,
+    cfg: &ConfigFile,
+    abs_gitdir: &Path,
+    submodule_name: &str,
+) -> Result<bool> {
+    let canon = canonical_abs(abs_gitdir);
+    let existing = existing_gitdir_abs_paths(work_tree, cfg, submodule_name)?;
+    Ok(existing.contains(&canon))
+}
+
+fn ignore_case_from_config(git_dir: &Path) -> bool {
+    let config_path = git_dir.join("config");
+    let Ok(content) = fs::read_to_string(&config_path) else {
+        return false;
+    };
+    let mut in_core = false;
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') {
+            in_core = trimmed.eq_ignore_ascii_case("[core]");
+            continue;
+        }
+        if in_core {
+            if let Some((k, v)) = trimmed.split_once('=') {
+                if k.trim().eq_ignore_ascii_case("ignorecase") {
+                    return parse_bool(v.trim());
+                }
+            }
+        }
+    }
+    false
+}
+
+fn fold_case_git_path(s: &str) -> String {
+    s.to_ascii_lowercase()
+}
+
+fn check_casefolding_conflict(
+    proposed_abs: &Path,
+    submodule_name: &str,
+    suffixes_match: bool,
+    taken_folded: &HashSet<String>,
+) -> bool {
+    let last = last_modules_segment(proposed_abs).unwrap_or_default();
+    let folded_last = fold_case_git_path(&last);
+    let folded_name = fold_case_git_path(submodule_name);
+    if suffixes_match {
+        taken_folded.contains(&folded_last)
+    } else {
+        taken_folded.contains(&folded_name) || taken_folded.contains(&folded_last)
+    }
+}
+
+/// Validates a legacy submodule gitdir path (extension disabled): name suffix and no nesting clash.
+pub fn validate_legacy_submodule_git_dir(git_dir: &Path, submodule_name: &str) -> Result<()> {
+    let gd = git_dir.to_string_lossy();
+    let suffix = submodule_name;
+    if gd.len() <= suffix.len() {
+        return Err(Error::ConfigError(
+            "submodule name not a suffix of git dir".into(),
+        ));
+    }
+    let cut = gd.len() - suffix.len();
+    if gd
+        .as_bytes()
+        .get(cut.wrapping_sub(1))
+        .is_none_or(|&b| b != b'/')
+    {
+        return Err(Error::ConfigError(
+            "submodule name not a suffix of git dir".into(),
+        ));
+    }
+    if &gd[cut..] != suffix {
+        return Err(Error::ConfigError(
+            "submodule name not a suffix of git dir".into(),
+        ));
+    }
+    if path_inside_other_gitdir(git_dir, submodule_name) {
+        return Err(Error::ConfigError(
+            "submodule git dir inside another submodule git dir".into(),
+        ));
+    }
+    Ok(())
+}
+
+/// Validates an encoded submodule gitdir path when `submodulePathConfig` is enabled.
+pub fn validate_encoded_submodule_git_dir(
+    work_tree: &Path,
+    cfg: &ConfigFile,
+    git_dir: &Path,
+    submodule_name: &str,
+    super_git_dir: &Path,
+) -> Result<()> {
+    let last = last_modules_segment(git_dir)
+        .ok_or_else(|| Error::ConfigError("submodule gitdir missing /modules/ segment".into()))?;
+    if last.contains('/') {
+        return Err(Error::ConfigError(
+            "encoded submodule gitdir must not contain '/' in module segment".into(),
+        ));
+    }
+    if is_git_directory(git_dir)
+        && gitdir_conflicts_with_existing(work_tree, cfg, git_dir, submodule_name)?
+    {
+        return Err(Error::ConfigError(
+            "submodule gitdir conflicts with existing".into(),
+        ));
+    }
+    if cfg!(unix) && ignore_case_from_config(super_git_dir) {
+        let mut taken: HashSet<String> = HashSet::new();
+        let suffix = ".gitdir";
+        for e in &cfg.entries {
+            if !e.key.starts_with("submodule.") || !e.key.ends_with(suffix) {
+                continue;
+            }
+            let inner = &e.key["submodule.".len()..e.key.len() - suffix.len()];
+            if inner == submodule_name {
+                continue;
+            }
+            if let Some(v) = e.value.as_deref() {
+                let abs = canonical_abs(&resolve_gitdir_value(work_tree, v));
+                if let Some(seg) = last_modules_segment(&abs) {
+                    taken.insert(fold_case_git_path(&seg));
+                }
+            }
+        }
+        let suffixes_match = last == submodule_name;
+        if check_casefolding_conflict(git_dir, submodule_name, suffixes_match, &taken) {
+            return Err(Error::ConfigError(
+                "case-folding conflict for submodule gitdir".into(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn repo_git_path_append(git_dir: &Path, tail: &str) -> PathBuf {
+    let mut buf = git_dir.to_path_buf();
+    if !tail.is_empty() {
+        buf.push(tail);
+    }
+    buf
+}
+
+/// Returns the 40-character hex SHA-1 of a blob object for `data` (same as `git hash-object`).
+pub fn hash_blob_sha1_hex(data: &[u8]) -> String {
+    let header = format!("blob {}\0", data.len());
+    let mut hasher = Sha1::new();
+    hasher.update(header.as_bytes());
+    hasher.update(data);
+    hex::encode(hasher.finalize())
+}
+
+/// Computes `submodule.<name>.gitdir` as a path relative to the work tree when not already set.
+pub fn compute_default_submodule_gitdir(
+    work_tree: &Path,
+    git_dir: &Path,
+    cfg: &ConfigFile,
+    submodule_name: &str,
+) -> Result<String> {
+    let key = format!("submodule.{submodule_name}.gitdir");
+    for e in &cfg.entries {
+        if e.key == key {
+            if let Some(v) = e.value.as_deref() {
+                return Ok(v.to_string());
+            }
+        }
+    }
+
+    let try_set = |rel_under_git: &str| -> Option<String> {
+        let abs = repo_git_path_append(git_dir, rel_under_git);
+        if validate_encoded_submodule_git_dir(work_tree, cfg, &abs, submodule_name, git_dir)
+            .is_err()
+        {
+            return None;
+        }
+        Some(format!(".git/{}", rel_under_git.replace('\\', "/")))
+    };
+
+    // Plain `modules/<name>` only when `name` has no directory separators: `PathBuf::push`
+    // splits on `/`, so e.g. `nested/sub` would become `modules/nested/sub` and the encoded
+    // validation rejects a multi-level tail under `modules/`.
+    let rel_plain = format!("modules/{}", submodule_name.replace('\\', "/"));
+    if !submodule_name.contains('/') && !submodule_name.contains('\\') {
+        if let Some(v) = try_set(&rel_plain) {
+            return Ok(v);
+        }
+    }
+
+    let enc = percent_encode(submodule_name, is_rfc3986_unreserved);
+    let rel_enc = format!("modules/{enc}");
+    if let Some(v) = try_set(&rel_enc) {
+        return Ok(v);
+    }
+
+    let enc_cf = percent_encode(submodule_name, is_casefolding_rfc3986_unreserved);
+    let rel_cf = format!("modules/{enc_cf}");
+    if let Some(v) = try_set(&rel_cf) {
+        return Ok(v);
+    }
+
+    for c in b'0'..=b'9' {
+        let rel = format!("modules/{}{}", enc, c as char);
+        if let Some(v) = try_set(&rel) {
+            return Ok(v);
+        }
+        let rel2 = format!("modules/{}{}", enc_cf, c as char);
+        if let Some(v) = try_set(&rel2) {
+            return Ok(v);
+        }
+    }
+
+    let hex = hash_blob_sha1_hex(submodule_name.as_bytes());
+    let rel_h = format!("modules/{hex}");
+    if let Some(v) = try_set(&rel_h) {
+        return Ok(v);
+    }
+
+    Err(Error::ConfigError(
+        "failed to allocate submodule gitdir path".into(),
+    ))
+}
+
+/// Ensures `submodule.<name>.gitdir` exists, writing it via [`compute_default_submodule_gitdir`] if needed.
+pub fn ensure_submodule_gitdir_config(
+    work_tree: &Path,
+    git_dir: &Path,
+    cfg: &mut ConfigFile,
+    submodule_name: &str,
+) -> Result<String> {
+    let key = format!("submodule.{submodule_name}.gitdir");
+    if let Some(existing) = cfg.entries.iter().find(|e| e.key == key) {
+        if let Some(v) = existing.value.as_deref() {
+            return Ok(v.to_string());
+        }
+    }
+    let value = compute_default_submodule_gitdir(work_tree, git_dir, cfg, submodule_name)?;
+    cfg.set(&key, &value)?;
+    cfg.write()?;
+    Ok(value)
+}
+
+/// Resolves the absolute filesystem path of a submodule's git directory.
+pub fn submodule_gitdir_filesystem_path(
+    work_tree: &Path,
+    git_dir: &Path,
+    cfg: &ConfigFile,
+    submodule_name: &str,
+) -> Result<PathBuf> {
+    if submodule_path_config_enabled(git_dir) {
+        let key = format!("submodule.{submodule_name}.gitdir");
+        let value = cfg
+            .entries
+            .iter()
+            .find(|e| e.key == key)
+            .and_then(|e| e.value.clone())
+            .ok_or_else(|| {
+                Error::ConfigError(format!(
+                    "submodule.{submodule_name}.gitdir is not set (submodulePathConfig enabled)"
+                ))
+            })?;
+        Ok(resolve_gitdir_value(work_tree, &value))
+    } else {
+        Ok(git_dir.join("modules").join(submodule_name))
+    }
+}
+
+/// Migrates legacy submodule dirs under `.git/modules/`: sets `submodule.*.gitdir` and enables the extension.
+pub fn migrate_gitdir_configs(work_tree: &Path, git_dir: &Path) -> Result<()> {
+    let modules_root = git_dir.join("modules");
+    if !modules_root.is_dir() {
+        return Ok(());
+    }
+
+    let config_path = git_dir.join("config");
+    let content = fs::read_to_string(&config_path).map_err(Error::Io)?;
+    let mut cfg = ConfigFile::parse(&config_path, &content, ConfigScope::Local)?;
+
+    for entry in fs::read_dir(&modules_root).map_err(Error::Io)? {
+        let entry = entry.map_err(Error::Io)?;
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if name_str == "." || name_str == ".." {
+            continue;
+        }
+        let gd_path = modules_root.join(&name);
+        if !is_git_directory(&gd_path) {
+            continue;
+        }
+        let key = format!("submodule.{name_str}.gitdir");
+        if cfg.entries.iter().any(|e| e.key == key) {
+            continue;
+        }
+        let _ = ensure_submodule_gitdir_config(work_tree, git_dir, &mut cfg, &name_str)?;
+    }
+
+    let mut repo_version = 0u32;
+    if let Some(v) = cfg
+        .entries
+        .iter()
+        .find(|e| e.key == "core.repositoryformatversion")
+    {
+        if let Some(s) = v.value.as_deref() {
+            repo_version = s.parse().unwrap_or(0);
+        }
+    }
+    if repo_version == 0 {
+        cfg.set("core.repositoryformatversion", "1")?;
+    }
+    cfg.set("extensions.submodulePathConfig", "true")?;
+    cfg.write()?;
+    Ok(())
+}
+
+/// Returns true if `new_path` is strictly inside a gitlink path recorded in `index` (stage 0).
+pub fn path_inside_indexed_submodule(index: &Index, new_path: &str) -> bool {
+    let new_norm = new_path.replace('\\', "/");
+    for e in &index.entries {
+        if e.mode != 0o160000 || e.stage() != 0 {
+            continue;
+        }
+        let ce = String::from_utf8_lossy(&e.path).replace('\\', "/");
+        let ce_len = ce.len();
+        if new_norm.len() <= ce_len {
+            continue;
+        }
+        if new_norm.as_bytes().get(ce_len) != Some(&b'/') {
+            continue;
+        }
+        if !new_norm.starts_with(&ce) {
+            continue;
+        }
+        if new_norm.len() == ce_len + 1 {
+            continue;
+        }
+        return true;
+    }
+    false
+}
+
+/// Returns true if `new_path` is under a submodule path declared in `.gitmodules`.
+pub fn path_inside_registered_submodule(work_tree: &Path, new_path: &str) -> bool {
+    let gitmodules = work_tree.join(".gitmodules");
+    let Ok(content) = fs::read_to_string(&gitmodules) else {
+        return false;
+    };
+    let Ok(mf) = ConfigFile::parse(&gitmodules, &content, ConfigScope::Local) else {
+        return false;
+    };
+    let mut paths: Vec<String> = Vec::new();
+    for e in &mf.entries {
+        if e.key.starts_with("submodule.") && e.key.ends_with(".path") {
+            if let Some(p) = e.value.as_deref() {
+                paths.push(p.replace('\\', "/"));
+            }
+        }
+    }
+    let new_norm = new_path.replace('\\', "/");
+    for p in paths {
+        if new_norm == p || new_norm.starts_with(&format!("{p}/")) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Fails when `submodulePathConfig` is off and `new_path` would nest inside an existing submodule.
+///
+/// `index` is optional; when set, checked gitlinks match Git's `die_path_inside_submodule`.
+pub fn die_path_inside_submodule_when_disabled(
+    git_dir: &Path,
+    work_tree: &Path,
+    new_path: &str,
+    index: Option<&Index>,
+) -> Result<()> {
+    if submodule_path_config_enabled(git_dir) {
+        return Ok(());
+    }
+    if path_inside_registered_submodule(work_tree, new_path) {
+        return Err(Error::ConfigError(
+            "cannot add submodule: path inside existing submodule".into(),
+        ));
+    }
+    if let Some(ix) = index {
+        if path_inside_indexed_submodule(ix, new_path) {
+            return Err(Error::ConfigError(
+                "cannot add submodule: path inside existing submodule".into(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Sets `core.worktree` in the submodule repo at `modules_dir` via `grit --git-dir`.
+pub fn set_submodule_repo_worktree(grit_bin: &Path, modules_dir: &Path, sub_worktree: &Path) {
+    let _ = std::process::Command::new(grit_bin)
+        .arg("--git-dir")
+        .arg(modules_dir)
+        .arg("config")
+        .arg("core.worktree")
+        .arg(sub_worktree)
+        .status();
+}
+
+/// Writes `sub_worktree/.git` as a gitfile pointing at `modules_dir` (relative when possible).
+pub fn write_submodule_gitfile(sub_worktree: &Path, modules_dir: &Path) -> Result<()> {
+    let rel = pathdiff_relative(sub_worktree, modules_dir);
+    let line = format!("gitdir: {rel}\n");
+    fs::write(sub_worktree.join(".git"), line).map_err(Error::Io)?;
+    Ok(())
+}
+
+fn pathdiff_relative(from: &Path, to: &Path) -> String {
+    let from_c = fs::canonicalize(from).unwrap_or_else(|_| from.to_path_buf());
+    let to_c = fs::canonicalize(to).unwrap_or_else(|_| to.to_path_buf());
+    let from_comp: Vec<Component<'_>> = from_c.components().collect();
+    let to_comp: Vec<Component<'_>> = to_c.components().collect();
+    let mut i = 0usize;
+    while i < from_comp.len() && i < to_comp.len() && from_comp[i] == to_comp[i] {
+        i += 1;
+    }
+    let mut out = PathBuf::new();
+    for _ in i..from_comp.len() {
+        out.push("..");
+    }
+    for c in &to_comp[i..] {
+        out.push(c.as_os_str());
+    }
+    out.to_string_lossy().replace('\\', "/")
+}
+
+/// Writes the gitfile and `core.worktree` for a submodule using configured `submodule.<name>.gitdir`.
+pub fn connect_submodule_work_tree_and_git_dir(
+    grit_bin: &Path,
+    work_tree: &Path,
+    super_git_dir: &Path,
+    cfg: &ConfigFile,
+    submodule_name: &str,
+    sub_worktree: &Path,
+) -> Result<()> {
+    let modules_dir =
+        submodule_gitdir_filesystem_path(work_tree, super_git_dir, cfg, submodule_name)?;
+    write_submodule_gitfile(sub_worktree, &modules_dir)?;
+    set_submodule_repo_worktree(grit_bin, &modules_dir, sub_worktree);
+    Ok(())
+}
+
+/// If `modules_dir/HEAD` is missing, sets it to `oid_hex` when that commit exists in `objects/`.
+pub fn init_submodule_head_from_gitlink(modules_dir: &Path, oid_hex: &str) -> Result<()> {
+    let head = modules_dir.join("HEAD");
+    if head.exists() {
+        return Ok(());
+    }
+    let obj_dir = modules_dir.join("objects");
+    if !obj_dir.is_dir() {
+        return Ok(());
+    }
+    let odb = Odb::new(&obj_dir);
+    let oid = ObjectId::from_hex(oid_hex)?;
+    let obj = odb.read(&oid)?;
+    if obj.kind != ObjectKind::Commit {
+        return Ok(());
+    }
+    fs::write(&head, format!("{oid_hex}\n")).map_err(Error::Io)?;
+    Ok(())
+}

--- a/grit/src/commands/clone.rs
+++ b/grit/src/commands/clone.rs
@@ -5,9 +5,13 @@
 
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
-use grit_lib::config::{ConfigFile, ConfigScope};
+use grit_lib::config::{ConfigFile, ConfigScope, ConfigSet};
 use grit_lib::objects::{parse_commit, parse_tag, parse_tree, ObjectId, ObjectKind};
 use grit_lib::repo::{init_repository, init_repository_separate_git_dir, Repository};
+use grit_lib::submodule_gitdir::{
+    connect_submodule_work_tree_and_git_dir, ensure_submodule_gitdir_config,
+    set_submodule_repo_worktree, submodule_path_config_enabled, write_submodule_gitfile,
+};
 use std::collections::{HashSet, VecDeque};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -69,6 +73,10 @@ pub struct Args {
     /// Recurse into submodules after cloning.
     #[arg(long = "recurse-submodules", alias = "recursive")]
     pub recurse_submodules: bool,
+
+    /// Number of parallel jobs for submodule cloning (local transport).
+    #[arg(short = 'j', long = "jobs", value_name = "N", default_value = "1")]
+    pub jobs: usize,
 
     /// Use remote-tracking branch for submodules.
     #[arg(long = "remote-submodules")]
@@ -294,7 +302,7 @@ pub fn run(args: Args) -> Result<()> {
     fs::create_dir_all(&target_path)
         .with_context(|| format!("cannot create directory '{}'", target_path.display()))?;
 
-    let template_dir = args.template.as_ref().map(|s| PathBuf::from(s));
+    let template_dir = args.template.as_ref().map(PathBuf::from);
 
     let dest = if let Some(ref sep_git) = args.separate_git_dir {
         if sep_git.exists() && sep_git.read_dir()?.next().is_some() {
@@ -434,6 +442,8 @@ pub fn run(args: Args) -> Result<()> {
         apply_clone_config(&dest.git_dir, &args.config).context("applying -c config")?;
     }
 
+    maybe_inherit_default_submodule_path_config(&dest.git_dir)?;
+
     // Handle --no-tags: set remote.origin.tagOpt
     if args.no_tags {
         let config_path = dest.git_dir.join("config");
@@ -471,7 +481,8 @@ pub fn run(args: Args) -> Result<()> {
     // Recurse into submodules if requested
     if args.recurse_submodules && !args.bare {
         if let Some(ref wt) = dest.work_tree {
-            clone_submodules(wt, &dest, args.quiet).context("cloning submodules")?;
+            clone_submodules(wt, &dest, &source_path, args.jobs.max(1), args.quiet)
+                .context("cloning submodules")?;
         }
     }
 
@@ -527,109 +538,231 @@ fn run_ssh_clone(args: Args) -> Result<()> {
     Ok(())
 }
 
-/// Clone submodules listed in .gitmodules.
-///
-/// Reads `.gitmodules` from the work tree, resolves each submodule's URL
-/// (relative paths are resolved against the parent repo's remote URL),
-/// and uses `grit clone` to clone each submodule.
-fn clone_submodules(work_tree: &Path, repo: &Repository, quiet: bool) -> Result<()> {
+fn clone_bool(s: &str) -> bool {
+    matches!(s.to_ascii_lowercase().as_str(), "true" | "yes" | "on" | "1")
+}
+
+/// If `init.defaultSubmodulePathConfig` is set in the environment, enable the extension in the new repo.
+fn maybe_inherit_default_submodule_path_config(git_dir: &Path) -> Result<()> {
+    let cfg = ConfigSet::load(Some(git_dir), true).unwrap_or_default();
+    let Some(v) = cfg.get("init.defaultSubmodulePathConfig") else {
+        return Ok(());
+    };
+    if !clone_bool(&v) {
+        return Ok(());
+    }
+    let config_path = git_dir.join("config");
+    let content = fs::read_to_string(&config_path).unwrap_or_default();
+    let mut c = ConfigFile::parse(&config_path, &content, ConfigScope::Local)?;
+    c.set("core.repositoryformatversion", "1")?;
+    c.set("extensions.submodulePathConfig", "true")?;
+    c.write().context("writing submodulePathConfig")?;
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct CloneSubmoduleTask {
+    name: String,
+    path: String,
+    url: String,
+}
+
+/// Clone submodules listed in `.gitmodules` (name, path, url), with Git-compatible URL resolution.
+fn clone_submodules(
+    work_tree: &Path,
+    repo: &Repository,
+    source_repo_path: &Path,
+    jobs: usize,
+    quiet: bool,
+) -> Result<()> {
     let gitmodules_path = work_tree.join(".gitmodules");
     if !gitmodules_path.exists() {
         return Ok(());
     }
 
     let content = fs::read_to_string(&gitmodules_path).context("reading .gitmodules")?;
+    let gitmodules_file = ConfigFile::parse(&gitmodules_path, &content, ConfigScope::Local)?;
 
-    // Simple parser for .gitmodules
-    let mut submodules: Vec<(String, String)> = Vec::new(); // (path, url)
-    let mut current_path: Option<String> = None;
-    let mut current_url: Option<String> = None;
-
-    for line in content.lines() {
-        let trimmed = line.trim();
-        if trimmed.starts_with('[') {
-            // Flush previous
-            if let (Some(p), Some(u)) = (current_path.take(), current_url.take()) {
-                submodules.push((p, u));
-            }
+    let mut by_name: std::collections::BTreeMap<String, (Option<String>, Option<String>)> =
+        std::collections::BTreeMap::new();
+    for e in &gitmodules_file.entries {
+        let key = &e.key;
+        if !key.starts_with("submodule.") {
             continue;
         }
-        if let Some(val) = trimmed
-            .strip_prefix("path = ")
-            .or_else(|| trimmed.strip_prefix("path="))
-        {
-            current_path = Some(val.trim().to_string());
+        let rest = &key["submodule.".len()..];
+        if let Some(last_dot) = rest.rfind('.') {
+            let name = &rest[..last_dot];
+            let var = &rest[last_dot + 1..];
+            let slot = by_name.entry(name.to_string()).or_insert((None, None));
+            match var {
+                "path" => slot.0 = e.value.clone(),
+                "url" => slot.1 = e.value.clone(),
+                _ => {}
+            }
         }
-        if let Some(val) = trimmed
-            .strip_prefix("url = ")
-            .or_else(|| trimmed.strip_prefix("url="))
-        {
-            current_url = Some(val.trim().to_string());
-        }
-    }
-    if let (Some(p), Some(u)) = (current_path.take(), current_url.take()) {
-        submodules.push((p, u));
     }
 
-    // Get the parent's remote URL to resolve relative submodule URLs
-    let parent_url = {
-        let config_path = repo.git_dir.join("config");
-        let config_content = fs::read_to_string(&config_path).unwrap_or_default();
-        extract_remote_url(&config_content, "origin")
-    };
+    let mut tasks: Vec<CloneSubmoduleTask> = Vec::new();
+    for (name, (path, url)) in by_name {
+        if let (Some(path), Some(url)) = (path, url) {
+            tasks.push(CloneSubmoduleTask { name, path, url });
+        }
+    }
+
+    let config_path = repo.git_dir.join("config");
+    let config_content = fs::read_to_string(&config_path).unwrap_or_default();
+    let origin_url = extract_remote_url(&config_content, "origin");
 
     let grit_bin = crate::grit_exe::grit_executable();
+    let _jobs = jobs.max(1);
 
-    for (path, url) in &submodules {
-        let sub_dest = work_tree.join(path);
-
-        // Resolve relative URLs
-        let resolved_url = if url.starts_with("./") || url.starts_with("../") {
-            if let Some(ref parent) = parent_url {
-                let base = PathBuf::from(parent);
-                let resolved = base.parent().unwrap_or(&base).join(url);
-                resolved.to_string_lossy().to_string()
-            } else {
-                url.clone()
-            }
-        } else {
-            url.clone()
-        };
+    let run_one = |task: CloneSubmoduleTask| -> Result<()> {
+        let sub_dest = work_tree.join(&task.path);
+        let resolved_url = resolve_submodule_clone_url(
+            work_tree,
+            source_repo_path,
+            origin_url.as_deref(),
+            &task.url,
+        )?;
 
         if !quiet {
             eprintln!("Cloning into '{}'...", sub_dest.display());
         }
 
-        // Remove the placeholder directory if it exists
         if sub_dest.exists() {
             let _ = fs::remove_dir_all(&sub_dest);
+        }
+
+        let mut local_cfg = match ConfigFile::from_path(&config_path, ConfigScope::Local)? {
+            Some(c) => c,
+            None => ConfigFile::parse(&config_path, &config_content, ConfigScope::Local)?,
+        };
+        local_cfg.set(&format!("submodule.{}.url", task.name), &task.url)?;
+        local_cfg.set(&format!("submodule.{}.active", task.name), "true")?;
+
+        let modules_fs = if submodule_path_config_enabled(&repo.git_dir) {
+            let rel = ensure_submodule_gitdir_config(
+                work_tree,
+                &repo.git_dir,
+                &mut local_cfg,
+                &task.name,
+            )
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+            work_tree.join(rel)
+        } else {
+            repo.git_dir.join("modules").join(&task.name)
+        };
+
+        if let Some(parent) = modules_fs.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        if modules_fs.exists() {
+            let _ = fs::remove_dir_all(&modules_fs);
         }
 
         let mut cmd = std::process::Command::new(&grit_bin);
         cmd.arg("clone")
             .arg("-c")
             .arg("protocol.file.allow=always")
+            .arg("--no-checkout")
+            .arg("--separate-git-dir")
+            .arg(&modules_fs)
             .arg(&resolved_url)
-            .arg(&sub_dest);
+            .arg(&sub_dest)
+            .current_dir(work_tree);
         if quiet {
             cmd.arg("-q");
         }
 
         let status = cmd
             .status()
-            .with_context(|| format!("failed to clone submodule '{}'", path))?;
+            .with_context(|| format!("failed to clone submodule '{}'", task.path))?;
 
         if !status.success() {
-            eprintln!("warning: failed to clone submodule '{}'", path);
             anyhow::bail!(
                 "clone of '{}' into submodule path '{}' failed",
                 resolved_url,
                 sub_dest.display()
             );
         }
-    }
 
+        if submodule_path_config_enabled(&repo.git_dir) {
+            local_cfg = match ConfigFile::from_path(&config_path, ConfigScope::Local)? {
+                Some(c) => c,
+                None => ConfigFile::parse(&config_path, &config_content, ConfigScope::Local)?,
+            };
+            connect_submodule_work_tree_and_git_dir(
+                &grit_bin,
+                work_tree,
+                &repo.git_dir,
+                &local_cfg,
+                &task.name,
+                &sub_dest,
+            )
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        } else {
+            write_submodule_gitfile(&sub_dest, &modules_fs).map_err(|e| anyhow::anyhow!("{e}"))?;
+            set_submodule_repo_worktree(&grit_bin, &modules_fs, &sub_dest);
+        }
+
+        let gitlink_oid = {
+            let index = repo
+                .load_index()
+                .with_context(|| format!("load index for submodule '{}'", task.path))?;
+            let path_bytes = task.path.as_bytes();
+            index
+                .get(path_bytes, 0)
+                .filter(|ie| ie.mode == 0o160000)
+                .map(|ie| ie.oid.to_hex())
+        };
+        if let Some(oid) = gitlink_oid {
+            let co = std::process::Command::new(&grit_bin)
+                .arg("checkout")
+                .arg("-q")
+                .arg(&oid)
+                .current_dir(&sub_dest)
+                .status()
+                .with_context(|| format!("checkout submodule '{}'", task.path))?;
+            if !co.success() {
+                anyhow::bail!("failed to checkout {} in submodule '{}'", oid, task.path);
+            }
+        }
+
+        local_cfg.write().context("writing submodule config")?;
+        Ok(())
+    };
+
+    for t in tasks {
+        run_one(t)?;
+    }
     Ok(())
+}
+
+fn resolve_submodule_clone_url(
+    work_tree: &Path,
+    source_repo_path: &Path,
+    origin_url: Option<&str>,
+    url: &str,
+) -> Result<String> {
+    if url.starts_with("./") || url.starts_with("../") {
+        let base = if origin_url.is_some_and(|u| u.starts_with("./") || u.starts_with("../")) {
+            work_tree
+        } else {
+            source_repo_path
+        };
+        let joined = base.join(url);
+        let canon = joined
+            .canonicalize()
+            .with_context(|| format!("cannot resolve submodule URL '{}'", url))?;
+        return Ok(canon.to_string_lossy().into_owned());
+    }
+    if let Some(ou) = origin_url {
+        if let Ok(u) = crate::git_path::relative_url(ou, url, None) {
+            return Ok(u);
+        }
+    }
+    Ok(url.to_string())
 }
 
 /// Extract a remote URL from config content.
@@ -690,9 +823,16 @@ fn open_source_repo(path: &Path) -> Result<Repository> {
     if let Ok(repo) = Repository::open(path, None) {
         return Ok(repo);
     }
-    // Try path/.git for non-bare repos
-    let git_dir = path.join(".git");
-    Repository::open(&git_dir, Some(path)).map_err(Into::into)
+    // Non-bare: `.git` may be a directory or a gitfile (submodule work trees).
+    let dot_git = path.join(".git");
+    if dot_git.exists() {
+        let resolved = grit_lib::repo::resolve_dot_git(&dot_git)?;
+        return Repository::open(&resolved, Some(path)).map_err(Into::into);
+    }
+    Err(anyhow::anyhow!(
+        "'{}' does not appear to be a git repository",
+        path.display()
+    ))
 }
 
 /// Write an alternates file pointing to the source and reference repos' object stores.

--- a/grit/src/commands/init.rs
+++ b/grit/src/commands/init.rs
@@ -5,7 +5,7 @@ use clap::Args as ClapArgs;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use grit_lib::config::ConfigSet;
+use grit_lib::config::{ConfigFile, ConfigScope, ConfigSet};
 
 /// `guess_repository_type` from git/builtin/init-db.c (used when `--bare` was not passed).
 fn guess_repository_type(git_dir: &Path, cwd: &Path, raw_git_dir_env: Option<&str>) -> bool {
@@ -333,6 +333,21 @@ pub fn run(args: Args, global_bare: bool) -> Result<()> {
         ref_format,
         work_tree_abs.as_deref(),
     )?;
+
+    if !is_reinit
+        && !bare
+        && config
+            .get("init.defaultSubmodulePathConfig")
+            .as_deref()
+            .is_some_and(|v| matches!(v.to_ascii_lowercase().as_str(), "true" | "yes" | "on" | "1"))
+    {
+        let config_path = real_git_dir.join("config");
+        let content = fs::read_to_string(&config_path).unwrap_or_default();
+        let mut cfg = ConfigFile::parse(&config_path, &content, ConfigScope::Local)?;
+        cfg.set("core.repositoryformatversion", "1")?;
+        cfg.set("extensions.submodulePathConfig", "true")?;
+        cfg.write()?;
+    }
 
     // Handle --separate-git-dir: write gitfile at path/.git
     if args.separate_git_dir.is_some() && !bare {

--- a/grit/src/commands/mod.rs
+++ b/grit/src/commands/mod.rs
@@ -132,6 +132,7 @@ pub mod stash;
 pub mod status;
 pub mod stripspace;
 pub mod submodule;
+pub mod submodule_helper;
 pub mod switch;
 pub mod symbolic_ref;
 pub mod tag;

--- a/grit/src/commands/submodule.rs
+++ b/grit/src/commands/submodule.rs
@@ -10,6 +10,12 @@ use grit_lib::config::{ConfigFile, ConfigScope};
 use grit_lib::objects::{parse_commit, parse_tree, ObjectKind};
 use grit_lib::repo::Repository;
 use grit_lib::state::resolve_head;
+use grit_lib::submodule_gitdir::{
+    connect_submodule_work_tree_and_git_dir, die_path_inside_submodule_when_disabled,
+    ensure_submodule_gitdir_config, init_submodule_head_from_gitlink, set_submodule_repo_worktree,
+    submodule_gitdir_filesystem_path, submodule_path_config_enabled,
+    validate_legacy_submodule_git_dir, write_submodule_gitfile,
+};
 use std::collections::BTreeMap;
 use std::fs;
 use std::io::{self, Write};
@@ -284,6 +290,34 @@ fn parse_gitmodules_with_repo(
 }
 
 /// Filter submodules by path args (empty = all).
+fn load_local_config(git_dir: &Path) -> Result<ConfigFile> {
+    let config_path = git_dir.join("config");
+    if config_path.exists() {
+        let content = fs::read_to_string(&config_path)?;
+        Ok(ConfigFile::parse(
+            &config_path,
+            &content,
+            ConfigScope::Local,
+        )?)
+    } else {
+        Ok(ConfigFile::parse(&config_path, "", ConfigScope::Local)?)
+    }
+}
+
+fn submodule_modules_dir(
+    work_tree: &Path,
+    git_dir: &Path,
+    cfg: &mut ConfigFile,
+    submodule_name: &str,
+) -> Result<PathBuf> {
+    if submodule_path_config_enabled(git_dir) {
+        let rel = ensure_submodule_gitdir_config(work_tree, git_dir, cfg, submodule_name)?;
+        Ok(work_tree.join(rel))
+    } else {
+        Ok(git_dir.join("modules").join(submodule_name))
+    }
+}
+
 fn filter_submodules<'a>(modules: &'a [SubmoduleInfo], paths: &[String]) -> Vec<&'a SubmoduleInfo> {
     if paths.is_empty() {
         modules.iter().collect()
@@ -350,6 +384,7 @@ fn run_status(args: &StatusArgs) -> Result<()> {
     let work_tree = repo.work_tree.as_ref().context("bare repository")?;
     let modules = parse_gitmodules(work_tree)?;
     let selected = filter_submodules(&modules, &args.paths);
+    let local_cfg = load_local_config(&repo.git_dir)?;
 
     let stdout = io::stdout();
     let mut out = stdout.lock();
@@ -373,10 +408,19 @@ fn run_status(args: &StatusArgs) -> Result<()> {
             let sub_head = if head_file.exists() {
                 read_submodule_head(&sub_path)
             } else {
-                // gitfile indirection: check .git/modules/<name>/HEAD
-                let modules_head = repo.git_dir.join("modules").join(&m.name).join("HEAD");
-                if modules_head.exists() {
-                    read_head_from_file(&modules_head)
+                let modules_head = if submodule_path_config_enabled(&repo.git_dir) {
+                    submodule_gitdir_filesystem_path(work_tree, &repo.git_dir, &local_cfg, &m.name)
+                        .ok()
+                        .map(|p| p.join("HEAD"))
+                } else {
+                    Some(repo.git_dir.join("modules").join(&m.name).join("HEAD"))
+                };
+                if let Some(p) = modules_head {
+                    if p.exists() {
+                        read_head_from_file(&p)
+                    } else {
+                        None
+                    }
                 } else {
                     None
                 }
@@ -496,6 +540,7 @@ fn run_update(args: &UpdateArgs) -> Result<()> {
     let selected = filter_submodules(&modules, &args.paths);
 
     let grit_bin = grit_exe::grit_executable();
+    let mut local_cfg = load_local_config(&repo.git_dir)?;
 
     for m in &selected {
         let sub_path = work_tree.join(&m.path);
@@ -524,7 +569,7 @@ fn run_update(args: &UpdateArgs) -> Result<()> {
             }
         }
 
-        let modules_dir = repo.git_dir.join("modules").join(&m.name);
+        let modules_dir = submodule_modules_dir(work_tree, &repo.git_dir, &mut local_cfg, &m.name)?;
 
         let needs_clone = if sub_path.exists() {
             // Directory exists but might be empty (from superproject clone).
@@ -606,7 +651,22 @@ fn run_update(args: &UpdateArgs) -> Result<()> {
                     eprintln!("error: failed to clone submodule from '{}'", clone_url);
                     bail!("failed to clone submodule '{}'", m.name);
                 }
+                if submodule_path_config_enabled(&repo.git_dir) {
+                    local_cfg = load_local_config(&repo.git_dir)?;
+                    connect_submodule_work_tree_and_git_dir(
+                        &grit_bin,
+                        work_tree,
+                        &repo.git_dir,
+                        &local_cfg,
+                        &m.name,
+                        &sub_path,
+                    )?;
+                }
             }
+        }
+
+        if submodule_path_config_enabled(&repo.git_dir) {
+            let _ = init_submodule_head_from_gitlink(&modules_dir, recorded_oid);
         }
 
         // Determine which commit to checkout.
@@ -713,15 +773,8 @@ fn attach_existing_submodule_worktree(
     if !sub_path.exists() {
         fs::create_dir_all(sub_path)?;
     }
-    let gitfile = sub_path.join(".git");
-    fs::write(&gitfile, format!("gitdir: {}\n", modules_dir.display()))?;
-    let _ = Command::new(grit_bin)
-        .arg("--git-dir")
-        .arg(modules_dir)
-        .arg("config")
-        .arg("core.worktree")
-        .arg(sub_path)
-        .status();
+    write_submodule_gitfile(sub_path, modules_dir)?;
+    set_submodule_repo_worktree(grit_bin, modules_dir, sub_path);
     Ok(())
 }
 
@@ -744,9 +797,19 @@ fn run_add(args: &AddArgs) -> Result<()> {
         }
     };
 
+    let head_index = repo.load_index().ok();
+    die_path_inside_submodule_when_disabled(&repo.git_dir, work_tree, &path, head_index.as_ref())
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    let name = args.name.as_deref().unwrap_or(&path).to_string();
+    if !submodule_path_config_enabled(&repo.git_dir) {
+        let would_be = repo.git_dir.join("modules").join(&name);
+        validate_legacy_submodule_git_dir(&would_be, &name).map_err(|e| anyhow::anyhow!("{e}"))?;
+    }
     let sub_path = work_tree.join(&path);
 
     let grit_bin = grit_exe::grit_executable();
+    let mut local_cfg = load_local_config(&repo.git_dir)?;
 
     if sub_path.exists() {
         // If the path already exists and is a valid git repo, treat it like
@@ -756,9 +819,51 @@ fn run_add(args: &AddArgs) -> Result<()> {
             bail!("'{}' already exists and is not a git repository", path);
         }
         eprintln!("Adding existing repo at '{}' to the index", path);
+        if submodule_path_config_enabled(&repo.git_dir) {
+            let dot_git = sub_path.join(".git");
+            let modules_dir =
+                submodule_modules_dir(work_tree, &repo.git_dir, &mut local_cfg, &name)?;
+            if dot_git.is_dir() {
+                if !modules_dir.exists() {
+                    if let Some(parent) = modules_dir.parent() {
+                        fs::create_dir_all(parent)?;
+                    }
+                    fs::rename(&dot_git, &modules_dir)
+                        .context("failed to relocate submodule .git")?;
+                    let moved_config_path = modules_dir.join("config");
+                    if moved_config_path.exists() {
+                        let content = fs::read_to_string(&moved_config_path)?;
+                        let mut cfg =
+                            ConfigFile::parse(&moved_config_path, &content, ConfigScope::Local)?;
+                        let relative_worktree = pathdiff_relative(&modules_dir, &sub_path);
+                        cfg.set("core.worktree", &relative_worktree)?;
+                        cfg.write()?;
+                    }
+                }
+                local_cfg = load_local_config(&repo.git_dir)?;
+                connect_submodule_work_tree_and_git_dir(
+                    &grit_bin,
+                    work_tree,
+                    &repo.git_dir,
+                    &local_cfg,
+                    &name,
+                    &sub_path,
+                )?;
+            } else if dot_git.is_file() {
+                local_cfg = load_local_config(&repo.git_dir)?;
+                connect_submodule_work_tree_and_git_dir(
+                    &grit_bin,
+                    work_tree,
+                    &repo.git_dir,
+                    &local_cfg,
+                    &name,
+                    &sub_path,
+                )?;
+            }
+        }
     } else {
         // Clone the submodule.
-        let modules_dir = repo.git_dir.join("modules").join(&path);
+        let modules_dir = submodule_modules_dir(work_tree, &repo.git_dir, &mut local_cfg, &name)?;
         // Only create the parent directory; git clone --separate-git-dir
         // will create the modules_dir itself.
         if let Some(parent) = modules_dir.parent() {
@@ -809,10 +914,18 @@ fn run_add(args: &AddArgs) -> Result<()> {
         if !status.success() {
             bail!("failed to clone submodule from '{}'", args.url);
         }
+        if submodule_path_config_enabled(&repo.git_dir) {
+            local_cfg = load_local_config(&repo.git_dir)?;
+            connect_submodule_work_tree_and_git_dir(
+                &grit_bin,
+                work_tree,
+                &repo.git_dir,
+                &local_cfg,
+                &name,
+                &sub_path,
+            )?;
+        }
     }
-
-    // Derive the submodule name (use --name if provided, otherwise path).
-    let name = args.name.as_deref().unwrap_or(&path);
 
     // Update .gitmodules.
     let gitmodules_path = work_tree.join(".gitmodules");
@@ -828,16 +941,9 @@ fn run_add(args: &AddArgs) -> Result<()> {
     config.write()?;
 
     // Also register the submodule in the local .git/config (like git does).
-    let local_config_path = repo.git_dir.join("config");
-    let mut local_config = if local_config_path.exists() {
-        let content = fs::read_to_string(&local_config_path)?;
-        ConfigFile::parse(&local_config_path, &content, ConfigScope::Local)?
-    } else {
-        ConfigFile::parse(&local_config_path, "", ConfigScope::Local)?
-    };
-    local_config.set(&format!("submodule.{name}.url"), &args.url)?;
-    local_config.set(&format!("submodule.{name}.active"), "true")?;
-    local_config.write()?;
+    local_cfg.set(&format!("submodule.{name}.url"), &args.url)?;
+    local_cfg.set(&format!("submodule.{name}.active"), "true")?;
+    local_cfg.write()?;
 
     // Add the submodule path to the index.
     // Use --no-warn-embedded-repo so the add doesn't warn about the
@@ -1163,6 +1269,8 @@ fn run_absorbgitdirs(args: &AbsorbgitdirsArgs) -> Result<()> {
     let work_tree = repo.work_tree.as_ref().context("bare repository")?;
     let modules = parse_gitmodules(work_tree)?;
     let selected = filter_submodules(&modules, &args.paths);
+    let grit_bin = grit_exe::grit_executable();
+    let mut local_cfg = load_local_config(&repo.git_dir)?;
 
     for m in &selected {
         let sub_path = work_tree.join(&m.path);
@@ -1173,7 +1281,7 @@ fn run_absorbgitdirs(args: &AbsorbgitdirsArgs) -> Result<()> {
             continue;
         }
 
-        let modules_dir = repo.git_dir.join("modules").join(&m.name);
+        let modules_dir = submodule_modules_dir(work_tree, &repo.git_dir, &mut local_cfg, &m.name)?;
 
         // Create the modules directory if needed.
         fs::create_dir_all(modules_dir.parent().unwrap())?;
@@ -1197,9 +1305,15 @@ fn run_absorbgitdirs(args: &AbsorbgitdirsArgs) -> Result<()> {
             cfg.write()?;
         }
 
-        // Write a gitfile in place of the .git directory.
-        let relative_gitdir = pathdiff_relative(&sub_path, &modules_dir);
-        fs::write(&dot_git, format!("gitdir: {}\n", relative_gitdir))?;
+        local_cfg = load_local_config(&repo.git_dir)?;
+        connect_submodule_work_tree_and_git_dir(
+            &grit_bin,
+            work_tree,
+            &repo.git_dir,
+            &local_cfg,
+            &m.name,
+            &sub_path,
+        )?;
 
         eprintln!(
             "Migrating git directory of '{}' from '{}' to '{}'",

--- a/grit/src/commands/submodule_helper.rs
+++ b/grit/src/commands/submodule_helper.rs
@@ -1,0 +1,46 @@
+//! `git submodule--helper` — internal plumbing used by shell scripts and tests.
+
+use anyhow::{bail, Context, Result};
+use grit_lib::config::{ConfigFile, ConfigScope};
+use grit_lib::repo::Repository;
+use grit_lib::submodule_gitdir::{migrate_gitdir_configs, submodule_gitdir_filesystem_path};
+use std::fs;
+
+fn load_local_config(git_dir: &std::path::Path) -> Result<ConfigFile> {
+    let config_path = git_dir.join("config");
+    if config_path.exists() {
+        let content = fs::read_to_string(&config_path)?;
+        ConfigFile::parse(&config_path, &content, ConfigScope::Local).map_err(Into::into)
+    } else {
+        ConfigFile::parse(&config_path, "", ConfigScope::Local).map_err(Into::into)
+    }
+}
+
+/// Run `git submodule--helper <subcommand> ...` (argv after the builtin name).
+pub fn run(rest: &[String]) -> Result<()> {
+    let sub = rest.first().map(|s| s.as_str()).unwrap_or("");
+    match sub {
+        "gitdir" => {
+            let name = rest
+                .get(1)
+                .map(String::as_str)
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("usage: git submodule--helper gitdir <name>"))?;
+            let repo = Repository::discover(None).context("not a git repository")?;
+            let work_tree = repo.work_tree.as_ref().context("bare repository")?;
+            let cfg = load_local_config(&repo.git_dir)?;
+            let path = submodule_gitdir_filesystem_path(work_tree, &repo.git_dir, &cfg, name)
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            println!("{}", path.display());
+            Ok(())
+        }
+        "migrate-gitdir-configs" => {
+            let repo = Repository::discover(None).context("not a git repository")?;
+            let work_tree = repo.work_tree.as_ref().context("bare repository")?;
+            migrate_gitdir_configs(work_tree, &repo.git_dir).map_err(|e| anyhow::anyhow!("{e}"))
+        }
+        _ => bail!(
+            "git submodule--helper: unknown subcommand '{sub}' (supported: gitdir, migrate-gitdir-configs)"
+        ),
+    }
+}

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -3057,6 +3057,7 @@ pub(crate) fn dispatch(subcmd: &str, rest: &[String], opts: &GlobalOpts) -> Resu
         "status" => commands::status::run(parse_cmd_args(subcmd, rest)),
         "stripspace" => commands::stripspace::run(parse_cmd_args(subcmd, rest)),
         "submodule" => commands::submodule::run(parse_cmd_args(subcmd, rest)),
+        "submodule--helper" => commands::submodule_helper::run(rest),
         "switch" => commands::switch::run(parse_cmd_args(subcmd, rest)),
         "symbolic-ref" => commands::symbolic_ref::run(parse_cmd_args(subcmd, rest)),
         "tag" => commands::tag::run(parse_cmd_args(subcmd, rest)),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git's `extensions.submodulePathConfig` flow enough for `t7425-submodule-gitdir-path-extension.sh` to pass (23/23).

### grit-lib
- Whitelist `submodulePathConfig` in repository format validation.
- New `submodule_gitdir` module: RFC3986-style encoding, conflict resolution, migration, legacy vs encoded validation, index-based nesting checks.
- `resolve_dot_git()` to open work trees whose `.git` is a gitfile (fixes cloning from submodule checkouts).

### grit
- `git init`: honors `init.defaultSubmodulePathConfig` (sets repo format v1 + extension).
- `git clone`: optional `--jobs` (accepted); `init.defaultSubmodulePathConfig` inheritance; recursive submodules use `--separate-git-dir` under `.git/modules` with encoded paths when the extension is on; registers submodule URL/active in config; checks out gitlink OIDs.
- `git submodule`: uses encoded gitdirs, relative gitfiles, legacy nesting validation when extension is off, index-aware path-inside-submodule checks.
- `git submodule--helper`: `gitdir` and `migrate-gitdir-configs`.

### Tests
- `data/test-files.csv` + dashboards updated via `./scripts/run-tests.sh t7425-submodule-gitdir-path-extension.sh` (23/23).

## Validation
- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t7425-submodule-gitdir-path-extension.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-825320b4-34c5-42ee-a301-3563882a9d44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-825320b4-34c5-42ee-a301-3563882a9d44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

