### PR TITLE
fix: pass t7409 submodule detached work tree

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -792,7 +792,7 @@ commit → check it off → move on.
 - [ ] `t7423-submodule-symlinks` █████████████░░░░░░░ 4/6 (2 left) — check that submodule operations do not follow symlinks
 - [ ] `t7606-merge-custom` ██████████░░░░░░░░░░ 2/4 (2 left) — git merge
 
-- [ ] `t7409-submodule-detached-work-tree` ██████░░░░░░░░░░░░░░ 1/3 (2 left) — Test submodules on detached working tree
+- [x] `t7409-submodule-detached-work-tree` — Test submodules on detached working tree (3/3 harness)
 
 - [ ] `t7420-submodule-set-url` ██████░░░░░░░░░░░░░░ 1/3 (2 left) — Test submodules set-url subcommand
 

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1201,7 +1201,7 @@ t7403-submodule-sync	t7	yes	18	1	17	false	ok	0
 t7406-submodule-update	t7	yes	70	5	65	false	ok	0
 t7407-submodule-foreach	t7	yes	23	3	20	false	ok	0
 t7408-submodule-reference	t7	yes	16	4	12	false	ok	0
-t7409-submodule-detached-work-tree	t7	yes	3	1	2	false	ok	0
+t7409-submodule-detached-work-tree	t7	yes	3	3	0	true	ok	0
 t7411-submodule-config	t7	yes	20	2	18	false	ok	0
 t7412-submodule-absorbgitdirs	t7	yes	12	5	7	false	ok	0
 t7413-submodule-is-active	t7	yes	10	1	9	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-07T23:13:56+00:00" class="gen-time" title="2026-04-07 23:13 UTC">2026-04-07 23:13 UTC</time> · <a href="https://github.com/schacon/grit/commit/9d8f463542bebd8a385a2949fb4fed9197acbb13" style="color:#58a6ff">9d8f463</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-07T23:39:26+00:00" class="gen-time" title="2026-04-07 23:39 UTC">2026-04-07 23:39 UTC</time> · d074fcf · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,469</div>
+      <div class="summary-big-val">29,471</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>604 files fully passing</span>
+    <span>605 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -256,11 +256,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">35/126 files · 11 skipped · 1,873/3,607 tests</span>
+        <span class="group-meta">36/126 files · 11 skipped · 1,875/3,607 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:51.9%"></div></div>
-        <span class="group-pct pct-orange">51.9%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:52.0%"></div></div>
+        <span class="group-pct pct-orange">52.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T23:13:56+00:00" class="gen-time" title="2026-04-07 23:13 UTC">2026-04-07 23:13 UTC</time> · <a href="https://github.com/schacon/grit/commit/9d8f463542bebd8a385a2949fb4fed9197acbb13" style="color:#58a6ff">9d8f463</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T23:39:26+00:00" class="gen-time" title="2026-04-07 23:39 UTC">2026-04-07 23:39 UTC</time> · d074fcf</p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,739</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,469</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,471</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">67.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -12147,14 +12147,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:25.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="3" data-passed="1">
+<tr class="" data-group="t7" data-tests="3" data-passed="3">
   <td class="mono">t7409-submodule-detached-work-tree</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">3</td>
-  <td class="right">1</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:33.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="20" data-passed="2">

--- a/grit/src/commands/checkout.rs
+++ b/grit/src/commands/checkout.rs
@@ -10,7 +10,7 @@
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use grit_lib::config::ConfigSet;
 use grit_lib::crlf;
@@ -723,6 +723,18 @@ fn switch_branch(
                 let target_tree = commit_to_tree(repo, &target_oid)?;
                 return force_reset_to_tree(repo, &target_tree);
             }
+            // Bare clone leaves an empty index while HEAD already points at the branch.
+            // Git still materializes the tree on `checkout <that-branch>`; match that.
+            let index_empty = repo
+                .load_index()
+                .map(|idx| idx.entries.is_empty())
+                .unwrap_or(true);
+            if index_empty {
+                let target_oid = refs::resolve_ref(&repo.git_dir, branch_ref)
+                    .with_context(|| format!("cannot resolve branch '{branch_name}'"))?;
+                let target_tree = commit_to_tree(repo, &target_oid)?;
+                switch_to_tree(repo, &head, &target_tree, false)?;
+            }
             return Ok(());
         }
     }
