### PR TITLE
test: t8650-cat-file-batch-extra fully passing (harness refresh)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1354,7 +1354,7 @@ t8600-update-ref-symref	t8	yes	28	20	8	false	ok	0
 t8610-checkout-index-modes	t8	yes	27	25	2	false	ok	0
 t8630-ls-tree-format	t8	yes	29	29	0	true	ok	0
 t8640-ls-files-stage-unmerged	t8	yes	31	18	13	false	ok	0
-t8650-cat-file-batch-extra	t8	yes	27	26	1	false	ok	0
+t8650-cat-file-batch-extra	t8	yes	27	27	0	true	ok	0
 t8660-mktree-ls-tree-modes	t8	yes	26	26	0	true	ok	0
 t8670-write-tree-index	t8	yes	27	27	0	true	ok	0
 t8680-commit-tree-verify	t8	yes	26	26	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-07T21:50:51+00:00" class="gen-time" title="2026-04-07 21:50 UTC">2026-04-07 21:50 UTC</time> · <a href="https://github.com/schacon/grit/commit/bf5ba144fabd92222ec2f3a37fc1e0284870bd4c" style="color:#58a6ff">bf5ba14</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-07T22:09:58+00:00" class="gen-time" title="2026-04-07 22:09 UTC">2026-04-07 22:09 UTC</time> · <a href="https://github.com/schacon/grit/commit/f79c64a6193b078f77c1e66c4fa7ffcd0d5e5262" style="color:#58a6ff">f79c64a</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,455</div>
+      <div class="summary-big-val">29,456</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>603 files fully passing</span>
+    <span>604 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -267,7 +267,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t8</span>
         <span class="group-desc">Porcelainish commands concerning forensics</span>
-        <span class="group-meta">64/105 files · 0 skipped · 2,545/2,763 tests</span>
+        <span class="group-meta">65/105 files · 0 skipped · 2,546/2,763 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-green" style="width:92.1%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T21:50:51+00:00" class="gen-time" title="2026-04-07 21:50 UTC">2026-04-07 21:50 UTC</time> · <a href="https://github.com/schacon/grit/commit/bf5ba144fabd92222ec2f3a37fc1e0284870bd4c" style="color:#58a6ff">bf5ba14</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T22:09:58+00:00" class="gen-time" title="2026-04-07 22:09 UTC">2026-04-07 22:09 UTC</time> · <a href="https://github.com/schacon/grit/commit/f79c64a6193b078f77c1e66c4fa7ffcd0d5e5262" style="color:#58a6ff">f79c64a</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,739</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,455</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,456</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">67.3%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -13677,14 +13677,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:58.1%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t8" data-tests="27" data-passed="26">
+<tr class="" data-group="t8" data-tests="27" data-passed="27">
   <td class="mono">t8650-cat-file-batch-extra</td>
   <td>t8</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">27</td>
-  <td class="right">26</td>
+  <td class="right">27</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:96.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t8" data-tests="26" data-passed="26">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`git cat-file --batch` / `--batch-check` behavior already satisfies `tests/t8650-cat-file-batch-extra.sh` (27/27). This change refresifies harness metadata after `./scripts/run-tests.sh t8650-cat-file-batch-extra.sh`.

## Changes

- Update `data/test-files.csv` row for `t8650-cat-file-batch-extra` to 27 passed / 0 failed, `fully_passing=true`
- Regenerate `docs/index.html` and `docs/testfiles.html`

## Verification

```bash
./scripts/run-tests.sh t8650-cat-file-batch-extra.sh
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7045dcc1-113b-45d1-b834-ffd09ae256b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7045dcc1-113b-45d1-b834-ffd09ae256b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

