### PR TITLE
fix: preserve section header for config unset --all (t8150)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1313,7 +1313,7 @@ t8100-tag-format	t8	yes	29	29	0	true	ok	0
 t8110-branch-merge-info	t8	yes	31	31	0	true	ok	0
 t8120-diff-tree-combined	t8	yes	30	30	0	true	ok	0
 t8130-show-ref-extra	t8	yes	31	26	5	false	ok	0
-t8150-config-multivar	t8	yes	29	28	1	false	ok	0
+t8150-config-multivar	t8	yes	29	29	0	true	ok	0
 t8160-config-section	t8	yes	27	27	0	true	ok	0
 t8170-init-reinitialize	t8	yes	35	35	0	true	ok	0
 t8180-add-chmod	t8	yes	29	29	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-07T22:26:52+00:00" class="gen-time" title="2026-04-07 22:26 UTC">2026-04-07 22:26 UTC</time> · <a href="https://github.com/schacon/grit/commit/88e7dfb6abc03b3ac789ce56edc7292e54b9ff71" style="color:#58a6ff">88e7dfb</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-07T22:47:37+00:00" class="gen-time" title="2026-04-07 22:47 UTC">2026-04-07 22:47 UTC</time> · <a href="https://github.com/schacon/grit/commit/94726ba9a81f55eea5b9fe203dda514eda5e3e79" style="color:#58a6ff">94726ba</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,467</div>
+      <div class="summary-big-val">29,468</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>603 files fully passing</span>
+    <span>604 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -267,7 +267,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t8</span>
         <span class="group-desc">Porcelainish commands concerning forensics</span>
-        <span class="group-meta">64/105 files · 0 skipped · 2,545/2,763 tests</span>
+        <span class="group-meta">65/105 files · 0 skipped · 2,546/2,763 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-green" style="width:92.1%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T22:26:52+00:00" class="gen-time" title="2026-04-07 22:26 UTC">2026-04-07 22:26 UTC</time> · <a href="https://github.com/schacon/grit/commit/88e7dfb6abc03b3ac789ce56edc7292e54b9ff71" style="color:#58a6ff">88e7dfb</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T22:47:37+00:00" class="gen-time" title="2026-04-07 22:47 UTC">2026-04-07 22:47 UTC</time> · <a href="https://github.com/schacon/grit/commit/94726ba9a81f55eea5b9fe203dda514eda5e3e79" style="color:#58a6ff">94726ba</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,739</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,467</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,468</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">67.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -13267,14 +13267,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:83.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t8" data-tests="29" data-passed="28">
+<tr class="" data-group="t8" data-tests="29" data-passed="29">
   <td class="mono">t8150-config-multivar</td>
   <td>t8</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">29</td>
-  <td class="right">28</td>
+  <td class="right">29</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:96.6%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t8" data-tests="27" data-passed="27">

