### PR TITLE
test: t12730-switch-start-point fully passing (36/36)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -325,7 +325,7 @@ t12670-branch-force-delete	t1	yes	32	30	2	false	ok	0
 t12700-add-edit-intent	t1	yes	37	31	6	false	ok	0
 t12710-rm-staged-conflict	t1	yes	37	37	0	true	ok	0
 t12720-mv-cross-directory	t1	yes	37	37	0	true	ok	0
-t12730-switch-start-point	t1	yes	36	17	19	false	ok	0
+t12730-switch-start-point	t1	yes	36	36	0	true	ok	0
 t12740-restore-deleted-paths	t1	yes	35	35	0	true	ok	0
 t12750-reset-mixed-paths	t1	yes	34	34	0	true	ok	0
 t12760-cherry-pick-multi-range	t1	yes	34	33	1	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,16 +141,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-07T22:10:58+00:00" class="gen-time" title="2026-04-07 22:10 UTC">2026-04-07 22:10 UTC</time> · <a href="https://github.com/schacon/grit/commit/c4eb18ffc5501e6dda6ef3ea5e60c2cb498d2623" style="color:#58a6ff">c4eb18f</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-07T22:24:04+00:00" class="gen-time" title="2026-04-07 22:24 UTC">2026-04-07 22:24 UTC</time> · <a href="https://github.com/schacon/grit/commit/9b53886a6a1966f6807e8ca0cbeae6b8f4447896" style="color:#58a6ff">9b53886</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">67.3%</div>
+      <div class="summary-big-val pct-blue">67.4%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,455</div>
+      <div class="summary-big-val">29,474</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -159,12 +159,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:67.3%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:67.4%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>603 files fully passing</span>
+    <span>604 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -190,11 +190,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">235/368 files · 8 skipped · 10,514/12,224 tests</span>
+        <span class="group-meta">236/368 files · 8 skipped · 10,533/12,224 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:86.0%"></div></div>
-        <span class="group-pct pct-green">86.0%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:86.2%"></div></div>
+        <span class="group-pct pct-green">86.2%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t2">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,13 +84,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T22:10:58+00:00" class="gen-time" title="2026-04-07 22:10 UTC">2026-04-07 22:10 UTC</time> · <a href="https://github.com/schacon/grit/commit/c4eb18ffc5501e6dda6ef3ea5e60c2cb498d2623" style="color:#58a6ff">c4eb18f</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T22:24:04+00:00" class="gen-time" title="2026-04-07 22:24 UTC">2026-04-07 22:24 UTC</time> · <a href="https://github.com/schacon/grit/commit/9b53886a6a1966f6807e8ca0cbeae6b8f4447896" style="color:#58a6ff">9b53886</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,739</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,455</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">67.3%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,474</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">67.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -3387,14 +3387,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="36" data-passed="17">
+<tr class="" data-group="t1" data-tests="36" data-passed="36">
   <td class="mono">t12730-switch-start-point</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">36</td>
-  <td class="right">17</td>
+  <td class="right">36</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:47.2%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="35" data-passed="35">

--- a/logs/2026-04-07_t12730-switch-start-point.md
+++ b/logs/2026-04-07_t12730-switch-start-point.md
@@ -1,0 +1,5 @@
+# t12730-switch-start-point
+
+- Ran `./scripts/run-tests.sh t12730-switch-start-point.sh` on branch `cursor/t12730-switch-start-point-5a8b`.
+- Result: **36/36** pass (no Rust changes required; `grit switch` already satisfies `-c`/start-point, `--detach`, `--orphan`, abbreviated OIDs, `HEAD~N`, etc.).
+- Refreshed `data/test-files.csv` and dashboard HTML via the harness.

--- a/progress.md
+++ b/progress.md
@@ -6,13 +6,14 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |    92 |
+| Completed   |    93 |
 | In progress |     0 |
-| Remaining   |   675 |
+| Remaining   |   674 |
 | **Total**   |   767 |
 
 ## Recently completed
 
+- `t12730-switch-start-point` — 36/36 tests pass (`grit switch -c` with start-point, `--detach`, `--orphan`, tags, abbreviated hashes, `HEAD~N`; harness CSV refreshed)
 - `t1451-fsck-buffer` — 72/72 tests pass (`hash-object` now runs Git-style standalone fsck on commit/tag/tree buffers with matching `missingTree`/`badTree`/ident diagnostics and stderr ordering; new `grit_lib::fsck_standalone`)
 - `t5405-send-pack-rewind` — 3/3 tests pass (`fetch --update-head-ok` now skips the “checked out branch” refusal when updating `refs/heads/*` destinations, matching Git; harness CSV refreshed)
 - `t6200-fmt-merge-msg-extra` — 23/23 tests pass (`fmt-merge-msg`: multi-branch/tag titles, remote URL suffix, `--into-name`, `-m` override, `--log`/`--no-log`, stdin vs `-F`, FETCH_HEAD edge cases; harness CSV refreshed)
@@ -83,4 +84,4 @@
 
 ## What Remains
 
-680 test files still pending. See `plan.md` for the full prioritized list.
+674 test files still pending. See `plan.md` for the full prioritized list.

--- a/t1-plan.md
+++ b/t1-plan.md
@@ -131,7 +131,7 @@
 - [ ] t12700-add-edit-intent.sh
 - [ ] t12710-rm-staged-conflict.sh
 - [ ] t12720-mv-cross-directory.sh
-- [ ] t12730-switch-start-point.sh
+- [x] t12730-switch-start-point.sh
 - [ ] t12740-restore-deleted-paths.sh
 - [ ] t12760-cherry-pick-multi-range.sh
 - [ ] t12770-for-each-ref-perl-format.sh


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`./scripts/run-tests.sh t12730-switch-start-point.sh` reports **36/36** passing on current `grit switch` behavior (no Rust code changes required for this file).

## Changes

- Refreshed harness metadata: `data/test-files.csv`, `docs/index.html`, `docs/testfiles.html`
- Marked `t12730-switch-start-point.sh` complete in `t1-plan.md` and adjusted counts in `progress.md`
- Added `logs/2026-04-07_t12730-switch-start-point.md`

## Verification

```bash
cargo build --release -p grit-rs
./scripts/run-tests.sh t12730-switch-start-point.sh
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9850c0f-67fc-4c7a-9f97-a315d6b3dd22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9850c0f-67fc-4c7a-9f97-a315d6b3dd22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

