### PR TITLE
fix: honor fetch --update-head-ok (t5405-send-pack-rewind)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -557,7 +557,7 @@ commit → check it off → move on.
 - [ ] `t5527-fetch-odd-refs` ████████████░░░░░░░░ 3/5 (2 left) — test fetching of oddly-named refs
 - [ ] `t5306-pack-nobase` ██████████░░░░░░░░░░ 2/4 (2 left) — git-pack-object with missing base
 
-- [ ] `t5405-send-pack-rewind` ██████░░░░░░░░░░░░░░ 1/3 (2 left) — forced push to replace commit we do not have
+- [x] `t5405-send-pack-rewind` ████████████████████ 3/3 (0 left) — forced push to replace commit we do not have
 - [ ] `t5524-pull-msg` ██████░░░░░░░░░░░░░░ 1/3 (2 left) — git pull message generation
 - [ ] `t5542-push-http-shallow` ██████░░░░░░░░░░░░░░ 1/3 (2 left) — push from/to a shallow clone over http
 - [ ] `t5321-pack-large-objects` ░░░░░░░░░░░░░░░░░░░░ 0/2 (2 left) — git pack-object with 

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -909,7 +909,7 @@ t5401-update-hooks	t5	yes	13	4	9	false	ok	0
 t5402-post-merge-hook	t5	yes	7	3	4	false	ok	0
 t5403-post-checkout-hook	t5	yes	14	3	11	false	ok	0
 t5404-tracking-branches	t5	yes	7	3	4	false	ok	0
-t5405-send-pack-rewind	t5	yes	3	1	2	false	ok	0
+t5405-send-pack-rewind	t5	yes	3	3	0	true	ok	0
 t5406-remote-rejects	t5	yes	3	2	1	false	ok	0
 t5407-post-rewrite-hook	t5	yes	17	3	14	false	ok	0
 t5408-send-pack-stdin	t5	yes	10	4	6	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-07T21:11:55+00:00" class="gen-time" title="2026-04-07 21:11 UTC">2026-04-07 21:11 UTC</time> · <a href="https://github.com/schacon/grit/commit/fc5772e630f2282e0c0345e35a08561f212954f4" style="color:#58a6ff">fc5772e</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-07T21:16:43+00:00" class="gen-time" title="2026-04-07 21:16 UTC">2026-04-07 21:16 UTC</time> · <a href="https://github.com/schacon/grit/commit/c014a5fc681d3a7ee035f841e5bd42b9115e6907" style="color:#58a6ff">c014a5f</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,453</div>
+      <div class="summary-big-val">29,455</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>602 files fully passing</span>
+    <span>603 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -234,7 +234,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">28/167 files · 17 skipped · 1,432/4,315 tests</span>
+        <span class="group-meta">29/167 files · 17 skipped · 1,434/4,315 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.2%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T21:11:55+00:00" class="gen-time" title="2026-04-07 21:11 UTC">2026-04-07 21:11 UTC</time> · <a href="https://github.com/schacon/grit/commit/fc5772e630f2282e0c0345e35a08561f212954f4" style="color:#58a6ff">fc5772e</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T21:16:43+00:00" class="gen-time" title="2026-04-07 21:16 UTC">2026-04-07 21:16 UTC</time> · <a href="https://github.com/schacon/grit/commit/c014a5fc681d3a7ee035f841e5bd42b9115e6907" style="color:#58a6ff">c014a5f</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,739</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,453</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,455</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">67.3%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -9227,14 +9227,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:42.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="3" data-passed="1">
+<tr class="" data-group="t5" data-tests="3" data-passed="3">
   <td class="mono">t5405-send-pack-rewind</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">3</td>
-  <td class="right">1</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:33.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="3" data-passed="2">

--- a/grit/src/commands/fetch.rs
+++ b/grit/src/commands/fetch.rs
@@ -401,8 +401,9 @@ fn fetch_remote(
                             has_updates = true;
                         }
 
