### PR TITLE
t10200-switch-orphan-detach: verify 31/31, refresh harness + plan

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -118,7 +118,7 @@ t10160-commit-amend-author	t1	yes	30	30	0	true	ok	0
 t10180-rm-recursive-quiet	t1	yes	34	34	0	true	ok	0
 t10190-mv-directory-rename	t1	yes	34	34	0	true	ok	0
 t1020-subdirectory	t1	yes	15	12	3	false	ok	0
-t10200-switch-orphan-detach	t1	yes	31	11	20	false	ok	0
+t10200-switch-orphan-detach	t1	yes	31	31	0	true	ok	0
 t10210-restore-staged-source	t1	yes	34	34	0	true	ok	0
 t1022-read-tree-partial-clone	t1	yes	1	1	0	true	ok	0
 t10220-reset-soft-commit	t1	yes	34	34	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,16 +141,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-07T21:11:55+00:00" class="gen-time" title="2026-04-07 21:11 UTC">2026-04-07 21:11 UTC</time> · <a href="https://github.com/schacon/grit/commit/fc5772e630f2282e0c0345e35a08561f212954f4" style="color:#58a6ff">fc5772e</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-07T21:19:53+00:00" class="gen-time" title="2026-04-07 21:19 UTC">2026-04-07 21:19 UTC</time> · <a href="https://github.com/schacon/grit/commit/c014a5fc681d3a7ee035f841e5bd42b9115e6907" style="color:#58a6ff">c014a5f</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">67.3%</div>
+      <div class="summary-big-val pct-blue">67.4%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,453</div>
+      <div class="summary-big-val">29,473</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -159,12 +159,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:67.3%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:67.4%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>602 files fully passing</span>
+    <span>603 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -190,11 +190,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">235/368 files · 8 skipped · 10,514/12,224 tests</span>
+        <span class="group-meta">236/368 files · 8 skipped · 10,534/12,224 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:86.0%"></div></div>
-        <span class="group-pct pct-green">86.0%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:86.2%"></div></div>
+        <span class="group-pct pct-green">86.2%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t2">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,13 +84,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T21:11:55+00:00" class="gen-time" title="2026-04-07 21:11 UTC">2026-04-07 21:11 UTC</time> · <a href="https://github.com/schacon/grit/commit/fc5772e630f2282e0c0345e35a08561f212954f4" style="color:#58a6ff">fc5772e</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T21:19:53+00:00" class="gen-time" title="2026-04-07 21:19 UTC">2026-04-07 21:19 UTC</time> · <a href="https://github.com/schacon/grit/commit/c014a5fc681d3a7ee035f841e5bd42b9115e6907" style="color:#58a6ff">c014a5f</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,739</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,453</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">67.3%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,473</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">67.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -1317,14 +1317,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:80.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="31" data-passed="11">
+<tr class="" data-group="t1" data-tests="31" data-passed="31">
   <td class="mono">t10200-switch-orphan-detach</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">31</td>
-  <td class="right">11</td>
+  <td class="right">31</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:35.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34">

--- a/logs/2026-04-07_t10200-switch-orphan-detach.md
+++ b/logs/2026-04-07_t10200-switch-orphan-detach.md
@@ -1,0 +1,13 @@
+# t10200-switch-orphan-detach
+
+**Date:** 2026-04-07
+
+## Outcome
+
+`./scripts/run-tests.sh t10200-switch-orphan-detach.sh` reports **31/31** passing on branch `cursor/switch-orphan-detach-f7db`. No Rust changes were required; implementation already satisfies the suite (delegation from `switch` to `checkout` for `-c`, `--orphan`, `--detach`, previous-branch `-`, etc.).
+
+## Actions
+
+- Re-ran release build and harness for `t10200-switch-orphan-detach.sh`.
+- Refreshed `data/test-files.csv` and dashboard HTML from the harness.
+- Marked task complete in `t1-plan.md` and updated `progress.md` counts.

--- a/progress.md
+++ b/progress.md
@@ -6,13 +6,14 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |    90 |
+| Completed   |    91 |
 | In progress |     0 |
-| Remaining   |   677 |
+| Remaining   |   676 |
 | **Total**   |   767 |
 
 ## Recently completed
 
+- `t10200-switch-orphan-detach` — 31/31 tests pass (`switch -c`, `--orphan`, `--detach`, `switch -`, dirty worktree conflict checks; harness CSV refreshed after clean run)
 - `t6200-fmt-merge-msg-extra` — 23/23 tests pass (`fmt-merge-msg`: multi-branch/tag titles, remote URL suffix, `--into-name`, `-m` override, `--log`/`--no-log`, stdin vs `-F`, FETCH_HEAD edge cases; harness CSV refreshed)
 - `t4048-diff-combined-binary` — 14/14 tests pass (`show` merge diffs: default `--cc`, `-m`/`--format=%s` spacing, `-c`/`--cc` combined headers; `-diff`/binary attribute; `diff.<driver>.textconv` with stdin and trailing `<` stripped; `diff-tree -c -p` without textconv; `git diff` during merge emits `diff --cc` conflict hunks with textconv on stages)
 - `t3406-rebase-message` — 32/32 tests pass (rebase stdout messages, `--stat`/`rebase.stat`, `-C`/`--whitespace` early errors, interactive listing + verbose diffstat; merge-base commit collection + fast-forward; Git-style rebase reflog including `GIT_REFLOG_ACTION`; checkout only logs branch switches on `HEAD` reflog)

--- a/t1-plan.md
+++ b/t1-plan.md
@@ -9,7 +9,7 @@
 - [ ] t10180-rm-recursive-quiet.sh
 - [ ] t10190-mv-directory-rename.sh
 - [ ] t1020-subdirectory.sh
-- [ ] t10200-switch-orphan-detach.sh
+- [x] t10200-switch-orphan-detach.sh
 - [ ] t10210-restore-staged-source.sh
 - [ ] t10230-cherry-pick-range.sh
 - [ ] t10300-for-each-ref-count-pattern.sh


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t10200-switch-orphan-detach.sh` already passes **31/31** on this branch; no Rust changes were required.

## Changes

- Refreshed harness artifacts (`data/test-files.csv`, `docs/index.html`, `docs/testfiles.html`) from `./scripts/run-tests.sh t10200-switch-orphan-detach.sh`.
- Marked the task complete in `t1-plan.md` and updated `progress.md` counts.
- Added `logs/2026-04-07_t10200-switch-orphan-detach.md`.

## Verification

```bash
cargo build --release -p grit-rs
./scripts/run-tests.sh t10200-switch-orphan-detach.sh
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8f197f3-edc9-42c5-97de-8fd8cc4c64a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8f197f3-edc9-42c5-97de-8fd8cc4c64a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

