### PR TITLE
fix: make t3704-add-pathspec-file pass

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -301,7 +301,7 @@ commit → check it off → move on.
 - [ ] `t3000-ls-files-others` ████████░░░░░░░░░░░░ 6/15 (9 left) — basic tests for ls-files --others
 
 - [ ] `t3508-cherry-pick-many-commits` ███████░░░░░░░░░░░░░ 5/14 (9 left) — test cherry-picking many commits
-- [ ] `t3704-add-pathspec-file` ███░░░░░░░░░░░░░░░░░ 2/11 (9 left) — add --pathspec-from-file
+- [x] `t3704-add-pathspec-file` ████████████████████ 11/11 (0 left) — add --pathspec-from-file
 - [ ] `t3440-rebase-trailer` ██░░░░░░░░░░░░░░░░░░ 1/10 (9 left) — git rebase --trailer integration tests
 
 - [ ] `t3907-stash-show-config` ██░░░░░░░░░░░░░░░░░░ 1/10 (9 left) — Test git stash show configuration.

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -656,7 +656,7 @@ t3700-add-pathspec-file	t3	yes	24	22	2	false	ok	0
 t3701-add-interactive	t3	yes	130	29	101	false	ok	0
 t3702-add-edit	t3	yes	3	1	2	false	ok	0
 t3703-add-magic-pathspec	t3	yes	6	6	0	true	ok	0
-t3704-add-pathspec-file	t3	yes	11	3	8	false	ok	0
+t3704-add-pathspec-file	t3	yes	11	11	0	true	ok	0
 t3705-add-sparse-checkout	t3	yes	20	3	17	false	ok	0
 t3800-mktag	t3	yes	151	85	66	false	ok	0
 t3900-i18n-commit	t3	yes	0	0	0	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-07T23:25:43+00:00" class="gen-time" title="2026-04-07 23:25 UTC">2026-04-07 23:25 UTC</time> · <a href="https://github.com/schacon/grit/commit/1e90909b3b71a2a3b43c42a6804e81d11465b23b" style="color:#58a6ff">1e90909</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-07T23:39:36+00:00" class="gen-time" title="2026-04-07 23:39 UTC">2026-04-07 23:39 UTC</time> · <a href="https://github.com/schacon/grit/commit/273195022b0ab178322d755f9b68c20084013c43" style="color:#58a6ff">2731950</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,471</div>
+      <div class="summary-big-val">29,479</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>606 files fully passing</span>
+    <span>607 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,11 +212,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">29/141 files · 2 skipped · 3,437/5,291 tests</span>
+        <span class="group-meta">30/141 files · 2 skipped · 3,445/5,291 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:65.0%"></div></div>
-        <span class="group-pct pct-blue">65.0%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:65.1%"></div></div>
+        <span class="group-pct pct-blue">65.1%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T23:25:43+00:00" class="gen-time" title="2026-04-07 23:25 UTC">2026-04-07 23:25 UTC</time> · <a href="https://github.com/schacon/grit/commit/1e90909b3b71a2a3b43c42a6804e81d11465b23b" style="color:#58a6ff">1e90909</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T23:39:36+00:00" class="gen-time" title="2026-04-07 23:39 UTC">2026-04-07 23:39 UTC</time> · <a href="https://github.com/schacon/grit/commit/273195022b0ab178322d755f9b68c20084013c43" style="color:#58a6ff">2731950</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,739</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,471</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,479</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">67.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -6697,14 +6697,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="11" data-passed="3">
+<tr class="" data-group="t3" data-tests="11" data-passed="11">
   <td class="mono">t3704-add-pathspec-file</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">11</td>
-  <td class="right">3</td>
+  <td class="right">11</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:27.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="20" data-passed="3">

--- a/grit/src/commands/add.rs
+++ b/grit/src/commands/add.rs
@@ -17,6 +17,7 @@ use grit_lib::objects::ObjectKind;
 use grit_lib::odb::Odb;
 use grit_lib::repo::Repository;
 use std::fs;
