### PR TITLE
fix: hash-object fsck for t1451-fsck-buffer (72/72)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -156,7 +156,7 @@ commit → check it off → move on.
 - [ ] `t0301-credential-cache` ██░░░░░░░░░░░░░░░░░░ 6/52 (46 left) — credential-cache tests
 - [ ] `t0300-credentials` █░░░░░░░░░░░░░░░░░░░ 3/56 (53 left) — basic credential helper tests
 - [ ] `t0302-credential-store` █░░░░░░░░░░░░░░░░░░░ 5/65 (60 left) — credential-store tests
-- [ ] `t1451-fsck-buffer` ██░░░░░░░░░░░░░░░░░░ 10/72 (62 left) — fsck on buffers without NUL termination
+- [x] `t1451-fsck-buffer` ████████████████████ 72/72 (0 left) — fsck on buffers without NUL termination
 
 - [ ] `t1091-sparse-checkout-builtin` ██░░░░░░░░░░░░░░░░░░ 10/77 (67 left) — sparse checkout builtin tests
 - [ ] `t0610-reftable-basics` ████░░░░░░░░░░░░░░░░ 21/91 (70 left) — reftable basics

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -428,7 +428,7 @@ t1430-bad-ref-name	t1	yes	40	6	34	false	ok	2
 t1450-fsck	t1	skip	74	0	0	false	ok	0
 t1450-fsck-basic	t1	yes	31	31	0	true	ok	0
 t1450-fsck-flags	t1	yes	10	8	2	false	ok	0
-t1451-fsck-buffer	t1	yes	72	10	62	false	ok	0
+t1451-fsck-buffer	t1	yes	72	72	0	true	ok	0
 t1460-refs-migrate	t1	skip	22	0	0	false	ok	0
 t1461-refs-list	t1	yes	0	0	0	false	timeout	0
 t1462-refs-exists	t1	yes	0	0	0	false	timeout	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,16 +141,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-07T21:20:13+00:00" class="gen-time" title="2026-04-07 21:20 UTC">2026-04-07 21:20 UTC</time> · <a href="https://github.com/schacon/grit/commit/7b5aca33bb719a2e7af9c190d95d645e007d8702" style="color:#58a6ff">7b5aca3</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-07T21:40:08+00:00" class="gen-time" title="2026-04-07 21:40 UTC">2026-04-07 21:40 UTC</time> · <a href="https://github.com/schacon/grit/commit/89eba8ff57f96746c2c90f02157b1d885e543afb" style="color:#58a6ff">89eba8f</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">67.3%</div>
+      <div class="summary-big-val pct-blue">67.5%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,455</div>
+      <div class="summary-big-val">29,517</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -159,12 +159,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:67.3%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:67.5%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>603 files fully passing</span>
+    <span>604 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -190,11 +190,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">235/368 files · 8 skipped · 10,514/12,224 tests</span>
+        <span class="group-meta">236/368 files · 8 skipped · 10,576/12,224 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:86.0%"></div></div>
-        <span class="group-pct pct-green">86.0%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:86.5%"></div></div>
+        <span class="group-pct pct-green">86.5%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t2">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,13 +84,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T21:20:13+00:00" class="gen-time" title="2026-04-07 21:20 UTC">2026-04-07 21:20 UTC</time> · <a href="https://github.com/schacon/grit/commit/7b5aca33bb719a2e7af9c190d95d645e007d8702" style="color:#58a6ff">7b5aca3</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T21:40:08+00:00" class="gen-time" title="2026-04-07 21:40 UTC">2026-04-07 21:40 UTC</time> · <a href="https://github.com/schacon/grit/commit/89eba8ff57f96746c2c90f02157b1d885e543afb" style="color:#58a6ff">89eba8f</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,739</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,455</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">67.3%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,517</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">67.5%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -4417,14 +4417,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:80.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="72" data-passed="10">
+<tr class="" data-group="t1" data-tests="72" data-passed="72">
   <td class="mono">t1451-fsck-buffer</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">72</td>
-  <td class="right">10</td>
+  <td class="right">72</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:13.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="row-skip" data-group="t1" data-tests="22" data-passed="0">