@@ -1207,7 +1219,13 @@ fn detach_head_inner(repo: &Repository, oid: &ObjectId, force: bool, explicit: b
     let head = resolve_head(&repo.git_dir)?;
 
     let already_at_target = head.oid() == Some(oid);
-    if !already_at_target || force {
+    let index_empty = repo
+        .load_index()
+        .map(|idx| idx.entries.is_empty())
+        .unwrap_or(true);
+    // `clone --no-checkout` leaves HEAD at a branch tip but no index / empty work tree; a detached
+    // checkout of that same OID must still materialize the tree (submodule clone uses this path).
+    if !already_at_target || force || index_empty {
         let target_tree = commit_to_tree(repo, oid)?;
         switch_to_tree(repo, &head, &target_tree, force)?;
     }
@@ -1636,6 +1654,12 @@ fn is_worktree_dirty(
     entry: &IndexEntry,
     abs_path: &std::path::Path,
 ) -> Result<bool> {
+    if entry.mode == grit_lib::index::MODE_GITLINK {
+        let Some(current) = read_submodule_head_oid_for_checkout(abs_path) else {
+            return Ok(true);
+        };
+        return Ok(current != entry.oid);
+    }
     if entry.mode == MODE_SYMLINK {
         // For symlinks, compare the target
         match std::fs::read_link(abs_path) {
@@ -1662,6 +1686,32 @@ fn is_worktree_dirty(
             Err(_) => grit_lib::odb::Odb::hash_object_data(ObjectKind::Blob, &raw),
         };
         Ok(oid != entry.oid)
+    }
+}
+
+fn read_submodule_head_oid_for_checkout(sub_path: &Path) -> Option<ObjectId> {
+    let dot_git = sub_path.join(".git");
+    let git_dir = if dot_git.is_file() {
+        let content = std::fs::read_to_string(&dot_git).ok()?;
+        let gitdir = content.strip_prefix("gitdir: ")?.trim();
+        if Path::new(gitdir).is_absolute() {
+            PathBuf::from(gitdir)
+        } else {
+            sub_path.join(gitdir)
+        }
+    } else if dot_git.is_dir() {
+        dot_git
+    } else {
+        return None;
+    };
+    let head_content = std::fs::read_to_string(git_dir.join("HEAD")).ok()?;
+    let head_content = head_content.trim();
+    if let Some(refname) = head_content.strip_prefix("ref: ") {
+        let ref_path = git_dir.join(refname);
+        let oid_hex = std::fs::read_to_string(&ref_path).ok()?;
+        ObjectId::from_hex(oid_hex.trim()).ok()
+    } else {
+        ObjectId::from_hex(head_content).ok()
     }
 }
 

--- a/grit/src/commands/merge.rs
+++ b/grit/src/commands/merge.rs
@@ -8,13 +8,13 @@ use clap::Args as ClapArgs;
 use std::collections::{BTreeSet, HashMap};
 use std::fs;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tempfile::NamedTempFile;
 
 use grit_lib::config::ConfigSet;
 use grit_lib::crlf::MergeAttr;
 use grit_lib::diff::{count_changes, detect_renames, diff_trees, DiffEntry, DiffStatus};
-use grit_lib::index::{Index, IndexEntry, MODE_EXECUTABLE, MODE_SYMLINK};
+use grit_lib::index::{Index, IndexEntry, MODE_EXECUTABLE, MODE_GITLINK, MODE_SYMLINK};
 use grit_lib::merge_base::is_ancestor;
 use grit_lib::merge_file::{self, ConflictStyle, MergeFavor, MergeInput};
 use grit_lib::objects::{
@@ -1343,6 +1343,14 @@ fn bail_if_merge_would_overwrite_local_changes(
 }
 
 fn is_worktree_entry_dirty(repo: &Repository, entry: &IndexEntry, abs_path: &Path) -> Result<bool> {
+    if entry.mode == MODE_GITLINK {
+        // Submodule: compare checked-out commit to the gitlink OID; do not use `read` on the path
+        // (it is a directory — that would incorrectly count as "dirty" and block merges/pulls).
+        let Some(current) = read_submodule_head_oid(abs_path) else {
+            return Ok(true);
+        };
+        return Ok(current != entry.oid);
+    }
     if entry.mode == MODE_SYMLINK {
         match fs::read_link(abs_path) {
             Ok(target) => {
@@ -1360,6 +1368,33 @@ fn is_worktree_entry_dirty(repo: &Repository, entry: &IndexEntry, abs_path: &Pat
             }
             Err(_) => Ok(true),
         }
+    }
+}
+
+/// Resolve the submodule's current HEAD commit from its working directory.
+fn read_submodule_head_oid(sub_path: &Path) -> Option<ObjectId> {
+    let dot_git = sub_path.join(".git");
+    let git_dir = if dot_git.is_file() {
+        let content = fs::read_to_string(&dot_git).ok()?;
+        let gitdir = content.strip_prefix("gitdir: ")?.trim();
+        if Path::new(gitdir).is_absolute() {
+            PathBuf::from(gitdir)
+        } else {
+            sub_path.join(gitdir)
+        }
+    } else if dot_git.is_dir() {
+        dot_git
+    } else {
+        return None;
+    };
+    let head_content = fs::read_to_string(git_dir.join("HEAD")).ok()?;
+    let head_content = head_content.trim();
+    if let Some(refname) = head_content.strip_prefix("ref: ") {
+        let ref_path = git_dir.join(refname);
+        let oid_hex = fs::read_to_string(&ref_path).ok()?;
+        ObjectId::from_hex(oid_hex.trim()).ok()
+    } else {
+        ObjectId::from_hex(head_content).ok()
     }
 }
 

--- a/grit/src/commands/submodule.rs
+++ b/grit/src/commands/submodule.rs
@@ -16,6 +16,27 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+/// Spawn grit for a nested operation without inheriting the superproject's `GIT_DIR` /
+/// `GIT_WORK_TREE` (tests and detached work trees set those in the parent shell).
+fn grit_subprocess(grit_bin: &Path) -> Command {
+    let mut cmd = Command::new(grit_bin);
+    cmd.env_remove("GIT_DIR");
+    cmd.env_remove("GIT_WORK_TREE");
+    cmd
+}
+
+/// Set `core.worktree` in a separate git-dir so checkouts materialize files (matches Git after
+/// `clone --separate-git-dir`).
+fn set_separate_gitdir_worktree(grit_bin: &Path, git_dir: &Path, work_tree: &Path) {
+    let _ = grit_subprocess(grit_bin)
+        .arg("--git-dir")
+        .arg(git_dir)
+        .arg("config")
+        .arg("core.worktree")
+        .arg(work_tree)
+        .status();
+}
+
 /// Arguments for `grit submodule`.
 #[derive(Debug, ClapArgs)]
 #[command(about = "Initialize, update, or inspect submodules")]
@@ -591,7 +612,7 @@ fn run_update(args: &UpdateArgs) -> Result<()> {
                 };
                 let clone_src_str = clone_src.to_string_lossy().into_owned();
 
-                let status = Command::new(&grit_bin)
+                let status = grit_subprocess(&grit_bin)
                     .arg("clone")
                     .arg("--no-checkout")
                     .arg("--separate-git-dir")
@@ -606,13 +627,14 @@ fn run_update(args: &UpdateArgs) -> Result<()> {
                     eprintln!("error: failed to clone submodule from '{}'", clone_url);
                     bail!("failed to clone submodule '{}'", m.name);
                 }
+                set_separate_gitdir_worktree(&grit_bin, &modules_dir, &sub_path);
             }
         }
 
         // Determine which commit to checkout.
         let checkout_oid = if args.remote {
             // Fetch from remote and use the remote tracking branch.
-            let fetch_status = Command::new(&grit_bin)
+            let fetch_status = grit_subprocess(&grit_bin)
                 .args(["fetch", "origin"])
                 .current_dir(&sub_path)
                 .status()
@@ -637,7 +659,7 @@ fn run_update(args: &UpdateArgs) -> Result<()> {
             };
 
             // Resolve origin/<branch> to an OID.
-            let output = Command::new(&grit_bin)
+            let output = grit_subprocess(&grit_bin)
                 .args(["rev-parse", &format!("origin/{branch}")])
                 .current_dir(&sub_path)
                 .output()
@@ -659,7 +681,7 @@ fn run_update(args: &UpdateArgs) -> Result<()> {
         }
 
         // Checkout the target commit.
-        let status = Command::new(&grit_bin)
+        let status = grit_subprocess(&grit_bin)
             .arg("checkout")
             .arg("--quiet")
             .arg(&checkout_oid)
@@ -691,7 +713,7 @@ fn run_update(args: &UpdateArgs) -> Result<()> {
             if parse_gitmodules(&sub_path).unwrap_or_default().is_empty() {
                 continue;
             }
-            let status = Command::new(&grit_bin)
+            let status = grit_subprocess(&grit_bin)
                 .args(["submodule", "update", "--init", "--recursive"])
                 .current_dir(&sub_path)
                 .status()
@@ -715,13 +737,7 @@ fn attach_existing_submodule_worktree(
     }
     let gitfile = sub_path.join(".git");
     fs::write(&gitfile, format!("gitdir: {}\n", modules_dir.display()))?;
-    let _ = Command::new(grit_bin)
-        .arg("--git-dir")
-        .arg(modules_dir)
-        .arg("config")
-        .arg("core.worktree")
-        .arg(sub_path)
-        .status();
+    set_separate_gitdir_worktree(grit_bin, modules_dir, sub_path);
     Ok(())
 }
 
@@ -793,7 +809,7 @@ fn run_add(args: &AddArgs) -> Result<()> {
         };
         let clone_source_str = clone_source.to_string_lossy().into_owned();
 
-        let status = Command::new(&grit_bin)
+        let status = grit_subprocess(&grit_bin)
             .arg("clone")
             .arg("--no-checkout")
             .arg("--separate-git-dir")
@@ -801,14 +817,13 @@ fn run_add(args: &AddArgs) -> Result<()> {
             .arg(&clone_source_str)
             .arg(&sub_path)
             .current_dir(work_tree)
-            .env_remove("GIT_WORK_TREE")
-            .env_remove("GIT_DIR")
             .status()
             .context("failed to clone submodule")?;
 
         if !status.success() {
             bail!("failed to clone submodule from '{}'", args.url);
         }
+        set_separate_gitdir_worktree(&grit_bin, &modules_dir, &sub_path);
     }
 
     // Derive the submodule name (use --name if provided, otherwise path).
@@ -1061,7 +1076,7 @@ fn run_sync(args: &SyncArgs) -> Result<()> {
                     // Use the grit binary for recursive sync in nested submodules.
                     let grit_bin =
                         std::env::current_exe().unwrap_or_else(|_| PathBuf::from("grit"));
-                    let _status = Command::new(&grit_bin)
+                    let _status = grit_subprocess(&grit_bin)
                         .arg("submodule")
                         .arg("sync")
                         .arg("--recursive")

--- a/logs/2026-04-07_t7409-submodule-detached-worktree.md
+++ b/logs/2026-04-07_t7409-submodule-detached-worktree.md
@@ -1,0 +1,26 @@
+# t7409-submodule-detached-work-tree
+
+## Summary
+
+Made `tests/t7409-submodule-detached-work-tree.sh` pass (3/3) under `./scripts/run-tests.sh`.
+
+## Root causes
+
+1. **Merge/pull** refused updates because `is_worktree_entry_dirty` used `fs::read` on gitlink paths (directories), always treating submodules as dirty.
+2. **Checkout** after `clone --bare` + `checkout main` did not populate the work tree when HEAD already pointed at `main` with an empty index (`switch_branch` early return).
+3. **Submodule update** ran `checkout <oid>` in detached mode but `detach_head_inner` skipped `switch_to_tree` when OID matched symbolic HEAD, leaving `--no-checkout` clones without an index or files.
+4. **`clone --separate-git-dir`** for submodules did not set `core.worktree` in the module git-dir (Git does), so checkout had nowhere to write.
+5. **Nested grit** in `submodule update` inherited parent `GIT_DIR`/`GIT_WORK_TREE`, breaking `clone` into the submodule path.
+6. **Harness** could inherit stray `GIT_DIR` from the agent environment; `run-tests.sh` now runs tests with `env -u GIT_DIR -u GIT_WORK_TREE`.
+
+## Files touched
+
+- `grit/src/commands/merge.rs` — gitlink dirty detection via submodule HEAD OID
+- `grit/src/commands/checkout.rs` — same for `is_worktree_dirty`; empty-index branch checkout; detach when index empty
+- `grit/src/commands/submodule.rs` — `grit_subprocess`, `set_separate_gitdir_worktree`, wire into clone/update/attach
+- `scripts/run-tests.sh` — clear `GIT_DIR`/`GIT_WORK_TREE` for each test file
+
+## Validation
+
+- `./scripts/run-tests.sh t7409-submodule-detached-work-tree.sh` → 3/3
+- `cargo test -p grit-lib --lib` → pass

--- a/progress.md
+++ b/progress.md
@@ -6,13 +6,14 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |    94 |
+| Completed   |    95 |
 | In progress |     0 |
-| Remaining   |   673 |
+| Remaining   |   672 |
 | **Total**   |   767 |
 
 ## Recently completed
 
+- `t7409-submodule-detached-work-tree` — 3/3 tests pass (submodule `clone --separate-git-dir` sets `core.worktree`; checkout populates work tree when index empty on same branch/detached OID; merge/checkout treat gitlinks as clean when submodule HEAD matches; nested grit subprocesses clear inherited `GIT_DIR`/`GIT_WORK_TREE`; harness clears those env vars per test)
 - `t5813-proto-disable-ssh` — 81/81 tests pass (`GIT_ALLOW_PROTOCOL` comma split, `protocol.*.allow=user` + `GIT_PROTOCOL_FROM_USER`, SSH URL validation, local SSH resolution via `TRASH_DIRECTORY` + absolute `ssh://` paths, pkt-line `upload-pack`/`receive-pack`, side-band pack streaming)
 - `t12730-switch-start-point` — 36/36 tests pass (`grit switch -c` with start-point, `--detach`, `--orphan`, tags, abbreviated hashes, `HEAD~N`; harness CSV refreshed)
 - `t1451-fsck-buffer` — 72/72 tests pass (`hash-object` now runs Git-style standalone fsck on commit/tag/tree buffers with matching `missingTree`/`badTree`/ident diagnostics and stderr ordering; new `grit_lib::fsck_standalone`)

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -162,6 +162,7 @@ run_one() {
     local output summary total pass fail status ef
     output=$(
         cd "$TESTS_DIR" &&
+            env -u GIT_DIR -u GIT_WORK_TREE \
             EDITOR=: VISUAL=: LC_ALL=C LANG=C _prereq_DEFAULT_REPO_FORMAT=set GRIT_TEST_LIB_SUMMARY=1 GUST_BIN="$(pwd)/grit" \
             GIT_SOURCE_DIR="$REPO/git" \
             "${TIMEOUT_PREFIX[@]}" bash "$f" 2>&1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes `t7409-submodule-detached-work-tree` pass all harness tests (3/3).

## Changes

- **Merge/checkout:** Gitlink (submodule) entries are no longer treated as “dirty” via `fs::read` on a directory; we compare the submodule’s resolved HEAD OID to the gitlink OID.
- **Checkout:** When already on the requested branch but the index is empty (typical after `git clone --bare` then `checkout main`), we still run `switch_to_tree` so `.gitmodules` and paths appear in the work tree.
- **Submodule update:** After `clone --no-checkout`, `checkout <recorded-oid>` could skip populating the tree when HEAD already resolved to that OID; we now run `switch_to_tree` when the index is empty.
- **`submodule` / `clone --separate-git-dir`:** Set `core.worktree` in the module git directory (matching Git) so checkouts write into the submodule path.
- **Nested grit calls:** Clear inherited `GIT_DIR` / `GIT_WORK_TREE` for submodule clone/fetch/checkout subprocesses (superproject `git add` still uses the parent env).
- **Harness:** `scripts/run-tests.sh` runs each test with `env -u GIT_DIR -u GIT_WORK_TREE` so agent/shell leakage cannot break nested repository operations.

## Validation

- `./scripts/run-tests.sh t7409-submodule-detached-work-tree.sh`
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c5d8bbb-f1ee-443a-8a96-59d65e10d2a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c5d8bbb-f1ee-443a-8a96-59d65e10d2a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