+use std::io::Read;
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 
@@ -91,23 +92,45 @@ pub struct Args {
     #[arg(long = "no-warn-embedded-repo")]
     pub no_warn_embedded_repo: bool,
 
-    /// Read pathspecs from a file (one per line).
+    /// Read pathspecs from a file (one per line, or NUL-separated with --pathspec-file-nul).
     #[arg(long = "pathspec-from-file", value_name = "FILE")]
     pub pathspec_from_file: Option<PathBuf>,
+
+    /// NUL-terminated pathspec input (requires --pathspec-from-file).
+    #[arg(long = "pathspec-file-nul")]
+    pub pathspec_file_nul: bool,
 }
 
 /// Run the `add` command.
 pub fn run(mut args: Args) -> Result<()> {
-    // --pathspec-from-file: read pathspecs from a file and append to pathspec list
+    if args.pathspec_file_nul && args.pathspec_from_file.is_none() {
+        bail!("the option '--pathspec-file-nul' requires '--pathspec-from-file'");
+    }
     if let Some(ref file) = args.pathspec_from_file {
-        let content = fs::read_to_string(file)
-            .with_context(|| format!("cannot read pathspec file '{}'", file.display()))?;
-        for line in content.lines() {
-            let line = line.trim();
-            if !line.is_empty() {
-                args.pathspec.push(line.to_owned());
-            }
+        if !args.pathspec.is_empty() {
+            bail!("'--pathspec-from-file' and pathspec arguments cannot be used together");
         }
+        if args.interactive || args.patch {
+            bail!(
+                "options '--pathspec-from-file' and '--interactive/--patch' cannot be used together"
+            );
+        }
+        if args.edit {
+            bail!("options '--pathspec-from-file' and '--edit' cannot be used together");
+        }
+        let path = file.as_os_str();
+        let data = if path == "-" {
+            let mut buf = Vec::new();
+            std::io::stdin()
+                .read_to_end(&mut buf)
+                .context("reading pathspecs from stdin")?;
+            buf
+        } else {
+            fs::read(file)
+                .with_context(|| format!("cannot read pathspec file '{}'", file.display()))?
+        };
+        args.pathspec =
+            crate::pathspec::parse_pathspecs_from_source(&data, args.pathspec_file_nul)?;
     }
 
     // --dry-run is incompatible with interactive modes

--- a/grit/src/commands/stage.rs
+++ b/grit/src/commands/stage.rs
@@ -61,5 +61,6 @@ pub fn run(args: Args) -> Result<()> {
         ignore_missing: false,
         no_warn_embedded_repo: false,
         pathspec_from_file: None,
+        pathspec_file_nul: false,
     })
 }

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -743,48 +743,6 @@ fn run_test_tool_dir_iterator(rest: &[String]) -> Result<()> {
     Ok(())
 }
 
