### PR TITLE
fix: make t4026-color fully pass

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -500,7 +500,7 @@ commit → check it off → move on.
 - [ ] `t4002-diff-basic` █████████████░░░░░░░ 44/63 (19 left) — Test diff raw-output.
 
 - [ ] `t4045-diff-relative` ██████████░░░░░░░░░░ 20/39 (19 left) — diff --relative tests
-- [ ] `t4026-color` ████████░░░░░░░░░░░░ 15/34 (19 left) — Test diff/status color escape codes
+- [x] `t4026-color` ████████████████████ 34/34 (0 left) — Test diff/status color escape codes (`parse_color` matches Git `color.c`; `config --get-color` argv joins default tokens and inserts `--` for leading `-` defaults)
 - [ ] `t4027-diff-submodule` █░░░░░░░░░░░░░░░░░░░ 1/20 (19 left) — difference in submodules
 - [ ] `t4038-diff-combined` ████░░░░░░░░░░░░░░░░ 6/26 (20 left) — combined diff
 - [ ] `t4032-diff-inter-hunk-context` ████████░░░░░░░░░░░░ 16/37 (21 left) — diff hunk fusing

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -703,7 +703,7 @@ t4022-diff-rewrite	t4	yes	11	6	5	false	ok	0
 t4023-diff-rename-typechange	t4	yes	4	0	4	false	ok	0
 t4024-diff-optimize-common	t4	yes	2	2	0	true	ok	0
 t4025-hunk-header	t4	yes	2	2	0	true	ok	0
-t4026-color	t4	yes	34	15	19	false	ok	0
+t4026-color	t4	yes	34	34	0	true	ok	0
 t4027-diff-submodule	t4	yes	20	2	18	false	ok	0
 t4028-format-patch-mime-headers	t4	yes	3	3	0	true	ok	0
 t4029-diff-trailing-space	t4	yes	1	1	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T00:09:04+00:00" class="gen-time" title="2026-04-08 00:09 UTC">2026-04-08 00:09 UTC</time> · <a href="https://github.com/schacon/grit/commit/9d17d92107b99a78cf8d8b6b334025243c31f24e" style="color:#58a6ff">9d17d92</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T00:32:44+00:00" class="gen-time" title="2026-04-08 00:32 UTC">2026-04-08 00:32 UTC</time> · <a href="https://github.com/schacon/grit/commit/b78c80c221416e6ff8947738b9174af6ec59b62d" style="color:#58a6ff">b78c80c</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,472</div>
+      <div class="summary-big-val">29,491</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>607 files fully passing</span>
+    <span>608 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -223,11 +223,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">62/178 files · 2 skipped · 2,161/4,387 tests</span>
+        <span class="group-meta">63/178 files · 2 skipped · 2,180/4,387 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:49.3%"></div></div>
-        <span class="group-pct pct-orange">49.3%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:49.7%"></div></div>
+        <span class="group-pct pct-orange">49.7%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T00:09:04+00:00" class="gen-time" title="2026-04-08 00:09 UTC">2026-04-08 00:09 UTC</time> · <a href="https://github.com/schacon/grit/commit/9d17d92107b99a78cf8d8b6b334025243c31f24e" style="color:#58a6ff">9d17d92</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T00:32:44+00:00" class="gen-time" title="2026-04-08 00:32 UTC">2026-04-08 00:32 UTC</time> · <a href="https://github.com/schacon/grit/commit/b78c80c221416e6ff8947738b9174af6ec59b62d" style="color:#58a6ff">b78c80c</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,739</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,472</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,491</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">67.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -7167,14 +7167,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="34" data-passed="15">
+<tr class="" data-group="t4" data-tests="34" data-passed="34">
   <td class="mono">t4026-color</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">34</td>
-  <td class="right">15</td>
+  <td class="right">34</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:44.1%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="20" data-passed="2">

