### PR TITLE
fix: t6137 pathspec wildcards and literal escapes

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -753,7 +753,7 @@ commit → check it off → move on.
 - [ ] `t6424-merge-unrelated-index-changes` ██░░░░░░░░░░░░░░░░░░ 2/19 (17 left) — merges with unrelated index changes
 - [ ] `t6019-rev-list-ancestry-path` █░░░░░░░░░░░░░░░░░░░ 1/18 (17 left) — --ancestry-path
 - [ ] `t6101-rev-parse-parents` ██████████░░░░░░░░░░ 20/38 (18 left) — Test git rev-parse with different parent options
-- [ ] `t6137-pathspec-wildcards-literal` █████░░░░░░░░░░░░░░░ 7/25 (18 left) — test wildcards and literals with git add/commit (subshell style)
+- [x] `t6137-pathspec-wildcards-literal` — 25/25 tests pass (pathspec `simple_length` + wildmatch; partial commit trees; skip `.git` on `*` expansion; bracket pathspec also matches literal `[abc]` filename)
 - [ ] `t6411-merge-filemode` █░░░░░░░░░░░░░░░░░░░ 1/19 (18 left) — merge: handle file mode
 - [ ] `t6500-gc` ████████░░░░░░░░░░░░ 15/35 (20 left) — basic git gc tests
 

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1088,7 +1088,7 @@ t6135-pathspec-with-attrs	t6	yes	37	5	32	false	ok	0
 t6135-rev-list-merge-order	t6	yes	31	31	0	true	ok	0
 t6136-pathspec-in-bare	t6	yes	3	3	0	true	ok	0
 t6136-rev-list-date-range	t6	yes	31	31	0	true	ok	0
-t6137-pathspec-wildcards-literal	t6	yes	25	7	18	false	ok	0
+t6137-pathspec-wildcards-literal	t6	yes	25	25	0	true	ok	0
 t6137-rev-parse-misc	t6	yes	34	31	3	false	ok	0
 t6138-rev-list-boundary	t6	yes	29	29	0	true	ok	0
 t6200-fmt-merge-msg	t6	skip	37	0	0	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,16 +141,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-07T21:42:02+00:00" class="gen-time" title="2026-04-07 21:42 UTC">2026-04-07 21:42 UTC</time> · <a href="https://github.com/schacon/grit/commit/9685dc050b9c69333fe99e39796e7f9e5350cb46" style="color:#58a6ff">9685dc0</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-07T22:08:09+00:00" class="gen-time" title="2026-04-07 22:08 UTC">2026-04-07 22:08 UTC</time> · <a href="https://github.com/schacon/grit/commit/3d14b3aa6fa6eca091ad8e3844bc5e301af176a8" style="color:#58a6ff">3d14b3a</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">67.3%</div>
+      <div class="summary-big-val pct-blue">67.4%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,455</div>
+      <div class="summary-big-val">29,473</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -159,12 +159,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:67.3%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:67.4%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>603 files fully passing</span>
+    <span>604 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -245,11 +245,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t6</span>
         <span class="group-desc">Revision tree commands (e.g. merge-base)</span>
-        <span class="group-meta">47/105 files · 3 skipped · 1,164/2,376 tests</span>
+        <span class="group-meta">48/105 files · 3 skipped · 1,182/2,376 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:49.0%"></div></div>
-        <span class="group-pct pct-orange">49.0%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:49.7%"></div></div>
+        <span class="group-pct pct-orange">49.7%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t7">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,13 +84,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T21:42:02+00:00" class="gen-time" title="2026-04-07 21:42 UTC">2026-04-07 21:42 UTC</time> · <a href="https://github.com/schacon/grit/commit/9685dc050b9c69333fe99e39796e7f9e5350cb46" style="color:#58a6ff">9685dc0</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T22:08:09+00:00" class="gen-time" title="2026-04-07 22:08 UTC">2026-04-07 22:08 UTC</time> · <a href="https://github.com/schacon/grit/commit/3d14b3aa6fa6eca091ad8e3844bc5e301af176a8" style="color:#58a6ff">3d14b3a</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,739</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,455</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">67.3%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,473</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">67.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -11017,14 +11017,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t6" data-tests="25" data-passed="7">
+<tr class="" data-group="t6" data-tests="25" data-passed="25">
   <td class="mono">t6137-pathspec-wildcards-literal</td>
   <td>t6</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">25</td>
-  <td class="right">7</td>
+  <td class="right">25</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:28.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t6" data-tests="34" data-passed="31">

--- a/grit-lib/src/write_tree.rs
+++ b/grit-lib/src/write_tree.rs
@@ -6,12 +6,36 @@ use crate::error::Result;
 use crate::index::{
     Index, IndexEntry, MODE_EXECUTABLE, MODE_GITLINK, MODE_REGULAR, MODE_SYMLINK, MODE_TREE,
 };
-use crate::objects::{serialize_tree, tree_entry_cmp, ObjectId, ObjectKind, TreeEntry};
+use crate::objects::{parse_tree, serialize_tree, tree_entry_cmp, ObjectId, ObjectKind, TreeEntry};
 use crate::odb::Odb;
 
 /// Build and write tree object(s) from index entries and return the tree OID.
 ///
 /// The `prefix` argument optionally limits the write to a subtree path.
