### PR TITLE
fix: t3011-ls-files-staged passes (harness 29/29)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -541,7 +541,7 @@ t3008-ls-files-lazy-init-name-hash	t3	yes	1	0	1	false	ok	0
 t3009-ls-files-others-nonsubmodule	t3	yes	2	1	1	false	ok	0
 t3010-ls-files-killed-modified	t3	yes	6	3	3	false	ok	0
 t3011-common-prefixes-and-directory-traversal	t3	yes	20	14	6	false	ok	1
-t3011-ls-files-staged	t3	yes	29	28	1	false	ok	0
+t3011-ls-files-staged	t3	yes	29	29	0	true	ok	0
 t3012-ls-files-dedup	t3	yes	3	2	1	false	ok	0
 t3013-ls-files-format	t3	yes	20	8	12	false	ok	0
 t3014-ls-files-pathspec-magic	t3	yes	29	29	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-07T23:22:48+00:00" class="gen-time" title="2026-04-07 23:22 UTC">2026-04-07 23:22 UTC</time> · <a href="https://github.com/schacon/grit/commit/adb725946a53efadb8d730f4cb7af1c55b49976d" style="color:#58a6ff">adb7259</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-07T23:24:41+00:00" class="gen-time" title="2026-04-07 23:24 UTC">2026-04-07 23:24 UTC</time> · <a href="https://github.com/schacon/grit/commit/98c34b0fca301bd17b35e36087273c6e933f6686" style="color:#58a6ff">98c34b0</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,470</div>
+      <div class="summary-big-val">29,471</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>605 files fully passing</span>
+    <span>606 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,11 +212,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">28/141 files · 2 skipped · 3,436/5,291 tests</span>
+        <span class="group-meta">29/141 files · 2 skipped · 3,437/5,291 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.9%"></div></div>
-        <span class="group-pct pct-blue">64.9%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:65.0%"></div></div>
+        <span class="group-pct pct-blue">65.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T23:22:48+00:00" class="gen-time" title="2026-04-07 23:22 UTC">2026-04-07 23:22 UTC</time> · <a href="https://github.com/schacon/grit/commit/adb725946a53efadb8d730f4cb7af1c55b49976d" style="color:#58a6ff">adb7259</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T23:24:41+00:00" class="gen-time" title="2026-04-07 23:24 UTC">2026-04-07 23:24 UTC</time> · <a href="https://github.com/schacon/grit/commit/98c34b0fca301bd17b35e36087273c6e933f6686" style="color:#58a6ff">98c34b0</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,739</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,470</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,471</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">67.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -5547,14 +5547,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t3" data-tests="29" data-passed="28">
+<tr class="" data-group="t3" data-tests="29" data-passed="29">
   <td class="mono">t3011-ls-files-staged</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">29</td>
-  <td class="right">28</td>
+  <td class="right">29</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:96.6%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="3" data-passed="2">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t3011-ls-files-staged` now passes all 29 harness tests. The implementation on this branch already provides correct `grit ls-files --stage` / `-s` output (modes, 40-char object names, stage column, pathspec filtering, `-z`, `--cached`, `--error-unmatch`, sorting).

This commit refreshes `data/test-files.csv` and the generated dashboards after a clean `./scripts/run-tests.sh t3011-ls-files-staged.sh` run.

## Verification

```bash
cargo build --release -p grit-rs
./scripts/run-tests.sh t3011-ls-files-staged.sh
```

Result: **29/29** tests passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d25197c-f4aa-47aa-a2c6-a8d3f2b922b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d25197c-f4aa-47aa-a2c6-a8d3f2b922b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

