### PR TITLE
t12590: confirm log --format / tformat fully passing

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -313,7 +313,7 @@ t12550-diff-stat-summary-line	t1	yes	39	39	0	true	ok	0
 t12560-diff-index-worktree	t1	yes	36	36	0	true	ok	0
 t12570-status-rename-copy	t1	yes	38	36	2	false	ok	0
 t12580-log-oneline-all	t1	yes	31	28	3	false	ok	0
-t12590-log-format-tformat	t1	yes	33	32	1	false	ok	0
+t12590-log-format-tformat	t1	yes	33	33	0	true	ok	0
 t12600-rev-list-not-exclude	t1	yes	32	31	1	false	ok	0
 t12610-rev-list-all-branches	t1	yes	32	30	2	false	ok	0
 t12620-rev-parse-resolve-ref	t1	yes	32	31	1	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-07T18:47:28+00:00" class="gen-time" title="2026-04-07 18:47 UTC">2026-04-07 18:47 UTC</time> · <a href="https://github.com/schacon/grit/commit/6b0446cd85a6615f2f8f250ae70da7f767e3e0d2" style="color:#58a6ff">6b0446c</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-07T19:06:42+00:00" class="gen-time" title="2026-04-07 19:06 UTC">2026-04-07 19:06 UTC</time> · <a href="https://github.com/schacon/grit/commit/9b592f98d75e9b5768687c193f844ff792a23181" style="color:#58a6ff">9b592f9</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,437</div>
+      <div class="summary-big-val">29,438</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>600 files fully passing</span>
+    <span>601 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -190,7 +190,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">234/368 files · 8 skipped · 10,499/12,224 tests</span>
+        <span class="group-meta">235/368 files · 8 skipped · 10,500/12,224 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-green" style="width:85.9%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T18:47:28+00:00" class="gen-time" title="2026-04-07 18:47 UTC">2026-04-07 18:47 UTC</time> · <a href="https://github.com/schacon/grit/commit/6b0446cd85a6615f2f8f250ae70da7f767e3e0d2" style="color:#58a6ff">6b0446c</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T19:06:42+00:00" class="gen-time" title="2026-04-07 19:06 UTC">2026-04-07 19:06 UTC</time> · <a href="https://github.com/schacon/grit/commit/9b592f98d75e9b5768687c193f844ff792a23181" style="color:#58a6ff">9b592f9</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,739</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,437</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,438</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">67.3%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -3267,14 +3267,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="33" data-passed="32">
+<tr class="" data-group="t1" data-tests="33" data-passed="33">
   <td class="mono">t12590-log-format-tformat</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">33</td>
-  <td class="right">32</td>
+  <td class="right">33</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:97.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="32" data-passed="31">

--- a/logs/2026-04-07_t12590-log-format-tformat.md
+++ b/logs/2026-04-07_t12590-log-format-tformat.md
@@ -1,0 +1,12 @@
+# t12590-log-format-tformat
+
+**Date:** 2026-04-07
+
+## Outcome
+
+`./scripts/run-tests.sh t12590-log-format-tformat.sh` reports **33/33** passing. No Rust changes were required; behavior already matches Git for the covered format specifiers and `format:` / `tformat:` handling.
+
+## Actions
+
+- Ran harness; refreshed `data/test-files.csv` and dashboards.
+- Marked `t12590-log-format-tformat.sh` complete in `t1-plan.md` and updated `progress.md` counts.

--- a/progress.md
+++ b/progress.md
@@ -6,13 +6,14 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |    85 |
+| Completed   |    86 |
 | In progress |     0 |
-| Remaining   |   682 |
+| Remaining   |   681 |
 | **Total**   |   767 |
 
 ## Recently completed
 
+- `t12590-log-format-tformat` — 33/33 tests pass (`log --format` with `%H`/`%h`/`%s`/`%an`/`%ae`/`%cn`/`%ce`/`%T`/`%t`/`%P`/`%p`/`%n`/`%%`, `format:` vs `tformat:` prefixes, `-n`/`--skip`/`--reverse`; verified clean harness run)
 - `t11290-update-ref-atomic-batch` — 33/33 tests pass (`test_must_fail` in `test-lib-tap.sh` now accepts absolute paths to `git`/`grit`/`scalar`, so `test_must_fail "$GUST_BIN"` and `test_must_fail "$REAL_GIT"` work under the harness)
 - `t1092-sparse-checkout-compatibility` — in progress (~39/106 passing): sparse index (`sdir`), expand/collapse, `sparse-checkout` CLI flags, `ls-files --sparse`, status sparse banner, index write finalization across commands; see `logs/2026-04-07_sparse-index-t1092-progress.md`
 - `t0450-txt-doc-vs-help` — 548/548 tests pass (`-h` synopsis generated from vendored `git/Documentation/*.adoc` at build time; harness sets `GIT_SOURCE_DIR`; trimmed `adoc-help-mismatches` to builtins Grit does not ship)
@@ -76,4 +77,4 @@
 
 ## What Remains
 
-682 test files still pending. See `plan.md` for the full prioritized list.
+681 test files still pending. See `plan.md` for the full prioritized list.

--- a/t1-plan.md
+++ b/t1-plan.md
@@ -120,7 +120,7 @@
 - [ ] t12560-diff-index-worktree.sh
 - [ ] t12570-status-rename-copy.sh
 - [ ] t12580-log-oneline-all.sh
-- [ ] t12590-log-format-tformat.sh
+- [x] t12590-log-format-tformat.sh
 - [ ] t12600-rev-list-not-exclude.sh
 - [ ] t12610-rev-list-all-branches.sh
 - [ ] t12620-rev-parse-resolve-ref.sh


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t12590-log-format-tformat.sh` passes **33/33** under `./scripts/run-tests.sh`. No code changes were needed; existing `log` format handling already matches Git for the tested specifiers and `format:` / `tformat:` prefixes.

## Changes

- Refreshed harness artifacts (`data/test-files.csv`, dashboards).
- Marked the test complete in `t1-plan.md`, updated `progress.md`, added `logs/2026-04-07_t12590-log-format-tformat.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-961d09ca-d696-43ce-a58d-c1cff067d2a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-961d09ca-d696-43ce-a58d-c1cff067d2a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