+/// Like [`write_tree_from_index`], but only index entries whose path is listed in `paths`
+/// (repository-relative, as stored in the index) are included in the tree.
+pub fn write_tree_from_index_subset(
+    odb: &Odb,
+    index: &Index,
+    paths: &std::collections::HashSet<Vec<u8>>,
+) -> Result<ObjectId> {
+    let _ = odb.write(ObjectKind::Blob, b"");
+
+    let mut entries: Vec<&IndexEntry> = index
+        .entries
+        .iter()
+        .filter(|entry| {
+            entry.stage() == 0
+                && !entry.intent_to_add()
+                && entry.mode != MODE_TREE
+                && paths.contains(&entry.path)
+        })
+        .collect();
+    entries.sort_by(|a, b| a.path.cmp(&b.path).then_with(|| a.stage().cmp(&b.stage())));
+    build_tree(odb, &entries, b"")
+}
+
+/// Build and write tree object(s) from index entries and return the tree OID.
 pub fn write_tree_from_index(odb: &Odb, index: &Index, prefix: &str) -> Result<ObjectId> {
     // Ensure implicit empty blobs used by intent-to-add entries exist.
     // These entries are skipped from tree construction below, but callers
@@ -94,6 +118,142 @@ fn build_tree(odb: &Odb, entries: &[&IndexEntry], dir_prefix: &[u8]) -> Result<O
 
     let data = serialize_tree(&tree_entries);
     odb.write(ObjectKind::Tree, &data)
+}
+
+/// Build a tree for a **partial** commit: paths listed in `paths_from_index` (repository-relative,
+/// UTF-8 path bytes) are taken from `index`; every other path is copied from `base_tree_oid`
+/// (typically `HEAD^{tree}`).
+///
+/// This matches Git's behaviour when committing with pathspecs while the index contains additional
+/// staged paths: the commit tree merges `HEAD` with only the pathspec-selected index updates.
+pub fn write_tree_partial_from_index(
+    odb: &Odb,
+    index: &Index,
+    base_tree_oid: &ObjectId,
+    paths_from_index: &std::collections::HashSet<Vec<u8>>,
+) -> Result<ObjectId> {
+    let _ = odb.write(ObjectKind::Blob, b"");
+
+    fn full_path(prefix: &[u8], name: &[u8]) -> Vec<u8> {
+        if prefix.is_empty() {
+            name.to_vec()
+        } else {
+            let mut p = prefix.to_vec();
+            p.push(b'/');
+            p.extend_from_slice(name);
+            p
+        }
+    }
+
+    fn subtree_affected(paths_from_index: &std::collections::HashSet<Vec<u8>>, dir: &[u8]) -> bool {
+        paths_from_index
+            .iter()
+            .any(|p| p == dir || (p.starts_with(dir) && p.get(dir.len()) == Some(&b'/')))
+    }
+
+    fn merge_level(
+        odb: &Odb,
+        index: &Index,
+        base_tree_oid: &ObjectId,
+        prefix: &[u8],
+        paths_from_index: &std::collections::HashSet<Vec<u8>>,
+    ) -> Result<ObjectId> {
+        let base_obj = odb.read(base_tree_oid)?;
+        let base_entries = parse_tree(&base_obj.data)?;
+
+        let mut by_name: BTreeMap<Vec<u8>, TreeEntry> = BTreeMap::new();
+        for te in base_entries {
+            let fp = full_path(prefix, &te.name);
+            if !subtree_affected(paths_from_index, &fp) {
+                by_name.insert(te.name.clone(), te);
+            } else if te.mode == MODE_TREE {
+                let sub_oid = merge_level(odb, index, &te.oid, &fp, paths_from_index)?;
+                by_name.insert(
+                    te.name.clone(),
+                    TreeEntry {
+                        mode: MODE_TREE,
+                        name: te.name,
+                        oid: sub_oid,
+                    },
+                );
+            } else if paths_from_index.contains(&fp) {
+                if let Some(ie) = index.entries.iter().find(|e| {
+                    e.stage() == 0 && !e.intent_to_add() && e.mode != MODE_TREE && e.path == fp
+                }) {
+                    by_name.insert(
+                        te.name.clone(),
+                        TreeEntry {
+                            mode: canonicalize_blob_mode(ie.mode),
+                            name: te.name,
+                            oid: ie.oid,
+                        },
+                    );
+                }
+                // No index entry: path was removed — omit from the merged tree.
+            } else {
+                by_name.insert(te.name.clone(), te);
+            }
+        }
+
+        for ie in &index.entries {
+            if ie.stage() != 0 || ie.intent_to_add() || ie.mode == MODE_TREE {
+                continue;
+            }
+            if !paths_from_index.contains(&ie.path) {
+                continue;
+            }
+            let rel = if prefix.is_empty() {
+                ie.path.as_slice()
+            } else if ie.path.starts_with(prefix) && ie.path.get(prefix.len()) == Some(&b'/') {
+                &ie.path[prefix.len() + 1..]
+            } else {
+                continue;
+            };
+            if rel.is_empty() {
+                continue;
+            }
+            if let Some(slash) = rel.iter().position(|&b| b == b'/') {
+                let dir_name = rel[..slash].to_vec();
+                if by_name.contains_key(&dir_name) {
+                    continue;
+                }
+                let sub_prefix = full_path(prefix, &dir_name);
+                let sub_oid =
+                    write_tree_from_index(odb, index, &String::from_utf8_lossy(&sub_prefix))?;
+                by_name.insert(
+                    dir_name.clone(),
+                    TreeEntry {
+                        mode: MODE_TREE,
+                        name: dir_name,
+                        oid: sub_oid,
+                    },
+                );
+            } else {
+                let name = rel.to_vec();
+                if !by_name.contains_key(&name) {
+                    by_name.insert(
+                        name.clone(),
+                        TreeEntry {
+                            mode: canonicalize_blob_mode(ie.mode),
+                            name,
+                            oid: ie.oid,
+                        },
+                    );
+                }
+            }
+        }
+
+        let mut out: Vec<TreeEntry> = by_name.into_values().collect();
+        out.sort_by(|a, b| {
+            let a_tree = a.mode == MODE_TREE;
+            let b_tree = b.mode == MODE_TREE;
+            tree_entry_cmp(&a.name, a_tree, &b.name, b_tree)
+        });
+        let data = serialize_tree(&out);
+        odb.write(ObjectKind::Tree, &data)
+    }
+
+    merge_level(odb, index, base_tree_oid, b"", paths_from_index)
 }
 
 fn canonicalize_blob_mode(mode: u32) -> u32 {

--- a/grit/src/commands/add.rs
+++ b/grit/src/commands/add.rs
@@ -16,6 +16,7 @@ use grit_lib::objects::ObjectId;
 use grit_lib::objects::ObjectKind;
 use grit_lib::odb::Odb;
 use grit_lib::repo::Repository;
+use grit_lib::wildmatch::wildmatch;
 use std::fs;
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
@@ -157,7 +158,7 @@ pub fn run(mut args: Args) -> Result<()> {
 
     // Resolve the current working directory relative to the worktree
     let cwd = std::env::current_dir()?;
-    let prefix = pathdiff(&cwd, work_tree);
+    let prefix = crate::pathspec::pathdiff(&cwd, work_tree);
     die_if_in_unpopulated_submodule(&index, prefix.as_deref());
 
     // Validate empty string pathspecs
@@ -260,7 +261,8 @@ pub fn run(mut args: Args) -> Result<()> {
         let mut had_errors = false;
         let mut had_ignored = false;
         for pathspec in &args.pathspec {
-            let resolved = resolve_pathspec(pathspec, work_tree, prefix.as_deref());
+            let resolved =
+                crate::pathspec::resolve_pathspec(pathspec, work_tree, prefix.as_deref());
             // Expand glob patterns (e.g. "file?.t", "*.c") against the working tree.
             let expanded = expand_glob_pathspec(&resolved, work_tree);
             for resolved in &expanded {
@@ -389,7 +391,7 @@ fn run_refresh(
         }
     } else {
         for pathspec in &args.pathspec {
-            let resolved = resolve_pathspec(pathspec, work_tree, prefix);
+            let resolved = crate::pathspec::resolve_pathspec(pathspec, work_tree, prefix);
             let found = index.entries.iter_mut().any(|ie| {
                 let path_str = String::from_utf8_lossy(&ie.path);
                 if path_str == resolved || path_str.starts_with(&format!("{resolved}/")) {
@@ -1279,21 +1281,6 @@ fn walk_directory(
     Ok(())
 }
 
-/// Compute path relative to work tree from cwd.
-fn pathdiff(cwd: &Path, work_tree: &Path) -> Option<String> {
-    let cwd_canon = cwd.canonicalize().ok()?;
-    let wt_canon = work_tree.canonicalize().ok()?;
-
-    if cwd_canon == wt_canon {
-        return None;
-    }
-
-    cwd_canon
-        .strip_prefix(&wt_canon)
-        .ok()
-        .map(|p| p.to_string_lossy().to_string())
-}
-
 /// Exit when running inside an unpopulated submodule worktree path.
 ///
 /// Git discovers the superproject when invoked from an unpopulated submodule
@@ -1347,136 +1334,12 @@ fn check_symlink_in_path(work_tree: &Path, rel_path: &Path) -> Option<PathBuf> {
     None
 }
 
-/// Resolve a pathspec relative to the prefix (cwd within worktree).
-fn resolve_pathspec(pathspec: &str, work_tree: &Path, prefix: Option<&str>) -> String {
-    if pathspec == "." {
-        return prefix.unwrap_or("").to_owned();
-    }
-    // Normalize relative paths with .. by converting to absolute first
-    if pathspec.contains("../") || pathspec.starts_with("../") {
-        let cwd = std::env::current_dir().unwrap_or_default();
-        let abs = cwd.join(pathspec);
-        let wt_canon = work_tree.canonicalize().unwrap_or(work_tree.to_path_buf());
-        // Normalize abs without requiring existence
-        let mut parts: Vec<std::ffi::OsString> = Vec::new();
-        for component in abs.components() {
-            use std::path::Component;
-            match component {
-                Component::ParentDir => {
-                    parts.pop();
-                }
-                Component::CurDir => {}
-                other => parts.push(other.as_os_str().to_os_string()),
-            }
-        }
-        let abs_norm: std::path::PathBuf = parts.iter().collect();
-        if let Ok(rel) = abs_norm.strip_prefix(&wt_canon) {
-            return rel.to_string_lossy().to_string();
-        }
-    }
-    // Handle absolute paths: make relative to work tree
-    if std::path::Path::new(pathspec).is_absolute() {
-        let abs = std::path::Path::new(pathspec);
-        // Try to strip work tree prefix
-        let wt_canon = work_tree.canonicalize().unwrap_or(work_tree.to_path_buf());
-        let abs_canon = abs.canonicalize().unwrap_or(abs.to_path_buf());
-        if let Ok(rel) = abs_canon.strip_prefix(&wt_canon) {
-            return rel.to_string_lossy().to_string();
-        }
-        // Not under work tree — error will be caught later
-        return pathspec.to_owned();
-    }
-
-    // Magic pathspecs starting with ":" should not have prefix prepended.
-    // ":/<pattern>" means match from the root of the working tree.
-    // ":(magic)pattern" means use magic signature parsing.
-    if pathspec.starts_with(':') {
-        // ":/<pattern>" — top-level pathspec from repo root
-        if let Some(rest) = pathspec.strip_prefix(":/") {
-            // Treat the pattern as a path from the repo root
-            return rest.to_owned();
-        }
-        // ":(magic)pattern" — long-form magic, extract the pattern part
-        if pathspec.len() > 1 && pathspec.as_bytes()[1] == b'(' {
-            if let Some(close) = pathspec[2..].find(')') {
-                let pattern = &pathspec[close + 3..];
-                return pattern.to_owned();
-            }
-        }
-        // Other colon-prefixed — return as-is
-        return pathspec.to_owned();
-    }
-
-    match prefix {
-        Some(p) if !p.is_empty() => {
-            let combined = PathBuf::from(p).join(pathspec);
-            combined.to_string_lossy().to_string()
-        }
-        _ => pathspec.to_owned(),
-    }
-}
-
-/// Check whether a string contains glob metacharacters.
-fn has_glob_chars(s: &str) -> bool {
-    s.contains('*') || s.contains('?') || s.contains('[')
-}
-
-/// Simple glob pattern matching against a single path component name.
-fn glob_matches(pattern: &str, name: &str) -> bool {
-    glob_match_inner(pattern.as_bytes(), name.as_bytes())
-}
-
-fn glob_match_inner(pat: &[u8], text: &[u8]) -> bool {
-    let mut pi = 0;
-    let mut ti = 0;
-    let mut star_pi = usize::MAX;
-    let mut star_ti = 0;
-    while ti < text.len() {
-        if pi < pat.len() && (pat[pi] == b'?' || pat[pi] == text[ti]) {
-            pi += 1;
-            ti += 1;
-        } else if pi < pat.len() && pat[pi] == b'[' {
-            // bracket expression
-            if let Some(end) = pat[pi..].iter().position(|&b| b == b']') {
-                let inside = &pat[pi + 1..pi + end];
-                let matches_bracket = inside.contains(&text[ti]);
-                if matches_bracket {
-                    pi = pi + end + 1;
-                    ti += 1;
-                } else if star_pi != usize::MAX {
-                    pi = star_pi + 1;
-                    star_ti += 1;
-                    ti = star_ti;
-                } else {
-                    return false;
-                }
-            } else {
-                return false;
-            }
-        } else if pi < pat.len() && pat[pi] == b'*' {
-            star_pi = pi;
-            star_ti = ti;
-            pi += 1;
-        } else if star_pi != usize::MAX {
-            pi = star_pi + 1;
-            star_ti += 1;
-            ti = star_ti;
-        } else {
-            return false;
-        }
-    }
-    while pi < pat.len() && pat[pi] == b'*' {
-        pi += 1;
-    }
-    pi == pat.len()
-}
-
 /// Expand a pathspec containing glob characters against the working tree.
 ///
 /// If the pathspec does not contain glob characters, returns it unchanged.
 /// Otherwise, matches it against files/dirs in the working tree directory.
 fn expand_glob_pathspec(pathspec: &str, work_tree: &Path) -> Vec<String> {
-    if !has_glob_chars(pathspec) {
+    if !crate::pathspec::has_glob_chars(pathspec) {
         return vec![pathspec.to_owned()];
     }
 
@@ -1499,7 +1362,10 @@ fn expand_glob_pathspec(pathspec: &str, work_tree: &Path) -> Vec<String> {
         for entry in entries.flatten() {
             let name = entry.file_name();
             let name_str = name.to_string_lossy();
-            if glob_matches(pattern, &name_str) {
+            if name_str == ".git" {
+                continue;
+            }
+            if wildmatch(pattern.as_bytes(), name_str.as_bytes(), 0) {
                 let rel = if dir_prefix.is_empty() {
                     name_str.to_string()
                 } else {
@@ -1507,6 +1373,19 @@ fn expand_glob_pathspec(pathspec: &str, work_tree: &Path) -> Vec<String> {
                 };
                 matches.push(rel);
             }
+        }
+    }
+
+    // Git pathspec: a bracket pattern like `[abc]` matches one character class member *and*
+    // the literal filename `[abc]` when present (wildmatch alone does not match that literal).
+    if pattern.contains('[') && fs::symlink_metadata(search_dir.join(pattern)).is_ok() {
+        let rel = if dir_prefix.is_empty() {
+            pattern.to_string()
+        } else {
+            format!("{dir_prefix}/{pattern}")
+        };
+        if !matches.contains(&rel) {
+            matches.push(rel);
         }
     }
 

--- a/grit/src/commands/commit.rs
+++ b/grit/src/commands/commit.rs
@@ -15,11 +15,13 @@ use grit_lib::refs::append_reflog;
 use grit_lib::repo::Repository;
 use grit_lib::rev_parse::resolve_revision;
 use grit_lib::state::{resolve_head, HeadState};
-use grit_lib::write_tree::write_tree_from_index;
-use std::collections::BTreeSet;
+use grit_lib::write_tree::{
+    write_tree_from_index, write_tree_from_index_subset, write_tree_partial_from_index,
+};
+use std::collections::{BTreeSet, HashSet};
 use std::fs;
 use std::io::{self, Write};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use time::OffsetDateTime;
 
 /// Arguments for `grit commit`.
@@ -214,12 +216,15 @@ pub fn run(args: Args) -> Result<()> {
         }
     }
 
-    // If pathspec given, stage those specific files first
-    if !args.pathspec.is_empty() {
-        if let Some(wt) = work_tree {
-            stage_pathspec_files(&repo, wt, &args.pathspec)?;
-        }
-    }
+    // If pathspec given, stage those specific files first (returns paths included in this commit)
+    let pathspec_matched: Option<HashSet<Vec<u8>>> = if !args.pathspec.is_empty() {
+        let Some(wt) = work_tree else {
+            bail!("pathspec requires a work tree");
+        };
+        Some(stage_pathspec_files(&repo, wt, &args.pathspec)?)
+    } else {
+        None
+    };
 
     // Load index
     let index = match repo.load_index() {
@@ -228,23 +233,62 @@ pub fn run(args: Args) -> Result<()> {
         Err(e) => return Err(e.into()),
     };
 
-    // Write tree from index
-    let tree_oid = match write_tree_from_index(&repo.odb, &index, "") {
-        Ok(oid) => oid,
-        Err(err) => {
-            if is_permission_denied_error(&err) {
-                eprintln!(
-                    "error: insufficient permission for adding an object to repository database .git/objects"
-                );
-                eprintln!("error: Error building trees");
-                std::process::exit(128);
-            }
-            return Err(err.into());
-        }
+    // Resolve HEAD for parent(s) and optional base tree for partial commits
+    let head = resolve_head(&repo.git_dir)?;
+    let parent_tree_oid = if let Some(head_oid) = head.oid() {
+        let obj = repo.odb.read(head_oid)?;
+        let commit = grit_lib::objects::parse_commit(&obj.data)?;
+        Some(commit.tree)
+    } else {
+        None
     };
 
-    // Resolve HEAD for parent(s)
-    let head = resolve_head(&repo.git_dir)?;
+    // Write tree: pathspec commits record only matched paths (Git partial / initial pathspec commit)
+    let tree_oid = match (&pathspec_matched, &parent_tree_oid) {
+        (Some(paths), Some(base)) if !paths.is_empty() => {
+            match write_tree_partial_from_index(&repo.odb, &index, base, paths) {
+                Ok(oid) => oid,
+                Err(err) => {
+                    if is_permission_denied_error(&err) {
+                        eprintln!(
+                            "error: insufficient permission for adding an object to repository database .git/objects"
+                        );
+                        eprintln!("error: Error building trees");
+                        std::process::exit(128);
+                    }
+                    return Err(err.into());
+                }
+            }
+        }
+        (Some(paths), None) if !paths.is_empty() => {
+            match write_tree_from_index_subset(&repo.odb, &index, paths) {
+                Ok(oid) => oid,
+                Err(err) => {
+                    if is_permission_denied_error(&err) {
+                        eprintln!(
+                            "error: insufficient permission for adding an object to repository database .git/objects"
+                        );
+                        eprintln!("error: Error building trees");
+                        std::process::exit(128);
+                    }
+                    return Err(err.into());
+                }
+            }
+        }
+        _ => match write_tree_from_index(&repo.odb, &index, "") {
+            Ok(oid) => oid,
+            Err(err) => {
+                if is_permission_denied_error(&err) {
+                    eprintln!(
+                        "error: insufficient permission for adding an object to repository database .git/objects"
+                    );
+                    eprintln!("error: Error building trees");
+                    std::process::exit(128);
+                }
+                return Err(err.into());
+            }
+        },
+    };
     let mut parents = Vec::new();
     let old_head_oid = head.oid().cloned();
 
@@ -732,59 +776,118 @@ fn walk_untracked(
 }
 
 /// Stage specific files given as pathspec arguments to `commit`.
-fn stage_pathspec_files(repo: &Repository, work_tree: &Path, pathspecs: &[String]) -> Result<()> {
+///
+/// Returns the set of repository-relative paths that were staged (or removed) for this commit.
+fn stage_pathspec_files(
+    repo: &Repository,
+    work_tree: &Path,
+    pathspecs: &[String],
+) -> Result<HashSet<Vec<u8>>> {
+    use std::os::unix::fs::MetadataExt;
+
     let mut index = match repo.load_index() {
         Ok(idx) => idx,
         Err(Error::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => Index::new(),
         Err(e) => return Err(e.into()),
     };
 
-    // Resolve pathspecs relative to the current directory
     let cwd = std::env::current_dir().unwrap_or_else(|_| work_tree.to_path_buf());
-    // Canonicalize work_tree to resolve symlinks for proper prefix stripping
-    let canon_work_tree = work_tree
-        .canonicalize()
-        .unwrap_or_else(|_| work_tree.to_path_buf());
+    let prefix = crate::pathspec::pathdiff(&cwd, work_tree);
+
+    let mut matched_paths = HashSet::new();
 
     for spec in pathspecs {
-        // Resolve the pathspec relative to cwd
-        let abs_path = if std::path::Path::new(spec).is_absolute() {
-            PathBuf::from(spec)
-        } else {
-            cwd.join(spec)
-        };
-        // Canonicalize to resolve symlinks, then compute relative path to work_tree
-        let canon_path = abs_path.canonicalize().unwrap_or(abs_path.clone());
-        let rel_path = canon_path
-            .strip_prefix(&canon_work_tree)
-            .unwrap_or_else(|_| {
-                // Fallback: try stripping non-canonical work_tree
-                abs_path
-                    .strip_prefix(work_tree)
-                    .unwrap_or(std::path::Path::new(spec))
-            });
-        let rel_str = rel_path.to_string_lossy().to_string();
-        if let Ok(meta) = fs::symlink_metadata(&canon_path) {
-            use std::os::unix::fs::MetadataExt;
-            let data = if meta.file_type().is_symlink() {
-                let target = fs::read_link(&canon_path)?;
-                target.to_string_lossy().into_owned().into_bytes()
+        let resolved = crate::pathspec::resolve_pathspec(spec, work_tree, prefix.as_deref());
+        if !crate::pathspec::has_glob_chars(&resolved) {
+            let abs_path = work_tree.join(&resolved);
+            if let Ok(meta) = fs::symlink_metadata(&abs_path) {
+                let data = if meta.file_type().is_symlink() {
+                    let target = fs::read_link(&abs_path)?;
+                    target.to_string_lossy().into_owned().into_bytes()
+                } else {
+                    fs::read(&abs_path)?
+                };
+                let oid = repo.odb.write(ObjectKind::Blob, &data)?;
+                let mode = grit_lib::index::normalize_mode(meta.mode());
+                let raw_path = resolved.as_bytes().to_vec();
+                let entry = grit_lib::index::entry_from_stat(&abs_path, &raw_path, oid, mode)?;
+                index.add_or_replace(entry);
+                matched_paths.insert(raw_path);
             } else {
-                fs::read(&canon_path)?
-            };
-            let oid = repo.odb.write(ObjectKind::Blob, &data)?;
-            let mode = grit_lib::index::normalize_mode(meta.mode());
-            let raw_path = rel_str.as_bytes().to_vec();
-            let entry = grit_lib::index::entry_from_stat(&canon_path, &raw_path, oid, mode)?;
-            index.add_or_replace(entry);
+                index.remove(resolved.as_bytes());
+                matched_paths.insert(resolved.as_bytes().to_vec());
+            }
+            continue;
+        }
+
+        let (dir_prefix, pattern) = if let Some(slash_pos) = resolved.rfind('/') {
+            (&resolved[..slash_pos], &resolved[slash_pos + 1..])
         } else {
-            // File deleted — remove from index
-            index.remove(rel_str.as_bytes());
+            ("", resolved.as_str())
+        };
+
+        let search_dir = if dir_prefix.is_empty() {
+            work_tree.to_path_buf()
+        } else {
+            work_tree.join(dir_prefix)
+        };
+
+        let mut spec_matched = false;
+        let mut matched_rels: Vec<String> = Vec::new();
+        if let Ok(entries) = fs::read_dir(&search_dir) {
+            for entry in entries.flatten() {
+                let name_str = entry.file_name().to_string_lossy().to_string();
+                if name_str == ".git" {
+                    continue;
+                }
+                if !grit_lib::wildmatch::wildmatch(pattern.as_bytes(), name_str.as_bytes(), 0) {
+                    continue;
+                }
+                let rel = if dir_prefix.is_empty() {
+                    name_str.clone()
+                } else {
+                    format!("{dir_prefix}/{name_str}")
+                };
+                matched_rels.push(rel);
+            }
+        }
+        if pattern.contains('[') && fs::symlink_metadata(search_dir.join(pattern)).is_ok() {
+            let rel = if dir_prefix.is_empty() {
+                pattern.to_string()
+            } else {
+                format!("{dir_prefix}/{pattern}")
+            };
+            if !matched_rels.contains(&rel) {
+                matched_rels.push(rel);
+            }
+        }
+
+        for rel in matched_rels {
+            let abs_path = work_tree.join(&rel);
+            if let Ok(meta) = fs::symlink_metadata(&abs_path) {
+                let data = if meta.file_type().is_symlink() {
+                    let target = fs::read_link(&abs_path)?;
+                    target.to_string_lossy().into_owned().into_bytes()
+                } else {
+                    fs::read(&abs_path)?
+                };
+                let oid = repo.odb.write(ObjectKind::Blob, &data)?;
+                let mode = grit_lib::index::normalize_mode(meta.mode());
+                let raw_path = rel.as_bytes().to_vec();
+                let entry = grit_lib::index::entry_from_stat(&abs_path, &raw_path, oid, mode)?;
+                index.add_or_replace(entry);
+                spec_matched = true;
+                matched_paths.insert(raw_path);
+            }
+        }
+
+        if !spec_matched {
+            bail!("pathspec '{spec}' did not match any file(s) known to git");
         }
     }
 
     repo.write_index(&mut index)?;
-    Ok(())
+    Ok(matched_paths)
 }
 
 /// Auto-stage tracked files (for `commit -a`).

--- a/grit/src/pathspec.rs
+++ b/grit/src/pathspec.rs
@@ -1,8 +1,36 @@
 //! Pathspec matching utilities shared across commands.
 
-/// Check if a string contains glob meta-characters.
+use grit_lib::wildmatch::{wildmatch, WM_CASEFOLD};
+use std::path::{Path, PathBuf};
+
+/// True if `c` is glob-special in Git's pathspec rules (`*`, `?`, `[`, `\`).
+#[inline]
+fn is_glob_special_byte(c: u8) -> bool {
+    matches!(c, b'*' | b'?' | b'[' | b'\\')
+}
+
+/// Length of the literal prefix before the first glob-special byte (Git's `simple_length`).
+///
+/// Backslash is glob-special: in `f\*` the prefix length is `1` (`f`), and the wildcard
+/// tail `\*` is matched with [`wildmatch`]. A lone `\` at the end is treated as a literal
+/// backslash (no glob tail).
+#[must_use]
+pub fn simple_length(pattern: &str) -> usize {
+    let b = pattern.as_bytes();
+    let mut i = 0usize;
+    while i < b.len() {
+        if is_glob_special_byte(b[i]) {
+            return i;
+        }
+        i += 1;
+    }
+    i
+}
+
+/// Whether the pattern uses wildcards after Git pathspec escaping rules.
+#[must_use]
 pub fn has_glob_chars(s: &str) -> bool {
-    s.contains('*') || s.contains('?') || s.contains('[')
+    simple_length(s) < s.len()
 }
 
 /// Simple glob matching for git pathspecs.
@@ -117,22 +145,42 @@ pub fn pathspec_matches(spec: &str, path: &str) -> bool {
         return true;
     }
 
-    if magic.icase {
-        let pattern_folded = pattern.to_ascii_lowercase();
-        let path_folded = path.to_ascii_lowercase();
-        if has_glob_chars(pattern) {
-            glob_match(&pattern_folded, &path_folded)
-        } else if let Some(prefix) = pattern_folded.strip_suffix('/') {
-            path_folded == prefix || path_folded.starts_with(&format!("{prefix}/"))
+    let wm_flags = if magic.icase { WM_CASEFOLD } else { 0 };
+    let nwl = simple_length(pattern);
+
+    if nwl == pattern.len() {
+        if magic.icase {
+            let pattern_folded = pattern.to_ascii_lowercase();
+            let path_folded = path.to_ascii_lowercase();
+            if let Some(prefix) = pattern_folded.strip_suffix('/') {
+                path_folded == prefix || path_folded.starts_with(&format!("{prefix}/"))
+            } else {
+                path_folded == pattern_folded
+                    || path_folded.starts_with(&format!("{pattern_folded}/"))
+            }
+        } else if let Some(prefix) = pattern.strip_suffix('/') {
+            path == prefix || path.starts_with(&format!("{prefix}/"))
         } else {
-            path_folded == pattern_folded || path_folded.starts_with(&format!("{pattern_folded}/"))
+            path == pattern || path.starts_with(&format!("{pattern}/"))
         }
-    } else if has_glob_chars(pattern) {
-        glob_match(pattern, path)
-    } else if let Some(prefix) = pattern.strip_suffix('/') {
-        path == prefix || path.starts_with(&format!("{prefix}/"))
     } else {
-        path == pattern || path.starts_with(&format!("{pattern}/"))
+        let lit = &pattern.as_bytes()[..nwl];
+        let path_b = path.as_bytes();
+        if path_b.len() < nwl {
+            return false;
+        }
+        let path_lit = &path_b[..nwl];
+        let same = if magic.icase {
+            path_lit.eq_ignore_ascii_case(lit)
+        } else {
+            path_lit == lit
+        };
+        if !same {
+            return false;
+        }
+        let pat_rest = &pattern[nwl..];
+        let path_rest = &path[nwl..];
+        wildmatch(pat_rest.as_bytes(), path_rest.as_bytes(), wm_flags)
     }
 }
 
@@ -255,4 +303,85 @@ fn normalize_relative_path_str(path: &str) -> String {
         }
     }
     parts.join("/")
+}
+
+/// Current directory relative to `work_tree`, or `None` if cwd is the work tree root.
+#[must_use]
+pub fn pathdiff(cwd: &Path, work_tree: &Path) -> Option<String> {
+    let cwd_canon = cwd.canonicalize().ok()?;
+    let wt_canon = work_tree.canonicalize().ok()?;
+
+    if cwd_canon == wt_canon {
+        return None;
+    }
+
+    cwd_canon
+        .strip_prefix(&wt_canon)
+        .ok()
+        .map(|p| p.to_string_lossy().to_string())
+}
+
+/// Resolve a pathspec string to a path relative to the repository work tree.
+///
+/// `prefix` is the current directory relative to the work tree (no trailing slash),
+/// or `None` when cwd is the work tree root.
+#[must_use]
+pub fn resolve_pathspec(pathspec: &str, work_tree: &Path, prefix: Option<&str>) -> String {
+    if pathspec == "." {
+        return prefix.unwrap_or("").to_owned();
+    }
+    if pathspec.contains("../") || pathspec.starts_with("../") {
+        let cwd = std::env::current_dir().unwrap_or_default();
+        let abs = cwd.join(pathspec);
+        let wt_canon = work_tree
+            .canonicalize()
+            .unwrap_or_else(|_| work_tree.to_path_buf());
+        let mut parts: Vec<std::ffi::OsString> = Vec::new();
+        for component in abs.components() {
+            use std::path::Component;
+            match component {
+                Component::ParentDir => {
+                    parts.pop();
+                }
+                Component::CurDir => {}
+                other => parts.push(other.as_os_str().to_os_string()),
+            }
+        }
+        let abs_norm: PathBuf = parts.iter().collect();
+        if let Ok(rel) = abs_norm.strip_prefix(&wt_canon) {
+            return rel.to_string_lossy().to_string();
+        }
+    }
+    if Path::new(pathspec).is_absolute() {
+        let abs = Path::new(pathspec);
+        let wt_canon = work_tree
+            .canonicalize()
+            .unwrap_or_else(|_| work_tree.to_path_buf());
+        let abs_canon = abs.canonicalize().unwrap_or_else(|_| abs.to_path_buf());
+        if let Ok(rel) = abs_canon.strip_prefix(&wt_canon) {
+            return rel.to_string_lossy().to_string();
+        }
+        return pathspec.to_owned();
+    }
+
+    if pathspec.starts_with(':') {
+        if let Some(rest) = pathspec.strip_prefix(":/") {
+            return rest.to_owned();
+        }
+        if pathspec.len() > 1 && pathspec.as_bytes()[1] == b'(' {
+            if let Some(close) = pathspec[2..].find(')') {
+                let pattern = &pathspec[close + 3..];
+                return pattern.to_owned();
+            }
+        }
+        return pathspec.to_owned();
+    }
+
+    match prefix {
+        Some(p) if !p.is_empty() => PathBuf::from(p)
+            .join(pathspec)
+            .to_string_lossy()
+            .to_string(),
+        _ => pathspec.to_owned(),
+    }
 }

--- a/logs/2026-04-07_t6137-pathspec-wildcards-literal.md
+++ b/logs/2026-04-07_t6137-pathspec-wildcards-literal.md
@@ -1,0 +1,22 @@
+# t6137-pathspec-wildcards-literal
+
+## Goal
+
+Make `tests/t6137-pathspec-wildcards-literal.sh` pass (25 tests): `git add` / `git commit` with shell-style pathspecs, escaped literals (`\*`, `\?`, `\[abc\]`), and wildcards.
+
+## Changes
+
+- **`grit/src/pathspec.rs`**: Added Git `simple_length` (treat `* ? [ \` as glob-special). `has_glob_chars` uses it. `pathspec_matches` compares literal prefix then `wildmatch` on the tail. Moved `resolve_pathspec` and `pathdiff` here for reuse.
+- **`grit/src/commands/add.rs`**: Use shared pathspec helpers; `expand_glob_pathspec` uses `wildmatch`; skip `.git` when expanding; if pattern contains `[` and a file exists whose name equals the pattern string, include it (matches test expectation for `[abc]` + `a`).
+- **`grit-lib/src/write_tree.rs`**: `write_tree_partial_from_index` merges `HEAD^{tree}` with index updates only for listed paths; `write_tree_from_index_subset` for root commit with pathspec.
+- **`grit/src/commands/commit.rs`**: Pathspec staging returns matched path set; tree OID from partial merge when `HEAD` exists, else subset of index; same bracket + `.git` rules as add.
+
+## Validation
+
+- `./scripts/run-tests.sh t6137-pathspec-wildcards-literal.sh` — 25/25 pass
+- `cargo test -p grit-lib --lib` — pass
+- `cargo fmt`
+
+## Note
+
+System `git` 2.43 in this environment stages only `[abc]` for `git add "[abc]"`; the upstream test expects both `[abc]` and `a`. Grit follows the vendored test file in `tests/`.

--- a/progress.md
+++ b/progress.md
@@ -6,13 +6,14 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |    92 |
+| Completed   |    93 |
 | In progress |     0 |
-| Remaining   |   675 |
+| Remaining   |   674 |
 | **Total**   |   767 |
 
 ## Recently completed
 
+- `t6137-pathspec-wildcards-literal` — 25/25 tests pass (Git-style pathspec glob boundaries with `\` escapes; `add`/`commit` pathspec expansion uses `wildmatch`, ignores `.git` for `*`/`**`, bracket patterns also pick up a literal `[abc]` file; `commit` with pathspec builds partial trees: merge with `HEAD^{tree}` or subset tree on root commit)
 - `t1451-fsck-buffer` — 72/72 tests pass (`hash-object` now runs Git-style standalone fsck on commit/tag/tree buffers with matching `missingTree`/`badTree`/ident diagnostics and stderr ordering; new `grit_lib::fsck_standalone`)
 - `t5405-send-pack-rewind` — 3/3 tests pass (`fetch --update-head-ok` now skips the “checked out branch” refusal when updating `refs/heads/*` destinations, matching Git; harness CSV refreshed)
 - `t6200-fmt-merge-msg-extra` — 23/23 tests pass (`fmt-merge-msg`: multi-branch/tag titles, remote URL suffix, `--into-name`, `-m` override, `--log`/`--no-log`, stdin vs `-F`, FETCH_HEAD edge cases; harness CSV refreshed)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-style pathspec glob boundaries (including `\` as glob-special per `simple_length`), uses `wildmatch` for expansion and matching, fixes `git add` glob expansion to ignore `.git` when `*` / `**` match directory entries, and implements partial commit trees when committing with pathspecs (merge `HEAD^{tree}` with only matched index paths, or subset tree on root commit).

Also handles bracket pathspecs so a pattern like `[abc]` stages both class members and a literal file named `[abc]` when present, matching `tests/t6137-pathspec-wildcards-literal.sh`.

## Test plan

- `./scripts/run-tests.sh t6137-pathspec-wildcards-literal.sh` (25/25)
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47761364-3c71-4ed2-ad95-97c28d0f950c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47761364-3c71-4ed2-ad95-97c28d0f950c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