-fn unquote_c_style(input: &str) -> String {
-    if input.len() >= 2 && input.starts_with('"') && input.ends_with('"') {
-        let mut out = String::new();
-        let mut chars = input[1..input.len() - 1].chars().peekable();
-        while let Some(ch) = chars.next() {
-            if ch != '\\' {
-                out.push(ch);
-                continue;
-            }
-
-            match chars.next() {
-                Some('a') => out.push('\u{0007}'),
-                Some('b') => out.push('\u{0008}'),
-                Some('f') => out.push('\u{000C}'),
-                Some('n') => out.push('\n'),
-                Some('r') => out.push('\r'),
-                Some('t') => out.push('\t'),
-                Some('v') => out.push('\u{000B}'),
-                Some('\\') => out.push('\\'),
-                Some('"') => out.push('"'),
-                Some(c @ '0'..='7') => {
-                    let mut value = c.to_digit(8).unwrap_or(0);
-                    for _ in 0..2 {
-                        if let Some(next @ '0'..='7') = chars.peek().copied() {
-                            let _ = chars.next();
-                            value = value * 8 + next.to_digit(8).unwrap_or(0);
-                        } else {
-                            break;
-                        }
-                    }
-                    out.push(char::from_u32(value).unwrap_or('\u{FFFD}'));
-                }
-                Some(other) => out.push(other),
-                None => {}
-            }
-        }
-        out
-    } else {
-        input.to_owned()
-    }
-}
-
 fn run_test_tool_parse_pathspec_file(rest: &[String]) -> Result<()> {
     let mut pathspec_from_file: Option<String> = None;
     let mut pathspec_file_nul = false;
@@ -814,19 +772,7 @@ fn run_test_tool_parse_pathspec_file(rest: &[String]) -> Result<()> {
         std::fs::read(&pathspec_source)?
     };
 
-    let items: Vec<String> = if pathspec_file_nul {
-        data.split(|b| *b == 0u8)
-            .filter(|chunk| !chunk.is_empty())
-            .map(|chunk| String::from_utf8_lossy(chunk).to_string())
-            .collect()
-    } else {
-        let text = String::from_utf8_lossy(&data);
-        text.split('\n')
-            .filter(|line| !line.is_empty())
-            .map(|line| line.strip_suffix('\r').unwrap_or(line))
-            .map(unquote_c_style)
-            .collect()
-    };
+    let items: Vec<String> = pathspec::parse_pathspecs_from_source(&data, pathspec_file_nul)?;
 
     for item in items {
         println!("{item}");

--- a/grit/src/pathspec.rs
+++ b/grit/src/pathspec.rs
@@ -1,5 +1,93 @@
 //! Pathspec matching utilities shared across commands.
 
+use anyhow::{bail, Context, Result};
+
+/// Read pathspec entries from raw file bytes (stdin or file), matching Git's
+/// `--pathspec-from-file` / `--pathspec-file-nul` rules.
+///
+/// * **NUL mode:** entries are separated by `NUL`; each segment must not use
+///   C-style quoted lines (Git rejects quoted pathspecs in this mode).
+/// * **Line mode:** entries are separated by `LF`; optional `CR` before `LF`
+///   is stripped; optional trailing line without a final newline is included;
+///   double-quoted lines are C-unquoted (including octal escapes).
+pub fn parse_pathspecs_from_source(data: &[u8], nul_terminated: bool) -> Result<Vec<String>> {
+    if nul_terminated {
+        let mut out = Vec::new();
+        for chunk in data.split(|b| *b == 0) {
+            if chunk.is_empty() {
+                continue;
+            }
+            let s = String::from_utf8_lossy(chunk);
+            let t = s.trim();
+            if t.starts_with('"') {
+                bail!("pathspec-from-file: line is not NUL terminated: {}", t);
+            }
+            out.push(t.to_string());
+        }
+        return Ok(out);
+    }
+
+    let text = String::from_utf8_lossy(data);
+    let mut out = Vec::new();
+    for raw in text.split_inclusive('\n') {
+        let line = raw.trim_end_matches('\n').trim_end_matches('\r');
+        if line.is_empty() {
+            continue;
+        }
+        if line.starts_with('"') && line.ends_with('"') && line.len() >= 2 {
+            out.push(unquote_c_style_pathspec_line(line)?);
+        } else {
+            out.push(line.to_string());
+        }
+    }
+    Ok(out)
+}
+
+/// Unquote a single `--pathspec-from-file` line that is wrapped in double quotes.
+fn unquote_c_style_pathspec_line(s: &str) -> Result<String> {
+    let bytes = s.as_bytes();
+    if bytes.first() != Some(&b'"') || bytes.last() != Some(&b'"') || bytes.len() < 2 {
+        bail!("invalid C-style quoting: {s}");
+    }
+
+    let inner = &bytes[1..bytes.len() - 1];
+    let mut out = Vec::with_capacity(inner.len());
+    let mut i = 0;
+    while i < inner.len() {
+        if inner[i] != b'\\' {
+            out.push(inner[i]);
+            i += 1;
+            continue;
+        }
+        i += 1;
+        if i >= inner.len() {
+            bail!("invalid escape at end of string");
+        }
+        match inner[i] {
+            b'\\' => out.push(b'\\'),
+            b'"' => out.push(b'"'),
+            b'a' => out.push(7),
+            b'b' => out.push(8),
+            b'f' => out.push(12),
+            b'n' => out.push(b'\n'),
+            b'r' => out.push(b'\r'),
+            b't' => out.push(b'\t'),
+            b'v' => out.push(11),
+            c if c.is_ascii_digit() => {
+                if i + 2 >= inner.len() {
+                    bail!("truncated octal escape");
+                }
+                let oct = std::str::from_utf8(&inner[i..i + 3]).context("invalid octal bytes")?;
+                out.push(u8::from_str_radix(oct, 8).context("invalid octal escape value")?);
+                i += 2;
+            }
+            other => bail!("invalid escape sequence \\{}", char::from(other)),
+        }
+        i += 1;
+    }
+    String::from_utf8(out).context("invalid UTF-8 in quoted pathspec")
+}
+
 /// Check if a string contains glob meta-characters.
 pub fn has_glob_chars(s: &str) -> bool {
     s.contains('*') || s.contains('?') || s.contains('[')

--- a/logs/2026-04-07_t3704-add-pathspec-file.md
+++ b/logs/2026-04-07_t3704-add-pathspec-file.md
@@ -1,0 +1,23 @@
+# t3704-add-pathspec-file
+
+## Goal
+
+Make `tests/t3704-add-pathspec-file.sh` fully pass (11/11).
+
+## Changes
+
+- Added `pathspec::parse_pathspecs_from_source` in `grit/src/pathspec.rs`: NUL-separated mode (reject quoted lines like Git), line mode with CRLF strip, optional final line without newline, double-quoted C-style unquoting with octal escapes.
+- `git add`: `--pathspec-file-nul`, read `-` via `read_to_end`, validate combinations (`--pathspec-from-file` vs interactive/patch/edit/extra pathspecs; `--pathspec-file-nul` requires `--pathspec-from-file`) before the interactive stub.
+- Error string for pathspec+interactive/patch matches upstream grep: `'--interactive/--patch'` as one quoted token.
+- `stage` command: pass `pathspec_file_nul: false` in `add::Args` literal.
+- `test-tool parse-pathspec-file`: delegate parsing to shared helper.
+
+## Verification
+
+- `./scripts/run-tests.sh t3704-add-pathspec-file.sh` → 11/11
+- `cargo test -p grit-lib --lib`
+- `cargo fmt`, `cargo check -p grit-rs`, `cargo clippy -p grit-rs --fix --allow-dirty`
+
+## Git
+
+Branch: `cursor/t3704-pathspec-file-tests-3715`

--- a/progress.md
+++ b/progress.md
@@ -6,13 +6,14 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |    94 |
+| Completed   |    95 |
 | In progress |     0 |
-| Remaining   |   673 |
+| Remaining   |   672 |
 | **Total**   |   767 |
 
 ## Recently completed
 
+- `t3704-add-pathspec-file` — 11/11 tests pass (`git add --pathspec-from-file` / `--pathspec-file-nul`: raw bytes + CRLF/LF/NUL splitting, C-quoted lines, conflict checks vs `--interactive`/`--patch`/`--edit`/pathspecs; shared `pathspec::parse_pathspecs_from_file`; error text matches grep expectations)
 - `t5813-proto-disable-ssh` — 81/81 tests pass (`GIT_ALLOW_PROTOCOL` comma split, `protocol.*.allow=user` + `GIT_PROTOCOL_FROM_USER`, SSH URL validation, local SSH resolution via `TRASH_DIRECTORY` + absolute `ssh://` paths, pkt-line `upload-pack`/`receive-pack`, side-band pack streaming)
 - `t12730-switch-start-point` — 36/36 tests pass (`grit switch -c` with start-point, `--detach`, `--orphan`, tags, abbreviated hashes, `HEAD~N`; harness CSV refreshed)
 - `t1451-fsck-buffer` — 72/72 tests pass (`hash-object` now runs Git-style standalone fsck on commit/tag/tree buffers with matching `missingTree`/`badTree`/ident diagnostics and stderr ordering; new `grit_lib::fsck_standalone`)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible `git add --pathspec-from-file` and `--pathspec-file-nul` so `tests/t3704-add-pathspec-file.sh` passes 11/11.

## Changes

- **`grit/src/pathspec.rs`**: `parse_pathspecs_from_source` — NUL-separated entries (reject C-quoted lines), LF mode with CRLF handling and last line without trailing newline, double-quoted C-style unquoting with octal escapes (aligned with `restore` / upstream behavior).
- **`grit/src/commands/add.rs`**: `--pathspec-file-nul`, read from file or stdin (`-`) as raw bytes, validate conflicts with `--interactive` / `--patch` / `--edit` / extra pathspecs before the interactive stub; error text matches the harness `test_grep` patterns (notably `'--interactive/--patch'` as a single quoted token).
- **`grit/src/main.rs`**: `test-tool parse-pathspec-file` uses the shared parser; removed unused local `unquote_c_style`.
- **`grit/src/commands/stage.rs`**: populate new `pathspec_file_nul` field on delegated `add::Args`.
- **`PLAN.md`**, **`progress.md`**, harness CSV + dashboards, **`logs/2026-04-07_t3704-add-pathspec-file.md`**.

## Verification

- `./scripts/run-tests.sh t3704-add-pathspec-file.sh`
- `cargo test -p grit-lib --lib`
- `cargo fmt`, `cargo check -p grit-rs`, `cargo clippy -p grit-rs --fix --allow-dirty`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bcd0910a-0677-4397-8490-f207434ddd58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bcd0910a-0677-4397-8490-f207434ddd58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

