### PR TITLE
fix: make t4007-rename-3 pass (diff-files copy detection)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -679,7 +679,7 @@ t4003-diff-rename-1	t4	yes	7	7	0	true	ok	0
 t4004-diff-rename-symlink	t4	yes	4	4	0	true	ok	0
 t4005-diff-rename-2	t4	yes	4	4	0	true	ok	0
 t4006-diff-mode	t4	yes	7	6	1	false	ok	0
-t4007-rename-3	t4	yes	13	11	2	false	ok	0
+t4007-rename-3	t4	yes	13	13	0	true	ok	0
 t4008-diff-break-rewrite	t4	yes	14	5	9	false	ok	0
 t4009-diff-rename-4	t4	yes	7	4	3	false	ok	0
 t4010-diff-pathspec	t4	yes	17	12	5	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T00:34:26+00:00" class="gen-time" title="2026-04-08 00:34 UTC">2026-04-08 00:34 UTC</time> · <a href="https://github.com/schacon/grit/commit/7bbd95c8cc5291a1adf65652cd6d5a923be2337e" style="color:#58a6ff">7bbd95c</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T01:12:52+00:00" class="gen-time" title="2026-04-08 01:12 UTC">2026-04-08 01:12 UTC</time> · <a href="https://github.com/schacon/grit/commit/ca6d020e37b7a1c717957e26f8e2be0e1644d46f" style="color:#58a6ff">ca6d020</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,472</div>
+      <div class="summary-big-val">29,474</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>607 files fully passing</span>
+    <span>608 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -223,7 +223,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">62/178 files · 2 skipped · 2,161/4,387 tests</span>
+        <span class="group-meta">63/178 files · 2 skipped · 2,163/4,387 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-orange" style="width:49.3%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T00:34:26+00:00" class="gen-time" title="2026-04-08 00:34 UTC">2026-04-08 00:34 UTC</time> · <a href="https://github.com/schacon/grit/commit/7bbd95c8cc5291a1adf65652cd6d5a923be2337e" style="color:#58a6ff">7bbd95c</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T01:12:52+00:00" class="gen-time" title="2026-04-08 01:12 UTC">2026-04-08 01:12 UTC</time> · <a href="https://github.com/schacon/grit/commit/ca6d020e37b7a1c717957e26f8e2be0e1644d46f" style="color:#58a6ff">ca6d020</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,739</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,472</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,474</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">67.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -6927,14 +6927,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:85.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="13" data-passed="11">
+<tr class="" data-group="t4" data-tests="13" data-passed="13">
   <td class="mono">t4007-rename-3</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">13</td>
-  <td class="right">11</td>
+  <td class="right">13</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:84.6%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="14" data-passed="5">

