### PR TITLE
fix: t4110-apply-scan — add missing patch fixtures

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -779,7 +779,7 @@ t4106-apply-stdin	t4	yes	3	3	0	true	ok	0
 t4107-apply-ignore-whitespace	t4	yes	11	11	0	true	ok	0
 t4108-apply-threeway	t4	yes	18	3	15	false	ok	0
 t4109-apply-multifrag	t4	yes	3	0	3	false	ok	0
-t4110-apply-scan	t4	yes	1	0	1	false	ok	0
+t4110-apply-scan	t4	yes	1	1	0	true	ok	0
 t4111-apply-subdir	t4	yes	10	3	7	false	ok	0
 t4112-apply-renames	t4	yes	2	2	0	true	ok	0
 t4113-apply-ending	t4	yes	3	1	2	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-07T23:41:35+00:00" class="gen-time" title="2026-04-07 23:41 UTC">2026-04-07 23:41 UTC</time> · <a href="https://github.com/schacon/grit/commit/dace7861338519c2719d4a4903b31ef8e397dd61" style="color:#58a6ff">dace786</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T00:06:58+00:00" class="gen-time" title="2026-04-08 00:06 UTC">2026-04-08 00:06 UTC</time> · <a href="https://github.com/schacon/grit/commit/036f59056dde567f710cd93c492429df07b6ade9" style="color:#58a6ff">036f590</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,471</div>
+      <div class="summary-big-val">29,472</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>606 files fully passing</span>
+    <span>607 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -223,11 +223,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">61/178 files · 2 skipped · 2,160/4,387 tests</span>
+        <span class="group-meta">62/178 files · 2 skipped · 2,161/4,387 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:49.2%"></div></div>
-        <span class="group-pct pct-orange">49.2%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:49.3%"></div></div>
+        <span class="group-pct pct-orange">49.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-07T23:41:35+00:00" class="gen-time" title="2026-04-07 23:41 UTC">2026-04-07 23:41 UTC</time> · <a href="https://github.com/schacon/grit/commit/dace7861338519c2719d4a4903b31ef8e397dd61" style="color:#58a6ff">dace786</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T00:06:58+00:00" class="gen-time" title="2026-04-08 00:06 UTC">2026-04-08 00:06 UTC</time> · <a href="https://github.com/schacon/grit/commit/036f59056dde567f710cd93c492429df07b6ade9" style="color:#58a6ff">036f590</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,739</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,471</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,472</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">67.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -7927,14 +7927,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="1" data-passed="0">
+<tr class="" data-group="t4" data-tests="1" data-passed="1">
   <td class="mono">t4110-apply-scan</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">1</td>
-  <td class="right">0</td>
+  <td class="right">1</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="10" data-passed="3">

--- a/logs/2026-04-08-t4110-apply-scan-fixtures.md
+++ b/logs/2026-04-08-t4110-apply-scan-fixtures.md
@@ -1,0 +1,19 @@
+# t4110-apply-scan
+
+## Issue
+
+`t4110-apply-scan.sh` failed because it looks for patches at
+`$TEST_DIRECTORY/t4110/patch*.patch`, but only `expect` lived at `tests/t4110/`;
+the five patch files were only under the nested `tests/t4110/t4110/` directory
+(copied incorrectly from upstream layout).
+
+## Fix
+
+Copied `patch1.patch` … `patch5.patch` from `git/t/t4110/` into `tests/t4110/`
+so paths match the test script. Grit `apply` already handled the scan case;
+no Rust changes.
+
+## Verification
+
+- `./scripts/run-tests.sh t4110-apply-scan.sh` → 1/1 pass
+- `cargo test -p grit-lib --lib` → pass

--- a/tests/t4110/patch1.patch
+++ b/tests/t4110/patch1.patch
@@ -1,0 +1,17 @@
+diff --git a/new.txt b/new.txt
+new file mode 100644
+--- /dev/null
++++ b/new.txt
+@@ -0,0 +1,12 @@
++a1
++a11
++a111
++a1111
++b1
++b11
++b111
++b1111
++c1
++c11
++c111
++c1111

--- a/tests/t4110/patch2.patch
+++ b/tests/t4110/patch2.patch
@@ -1,0 +1,11 @@
+diff --git a/new.txt b/new.txt
+--- a/new.txt
++++ b/new.txt
+@@ -1,7 +1,3 @@
+-a1
+-a11
+-a111
+-a1111
+ b1
+ b11
+ b111

--- a/tests/t4110/patch3.patch
+++ b/tests/t4110/patch3.patch
@@ -1,0 +1,14 @@
+diff --git a/new.txt b/new.txt
+--- a/new.txt
++++ b/new.txt
+@@ -6,6 +6,10 @@
+ b11
+ b111
+ b1111
++b2
++b22
++b222
++b2222
+ c1
+ c11
+ c111

--- a/tests/t4110/patch4.patch
+++ b/tests/t4110/patch4.patch
@@ -1,0 +1,11 @@
+diff --git a/new.txt b/new.txt
+--- a/new.txt
++++ b/new.txt
+@@ -1,3 +1,7 @@
++a1
++a11
++a111
++a1111
+ b1
+ b11
+ b111

--- a/tests/t4110/patch5.patch
+++ b/tests/t4110/patch5.patch
@@ -1,0 +1,11 @@
+diff --git a/new.txt b/new.txt
+--- a/new.txt
++++ b/new.txt
+@@ -10,3 +10,7 @@
+ c11
+ c111
+ c1111
++c2
++c22
++c222
++c2222


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t4110-apply-scan.sh` loads patches from `$TEST_DIRECTORY/t4110/patch1.patch` … `patch5.patch`. Only `expect` existed at `tests/t4110/`; the patch files had been placed only under the nested `tests/t4110/t4110/` directory, so `grit apply` failed with “cannot read … patch1.patch”.

## Changes

- Copy `patch1.patch`–`patch5.patch` from `git/t/t4110/` into `tests/t4110/` (same content as upstream).
- Refresh `data/test-files.csv` and dashboard HTML via `./scripts/run-tests.sh t4110-apply-scan.sh`.
- Add `logs/2026-04-08-t4110-apply-scan-fixtures.md` with notes.

## Verification

- `./scripts/run-tests.sh t4110-apply-scan.sh` → **1/1** pass
- `cargo test -p grit-lib --lib` → pass

No Rust changes; `git apply` behavior was already sufficient once fixtures were on the expected paths.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ff62b7a-cc09-490c-9f6d-a893bca29bab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ff62b7a-cc09-490c-9f6d-a893bca29bab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