--- a/grit-lib/src/fsck_standalone.rs
+++ b/grit-lib/src/fsck_standalone.rs
@@ -1,0 +1,482 @@
+//! Standalone object fsck for `hash-object` and similar entry points.
+//!
+//! Mirrors the buffer-safe checks in Git's `fsck.c` (`verify_headers`,
+//! `fsck_commit`, `fsck_tag_standalone`, `fsck_tree`) so error messages match
+//! `error: object fails fsck: <camelCaseId>: <detail>`.
+
+use crate::check_ref_format::{check_refname_format, RefNameOptions};
+use crate::objects::{ObjectId, ObjectKind};
+
+/// Git-compatible fsck failure for loose object validation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FsckError {
+    /// CamelCase message id (e.g. `missingTree`).
+    pub id: &'static str,
+    /// Human-readable detail after `id: `.
+    pub detail: String,
+}
+
+impl FsckError {
+    fn new(id: &'static str, detail: impl Into<String>) -> Self {
+        Self {
+            id,
+            detail: detail.into(),
+        }
+    }
+
+    /// Full line after `error: object fails fsck: ` (matches Git).
+    #[must_use]
+    pub fn report_line(&self) -> String {
+        format!("{}: {}", self.id, self.detail)
+    }
+}
+
+/// Validate raw object bytes the same way `git hash-object` does before hashing.
+///
+/// Returns `Ok(())` when the object is well-formed, or the first fsck error Git
+/// would report for truncated or malformed buffers.
+pub fn fsck_object(kind: ObjectKind, data: &[u8]) -> Result<(), FsckError> {
+    match kind {
+        ObjectKind::Blob => Ok(()),
+        ObjectKind::Commit => fsck_commit(data),
+        ObjectKind::Tag => fsck_tag(data),
+        ObjectKind::Tree => fsck_tree(data),
+    }
+}
+
+fn verify_headers(data: &[u8], nul_msg_id: &'static str) -> Result<(), FsckError> {
+    for (i, &b) in data.iter().enumerate() {
+        if b == 0 {
+            return Err(FsckError::new(
+                nul_msg_id,
+                format!("unterminated header: NUL at offset {i}"),
+            ));
+        }
+        if b == b'\n' && i + 1 < data.len() && data[i + 1] == b'\n' {
+            return Ok(());
+        }
+    }
+    if !data.is_empty() && data[data.len() - 1] == b'\n' {
+        Ok(())
+    } else {
+        Err(FsckError::new("unterminatedHeader", "unterminated header"))
+    }
+}
+
+fn is_hex_lower(b: u8) -> bool {
+    matches!(b, b'0'..=b'9' | b'a'..=b'f')
+}
+
+/// Parse a 40-character lowercase hex object id at the start of `buf`, requiring
+/// the next byte to be `\n`. Returns bytes consumed (41).
+fn parse_oid_line(buf: &[u8], bad_sha1_id: &'static str) -> Result<usize, FsckError> {
+    if buf.len() < 41 {
+        return Err(FsckError::new(
+            bad_sha1_id,
+            format!(
+                "invalid '{}' line format - bad sha1",
+                line_kind(bad_sha1_id)
+            ),
+        ));
+    }
+    let hex = &buf[..40];
+    if !hex.iter().copied().all(is_hex_lower) {
+        return Err(FsckError::new(
+            bad_sha1_id,
+            format!(
+                "invalid '{}' line format - bad sha1",
+                line_kind(bad_sha1_id)
+            ),
+        ));
+    }
+    if buf[40] != b'\n' {
+        return Err(FsckError::new(
+            bad_sha1_id,
+            format!(
+                "invalid '{}' line format - bad sha1",
+                line_kind(bad_sha1_id)
+            ),
+        ));
+    }
+    let hex_str = std::str::from_utf8(hex).map_err(|_| {
+        FsckError::new(
+            bad_sha1_id,
+            format!(
+                "invalid '{}' line format - bad sha1",
+                line_kind(bad_sha1_id)
+            ),
+        )
+    })?;
+    hex_str.parse::<ObjectId>().map_err(|_| {
+        FsckError::new(
+            bad_sha1_id,
+            format!(
+                "invalid '{}' line format - bad sha1",
+                line_kind(bad_sha1_id)
+            ),
+        )
+    })?;
+    Ok(41)
+}
+
+fn line_kind(bad_sha1_id: &'static str) -> &'static str {
+    match bad_sha1_id {
+        "badObjectSha1" => "object",
+        "badParentSha1" => "parent",
+        _ => "tree",
+    }
+}
+
+fn fsck_ident(
+    data: &[u8],
+    start: usize,
+    buffer_end: usize,
+    oid_line: &'static str,
+) -> Result<usize, FsckError> {
+    let mut p = start;
+    if p >= buffer_end {
+        return Err(FsckError::new(
+            "missingEmail",
+            format!("invalid {oid_line} line - missing email"),
+        ));
+    }
+
+    let line_end = data[p..buffer_end]
+        .iter()
+        .position(|&b| b == b'\n')
+        .map(|rel| p + rel)
+        .ok_or_else(|| {
+            FsckError::new(
+                "missingEmail",
+                format!("invalid {oid_line} line - missing email"),
+            )
+        })?;
+
+    if data[p] == b'<' {
+        return Err(FsckError::new(
+            "missingNameBeforeEmail",
+            format!("invalid {oid_line} line - missing space before email"),
+        ));
+    }
+
+    let ident_end = line_end;
+    while p < ident_end {
+        if data[p] == b'\n' {
+            return Err(FsckError::new(
+                "missingEmail",
+                format!("invalid {oid_line} line - missing email"),
+            ));
+        }
+        if data[p] == b'>' {
+            return Err(FsckError::new(
+                "badName",
+                format!("invalid {oid_line} line - bad name"),
+            ));
+        }
+        if data[p] == b'<' {
+            break;
+        }
+        p += 1;
+    }
+
+    if p >= ident_end {
+        return Err(FsckError::new(
+            "missingEmail",
+            format!("invalid {oid_line} line - missing email"),
+        ));
+    }
+
+    if p == start || data[p - 1] != b' ' {
+        return Err(FsckError::new(
+            "missingSpaceBeforeEmail",
+            format!("invalid {oid_line} line - missing space before email"),
+        ));
+    }
+    p += 1; // skip '<'
+
+    let email_start = p;
+    while p < ident_end {
+        if data[p] == b'<' || data[p] == b'\n' {
+            return Err(FsckError::new(
+                "badEmail",
+                format!("invalid {oid_line} line - bad email"),
+            ));
+        }
+        if data[p] == b'>' {
+            break;
+        }
+        p += 1;
+    }
+
+    if p >= ident_end || p == email_start {
+        return Err(FsckError::new(
+            "badEmail",
+            format!("invalid {oid_line} line - bad email"),
+        ));
+    }
+    p += 1; // skip '>'
+
+    if p >= ident_end || data[p] != b' ' {
+        return Err(FsckError::new(
+            "missingSpaceBeforeDate",
+            format!("invalid {oid_line} line - missing space before date"),
+        ));
+    }
+    p += 1;
+
+    while p < ident_end && (data[p] == b' ' || data[p] == b'\t') {
+        p += 1;
+    }
+
+    if p >= ident_end || !data[p].is_ascii_digit() {
+        return Err(FsckError::new(
+            "badDate",
+            format!("invalid {oid_line} line - bad date"),
+        ));
+    }
+
+    if data[p] == b'0' && p + 1 < ident_end && data[p + 1] != b' ' {
+        return Err(FsckError::new(
+            "zeroPaddedDate",
+            format!("invalid {oid_line} line - zero-padded date"),
+        ));
+    }
+
+    while p < ident_end && data[p].is_ascii_digit() {
+        p += 1;
+    }
+
+    if p >= ident_end || data[p] != b' ' {
+        return Err(FsckError::new(
+            "badDate",
+            format!("invalid {oid_line} line - bad date"),
+        ));
+    }
+    p += 1;
+
+    if p + 5 > ident_end
+        || (data[p] != b'+' && data[p] != b'-')
+        || !data[p + 1..p + 5].iter().all(|b| b.is_ascii_digit())
+        || data[p + 5] != b'\n'
+    {
+        return Err(FsckError::new(
+            "badTimezone",
+            format!("invalid {oid_line} line - bad time zone"),
+        ));
+    }
+
+    Ok(line_end + 1)
+}
+
+fn fsck_commit(data: &[u8]) -> Result<(), FsckError> {
+    verify_headers(data, "nulInHeader")?;
+
+    let buffer_end = data.len();
+    let mut i = 0usize;
+
+    if i >= buffer_end || !data[i..].starts_with(b"tree ") {
+        return Err(FsckError::new(
+            "missingTree",
+            "invalid format - expected 'tree' line",
+        ));
+    }
+    i += 5;
+    let n = parse_oid_line(&data[i..], "badTreeSha1")?;
+    i += n;
+
+    while i < buffer_end && data[i..].starts_with(b"parent ") {
+        i += 7;
+        let n = parse_oid_line(&data[i..], "badParentSha1")?;
+        i += n;
+    }
+
+    let mut author_count = 0usize;
+    while i < buffer_end && data[i..].starts_with(b"author ") {
+        author_count += 1;
+        i += 7;
+        i = fsck_ident(data, i, buffer_end, "author/committer")?;
+    }
+
+    if author_count < 1 {
+        return Err(FsckError::new(
+            "missingAuthor",
+            "invalid format - expected 'author' line",
+        ));
+    }
+    if author_count > 1 {
+        return Err(FsckError::new(
+            "multipleAuthors",
+            "invalid format - multiple 'author' lines",
+        ));
+    }
+
+    if i >= buffer_end || !data[i..].starts_with(b"committer ") {
+        return Err(FsckError::new(
+            "missingCommitter",
+            "invalid format - expected 'committer' line",
+        ));
+    }
+    i += 10;
+    fsck_ident(data, i, buffer_end, "author/committer")?;
+
+    if data.contains(&0) {
+        return Err(FsckError::new(
+            "nulInCommit",
+            "NUL byte in the commit object body",
+        ));
+    }
+
+    Ok(())
+}
+
+fn object_type_from_tag_type_line(s: &str) -> Option<ObjectKind> {
+    match s {
+        "blob" => Some(ObjectKind::Blob),
+        "tree" => Some(ObjectKind::Tree),
+        "commit" => Some(ObjectKind::Commit),
+        "tag" => Some(ObjectKind::Tag),
+        _ => None,
+    }
+}
+
+fn fsck_tag(data: &[u8]) -> Result<(), FsckError> {
+    verify_headers(data, "nulInHeader")?;
+
+    let buffer_end = data.len();
+    let mut i = 0usize;
+
+    if i >= buffer_end || !data[i..].starts_with(b"object ") {
+        return Err(FsckError::new(
+            "missingObject",
+            "invalid format - expected 'object' line",
+        ));
+    }
+    i += 7;
+    let n = parse_oid_line(&data[i..], "badObjectSha1")?;
+    i += n;
+
+    if i >= buffer_end || !data[i..].starts_with(b"type ") {
+        return Err(FsckError::new(
+            "missingTypeEntry",
+            "invalid format - expected 'type' line",
+        ));
+    }
+    i += 5;
+    let type_start = i;
+    let eol = data[type_start..buffer_end]
+        .iter()
+        .position(|&b| b == b'\n')
+        .map(|rel| type_start + rel)
+        .ok_or_else(|| {
+            FsckError::new(
+                "missingType",
+                "invalid format - unexpected end after 'type' line",
+            )
+        })?;
+
+    let type_str = std::str::from_utf8(&data[type_start..eol])
+        .map_err(|_| FsckError::new("badType", "invalid 'type' value"))?;
+    if object_type_from_tag_type_line(type_str).is_none() {
+        return Err(FsckError::new("badType", "invalid 'type' value"));
+    }
+    i = eol + 1;
+
+    if i >= buffer_end || !data[i..].starts_with(b"tag ") {
+        return Err(FsckError::new(
+            "missingTagEntry",
+            "invalid format - expected 'tag' line",
+        ));
+    }
+    i += 4;
+    let tag_start = i;
+    let eol = data[tag_start..buffer_end]
+        .iter()
+        .position(|&b| b == b'\n')
+        .map(|rel| tag_start + rel)
+        .ok_or_else(|| {
+            FsckError::new(
+                "missingTag",
+                "invalid format - unexpected end after 'type' line",
+            )
+        })?;
+
+    let tag_name = std::str::from_utf8(&data[tag_start..eol])
+        .map_err(|_| FsckError::new("badTagName", "invalid 'tag' name"))?;
+    let refname = format!("refs/tags/{tag_name}");
+    if check_refname_format(&refname, &RefNameOptions::default()).is_err() {
+        return Err(FsckError::new(
+            "badTagName",
+            format!("invalid 'tag' name: {tag_name}"),
+        ));
+    }
+    i = eol + 1;
+
+    if i >= buffer_end || !data[i..].starts_with(b"tagger ") {
+        return Err(FsckError::new(
+            "missingTaggerEntry",
+            "invalid format - expected 'tagger' line",
+        ));
+    }
+    i += 7;
+    fsck_ident(data, i, buffer_end, "author/committer")?;
+
+    Ok(())
+}
+
+fn fsck_tree(data: &[u8]) -> Result<(), FsckError> {
+    if parse_tree_gently(data).is_err() {
+        return Err(FsckError::new("badTree", "cannot be parsed as a tree"));
+    }
+    Ok(())
+}
+
+fn parse_tree_gently(data: &[u8]) -> Result<(), ()> {
+    let mut pos = 0usize;
+    while pos < data.len() {
+        let sp = data[pos..].iter().position(|&b| b == b' ').ok_or(())?;
+        let mode_bytes = &data[pos..pos + sp];
+        let mode_ok = std::str::from_utf8(mode_bytes)
+            .ok()
+            .and_then(|s| u32::from_str_radix(s, 8).ok())
+            .is_some();
+        if !mode_ok {
+            return Err(());
+        }
+        pos += sp + 1;
+
+        let nul = data[pos..].iter().position(|&b| b == 0).ok_or(())?;
+        pos += nul + 1;
+
+        if pos + 20 > data.len() {
+            return Err(());
+        }
+        if ObjectId::from_bytes(&data[pos..pos + 20]).is_err() {
+            return Err(());
+        }
+        pos += 20;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_commit_is_unterminated_header() {
+        let e = fsck_object(ObjectKind::Commit, b"").unwrap_err();
+        assert_eq!(e.id, "unterminatedHeader");
+    }
+
+    #[test]
+    fn commit_missing_tree_matches_git() {
+        let e = fsck_object(ObjectKind::Commit, b"\n\n").unwrap_err();
+        assert_eq!(e.id, "missingTree");
+    }
+
+    #[test]
+    fn tree_truncated_is_bad_tree() {
+        let e = fsck_object(ObjectKind::Tree, b"100644 foo\0\x01\x01\x01\x01").unwrap_err();
+        assert_eq!(e.id, "badTree");
+    }
+}

--- a/grit-lib/src/lib.rs
+++ b/grit-lib/src/lib.rs
@@ -23,6 +23,7 @@ pub mod delta_encode;
 pub mod diff;
 pub mod error;
 pub mod fmt_merge_msg;
+pub mod fsck_standalone;
 pub mod git_date;
 pub mod hooks;
 pub mod ignore;

--- a/grit/src/commands/hash_object.rs
+++ b/grit/src/commands/hash_object.rs
@@ -6,7 +6,8 @@ use std::io::Read;
 use std::path::PathBuf;
 use std::str::FromStr;
 
-use grit_lib::objects::{parse_commit, parse_tree, ObjectKind};
+use grit_lib::fsck_standalone::fsck_object;
+use grit_lib::objects::ObjectKind;
 use grit_lib::odb::Odb;
 use grit_lib::repo::Repository;
 
@@ -102,44 +103,16 @@ fn validate_object_data(kind: ObjectKind, data: &[u8], literally: bool) -> Resul
     if literally {
         return Ok(());
     }
-    match kind {
-        ObjectKind::Commit => {
-            parse_commit(data).context("corrupt commit object")?;
-            Ok(())
+    if let Err(e) = fsck_object(kind, data) {
+        if kind == ObjectKind::Tree && e.id == "badTree" {
+            eprintln!("error: too-short tree object");
         }
-        ObjectKind::Tag => validate_tag_data(data),
-        ObjectKind::Tree => {
-            parse_tree(data).context("corrupt tree object")?;
-            Ok(())
-        }
-        ObjectKind::Blob => Ok(()),
+        return Err(anyhow::anyhow!(grit_lib::error::Error::Message(format!(
+            "error: object fails fsck: {}\nfatal: refusing to create malformed object",
+            e.report_line()
+        ))));
     }
-}
-
-fn validate_tag_data(data: &[u8]) -> Result<()> {
-    let text = std::str::from_utf8(data).context("corrupt tag object")?;
-    let mut has_object = false;
-    let mut has_type = false;
-    let mut has_tag = false;
-    let mut has_tagger = false;
-    for line in text.lines() {
-        if line.is_empty() {
-            break;
-        }
-        if line.starts_with("object ") {
-            has_object = true;
-        } else if line.starts_with("type ") {
-            has_type = true;
-        } else if line.starts_with("tag ") {
-            has_tag = true;
-        } else if line.starts_with("tagger ") {
-            has_tagger = true;
-        }
-    }
-    if has_object && has_type && has_tag && has_tagger {
-        return Ok(());
-    }
-    anyhow::bail!("corrupt tag object")
+    Ok(())
 }
 
 fn hash_and_maybe_write(

--- a/logs/2026-04-07_t1451-fsck-buffer.md
+++ b/logs/2026-04-07_t1451-fsck-buffer.md
@@ -1,0 +1,16 @@
+# t1451-fsck-buffer
+
+## Goal
+
+Make `tests/t1451-fsck-buffer.sh` pass: `git hash-object` must reject truncated commit/tag/tree buffers with the same fsck message ids and stderr as upstream Git.
+
+## Changes
+
+- Added `grit-lib/src/fsck_standalone.rs` implementing buffer-safe parsing aligned with `git/fsck.c` (`verify_headers`, commit/tree/tag validation, author/committer/tagger identity parsing).
+- `grit hash-object` calls `fsck_object` before hashing; on failure prints `error: object fails fsck: <id>: <detail>` and `fatal: refusing to create malformed object` via `Error::Message` (verbatim multi-line). Tree `badTree` also prints leading `error: too-short tree object` like Git.
+
+## Verification
+
+- `cargo build --release -p grit-rs`
+- `cargo test -p grit-lib --lib`
+- `./scripts/run-tests.sh t1451-fsck-buffer.sh` → 72/72

--- a/progress.md
+++ b/progress.md
@@ -6,13 +6,14 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |    91 |
+| Completed   |    92 |
 | In progress |     0 |
-| Remaining   |   676 |
+| Remaining   |   675 |
 | **Total**   |   767 |
 
 ## Recently completed
 
+- `t1451-fsck-buffer` — 72/72 tests pass (`hash-object` now runs Git-style standalone fsck on commit/tag/tree buffers with matching `missingTree`/`badTree`/ident diagnostics and stderr ordering; new `grit_lib::fsck_standalone`)
 - `t5405-send-pack-rewind` — 3/3 tests pass (`fetch --update-head-ok` now skips the “checked out branch” refusal when updating `refs/heads/*` destinations, matching Git; harness CSV refreshed)
 - `t6200-fmt-merge-msg-extra` — 23/23 tests pass (`fmt-merge-msg`: multi-branch/tag titles, remote URL suffix, `--into-name`, `-m` override, `--log`/`--no-log`, stdin vs `-F`, FETCH_HEAD edge cases; harness CSV refreshed)
 - `t4048-diff-combined-binary` — 14/14 tests pass (`show` merge diffs: default `--cc`, `-m`/`--format=%s` spacing, `-c`/`--cc` combined headers; `-diff`/binary attribute; `diff.<driver>.textconv` with stdin and trailing `<` stripped; `diff-tree -c -p` without textconv; `git diff` during merge emits `diff --cc` conflict hunks with textconv on stages)

--- a/t1-plan.md
+++ b/t1-plan.md
@@ -195,7 +195,7 @@
 - [ ] t1430-bad-ref-name.sh
 - [ ] t1450-fsck-basic.sh
 - [ ] t1450-fsck-flags.sh
-- [ ] t1451-fsck-buffer.sh
+- [x] t1451-fsck-buffer.sh
 - [ ] t1461-refs-list.sh
 - [ ] t1462-refs-exists.sh
 - [ ] t1463-refs-optimize.sh


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`git hash-object` must fsck commit/tag/tree payloads with the same message ids and stderr ordering as upstream Git so `t1451-fsck-buffer` can grep `missingTree`, `badTree`, etc.

## Changes

- New `grit_lib::fsck_standalone` implementing buffer-safe validation aligned with `git/fsck.c` (headers, tree OID lines, parent lines, author/committer/tagger identity parsing, gentle tree parse).
- `hash-object` validates via `fsck_object` before hashing; failures use `Error::Message` for verbatim multi-line output (`error: object fails fsck: …` + `fatal: refusing to create malformed object`). Tree `badTree` also prints the leading `error: too-short tree object` line like Git.
- Plan/progress/log updates; harness CSV and dashboards refreshed (72/72).

## Test plan

- `cargo build --release -p grit-rs`
- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t1451-fsck-buffer.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2179e8a-dbcc-44e5-ac54-650b05419177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2179e8a-dbcc-44e5-ac54-650b05419177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