--- a/grit-lib/src/config.rs
+++ b/grit-lib/src/config.rs
@@ -1488,79 +1488,303 @@ pub fn parse_i64(s: &str) -> std::result::Result<i64, String> {
 }
 
 /// Parse a Git color value and return the ANSI escape sequence.
+///
+/// Matches Git's `color_parse_mem` (`git/color.c`): whitespace-separated words,
+/// optional leading `reset`, up to two color tokens (foreground then background),
+/// then graphic rendition attributes. Attribute codes are accumulated as a
+/// bitmask keyed by SGR number (so `bold` sets bit 1, `nobold` sets bit 22).
 pub fn parse_color(s: &str) -> std::result::Result<String, String> {
-    let s = s.trim();
-    if s.is_empty() || s == "reset" || s == "normal" {
-        return Ok("\x1b[m".to_owned());
+    const COLOR_BACKGROUND_OFFSET: i32 = 10;
+    const COLOR_FOREGROUND_ANSI: i32 = 30;
+    const COLOR_FOREGROUND_RGB: i32 = 38;
+    const COLOR_FOREGROUND_256: i32 = 38;
+    const COLOR_FOREGROUND_BRIGHT_ANSI: i32 = 90;
+
+    #[derive(Clone, Copy, Default)]
+    struct Color {
+        kind: u8,
+        value: u8,
+        red: u8,
+        green: u8,
+        blue: u8,
     }
 
-    let mut codes: Vec<String> = Vec::new();
-    let mut fg_set = false;
-    let mut bg_set = false;
+    const COLOR_UNSPECIFIED: u8 = 0;
+    const COLOR_NORMAL: u8 = 1;
+    const COLOR_ANSI: u8 = 2;
+    const COLOR_256: u8 = 3;
+    const COLOR_RGB: u8 = 4;
 
-    for token in s.split_whitespace() {
-        match token.to_lowercase().as_str() {
-            "bold" => codes.push("1".to_owned()),
-            "dim" => codes.push("2".to_owned()),
-            "italic" => codes.push("3".to_owned()),
-            "ul" | "underline" => codes.push("4".to_owned()),
-            "blink" => codes.push("5".to_owned()),
-            "reverse" => codes.push("7".to_owned()),
-            "strike" => codes.push("9".to_owned()),
-            "nobold" | "nodim" => codes.push("22".to_owned()),
-            "noitalic" => codes.push("23".to_owned()),
-            "noul" | "nounderline" => codes.push("24".to_owned()),
-            "noblink" => codes.push("25".to_owned()),
-            "noreverse" => codes.push("27".to_owned()),
-            "nostrike" => codes.push("29".to_owned()),
-            name => {
-                if let Some(code) = color_name_to_ansi(name) {
-                    if !fg_set {
-                        codes.push(format!("3{code}"));
-                        fg_set = true;
-                    } else if !bg_set {
-                        codes.push(format!("4{code}"));
-                        bg_set = true;
-                    } else {
-                        return Err(format!("bad color value '{s}'"));
-                    }
-                } else if let Ok(n) = token.parse::<u8>() {
-                    if !fg_set {
-                        codes.push(format!("38;5;{n}"));
-                        fg_set = true;
-                    } else if !bg_set {
-                        codes.push(format!("48;5;{n}"));
-                        bg_set = true;
-                    } else {
-                        return Err(format!("bad color value '{s}'"));
-                    }
-                } else {
-                    return Err(format!("bad color value '{s}'"));
-                }
+    fn color_empty(c: &Color) -> bool {
+        c.kind == COLOR_UNSPECIFIED || c.kind == COLOR_NORMAL
+    }
+
+    fn parse_ansi_color(name: &str) -> Option<Color> {
+        let color_names = [
+            "black", "red", "green", "yellow", "blue", "magenta", "cyan", "white",
+        ];
+        let color_offset = COLOR_FOREGROUND_ANSI;
+
+        if name.eq_ignore_ascii_case("default") {
+            return Some(Color {
+                kind: COLOR_ANSI,
+                value: (9 + color_offset) as u8,
+                ..Default::default()
+            });
+        }
+
+        let (name, color_offset) = if name.len() >= 6 && name[..6].eq_ignore_ascii_case("bright") {
+            (&name[6..], COLOR_FOREGROUND_BRIGHT_ANSI)
+        } else {
+            (name, COLOR_FOREGROUND_ANSI)
+        };
+
+        for (i, cn) in color_names.iter().enumerate() {
+            if name.eq_ignore_ascii_case(cn) {
+                return Some(Color {
+                    kind: COLOR_ANSI,
+                    value: (i as i32 + color_offset) as u8,
+                    ..Default::default()
+                });
             }
+        }
+        None
+    }
+
+    fn hex_val(b: u8) -> Option<u8> {
+        match b {
+            b'0'..=b'9' => Some(b - b'0'),
+            b'a'..=b'f' => Some(b - b'a' + 10),
+            b'A'..=b'F' => Some(b - b'A' + 10),
+            _ => None,
         }
     }
 
-    if codes.is_empty() {
+    fn get_hex_color(chars: &[u8], width: usize) -> Option<(u8, usize)> {
+        assert!(width == 1 || width == 2);
+        if chars.len() < width {
+            return None;
+        }
+        let v = if width == 2 {
+            let hi = hex_val(chars[0])?;
+            let lo = hex_val(chars[1])?;
+            (hi << 4) | lo
+        } else {
+            let n = hex_val(chars[0])?;
+            (n << 4) | n
+        };
+        Some((v, width))
+    }
+
+    fn parse_single_color(word: &str) -> Option<Color> {
+        if word.eq_ignore_ascii_case("normal") {
+            return Some(Color {
+                kind: COLOR_NORMAL,
+                ..Default::default()
+            });
+        }
+
+        let bytes = word.as_bytes();
+        if (bytes.len() == 7 || bytes.len() == 4) && bytes.first() == Some(&b'#') {
+            let width = if bytes.len() == 7 { 2 } else { 1 };
+            let mut idx = 1;
+            let (r, n1) = get_hex_color(&bytes[idx..], width)?;
+            idx += n1;
+            let (g, n2) = get_hex_color(&bytes[idx..], width)?;
+            idx += n2;
+            let (b, n3) = get_hex_color(&bytes[idx..], width)?;
+            idx += n3;
+            if idx != bytes.len() {
+                return None;
+            }
+            return Some(Color {
+                kind: COLOR_RGB,
+                red: r,
+                green: g,
+                blue: b,
+                ..Default::default()
+            });
+        }
+
+        if let Some(c) = parse_ansi_color(word) {
+            return Some(c);
+        }
+
+        let Ok(val) = word.parse::<i64>() else {
+            return None;
+        };
+        if val < -1 {
+            return None;
+        }
+        if val < 0 {
+            return Some(Color {
+                kind: COLOR_NORMAL,
+                ..Default::default()
+            });
+        }
+        if val < 8 {
+            return Some(Color {
+                kind: COLOR_ANSI,
+                value: (val as i32 + COLOR_FOREGROUND_ANSI) as u8,
+                ..Default::default()
+            });
+        }
+        if val < 16 {
+            return Some(Color {
+                kind: COLOR_ANSI,
+                value: (val as i32 - 8 + COLOR_FOREGROUND_BRIGHT_ANSI) as u8,
+                ..Default::default()
+            });
+        }
+        if val < 256 {
+            return Some(Color {
+                kind: COLOR_256,
+                value: val as u8,
+                ..Default::default()
+            });
+        }
+        None
+    }
+
+    fn parse_attr(word: &str) -> Option<u8> {
+        const ATTRS: [(&str, u8, u8); 8] = [
+            ("bold", 1, 22),
+            ("dim", 2, 22),
+            ("italic", 3, 23),
+            ("ul", 4, 24),
+            ("underline", 4, 24),
+            ("blink", 5, 25),
+            ("reverse", 7, 27),
+            ("strike", 9, 29),
+        ];
+
+        let mut negate = false;
+        let mut rest = word;
+        if let Some(stripped) = rest.strip_prefix("no") {
+            negate = true;
+            rest = stripped;
+            if let Some(s) = rest.strip_prefix('-') {
+                rest = s;
+            }
+        }
+
+        for (name, val, neg) in ATTRS {
+            if rest == name {
+                return Some(if negate { neg } else { val });
+            }
+        }
+        None
+    }
+
+    fn append_color_output(out: &mut String, c: &Color, background: bool) {
+        let offset = if background {
+            COLOR_BACKGROUND_OFFSET
+        } else {
+            0
+        };
+        match c.kind {
+            COLOR_UNSPECIFIED | COLOR_NORMAL => {}
+            COLOR_ANSI => {
+                use std::fmt::Write;
+                let _ = write!(out, "{}", i32::from(c.value) + offset);
+            }
+            COLOR_256 => {
+                use std::fmt::Write;
+                let _ = write!(out, "{};5;{}", COLOR_FOREGROUND_256 + offset, c.value);
+            }
+            COLOR_RGB => {
+                use std::fmt::Write;
+                let _ = write!(
+                    out,
+                    "{};2;{};{};{}",
+                    COLOR_FOREGROUND_RGB + offset,
+                    c.red,
+                    c.green,
+                    c.blue
+                );
+            }
+            _ => {}
+        }
+    }
+
+    let s = s.trim();
+    if s.is_empty() {
+        return Ok(String::new());
+    }
+
+    let mut has_reset = false;
+    let mut attr: u64 = 0;
+    let mut fg = Color::default();
+    let mut bg = Color::default();
+    fg.kind = COLOR_UNSPECIFIED;
+    bg.kind = COLOR_UNSPECIFIED;
+
+    for word in s.split_whitespace() {
+        if word.eq_ignore_ascii_case("reset") {
+            has_reset = true;
+            continue;
+        }
+
+        if let Some(c) = parse_single_color(word) {
+            if fg.kind == COLOR_UNSPECIFIED {
+                fg = c;
+                continue;
+            }
+            if bg.kind == COLOR_UNSPECIFIED {
+                bg = c;
+                continue;
+            }
+            return Err(format!("bad color value '{s}'"));
+        }
+
+        if let Some(code) = parse_attr(word) {
+            attr |= 1u64 << u64::from(code);
+            continue;
+        }
+
         return Err(format!("bad color value '{s}'"));
     }
 
-    Ok(format!("\x1b[{}m", codes.join(";")))
-}
-
-fn color_name_to_ansi(name: &str) -> Option<&'static str> {
-    match name.to_lowercase().as_str() {
-        "normal" | "default" => Some("9"),
-        "black" => Some("0"),
-        "red" => Some("1"),
-        "green" => Some("2"),
-        "yellow" => Some("3"),
-        "blue" => Some("4"),
-        "magenta" => Some("5"),
-        "cyan" => Some("6"),
-        "white" => Some("7"),
-        _ => None,
+    if !has_reset && attr == 0 && color_empty(&fg) && color_empty(&bg) {
+        return Err(format!("bad color value '{s}'"));
     }
+
+    let mut out = String::from("\x1b[");
+    let mut sep = if has_reset { 1u32 } else { 0u32 };
+
+    let mut attr_bits = attr;
+    let mut i = 0u32;
+    while attr_bits != 0 {
+        let bit = 1u64 << i;
+        if attr_bits & bit == 0 {
+            i += 1;
+            continue;
+        }
+        attr_bits &= !bit;
+        if sep > 0 {
+            out.push(';');
+        }
+        sep += 1;
+        use std::fmt::Write;
+        let _ = write!(out, "{i}");
+        i += 1;
+    }
+
+    if !color_empty(&fg) {
+        if sep > 0 {
+            out.push(';');
+        }
+        sep += 1;
+        append_color_output(&mut out, &fg, false);
+    }
+    if !color_empty(&bg) {
+        if sep > 0 {
+            out.push(';');
+        }
+        append_color_output(&mut out, &bg, true);
+    }
+    out.push('m');
+    Ok(out)
 }
 
 /// Match a URL against a URL pattern from config.

--- a/grit/src/commands/config.rs
+++ b/grit/src/commands/config.rs
@@ -15,7 +15,8 @@ use std::path::{Path, PathBuf};
 #[derive(Debug, ClapArgs)]
 #[command(
     about = "Get and set repository or global options",
-    after_help = "Use subcommands (get, set, unset, list) or legacy flags (--get, key value)."
+    after_help = "Use subcommands (get, set, unset, list) or legacy flags (--get, key value).",
+    allow_negative_numbers = true
 )]
 pub struct Args {
     #[command(subcommand)]
@@ -156,7 +157,10 @@ pub struct Args {
 
     // ── Positional args for legacy set (`git config key value`) ──
     /// Positional arguments (key, value, value-pattern for legacy mode).
-    #[arg(trailing_var_arg = true)]
+    ///
+    /// `allow_negative_numbers` is required so `git config --get-color SLOT -1` treats `-1` as
+    /// a default color (Git synonym for `normal`), not as a clap flag.
+    #[arg(trailing_var_arg = true, allow_negative_numbers = true)]
     pub positional: Vec<String>,
 }
 

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -2021,6 +2021,37 @@ fn print_upstream_synopsis_and_exit(subcmd: &str, syn: &str) -> ! {
 /// (Git convention for usage errors) instead of clap's default exit code 0.
 /// Git allows `git status --porcelain path`; clap would treat `path` as the optional porcelain
 /// version unless we insert `--` after a bare `--porcelain` when the next token is a pathspec.
+/// `git config --get-color <slot> <default>` allows a multi-word default (e.g. `-1 black`).
+/// The shell passes `-1` and `black` as separate argv entries; clap would treat `-1` as a flag.
+/// Join all arguments after the slot into one default string, like Git's argv consumption.
+fn preprocess_config_argv(rest: &[String]) -> Vec<String> {
+    let Some(pos) = rest.iter().position(|a| a == "--get-color") else {
+        return rest.to_vec();
+    };
+    let key_idx = pos + 1;
+    if key_idx >= rest.len() {
+        return rest.to_vec();
+    }
+    let mut tail_idx = key_idx + 1;
+    if tail_idx >= rest.len() {
+        return rest.to_vec();
+    }
+    if rest[tail_idx] == "--" {
+        tail_idx += 1;
+        if tail_idx >= rest.len() {
+            return rest.to_vec();
+        }
+    }
+    let default_str = rest[tail_idx..].join(" ");
+    let mut out = rest[..=key_idx].to_vec();
+    // Values starting with `-` must follow `--` or clap treats them as flags.
+    if default_str.starts_with('-') {
+        out.push("--".to_owned());
+    }
+    out.push(default_str);
+    out
+}
+
 fn preprocess_status_argv(rest: &[String]) -> Vec<String> {
     fn next_is_pathspec_after_bare_porcelain(next: Option<&str>) -> bool {
         let Some(n) = next else {
@@ -2848,7 +2879,7 @@ pub(crate) fn dispatch(subcmd: &str, rest: &[String], opts: &GlobalOpts) -> Resu
         "commit" => commands::commit::run(parse_cmd_args(subcmd, rest)),
         "commit-graph" => commands::commit_graph::run(parse_cmd_args(subcmd, rest)),
         "commit-tree" => commands::commit_tree::run(parse_cmd_args(subcmd, rest)),
-        "config" => commands::config::run(parse_cmd_args(subcmd, rest)),
+        "config" => commands::config::run(parse_cmd_args(subcmd, &preprocess_config_argv(rest))),
         "count-objects" => commands::count_objects::run(parse_cmd_args(subcmd, rest)),
         "credential" => commands::credential::run(parse_cmd_args(subcmd, rest)),
         "credential-cache" => commands::credential_cache::run(parse_cmd_args(subcmd, rest)),

--- a/logs/2026-04-08_t4026-color.md
+++ b/logs/2026-04-08_t4026-color.md
@@ -1,0 +1,18 @@
+# t4026-color
+
+## Goal
+
+Make `tests/t4026-color.sh` fully pass (Git `config --get-color` + color parsing).
+
+## Changes
+
+1. **`grit-lib/src/config.rs`** — Replaced simplified `parse_color` with behavior aligned to `git/color.c` (`color_parse_mem_1`): reset / normal / default, 256 and RGB, bright names, numeric 0–7 and 8–15 aliases, attribute bitmask ordering, `no-` / `no` negation, `underline` alias.
+
+2. **`grit/src/main.rs`** — `preprocess_config_argv`: after `--get-color <key>`, join remaining argv into a single default string (shell splits e.g. `-1 black`). If the merged default starts with `-`, insert `--` before it so clap does not treat it as a flag.
+
+3. **`grit/src/commands/config.rs`** — `allow_negative_numbers` on the `Args` struct and command (belt-and-suspenders with preprocessing).
+
+## Verification
+
+- `./scripts/run-tests.sh t4026-color.sh` → 34/34
+- `cargo test -p grit-lib --lib`

--- a/progress.md
+++ b/progress.md
@@ -1,18 +1,21 @@
 # Progress — Grit Test Coverage
 
-**Updated:** 2026-04-07
+**Updated:** 2026-04-08
 
 ## Counts (derived from plan.md)
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |    95 |
-| In progress |     0 |
-| Remaining   |   672 |
-| **Total**   |   767 |
+| Completed   |   225 |
+| In progress |     2 |
+| Remaining   |   541 |
+| **Total**   |   768 |
+
+Task lines in `PLAN.md`: 225 completed (`[x]`), 2 in progress (`[~]`), 541 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t4026-color` — 34/34 tests pass (Git-compatible `config::parse_color` per `git/color.c`; `git config --get-color` merges argv after the slot into one default and uses `--` when the default begins with `-` so clap accepts `-1 black`)
 - `t3704-add-pathspec-file` — 11/11 tests pass (`git add --pathspec-from-file` / `--pathspec-file-nul`: raw bytes + CRLF/LF/NUL splitting, C-quoted lines, conflict checks vs `--interactive`/`--patch`/`--edit`/pathspecs; shared `pathspec::parse_pathspecs_from_file`; error text matches grep expectations)
 - `t5813-proto-disable-ssh` — 81/81 tests pass (`GIT_ALLOW_PROTOCOL` comma split, `protocol.*.allow=user` + `GIT_PROTOCOL_FROM_USER`, SSH URL validation, local SSH resolution via `TRASH_DIRECTORY` + absolute `ssh://` paths, pkt-line `upload-pack`/`receive-pack`, side-band pack streaming)
 - `t12730-switch-start-point` — 36/36 tests pass (`grit switch -c` with start-point, `--detach`, `--orphan`, tags, abbreviated hashes, `HEAD~N`; harness CSV refreshed)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible `git config --get-color` behavior so `tests/t4026-color.sh` passes (34/34).

## Changes

- **`grit-lib`**: Rewrote `config::parse_color` to follow `git/color.c` (`color_parse_mem_1`): reset / normal / default semantics, 256-color and truecolor RGB, bright color names, numeric 0–7 and 8–15 aliases, SGR attribute bitmask ordering (so combined attrs match Git), and `no` / `no-` attribute negation (including shared code 22 for bold/dim cancel).
- **`grit`**: Preprocess `config` argv when `--get-color` is used: join all arguments after the slot key into a single default string (the shell splits e.g. `-1` and `black`). If the merged default starts with `-`, insert `--` before it so clap accepts it as a positional value. Also set `allow_negative_numbers` on the config `Args` struct.

## Testing

- `./scripts/run-tests.sh t4026-color.sh`
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99a242ef-ffd0-4b9c-82a3-b1a27d907ca1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99a242ef-ffd0-4b9c-82a3-b1a27d907ca1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

