### PR TITLE
fix: make t11530-switch-orphan-track pass (switch --orphan / -d)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -235,7 +235,7 @@ t11490-commit-fixup-squash	t1	yes	33	32	1	false	ok	0
 t11500-add-chmod-intent	t1	yes	31	29	2	false	ok	0
 t11510-rm-cached-worktree	t1	yes	30	30	0	true	ok	0
 t11520-mv-directory-structure	t1	yes	31	31	0	true	ok	0
-t11530-switch-orphan-track	t1	yes	30	10	20	false	ok	0
+t11530-switch-orphan-track	t1	yes	30	30	0	true	ok	0
 t11540-restore-staged-worktree	t1	yes	30	30	0	true	ok	0
 t11550-reset-merge-keep	t1	yes	30	30	0	true	ok	0
 t11560-cherry-pick-signoff-edit	t1	yes	32	30	2	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,16 +141,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-07T19:29:06+00:00" class="gen-time" title="2026-04-07 19:29 UTC">2026-04-07 19:29 UTC</time> · <a href="https://github.com/schacon/grit/commit/7eb6d5259539271794901ebc9ca8935fa698b4ca" style="color:#58a6ff">7eb6d52</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-07T19:47:22+00:00" class="gen-time" title="2026-04-07 19:47 UTC">2026-04-07 19:47 UTC</time> · <a href="https://github.com/schacon/grit/commit/9c109c8dccd9f63ef03d367d16f4c6da3f649c66" style="color:#58a6ff">9c109c8</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">67.3%</div>
+      <div class="summary-big-val pct-blue">67.4%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,442</div>
+      <div class="summary-big-val">29,462</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -159,12 +159,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:67.3%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:67.4%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>601 files fully passing</span>
+    <span>602 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -190,11 +190,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">235/368 files · 8 skipped · 10,504/12,224 tests</span>
+        <span class="group-meta">236/368 files · 8 skipped · 10,524/12,224 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:85.9%"></div></div>
-        <span class="group-pct pct-green">85.9%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:86.1%"></div></div>
+        <span class="group-pct pct-green">86.1%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t2">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,13 +84,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T19:29:06+00:00" class="gen-time" title="2026-04-07 19:29 UTC">2026-04-07 19:29 UTC</time> · <a href="https://github.com/schacon/grit/commit/7eb6d5259539271794901ebc9ca8935fa698b4ca" style="color:#58a6ff">7eb6d52</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T19:47:22+00:00" class="gen-time" title="2026-04-07 19:47 UTC">2026-04-07 19:47 UTC</time> · <a href="https://github.com/schacon/grit/commit/9c109c8dccd9f63ef03d367d16f4c6da3f649c66" style="color:#58a6ff">9c109c8</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,739</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,442</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">67.3%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,462</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">67.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -2487,14 +2487,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="30" data-passed="10">
+<tr class="" data-group="t1" data-tests="30" data-passed="30">
   <td class="mono">t11530-switch-orphan-track</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">30</td>
-  <td class="right">10</td>
+  <td class="right">30</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:33.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="30" data-passed="30">

--- a/grit/src/commands/checkout.rs
+++ b/grit/src/commands/checkout.rs
@@ -266,6 +266,29 @@ pub fn run(mut args: Args) -> Result<()> {
         args.rest = new_rest;
     }
 
+    // `git switch` forwards `--orphan`, `--detach`, and `-d` via positional `rest`;
+    // clap does not parse them there, so peel them off before treating `rest` as refs/paths.
+    {
+        let mut new_rest: Vec<String> = Vec::new();
+        let mut i = 0;
+        while i < args.rest.len() {
+            let s = &args.rest[i];
+            if s == "--orphan" && args.orphan.is_none() && i + 1 < args.rest.len() {
+                args.orphan = Some(args.rest[i + 1].clone());
+                i += 2;
+                continue;
+            }
+            if (s == "--detach" || s == "-d") && !args.detach {
+                args.detach = true;
+                i += 1;
+                continue;
+            }
+            new_rest.push(s.clone());
+            i += 1;
+        }
+        args.rest = new_rest;
+    }
+
     // Detect if `--` was used in the original command line. Clap strips a
     // leading `--` from trailing_var_arg, so we check the raw args.
     let raw_args: Vec<String> = std::env::args().collect();
@@ -1056,6 +1079,11 @@ fn create_orphan_branch(repo: &Repository, name: &str, start_point: Option<&str>
         new_index.sort();
         checkout_index_to_worktree(repo, &old_index, &new_index, work_tree, true)?;
         repo.write_index(&mut new_index).context("writing index")?;
+    } else if let Some(work_tree) = repo.work_tree.as_ref() {
+        let old_index = repo.load_index().unwrap_or_else(|_| Index::new());
+        let new_index = Index::new();
+        checkout_index_to_worktree(repo, &old_index, &new_index, work_tree, true)?;
+        repo.write_index(&mut Index::new()).context("writing index")?;
     }
 
     // Point HEAD at the new branch (which doesn't exist yet = unborn)

--- a/logs/2026-04-07_t11530-switch-orphan-track.md
+++ b/logs/2026-04-07_t11530-switch-orphan-track.md
@@ -1,0 +1,17 @@
+# t11530-switch-orphan-track
+
+## Problem
+
+`grit switch --orphan` and `grit switch -d` passed those flags through `rest` to `checkout`; clap did not parse them, so `--orphan` / `--detach` were treated as revision names.
+
+Orphan without a start point also left the previous branch’s index and tracked files in the worktree; Git clears both.
+
+## Fix
+
+- In `checkout::run`, after extracting `-b`/`-c` from `rest`, strip `--orphan <name>`, `--detach`, and `-d` into `args.orphan` / `args.detach`.
+- In `create_orphan_branch`, when there is no start point and a work tree exists, sync to an empty index via `checkout_index_to_worktree` and write an empty index.
+
+## Verification
+
+- `./scripts/run-tests.sh t11530-switch-orphan-track.sh` — 30/30 pass
+- `cargo test -p grit-lib --lib` — pass


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`grit switch` forwards `--orphan`, `--detach`, and `-d` as trailing arguments to `checkout`, but clap never parsed them there, so they were treated as revision names (`unknown revision: '--orphan'`).

This change:

1. **Peels** `--orphan <branch>`, `--detach`, and `-d` out of `checkout`’s `rest` vector into `args.orphan` / `args.detach` (same as normal `git checkout` parsing).
2. **Orphan without start point**: clears the index and removes files that were tracked on the previous branch from the worktree (matches Git’s behavior and fixes the “empty index” / “clears worktree” tests).

## Testing

- `./scripts/run-tests.sh t11530-switch-orphan-track.sh` — 30/30
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f36354f-6a20-4e68-926c-986fc809e483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f36354f-6a20-4e68-926c-986fc809e483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