--- a/grit-lib/src/config.rs
+++ b/grit-lib/src/config.rs
@@ -881,7 +881,16 @@ impl ConfigFile {
     ///
     /// If `value_pattern` is `None`, removes all entries with the given key.
     /// If `value_pattern` is `Some(pat)`, only removes entries whose value matches the regex.
-    pub fn unset_matching(&mut self, key: &str, value_pattern: Option<&str>) -> Result<usize> {
+    ///
+    /// When `preserve_empty_section_header` is `true`, a section header is kept even if the
+    /// section has no remaining keys (Git's `config unset --all`). When `false`, empty sections
+    /// are stripped (`config --unset`, `config --unset-all`, and value-pattern unsets).
+    pub fn unset_matching(
+        &mut self,
+        key: &str,
+        value_pattern: Option<&str>,
+        preserve_empty_section_header: bool,
+    ) -> Result<usize> {
         let canon = canonical_key(key)?;
         let re = match value_pattern {
             Some(pat) => Some(
@@ -914,8 +923,10 @@ impl ConfigFile {
         }
 
         if count > 0 {
-            // Remove empty section headers (sections with no remaining entries and no comments)
-            self.remove_empty_section_headers();
+            if !preserve_empty_section_header {
+                // Remove empty section headers (sections with no remaining entries and no comments)
+                self.remove_empty_section_headers();
+            }
 
             let content = self.raw_lines.join("\n");
             let reparsed = Self::parse(&self.path, &content, self.scope)?;

--- a/grit/src/commands/config.rs
+++ b/grit/src/commands/config.rs
@@ -313,7 +313,10 @@ pub fn run(args: Args) -> Result<()> {
             ConfigSubcommand::Get(get_args) => cmd_get(&args, get_args, git_dir.as_deref(), None),
             ConfigSubcommand::Set(set_args) => cmd_set(&args, set_args, scope, &file_path, None),
             ConfigSubcommand::Unset(unset_args) => {
-                cmd_unset(&args, unset_args, scope, &file_path, None)
+                cmd_unset(
+                    &args, unset_args, scope, &file_path, None,
+                    /* preserve_empty_section_header_on_unset_all */ true,
+                )
             }
             ConfigSubcommand::List(list_args) => {
                 // Merge list-level flags into top-level args
@@ -456,7 +459,7 @@ pub fn run(args: Args) -> Result<()> {
             bail!("usage: git config --unset <key>");
         }
         let unset_args = UnsetArgs { key, all: false };
-        return cmd_unset(&args, &unset_args, scope, &file_path, value_pattern);
+        return cmd_unset(&args, &unset_args, scope, &file_path, value_pattern, false);
     }
 
     if let Some(ref key_raw) = args.unset_all_key {
@@ -471,7 +474,7 @@ pub fn run(args: Args) -> Result<()> {
             bail!("usage: git config --unset-all <key>");
         }
         let unset_args = UnsetArgs { key, all: true };
-        return cmd_unset(&args, &unset_args, scope, &file_path, value_pattern);
+        return cmd_unset(&args, &unset_args, scope, &file_path, value_pattern, false);
     }
 
     if let Some(ref key) = args.add_key {
@@ -746,19 +749,21 @@ fn cmd_unset(
     scope: ConfigScope,
     file_path: &Path,
     value_pattern: Option<&str>,
+    preserve_empty_section_header_on_unset_all: bool,
 ) -> Result<()> {
     let mut config = ConfigFile::from_path(file_path, scope).context("reading config file")?;
 
     match config {
         Some(ref mut cfg) => {
             if unset_args.all {
-                let removed = cfg.unset_matching(&unset_args.key, value_pattern)?;
+                let preserve = preserve_empty_section_header_on_unset_all;
+                let removed = cfg.unset_matching(&unset_args.key, value_pattern, preserve)?;
                 if removed == 0 {
                     std::process::exit(5);
                 }
             } else if let Some(pattern) = value_pattern {
                 // --unset with value-pattern: remove only matching values
-                let removed = cfg.unset_matching(&unset_args.key, Some(pattern))?;
+                let removed = cfg.unset_matching(&unset_args.key, Some(pattern), false)?;
                 if removed == 0 {
                     std::process::exit(5);
                 }
@@ -772,7 +777,7 @@ fn cmd_unset(
                     eprintln!("warning: {}: has multiple values", unset_args.key);
                     std::process::exit(5);
                 }
-                let removed = cfg.unset_matching(&unset_args.key, None)?;
+                let removed = cfg.unset_matching(&unset_args.key, None, false)?;
                 if removed == 0 {
                     std::process::exit(5);
                 }

--- a/logs/2026-04-07_t8150-config-unset-all-section.md
+++ b/logs/2026-04-07_t8150-config-unset-all-section.md
@@ -1,0 +1,22 @@
+# t8150-config-multivar — `config unset --all` section header
+
+## Issue
+
+Test `config unset --all leaves section header behind` failed: after removing all
+values for a key, `[ns]` was stripped from `.git/config`.
+
+## Cause
+
+`ConfigFile::unset_matching` always called `remove_empty_section_headers()`, which
+matches Git for legacy `--unset` / `--unset-all` but not for the new subcommand
+`git config unset --all`, which leaves an empty section header.
+
+## Fix
+
+- Added `preserve_empty_section_header` to `unset_matching`.
+- `cmd_unset` passes `true` for `config unset --all` only; legacy paths pass `false`.
+
+## Validation
+
+- `./scripts/run-tests.sh t8150-config-multivar.sh` → 29/29
+- `cargo test -p grit-lib --lib`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t8150-config-multivar` failed on **config unset --all leaves section header behind**: after `git config unset --all ns.k`, the `[ns]` section header was removed from `.git/config`, but Git keeps it for the new-style subcommand.

## Changes

- **`ConfigFile::unset_matching`** now takes `preserve_empty_section_header`. When `true`, we skip `remove_empty_section_headers()` after removals.
- **`cmd_unset`** passes `preserve_empty_section_header_on_unset_all: true` only for `config unset` subcommand with `--all`; legacy `--unset`, `--unset-all`, and value-pattern unsets still pass `false`.

## Validation

- `./scripts/run-tests.sh t8150-config-multivar.sh` → **29/29**
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba7c52f9-f0c8-44b7-9d41-f35597f45f6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba7c52f9-f0c8-44b7-9d41-f35597f45f6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