--- a/grit-lib/src/diff.rs
+++ b/grit-lib/src/diff.rs
@@ -1254,8 +1254,13 @@ pub fn detect_copies(
 
     // Build score matrix: (score, source_idx, added_idx)
     let mut scores: Vec<(u32, usize, usize)> = Vec::new();
-    for (si, (_, src_oid, _)) in sources.iter().enumerate() {
+    for (si, (src_path, src_oid, _)) in sources.iter().enumerate() {
         for (ai, add) in added.iter().enumerate() {
+            // Never pair a path with itself as copy source (matches Git; avoids
+            // arbitrary tie-breaking when several sources share the same blob).
+            if add.new_path.as_deref() == Some(src_path.as_str()) {
+                continue;
+            }
             if *src_oid == add.new_oid {
                 scores.push((100, si, ai));
                 continue;

--- a/grit/src/commands/diff_files.rs
+++ b/grit/src/commands/diff_files.rs
@@ -5,7 +5,10 @@
 
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
-use grit_lib::diff::{count_changes, format_stat_line, stat_matches, unified_diff, zero_oid};
+use grit_lib::diff::{
+    count_changes, detect_copies, format_stat_line, stat_matches, unified_diff, zero_oid,
+    DiffEntry, DiffStatus,
+};
 use grit_lib::index::{
     Index, IndexEntry, MODE_EXECUTABLE, MODE_GITLINK, MODE_REGULAR, MODE_SYMLINK,
 };
@@ -45,38 +48,97 @@ pub fn run(args: Args) -> Result<()> {
 
     let changes = collect_changes(&repo, &index, &work_tree, &options)?;
 
+    let mut diff_entries: Vec<DiffEntry> = changes.iter().map(change_to_diff_entry).collect();
+
+    if options.reverse {
+        diff_entries = diff_entries
+            .into_iter()
+            .map(reverse_diff_entry_for_diff_files)
+            .collect();
+    }
+
+    if options.find_copies {
+        let threshold = options.find_renames.unwrap_or(50);
+        let source_index_entries: Vec<(String, String, ObjectId)> = index
+            .entries
+            .iter()
+            .filter(|e| e.stage() == 0)
+            .filter_map(|e| {
+                let path = String::from_utf8(e.path.clone()).ok()?;
+                if options.ignore_submodules && e.mode == MODE_GITLINK {
+                    return None;
+                }
+                if !matches_pathspec(&path, &options.pathspecs) {
+                    return None;
+                }
+                let mode = format!("{:06o}", canonicalize_mode(e.mode));
+                Some((path, mode, e.oid))
+            })
+            .collect();
+        diff_entries = detect_copies(
+            &repo.odb,
+            diff_entries,
+            threshold,
+            options.find_copies_harder,
+            &source_index_entries,
+        );
+    } else if let Some(threshold) = options.find_renames {
+        diff_entries = grit_lib::diff::detect_renames(&repo.odb, diff_entries, threshold);
+    }
+
     if !options.quiet && !options.suppress_diff {
         match options.format {
             OutputFormat::Raw => {
-                for change in &changes {
-                    println!("{}", render_raw(change, &repo, options.abbrev)?);
+                for entry in &diff_entries {
+                    println!(
+                        "{}",
+                        render_raw_diff_entry(entry, &repo, options.abbrev, options.reverse)?
+                    );
                 }
             }
             OutputFormat::NameOnly => {
-                for change in &changes {
-                    println!("{}", change.path);
+                for entry in &diff_entries {
+                    println!("{}", entry.path());
                 }
             }
             OutputFormat::NameStatus => {
-                for change in &changes {
-                    println!("{}\t{}", change.status, change.path);
+                for entry in &diff_entries {
+                    match (entry.status, entry.score) {
+                        (DiffStatus::Renamed, Some(s)) => {
+                            println!(
+                                "R{s:03}\t{}\t{}",
+                                entry.old_path.as_deref().unwrap_or(""),
+                                entry.new_path.as_deref().unwrap_or("")
+                            );
+                        }
+                        (DiffStatus::Copied, Some(s)) => {
+                            println!(
+                                "C{s:03}\t{}\t{}",
+                                entry.old_path.as_deref().unwrap_or(""),
+                                entry.new_path.as_deref().unwrap_or("")
+                            );
+                        }
+                        _ => {
+                            println!("{}\t{}", entry.status.letter(), entry.path());
+                        }
+                    }
                 }
             }
             OutputFormat::Patch => {
-                for change in &changes {
-                    print_patch(change, &repo, &work_tree)?;
+                for entry in &diff_entries {
+                    print_patch_from_diff_entry(entry, &repo, &work_tree)?;
                 }
             }
             OutputFormat::Stat => {
-                print_stat(&changes, &repo, &work_tree)?;
+                print_stat_from_diff_entries(&diff_entries, &repo, &work_tree)?;
             }
             OutputFormat::NumStat => {
-                print_numstat(&changes, &repo, &work_tree)?;
+                print_numstat_from_diff_entries(&diff_entries, &repo, &work_tree)?;
             }
         }
     }
 
-    if (options.exit_code || options.quiet) && !changes.is_empty() {
+    if (options.exit_code || options.quiet) && !diff_entries.is_empty() {
         std::process::exit(1);
     }
     Ok(())
@@ -122,6 +184,14 @@ struct Options {
     diff_filter: Option<String>,
     /// Omit submodule entries (gitlinks) from the diff.
     ignore_submodules: bool,
+    /// Rename similarity threshold (percent); `None` disables rename detection.
+    find_renames: Option<u32>,
+    /// Enable copy detection (`-C` / `--find-copies`).
+    find_copies: bool,
+    /// Consider unmodified index entries as copy sources (`--find-copies-harder`).
+    find_copies_harder: bool,
+    /// Swap old/new sides (reverse diff).
+    reverse: bool,
 }
 
 /// A single changed file: index side vs working tree.
@@ -137,6 +207,8 @@ struct Change {
     new_mode: u32,
     /// Index-side OID.
     old_oid: ObjectId,
+    /// Working-tree blob OID (hashed content); zero when unknown or deleted from worktree.
+    new_oid: ObjectId,
 }
 
 // ── Option parsing ───────────────────────────────────────────────────
@@ -151,6 +223,11 @@ fn parse_options(argv: &[String]) -> Result<Options> {
     let mut suppress_diff = false;
     let mut diff_filter: Option<String> = None;
     let mut ignore_submodules = false;
+    let mut find_renames: Option<u32> = None;
+    let mut find_copies = false;
+    let mut find_copies_harder = false;
+    let mut c_count = 0u32;
+    let mut reverse = false;
     let mut end_of_options = false;
 
     let mut idx = 0usize;
@@ -163,6 +240,7 @@ fn parse_options(argv: &[String]) -> Result<Options> {
         }
         if !end_of_options && arg.starts_with('-') {
             match arg.as_str() {
+                "-R" => reverse = true,
                 "--raw" => {
                     format = OutputFormat::Raw;
                     suppress_diff = false;
@@ -220,8 +298,48 @@ fn parse_options(argv: &[String]) -> Result<Options> {
                 | "--full-index"
                 | "--no-ext-diff"
                 | "--no-prefix"
-                | "--no-renames"
                 | "--no-abbrev" => {}
+                "-M" | "--find-renames" => {
+                    find_renames = Some(50);
+                }
+                "--no-renames" => {
+                    find_renames = None;
+                }
+                _ if arg.starts_with("-M") && arg.len() > 2 => {
+                    let val = &arg[2..];
+                    let pct = if val.ends_with('%') {
+                        val[..val.len() - 1].parse::<u32>().unwrap_or(50)
+                    } else {
+                        val.parse::<u32>().unwrap_or(50)
+                    };
+                    find_renames = Some(pct);
+                }
+                _ if arg.starts_with("--find-renames=") => {
+                    let val = &arg["--find-renames=".len()..];
+                    let pct = if val.ends_with('%') {
+                        val[..val.len() - 1].parse::<u32>().unwrap_or(50)
+                    } else {
+                        val.parse::<u32>().unwrap_or(50)
+                    };
+                    find_renames = Some(pct);
+                }
+                "-C" | "--find-copies" => {
+                    c_count += 1;
+                    find_copies = true;
+                    if c_count >= 2 {
+                        find_copies_harder = true;
+                    }
+                    if find_renames.is_none() {
+                        find_renames = Some(50);
+                    }
+                }
+                "--find-copies-harder" => {
+                    find_copies = true;
+                    find_copies_harder = true;
+                    if find_renames.is_none() {
+                        find_renames = Some(50);
+                    }
+                }
                 "--diff-filter" => {
                     if idx + 1 < argv.len() {
                         diff_filter = Some(argv[idx + 1].clone());
@@ -269,6 +387,10 @@ fn parse_options(argv: &[String]) -> Result<Options> {
         suppress_diff,
         diff_filter,
         ignore_submodules,
+        find_renames,
+        find_copies,
+        find_copies_harder,
+        reverse,
     })
 }
 
@@ -337,6 +459,7 @@ fn collect_changes(
                                 old_mode: idx_canonical,
                                 new_mode: wt_mode,
                                 old_oid: *idx_oid,
+                                new_oid: wt_oid,
                             },
                         );
                     }
@@ -351,6 +474,7 @@ fn collect_changes(
                             old_mode: canonicalize_mode(*idx_mode),
                             new_mode: 0,
                             old_oid: *idx_oid,
+                            new_oid: zero_oid(),
                         },
                     );
                 }
@@ -373,6 +497,7 @@ fn collect_changes(
                     old_mode: 0,
                     new_mode: 0,
                     old_oid: zero_oid(),
+                    new_oid: zero_oid(),
                 },
             );
         }
@@ -381,7 +506,7 @@ fn collect_changes(
         for (path, (idx_mode, idx_oid)) in &staged {
             let abs = work_tree.join(path);
             match read_worktree_info(repo, &abs)? {
-                Some((wt_mode, _wt_oid)) => {
+                Some((wt_mode, wt_oid)) => {
                     changes.insert(
                         path.clone(),
                         Change {
@@ -390,6 +515,7 @@ fn collect_changes(
                             old_mode: canonicalize_mode(*idx_mode),
                             new_mode: wt_mode,
                             old_oid: *idx_oid,
+                            new_oid: wt_oid,
                         },
                     );
                 }
@@ -402,6 +528,7 @@ fn collect_changes(
                             old_mode: canonicalize_mode(*idx_mode),
                             new_mode: 0,
                             old_oid: *idx_oid,
+                            new_oid: zero_oid(),
                         },
                     );
                 }
@@ -414,6 +541,293 @@ fn collect_changes(
         out.retain(|change| matches_diff_filter(change.status, spec));
     }
     Ok(out)
+}
+
+fn change_to_diff_entry(c: &Change) -> DiffEntry {
+    let old_mode_str = format!("{:06o}", c.old_mode);
+    let new_mode_str = format!("{:06o}", c.new_mode);
+    match c.status {
+        'D' => DiffEntry {
+            status: DiffStatus::Deleted,
+            old_path: Some(c.path.clone()),
+            new_path: None,
+            old_mode: old_mode_str,
+            new_mode: new_mode_str,
+            old_oid: c.old_oid,
+            new_oid: zero_oid(),
+            score: None,
+        },
+        'U' => DiffEntry {
+            status: DiffStatus::Unmerged,
+            old_path: Some(c.path.clone()),
+            new_path: Some(c.path.clone()),
+            old_mode: old_mode_str,
+            new_mode: new_mode_str,
+            old_oid: c.old_oid,
+            new_oid: c.new_oid,
+            score: None,
+        },
+        'T' => DiffEntry {
+            status: DiffStatus::TypeChanged,
+            old_path: Some(c.path.clone()),
+            new_path: Some(c.path.clone()),
+            old_mode: old_mode_str,
+            new_mode: new_mode_str,
+            old_oid: c.old_oid,
+            new_oid: c.new_oid,
+            score: None,
+        },
+        _ => DiffEntry {
+            status: DiffStatus::Modified,
+            old_path: Some(c.path.clone()),
+            new_path: Some(c.path.clone()),
+            old_mode: old_mode_str,
+            new_mode: new_mode_str,
+            old_oid: c.old_oid,
+            new_oid: c.new_oid,
+            score: None,
+        },
+    }
+}
+
+/// Swap old/new sides for `diff-files -R` before rename/copy detection.
+fn reverse_diff_entry_for_diff_files(mut e: DiffEntry) -> DiffEntry {
+    match e.status {
+        DiffStatus::Added => {
+            e.status = DiffStatus::Deleted;
+            e.old_path = e.new_path.take();
+            e.new_path = None;
+            std::mem::swap(&mut e.old_mode, &mut e.new_mode);
+            std::mem::swap(&mut e.old_oid, &mut e.new_oid);
+        }
+        DiffStatus::Deleted => {
+            e.status = DiffStatus::Added;
+            e.new_path = e.old_path.take();
+            e.old_path = None;
+            std::mem::swap(&mut e.old_mode, &mut e.new_mode);
+            std::mem::swap(&mut e.old_oid, &mut e.new_oid);
+        }
+        DiffStatus::Renamed | DiffStatus::Copied => {
+            std::mem::swap(&mut e.old_path, &mut e.new_path);
+            std::mem::swap(&mut e.old_mode, &mut e.new_mode);
+            std::mem::swap(&mut e.old_oid, &mut e.new_oid);
+        }
+        DiffStatus::Modified | DiffStatus::TypeChanged | DiffStatus::Unmerged => {
+            std::mem::swap(&mut e.old_mode, &mut e.new_mode);
+            std::mem::swap(&mut e.old_oid, &mut e.new_oid);
+        }
+    }
+    e
+}
+
+fn render_raw_diff_entry(
+    entry: &DiffEntry,
+    repo: &Repository,
+    abbrev: Option<usize>,
+    reverse: bool,
+) -> Result<String> {
+    let width = abbrev.unwrap_or(40).clamp(4, 40);
+    let old_oid = format_oid_for_raw(entry.old_oid, repo, abbrev, width)?;
+    let new_oid = if reverse {
+        format_oid_for_raw(entry.new_oid, repo, abbrev, width)?
+    } else {
+        "0".repeat(width)
+    };
+
+    let status_str = match (entry.status, entry.score) {
+        (DiffStatus::Renamed, Some(s)) => format!("R{s:03}"),
+        (DiffStatus::Copied, Some(s)) => format!("C{s:03}"),
+        _ => entry.status.letter().to_string(),
+    };
+
+    let path = match entry.status {
+        DiffStatus::Renamed | DiffStatus::Copied => format!(
+            "{}\t{}",
+            entry.old_path.as_deref().unwrap_or(""),
+            entry.new_path.as_deref().unwrap_or("")
+        ),
+        _ => entry.path().to_owned(),
+    };
+
+    Ok(format!(
+        ":{} {} {} {} {}\t{}",
+        entry.old_mode, entry.new_mode, old_oid, new_oid, status_str, path
+    ))
+}
+
+fn format_oid_for_raw(
+    oid: ObjectId,
+    repo: &Repository,
+    abbrev: Option<usize>,
+    width: usize,
+) -> Result<String> {
+    if oid == zero_oid() {
+        return Ok("0".repeat(width));
+    }
+    match abbrev {
+        Some(min_len) => abbreviate_object_id(repo, oid, min_len).map_err(Into::into),
+        None => Ok(oid.to_hex()),
+    }
+}
+
+fn print_patch_from_diff_entry(
+    entry: &DiffEntry,
+    repo: &Repository,
+    work_tree: &Path,
+) -> Result<()> {
+    let (old_content, new_content) = load_patch_contents_for_diff_entry(entry, repo, work_tree)?;
+    let old_path = entry
+        .old_path
+        .as_deref()
+        .unwrap_or(entry.new_path.as_deref().unwrap_or(""));
+    let new_path = entry
+        .new_path
+        .as_deref()
+        .unwrap_or(entry.old_path.as_deref().unwrap_or(""));
+
+    let old_label = match entry.status {
+        DiffStatus::Added => "/dev/null".to_owned(),
+        _ => format!("a/{old_path}"),
+    };
+    let new_label = match entry.status {
+        DiffStatus::Deleted => "/dev/null".to_owned(),
+        _ => format!("b/{new_path}"),
+    };
+
+    let display_path = entry.path();
+    let mut header = format!("diff --git a/{old_path} b/{new_path}");
+    match entry.status {
+        DiffStatus::Deleted => {
+            header.push_str(&format!("\ndeleted file mode {}", entry.old_mode));
+        }
+        DiffStatus::Added => {
+            header.push_str(&format!("\nnew file mode {}", entry.new_mode));
+        }
+        DiffStatus::Renamed => {
+            let sim = entry.score.unwrap_or(100);
+            header.push_str(&format!(
+                "\nsimilarity index {sim}%\nrename from {old_path}\nrename to {new_path}"
+            ));
+        }
+        DiffStatus::Copied => {
+            let sim = entry.score.unwrap_or(100);
+            header.push_str(&format!(
+                "\nsimilarity index {sim}%\ncopy from {old_path}\ncopy to {new_path}"
+            ));
+        }
+        _ => {
+            if entry.old_mode != entry.new_mode {
+                header.push_str(&format!(
+                    "\nold mode {}\nnew mode {}",
+                    entry.old_mode, entry.new_mode
+                ));
+            }
+        }
+    }
+
+    if (entry.status == DiffStatus::Renamed || entry.status == DiffStatus::Copied)
+        && entry.old_oid == entry.new_oid
+    {
+        println!("{header}");
+        return Ok(());
+    }
+
+    if old_content == new_content
+        && entry.old_mode != entry.new_mode
+        && entry.status != DiffStatus::Renamed
+        && entry.status != DiffStatus::Copied
+    {
+        println!("{header}");
+    } else if old_content != new_content {
+        let patch = unified_diff(&old_content, &new_content, display_path, display_path, 3);
+        let body: String = patch.lines().skip(2).map(|l| format!("\n{l}")).collect();
+        println!("{header}\n--- {old_label}\n+++ {new_label}{body}");
+    } else {
+        println!("{header}\n--- {old_label}\n+++ {new_label}");
+    }
+    Ok(())
+}
+
+fn print_stat_from_diff_entries(
+    entries: &[DiffEntry],
+    repo: &Repository,
+    work_tree: &Path,
+) -> Result<()> {
+    if entries.is_empty() {
+        return Ok(());
+    }
+    let max_len = entries.iter().map(|e| e.path().len()).max().unwrap_or(0);
+    let mut total_ins = 0usize;
+    let mut total_del = 0usize;
+    for entry in entries {
+        let (old, new) = load_patch_contents_for_diff_entry(entry, repo, work_tree)?;
+        let (ins, del) = count_changes(&old, &new);
+        total_ins += ins;
+        total_del += del;
+        println!("{}", format_stat_line(entry.path(), ins, del, max_len));
+    }
+    let files = entries.len();
+    let mut summary = format!(
+        " {} file{} changed",
+        files,
+        if files == 1 { "" } else { "s" },
+    );
+    if total_ins > 0 || (total_ins == 0 && total_del == 0) {
+        summary.push_str(&format!(
+            ", {} insertion{}(+)",
+            total_ins,
+            if total_ins == 1 { "" } else { "s" }
+        ));
+    }
+    if total_del > 0 || (total_ins == 0 && total_del == 0) {
+        summary.push_str(&format!(
+            ", {} deletion{}(-)",
+            total_del,
+            if total_del == 1 { "" } else { "s" }
+        ));
+    }
+    println!("{summary}");
+    Ok(())
+}
+
+fn print_numstat_from_diff_entries(
+    entries: &[DiffEntry],
+    repo: &Repository,
+    work_tree: &Path,
+) -> Result<()> {
+    for entry in entries {
+        let (old, new) = load_patch_contents_for_diff_entry(entry, repo, work_tree)?;
+        let (ins, del) = count_changes(&old, &new);
+        println!("{}\t{}\t{}", ins, del, entry.path());
+    }
+    Ok(())
+}
+
+fn load_patch_contents_for_diff_entry(
+    entry: &DiffEntry,
+    repo: &Repository,
+    work_tree: &Path,
+) -> Result<(String, String)> {
+    let old_content = if entry.status == DiffStatus::Added || entry.old_oid == zero_oid() {
+        String::new()
+    } else {
+        let obj = repo.odb.read(&entry.old_oid)?;
+        String::from_utf8(obj.data).unwrap_or_default()
+    };
+
+    let new_content = if entry.status == DiffStatus::Deleted {
+        String::new()
+    } else {
+        let path = entry.new_path.as_deref().unwrap_or(entry.path());
+        let abs = work_tree.join(path);
+        match fs::read(&abs) {
+            Ok(bytes) => String::from_utf8(bytes).unwrap_or_default(),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+            Err(e) => return Err(e.into()),
+        }
+    };
+
+    Ok((old_content, new_content))
 }
 
 fn matches_diff_filter(status: char, spec: &str) -> bool {
@@ -588,164 +1002,6 @@ fn read_worktree_info(repo: &Repository, abs_path: &Path) -> Result<Option<(u32,
     }
 
     Ok(None)
-}
-
-// ── Output renderers ─────────────────────────────────────────────────
-
-/// Format a change in Git's raw diff format.
-///
-/// For `diff-files` the working-tree OID is always shown as zeros —
-/// the worktree side has not been committed into the object store.
-fn render_raw(change: &Change, repo: &Repository, abbrev: Option<usize>) -> Result<String> {
-    let width = abbrev.unwrap_or(40).clamp(4, 40);
-    let old_oid = format_oid(change.old_oid, repo, abbrev, width)?;
-    // Working-tree OID is always zeros in diff-files output.
-    let new_oid = "0".repeat(width);
-    Ok(format!(
-        ":{:06o} {:06o} {} {} {}\t{}",
-        change.old_mode, change.new_mode, old_oid, new_oid, change.status, change.path
-    ))
-}
-
-/// Print unified patch output for a single change.
-fn print_patch(change: &Change, repo: &Repository, work_tree: &Path) -> Result<()> {
-    let (old_content, new_content) = load_patch_contents(change, repo, work_tree)?;
-    let path = &change.path;
-    let old_label = if change.status == 'A' {
-        "/dev/null".to_owned()
-    } else {
-        format!("a/{path}")
-    };
-    let new_label = if change.status == 'D' {
-        "/dev/null".to_owned()
-    } else {
-        format!("b/{path}")
-    };
-
-    // Build mode header lines
-    let mut header = format!("diff --git a/{path} b/{path}");
-    if change.status == 'D' {
-        header.push_str(&format!("\ndeleted file mode {:06o}", change.old_mode));
-    } else if change.status == 'A' {
-        header.push_str(&format!("\nnew file mode {:06o}", change.new_mode));
-    } else if change.old_mode != change.new_mode {
-        header.push_str(&format!(
-            "\nold mode {:06o}\nnew mode {:06o}",
-            change.old_mode, change.new_mode
-        ));
-    }
-
-    if old_content == new_content && change.old_mode != change.new_mode {
-        // Mode-only change, no content diff needed
-        println!("{header}");
-    } else if old_content != new_content {
-        let patch = unified_diff(&old_content, &new_content, path, path, 3);
-        // unified_diff already includes the --- / +++ lines; strip them.
-        let body: String = patch.lines().skip(2).map(|l| format!("\n{l}")).collect();
-        println!("{header}\n--- {old_label}\n+++ {new_label}{body}");
-    } else {
-        println!("{header}\n--- {old_label}\n+++ {new_label}");
-    }
-    Ok(())
-}
-
-/// Print `--stat` output for all changes.
-fn print_stat(changes: &[Change], repo: &Repository, work_tree: &Path) -> Result<()> {
-    if changes.is_empty() {
-        return Ok(());
-    }
-    let max_len = changes.iter().map(|c| c.path.len()).max().unwrap_or(0);
-    let mut total_ins = 0usize;
-    let mut total_del = 0usize;
-    for change in changes {
-        let (old, new) = load_patch_contents(change, repo, work_tree)?;
-        let (ins, del) = count_changes(&old, &new);
-        total_ins += ins;
-        total_del += del;
-        println!("{}", format_stat_line(&change.path, ins, del, max_len));
-    }
-    let files = changes.len();
-    let mut summary = format!(
-        " {} file{} changed",
-        files,
-        if files == 1 { "" } else { "s" },
-    );
-    if total_ins > 0 || (total_ins == 0 && total_del == 0) {
-        summary.push_str(&format!(
-            ", {} insertion{}(+)",
-            total_ins,
-            if total_ins == 1 { "" } else { "s" }
-        ));
-    }
-    if total_del > 0 || (total_ins == 0 && total_del == 0) {
-        summary.push_str(&format!(
-            ", {} deletion{}(-)",
-            total_del,
-            if total_del == 1 { "" } else { "s" }
-        ));
-    }
-    println!("{summary}");
-    Ok(())
-}
-
-/// Print `--numstat` output for all changes.
-fn print_numstat(changes: &[Change], repo: &Repository, work_tree: &Path) -> Result<()> {
-    for change in changes {
-        let (old, new) = load_patch_contents(change, repo, work_tree)?;
-        let (ins, del) = count_changes(&old, &new);
-        println!("{}\t{}\t{}", ins, del, change.path);
-    }
-    Ok(())
-}
-
-/// Load old (index) and new (worktree) content for a change as UTF-8 strings.
-///
-/// Binary or unreadable content is returned as an empty string so that the
-/// caller still produces correct insertion/deletion counts (zero vs zero).
-fn load_patch_contents(
-    change: &Change,
-    repo: &Repository,
-    work_tree: &Path,
-) -> Result<(String, String)> {
-    // Old side: read blob from object database.
-    let old_content = if change.status == 'A' || change.old_oid == zero_oid() {
-        String::new()
-    } else {
-        let obj = repo.odb.read(&change.old_oid)?;
-        String::from_utf8(obj.data).unwrap_or_default()
-    };
-
-    // New side: read file from working tree.
-    let new_content = if change.status == 'D' || change.new_mode == 0 {
-        String::new()
-    } else {
-        let abs = work_tree.join(&change.path);
-        match fs::read(&abs) {
-            Ok(bytes) => String::from_utf8(bytes).unwrap_or_default(),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
-            Err(e) => return Err(e.into()),
-        }
-    };
-
-    Ok((old_content, new_content))
-}
-
-// ── Helpers ──────────────────────────────────────────────────────────
-
-/// Format an OID, optionally abbreviated.
-fn format_oid(
-    oid: ObjectId,
-    repo: &Repository,
-    abbrev: Option<usize>,
-    width: usize,
-) -> Result<String> {
-    if oid == zero_oid() {
-        return Ok("0".repeat(width));
-    }
-    match abbrev {
-        Some(min_len) => abbreviate_object_id(repo, oid, min_len).map_err(Into::into),
-        None => Ok(oid.to_hex()),
-    }
 }
 
 /// Canonicalize a raw file mode to one of the four Git modes.

--- a/logs/2026-04-08_t4007-diff-files-copy-detection.md
+++ b/logs/2026-04-08_t4007-diff-files-copy-detection.md
@@ -1,0 +1,16 @@
+# t4007-rename-3 — diff-files copy detection
+
+## Failures
+
+- `git diff-files -C --find-copies-harder -R` returned `unsupported option: -C`.
+- After wiring options, raw output showed `C path0 path0` instead of `C path1 path0` (wrong copy pairing when multiple index entries shared the same blob).
+
+## Fixes
+
+1. **`grit/src/commands/diff_files.rs`**: Parse `-M`, `-C`, `--find-copies-harder`, `-R`; build `DiffEntry` list with real worktree OIDs; reverse entries before `detect_copies` when `-R`; run `detect_copies` with index stage-0 paths as `find_copies_harder` sources; raw output uses real new OID when reversed (matches Git).
+2. **`grit-lib/src/diff.rs`**: In `detect_copies`, skip score entries where source path equals the added path (Git does not treat a path as a copy of itself).
+
+## Verification
+
+- `./scripts/run-tests.sh t4007-rename-3.sh` → 13/13
+- `cargo test -p grit-lib --lib`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t4007-rename-3` was failing on `git diff-files -C --find-copies-harder -R` (unsupported `-C`) and, once enabled, on wrong copy pairing when the same blob appeared on multiple index paths.

## Changes

- **`diff-files`**: Parse `-M`, `-C`, `--find-copies-harder`, and `-R`. Build `DiffEntry` values with real worktree OIDs for modified paths. Apply `-R` by swapping sides **before** `detect_copies`, pass stage-0 index paths as `find_copies_harder` sources, and in raw mode show the real new OID when output is reversed (matching Git).
- **`detect_copies`**: Ignore copy pairs where the source path equals the added path so tie-breaking matches Git (`path1/COPYING` → `path0/COPYING`, not `path0` → `path0`).

## Verification

- `./scripts/run-tests.sh t4007-rename-3.sh` → 13/13
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-011ce948-3fa4-4ced-8aaa-05604a7d1239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-011ce948-3fa4-4ced-8aaa-05604a7d1239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

