### PR TITLE
test: t11490-commit-fixup-squash fully passing (33/33)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -231,7 +231,7 @@ t11450-config-include-path	t1	yes	28	28	0	true	ok	0
 t11460-init-separate-git-dir	t1	yes	34	34	0	true	ok	0
 t11470-branch-copy-move	t1	yes	31	31	0	true	ok	0
 t11480-tag-message-file	t1	yes	35	35	0	true	ok	0
-t11490-commit-fixup-squash	t1	yes	33	32	1	false	ok	0
+t11490-commit-fixup-squash	t1	yes	33	33	0	true	ok	0
 t11500-add-chmod-intent	t1	yes	31	29	2	false	ok	0
 t11510-rm-cached-worktree	t1	yes	30	30	0	true	ok	0
 t11520-mv-directory-structure	t1	yes	31	31	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-07T19:08:19+00:00" class="gen-time" title="2026-04-07 19:08 UTC">2026-04-07 19:08 UTC</time> · <a href="https://github.com/schacon/grit/commit/acc5775fd2ab8bd458e19f41eb3465645ab9e234" style="color:#58a6ff">acc5775</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-07T19:10:46+00:00" class="gen-time" title="2026-04-07 19:10 UTC">2026-04-07 19:10 UTC</time> · <a href="https://github.com/schacon/grit/commit/974b0fb3cf89b466310436d54087fe46683a5cec" style="color:#58a6ff">974b0fb</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,437</div>
+      <div class="summary-big-val">29,438</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>600 files fully passing</span>
+    <span>601 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -190,7 +190,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">234/368 files · 8 skipped · 10,499/12,224 tests</span>
+        <span class="group-meta">235/368 files · 8 skipped · 10,500/12,224 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-green" style="width:85.9%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T19:08:19+00:00" class="gen-time" title="2026-04-07 19:08 UTC">2026-04-07 19:08 UTC</time> · <a href="https://github.com/schacon/grit/commit/acc5775fd2ab8bd458e19f41eb3465645ab9e234" style="color:#58a6ff">acc5775</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T19:10:46+00:00" class="gen-time" title="2026-04-07 19:10 UTC">2026-04-07 19:10 UTC</time> · <a href="https://github.com/schacon/grit/commit/974b0fb3cf89b466310436d54087fe46683a5cec" style="color:#58a6ff">974b0fb</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,739</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,437</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,438</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">67.3%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -2447,14 +2447,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="33" data-passed="32">
+<tr class="" data-group="t1" data-tests="33" data-passed="33">
   <td class="mono">t11490-commit-fixup-squash</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">33</td>
-  <td class="right">32</td>
+  <td class="right">33</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:97.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="31" data-passed="29">

--- a/logs/2026-04-07_t11490-commit-fixup-squash.md
+++ b/logs/2026-04-07_t11490-commit-fixup-squash.md
@@ -1,0 +1,10 @@
+# t11490-commit-fixup-squash
+
+## Result
+
+- Ran `./scripts/run-tests.sh t11490-commit-fixup-squash.sh` on branch `cursor/t11490-commit-fixup-squash-020d`.
+- **33/33 tests pass** (no Rust changes required; `data/test-files.csv` had stale 32/1 counts).
+
+## Notes
+
+- Covers `commit -m`, `-F` (file/stdin), `--amend`, `--allow-empty`, `--allow-empty-message`, `-a`, `--author`, `--date`, `-q`, plus log/rev-list sanity checks.

--- a/progress.md
+++ b/progress.md
@@ -6,13 +6,14 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |    86 |
+| Completed   |    87 |
 | In progress |     0 |
-| Remaining   |   681 |
+| Remaining   |   680 |
 | **Total**   |   767 |
 
 ## Recently completed
 
+- `t11490-commit-fixup-squash` — 33/33 tests pass (`commit` message sources, amend, allow-empty, `-a`, `--author`, `--date`, `-q`; harness CSV refreshed after clean run)
 - `t12590-log-format-tformat` — 33/33 tests pass (`log --format` with `%H`/`%h`/`%s`/`%an`/`%ae`/`%cn`/`%ce`/`%T`/`%t`/`%P`/`%p`/`%n`/`%%`, `format:` vs `tformat:` prefixes, `-n`/`--skip`/`--reverse`; verified clean harness run)
 - `t11290-update-ref-atomic-batch` — 33/33 tests pass (`test_must_fail` in `test-lib-tap.sh` now accepts absolute paths to `git`/`grit`/`scalar`, so `test_must_fail "$GUST_BIN"` and `test_must_fail "$REAL_GIT"` work under the harness)
 - `t1092-sparse-checkout-compatibility` — in progress (~39/106 passing): sparse index (`sdir`), expand/collapse, `sparse-checkout` CLI flags, `ls-files --sparse`, status sparse banner, index write finalization across commands; see `logs/2026-04-07_sparse-index-t1092-progress.md`
@@ -77,4 +78,4 @@
 
 ## What Remains
 
-681 test files still pending. See `plan.md` for the full prioritized list.
+680 test files still pending. See `plan.md` for the full prioritized list.

--- a/t1-plan.md
+++ b/t1-plan.md
@@ -72,7 +72,7 @@
 - [x] t11290-update-ref-atomic-batch.sh
 - [ ] t11300-symbolic-ref-head-detach.sh
 - [ ] t11310-check-ignore-global.sh
-- [ ] t11380-log-graph-all.sh                                                                           - [ ] t11490-commit-fixup-squash.sh
+- [ ] t11380-log-graph-all.sh                                                                           - [x] t11490-commit-fixup-squash.sh
 - [ ] t11500-add-chmod-intent.sh
 - [ ] t11510-rm-cached-worktree.sh
 - [ ] t11520-mv-directory-structure.sh


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`tests/t11490-commit-fixup-squash.sh` already passes end-to-end against current Grit (33/33). This change refresifies harness metadata and tracking docs that still showed one failure.

## Changes

- Update `data/test-files.csv` row for `t11490-commit-fixup-squash` to 33/33, `fully_passing=true`.
- Regenerate `docs/index.html` and `docs/testfiles.html` via the test runner.
- Mark `t11490-commit-fixup-squash.sh` done in `t1-plan.md`, bump counts in `progress.md`, add `logs/2026-04-07_t11490-commit-fixup-squash.md`.

## Verification

```bash
./scripts/run-tests.sh t11490-commit-fixup-squash.sh
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83f79c3c-225c-49fe-9346-b1664081fea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83f79c3c-225c-49fe-9346-b1664081fea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

