### PR TITLE
fix: make t13070-for-each-ref-points-at fully pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -364,7 +364,7 @@ t13050-reset-hard-untracked	t1	yes	30	30	0	true	ok	0
 t1306-xdg-files	t1	yes	21	20	1	false	ok	0
 t13060-cherry-pick-mainline	t1	yes	31	2	29	false	ok	0
 t1307-config-blob	t1	yes	13	11	2	false	ok	0
-t13070-for-each-ref-points-at	t1	yes	32	18	14	false	ok	0
+t13070-for-each-ref-points-at	t1	yes	32	32	0	true	ok	0
 t1308-config-set	t1	yes	39	12	27	false	ok	0
 t13080-show-ref-loose-packed	t1	yes	31	18	13	false	ok	0
 t1309-early-config	t1	yes	8	1	7	false	ok	2

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-07T19:13:19+00:00" class="gen-time" title="2026-04-07 19:13 UTC">2026-04-07 19:13 UTC</time> · <a href="https://github.com/schacon/grit/commit/c5912ebbe2370a41b7965db957f1484d3803de07" style="color:#58a6ff">c5912eb</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-07T19:19:57+00:00" class="gen-time" title="2026-04-07 19:19 UTC">2026-04-07 19:19 UTC</time> · <a href="https://github.com/schacon/grit/commit/6727f237df603a43f91511921c63e2dbaa576441" style="color:#58a6ff">6727f23</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,437</div>
+      <div class="summary-big-val">29,451</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>600 files fully passing</span>
+    <span>601 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -190,11 +190,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">234/368 files · 8 skipped · 10,499/12,224 tests</span>
+        <span class="group-meta">235/368 files · 8 skipped · 10,513/12,224 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:85.9%"></div></div>
-        <span class="group-pct pct-green">85.9%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:86.0%"></div></div>
+        <span class="group-pct pct-green">86.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t2">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T19:13:19+00:00" class="gen-time" title="2026-04-07 19:13 UTC">2026-04-07 19:13 UTC</time> · <a href="https://github.com/schacon/grit/commit/c5912ebbe2370a41b7965db957f1484d3803de07" style="color:#58a6ff">c5912eb</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T19:19:57+00:00" class="gen-time" title="2026-04-07 19:19 UTC">2026-04-07 19:19 UTC</time> · <a href="https://github.com/schacon/grit/commit/6727f237df603a43f91511921c63e2dbaa576441" style="color:#58a6ff">6727f23</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,739</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,437</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,451</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">67.3%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -3777,14 +3777,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:84.6%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="32" data-passed="18">
+<tr class="" data-group="t1" data-tests="32" data-passed="32">
   <td class="mono">t13070-for-each-ref-points-at</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">32</td>
-  <td class="right">18</td>
+  <td class="right">32</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.2%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="39" data-passed="12">

--- a/grit/src/commands/for_each_ref.rs
+++ b/grit/src/commands/for_each_ref.rs
@@ -475,6 +475,12 @@ fn parse_packed_refs(git_dir: &Path) -> Result<Vec<(String, ObjectId)>> {
 fn apply_filters(repo: &Repository, opts: &Options, refs: &mut Vec<RefEntry>) -> Result<()> {
     if let Some(points_spec) = &opts.points_at {
         let points_oid = resolve_revision(repo, points_spec)?;
+        // `resolve_revision` accepts a full 40-hex OID even when the object is
+        // absent (matching `git rev-parse`). For `--points-at`, Grit requires
+        // the object to exist so invalid targets are rejected (see t13070).
+        repo.odb
+            .read(&points_oid)
+            .map_err(|_| anyhow::anyhow!("object {points_oid} not found"))?;
         refs.retain(|entry| {
             entry.oid == Some(points_oid)
                 || entry.oid.and_then(|oid| peel_to_non_tag(repo, oid).ok()) == Some(points_oid)

--- a/logs/2026-04-07-for-each-ref-points-at-missing-object.md
+++ b/logs/2026-04-07-for-each-ref-points-at-missing-object.md
@@ -1,0 +1,14 @@
+# t13070 for-each-ref --points-at
+
+## Issue
+
+`t13070-for-each-ref-points-at.sh` failed on "for-each-ref --points-at nonexistent SHA errors": `resolve_revision` returns a parsed 40-hex OID even when the object is absent (Git `rev-parse` behavior), so `--points-at` produced empty output with exit 0 instead of failing.
+
+## Fix
+
+In `apply_filters`, after resolving `--points-at`, verify the object exists in the ODB via `repo.odb.read` before filtering refs.
+
+## Validation
+
+- `./scripts/run-tests.sh t13070-for-each-ref-points-at.sh` — 32/32 pass
+- `cargo test -p grit-lib --lib` — pass


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`git for-each-ref --points-at` must fail when the argument resolves to an object ID that is not present in the object database. Our `resolve_revision` intentionally accepts a full 40-hex OID even when missing (matching `git rev-parse`), which left `--points-at` succeeding with no output.

## Changes

- After resolving `--points-at`, verify the object exists via `repo.odb.read` before filtering refs.
- Refreshed harness artifacts for `t13070-for-each-ref-points-at` (32/32).

## Testing

- `./scripts/run-tests.sh t13070-for-each-ref-points-at.sh`
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-415282b5-d636-4bf9-bb5b-13eb51d1dbaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-415282b5-d636-4bf9-bb5b-13eb51d1dbaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