-                        // Refuse to update a ref that's checked out in a worktree
-                        if local_ref.starts_with("refs/heads/") {
+                        // Refuse to update a ref that's checked out in a worktree (unless
+                        // `--update-head-ok`, matching Git's fetch safety valve).
+                        if local_ref.starts_with("refs/heads/") && !args.update_head_ok {
                             if let Some(wt_path) = is_branch_in_worktree(git_dir, &local_ref) {
                                 bail!(
                                     "refusing to fetch into branch '{}' checked out at '{}'",
@@ -488,8 +489,8 @@ fn fetch_remote(
                         has_updates = true;
                     }
 
-                    // Check if branch is checked out in a worktree before updating
-                    if local_ref.starts_with("refs/heads/") {
+                    // Check if branch is checked out in a worktree before updating.
+                    if local_ref.starts_with("refs/heads/") && !args.update_head_ok {
                         if let Some(wt_path) = is_branch_in_worktree(git_dir, &local_ref) {
                             bail!(
                                 "refusing to fetch into branch '{}' checked out at '{}'",

--- a/logs/2026-04-07_t5405-send-pack-rewind.md
+++ b/logs/2026-04-07_t5405-send-pack-rewind.md
@@ -1,0 +1,15 @@
+# t5405-send-pack-rewind
+
+## Symptom
+
+Harness failed at setup: `git fetch --update-head-ok .. main:main` in clone `another/` errored with refusal to update `refs/heads/main` while checked out.
+
+## Fix
+
+In `grit/src/commands/fetch.rs`, skip the `is_branch_in_worktree` check when `args.update_head_ok` is true (CLI already had `--update-head-ok`); applied for both glob-refspec and single-refspec update paths.
+
+## Validation
+
+- `GUST_BIN=... sh tests/t5405-send-pack-rewind.sh` — 3/3
+- `./scripts/run-tests.sh t5405-send-pack-rewind.sh` — 3/3
+- `cargo fmt`, `cargo check -p grit-rs`, `cargo clippy -p grit-rs --fix --allow-dirty`, `cargo test -p grit-lib --lib`

--- a/progress.md
+++ b/progress.md
@@ -6,13 +6,14 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |    90 |
+| Completed   |    91 |
 | In progress |     0 |
-| Remaining   |   677 |
+| Remaining   |   676 |
 | **Total**   |   767 |
 
 ## Recently completed
 
+- `t5405-send-pack-rewind` — 3/3 tests pass (`fetch --update-head-ok` now skips the “checked out branch” refusal when updating `refs/heads/*` destinations, matching Git; harness CSV refreshed)
 - `t6200-fmt-merge-msg-extra` — 23/23 tests pass (`fmt-merge-msg`: multi-branch/tag titles, remote URL suffix, `--into-name`, `-m` override, `--log`/`--no-log`, stdin vs `-F`, FETCH_HEAD edge cases; harness CSV refreshed)
 - `t4048-diff-combined-binary` — 14/14 tests pass (`show` merge diffs: default `--cc`, `-m`/`--format=%s` spacing, `-c`/`--cc` combined headers; `-diff`/binary attribute; `diff.<driver>.textconv` with stdin and trailing `<` stripped; `diff-tree -c -p` without textconv; `git diff` during merge emits `diff --cc` conflict hunks with textconv on stages)
 - `t3406-rebase-message` — 32/32 tests pass (rebase stdout messages, `--stat`/`rebase.stat`, `-C`/`--whitespace` early errors, interactive listing + verbose diffstat; merge-base commit collection + fast-forward; Git-style rebase reflog including `GIT_REFLOG_ACTION`; checkout only logs branch switches on `HEAD` reflog)

--- a/test-results.md
+++ b/test-results.md
@@ -2,6 +2,7 @@
 
 **Updated:** 2026-04-07
 
+- `./scripts/run-tests.sh t5405-send-pack-rewind.sh`: 3/3 passing (`fetch` honors `--update-head-ok` for refspecs that target the checked-out branch; harness CSV/dashboards refreshed).
 - `./scripts/run-tests.sh t6200-fmt-merge-msg-extra.sh`: 23/23 passing (harness CSV/dashboards refreshed; no code changes required).
 - `./scripts/run-tests.sh t11290-update-ref-atomic-batch.sh`: 33/33 passing (harness `test_must_fail` now allows absolute `git`/`grit`/`scalar` paths).
 - Test pipeline: `data/test-files.csv` + `scripts/generate-dashboard-from-test-files.py`; `./scripts/run-tests.sh` updates CSV and `docs/index.html` / `docs/testfiles.html`. `cargo test -p grit-lib --lib`: 102/102 passing (2026-04-07).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t5405-send-pack-rewind` failed in setup because `git fetch --update-head-ok .. main:main` was still refusing to update `refs/heads/main` while that branch was checked out.

## Changes

- **`grit fetch`**: When `--update-head-ok` is set, skip the worktree “branch checked out” refusal for `refs/heads/*` destination updates (both glob and single refspec paths). The CLI flag already existed; it was not wired into the safety check.

## Validation

- `./scripts/run-tests.sh t5405-send-pack-rewind.sh` — 3/3
- `cargo fmt`, `cargo check -p grit-rs`, `cargo clippy -p grit-rs --fix --allow-dirty`, `cargo test -p grit-lib --lib`

Also refreshed harness CSV/dashboards and marked `t5405-send-pack-rewind` complete in `PLAN.md` / `progress.md` / `test-results.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2bbfaab0-5f17-468f-9864-d33704ee1ea6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2bbfaab0-5f17-468f-9864-d33704ee1ea6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

