### PR TITLE
fix: t0034 root safe.directory ownership and harness

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -28,8 +28,8 @@ t0028-working-tree-encoding	t0	yes	0	0	0	false	ok	0
 t0029-core-unsetenvvars	t0	skip	2	0	0	false	ok	0
 t0030-stripspace	t0	yes	30	30	0	true	ok	0
 t0031-lockfile-pid	t0	yes	7	7	0	true	ok	0
-t0033-safe-directory	t0	yes	22	20	2	false	ok	0
-t0034-root-safe-directory	t0	yes	0	0	0	false	ok	0
+t0033-safe-directory	t0	yes	22	22	0	true	ok	0
+t0034-root-safe-directory	t0	yes	8	8	0	true	ok	0
 t0035-safe-bare-repository	t0	yes	12	8	4	false	ok	0
 t0040-parse-options	t0	yes	94	73	21	false	ok	0
 t0041-usage	t0	yes	16	14	2	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T01:14:00+00:00" class="gen-time" title="2026-04-08 01:14 UTC">2026-04-08 01:14 UTC</time> · <a href="https://github.com/schacon/grit/commit/bebe0f7b783fd237659f6c9115d244a7425cbda2" style="color:#58a6ff">bebe0f7</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T01:58:07+00:00" class="gen-time" title="2026-04-08 01:58 UTC">2026-04-08 01:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/3a6be32e1aee834646f76989b99a01ec1bc7b12c" style="color:#58a6ff">3a6be32</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,11 +150,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,472</div>
+      <div class="summary-big-val">29,482</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">43,739</div>
+      <div class="summary-big-val">43,747</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>607 files fully passing</span>
+    <span>609 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -179,11 +179,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t0</span>
         <span class="group-desc">Absolute basics and global stuff</span>
-        <span class="group-meta">38/63 files · 21 skipped · 3,430/5,057 tests</span>
+        <span class="group-meta">40/63 files · 21 skipped · 3,440/5,065 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:67.8%"></div></div>
-        <span class="group-pct pct-blue">67.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:67.9%"></div></div>
+        <span class="group-pct pct-blue">67.9%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t1">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T01:14:00+00:00" class="gen-time" title="2026-04-08 01:14 UTC">2026-04-08 01:14 UTC</time> · <a href="https://github.com/schacon/grit/commit/bebe0f7b783fd237659f6c9115d244a7425cbda2" style="color:#58a6ff">bebe0f7</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T01:58:07+00:00" class="gen-time" title="2026-04-08 01:58 UTC">2026-04-08 01:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/3a6be32e1aee834646f76989b99a01ec1bc7b12c" style="color:#58a6ff">3a6be32</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">43,739</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,472</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n" id="sum-tests">43,747</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,482</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">67.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -417,24 +417,24 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t0" data-tests="22" data-passed="20">
+<tr class="" data-group="t0" data-tests="22" data-passed="22">
   <td class="mono">t0033-safe-directory</td>
   <td>t0</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">22</td>
-  <td class="right">20</td>
+  <td class="right">22</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t0" data-tests="0" data-passed="0">
+<tr class="" data-group="t0" data-tests="8" data-passed="8">
   <td class="mono">t0034-root-safe-directory</td>
   <td>t0</td>
-  <td></td>
-  <td class="right">0</td>
-  <td class="right">0</td>
+  <td><span class="badge ok">full pass</span></td>
+  <td class="right">8</td>
+  <td class="right">8</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t0" data-tests="12" data-passed="8">

--- a/grit-lib/src/repo.rs
+++ b/grit-lib/src/repo.rs
@@ -192,7 +192,7 @@ impl Repository {
             }
             first = false;
 
-            if let Some(mut repo) = try_open_at(current)? {
+            if let Some(DiscoveredAt { mut repo, gitfile }) = try_open_at(current)? {
                 if let Some(ref wt) = env_work_tree {
                     repo.work_tree = Some(wt.canonicalize().unwrap_or_else(|_| wt.clone()));
                 } else {
@@ -203,7 +203,23 @@ impl Repository {
                         repo.work_tree = Some(resolve_core_worktree_path(&repo.git_dir, &raw)?);
                     }
                 }
-                repo.enforce_safe_directory()?;
+                let assume_different = env::var("GIT_TEST_ASSUME_DIFFERENT_OWNER")
+                    .ok()
+                    .map(|v| {
+                        let lower = v.to_ascii_lowercase();
+                        v == "1" || lower == "true" || lower == "yes" || lower == "on"
+                    })
+                    .unwrap_or(false);
+                if assume_different {
+                    repo.enforce_safe_directory()?;
+                } else {
+                    #[cfg(unix)]
+                    ensure_valid_ownership(
+                        gitfile.as_deref(),
+                        repo.work_tree.as_deref(),
+                        &repo.git_dir,
+                    )?;
+                }
                 return Ok(repo);
             }
             match current.parent() {
@@ -688,7 +704,14 @@ fn validate_repository_format(git_dir: &Path) -> Result<()> {
 ///
 /// Returns `Ok(None)` when `dir` is not a repository root (the caller should
 /// walk up); returns `Err` on a structural problem.
-fn try_open_at(dir: &Path) -> Result<Option<Repository>> {
+/// Result of probing a single directory during [`Repository::discover`].
+struct DiscoveredAt {
+    repo: Repository,
+    /// When discovery used a `.git` gitfile, the path to that file (for ownership checks).
+    gitfile: Option<PathBuf>,
+}
+
+fn try_open_at(dir: &Path) -> Result<Option<DiscoveredAt>> {
     let dot_git = dir.join(".git");
 
     // Check for special file types (FIFO, socket, etc.) — reject them
@@ -728,7 +751,10 @@ fn try_open_at(dir: &Path) -> Result<Option<Repository>> {
             fs::read_to_string(&dot_git).map_err(|e| Error::NotARepository(e.to_string()))?;
         let git_dir = parse_gitfile(&content, dir)?;
         let repo = Repository::open(&git_dir, Some(dir))?;
-        return Ok(Some(repo));
+        return Ok(Some(DiscoveredAt {
+            repo,
+            gitfile: Some(dot_git.clone()),
+        }));
     }
 
     if dot_git.is_dir() {
@@ -755,7 +781,10 @@ fn try_open_at(dir: &Path) -> Result<Option<Repository>> {
                     };
                     repo.git_dir = abs_dot_git;
                 }
-                return Ok(Some(repo));
+                return Ok(Some(DiscoveredAt {
+                    repo,
+                    gitfile: None,
+                }));
             }
             Err(Error::NotARepository(_)) => return Ok(None),
             Err(e) => return Err(e),
@@ -767,7 +796,10 @@ fn try_open_at(dir: &Path) -> Result<Option<Repository>> {
     if dir.join("HEAD").is_file() && dir.join("commondir").is_file() {
         maybe_trace_implicit_bare_repository(dir);
         let repo = Repository::open(dir, None)?;
-        return Ok(Some(repo));
+        return Ok(Some(DiscoveredAt {
+            repo,
+            gitfile: None,
+        }));
     }
 
     // Check if `dir` itself is a bare repo (has objects/ and HEAD directly)
@@ -786,7 +818,10 @@ fn try_open_at(dir: &Path) -> Result<Option<Repository>> {
             }
         }
         let repo = Repository::open(dir, None)?;
-        return Ok(Some(repo));
+        return Ok(Some(DiscoveredAt {
+            repo,
+            gitfile: None,
+        }));
     }
 
     Ok(None)
@@ -805,6 +840,127 @@ fn maybe_trace_implicit_bare_repository(dir: &Path) {
     if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) {
         let _ = writeln!(file, "setup: implicit-bare-repository:{}", dir.display());
     }
+}
+
+/// Collect effective `safe.directory` values from protected config (system/global/command),
+/// applying empty-value resets like Git.
+fn safe_directory_effective_values(git_dir: &Path) -> Vec<String> {
+    let cfg = crate::config::ConfigSet::load(Some(git_dir), true)
+        .unwrap_or_else(|_| crate::config::ConfigSet::new());
+    let mut values: Vec<String> = Vec::new();
+    for e in cfg.entries() {
+        if e.key == "safe.directory"
+            && e.scope != crate::config::ConfigScope::Local
+            && e.scope != crate::config::ConfigScope::Worktree
+        {
+            values.push(e.value.clone().unwrap_or_else(|| "true".to_owned()));
+        }
+    }
+    let mut effective: Vec<String> = Vec::new();
+    for v in values {
+        if v.is_empty() {
+            effective.clear();
+        } else {
+            effective.push(v);
+        }
+    }
+    effective
+}
+
+fn ensure_safe_directory_allows(git_dir: &Path, checked: &Path) -> Result<()> {
+    let effective = safe_directory_effective_values(git_dir);
+    let checked_s = checked.to_string_lossy().to_string();
+    if std::env::var("GRIT_DEBUG_SAFE_DIR").is_ok() {
+        eprintln!("debug-safe-directory values={:?}", effective);
+    }
+    if effective
+        .iter()
+        .any(|v| safe_directory_matches(v, &checked_s))
+    {
+        return Ok(());
+    }
+    Err(Error::DubiousOwnership(checked_s))
+}
+
+#[cfg(unix)]
+fn path_lstat_uid(path: &Path) -> std::io::Result<u32> {
+    use std::os::unix::fs::MetadataExt;
+    let meta = fs::symlink_metadata(path)?;
+    Ok(meta.uid())
+}
+
+#[cfg(unix)]
+fn extract_uid_from_env(name: &str) -> Option<u32> {
+    let raw = std::env::var(name).ok()?;
+    if raw.is_empty() {
+        return None;
+    }
+    raw.parse::<u32>().ok()
+}
+
+/// Match Git's `ensure_valid_ownership`: check gitfile, worktree, and gitdir ownership,
+/// then `safe.directory` when any path is not owned by the effective user.
+#[cfg(unix)]
+fn ensure_valid_ownership(
+    gitfile: Option<&Path>,
+    worktree: Option<&Path>,
+    gitdir: &Path,
+) -> Result<()> {
+    const ROOT_UID: u32 = 0;
+
+    fn owned_by_effective_user(path: &Path) -> std::io::Result<bool> {
+        let st_uid = path_lstat_uid(path)?;
+        let mut euid = unsafe { libc::geteuid() };
+        if euid == ROOT_UID {
+            if st_uid == ROOT_UID {
+                return Ok(true);
+            }
+            if let Some(sudo_uid) = extract_uid_from_env("SUDO_UID") {
+                euid = sudo_uid;
+            }
+        }
+        Ok(st_uid == euid)
+    }
+
+    let assume_different = std::env::var("GIT_TEST_ASSUME_DIFFERENT_OWNER")
+        .ok()
+        .map(|v| {
+            let lower = v.to_ascii_lowercase();
+            v == "1" || lower == "true" || lower == "yes" || lower == "on"
+        })
+        .unwrap_or(false);
+    if !assume_different {
+        let gitfile_ok = gitfile
+            .map(owned_by_effective_user)
+            .transpose()?
+            .unwrap_or(true);
+        let wt_ok = worktree
+            .map(owned_by_effective_user)
+            .transpose()?
+            .unwrap_or(true);
+        let gd_ok = owned_by_effective_user(gitdir)?;
+        if gitfile_ok && wt_ok && gd_ok {
+            return Ok(());
+        }
+    }
+
+    let data_path = if let Some(wt) = worktree {
+        wt.canonicalize().unwrap_or_else(|_| wt.to_path_buf())
+    } else {
+        gitdir
+            .canonicalize()
+            .unwrap_or_else(|_| gitdir.to_path_buf())
+    };
+    ensure_safe_directory_allows(gitdir, &data_path)
+}
+
+#[cfg(not(unix))]
+fn ensure_valid_ownership(
+    _gitfile: Option<&Path>,
+    _worktree: Option<&Path>,
+    _gitdir: &Path,
+) -> Result<()> {
+    Ok(())
 }
 
 impl Repository {
@@ -913,40 +1069,34 @@ impl Repository {
     }
 
     fn enforce_safe_directory_checked(&self, checked: &Path) -> Result<()> {
-        let cfg = crate::config::ConfigSet::load(Some(&self.git_dir), true)
-            .unwrap_or_else(|_| crate::config::ConfigSet::new());
-        let mut values: Vec<String> = Vec::new();
-        for e in cfg.entries() {
-            if e.key == "safe.directory"
-                && e.scope != crate::config::ConfigScope::Local
-                && e.scope != crate::config::ConfigScope::Worktree
+        ensure_safe_directory_allows(&self.git_dir, checked)
+    }
+
+    /// Verify the repository is safe to use as a `git clone` source (local clone).
+    ///
+    /// When `GIT_TEST_ASSUME_DIFFERENT_OWNER` is set, applies the same `safe.directory`
+    /// rules as discovery. Otherwise checks filesystem ownership of the git directory
+    /// only (matching Git's `die_upon_dubious_ownership` for clone).
+    pub fn verify_safe_for_clone_source(&self) -> Result<()> {
+        let assume_different = std::env::var("GIT_TEST_ASSUME_DIFFERENT_OWNER")
+            .ok()
+            .map(|v| {
+                let lower = v.to_ascii_lowercase();
+                v == "1" || lower == "true" || lower == "yes" || lower == "on"
+            })
+            .unwrap_or(false);
+        if assume_different {
+            self.enforce_safe_directory_git_dir()
+        } else {
+            #[cfg(unix)]
             {
-                values.push(e.value.clone().unwrap_or_else(|| "true".to_owned()));
+                ensure_valid_ownership(None, None, &self.git_dir)
+            }
+            #[cfg(not(unix))]
+            {
+                Ok(())
             }
         }
-
-        // Last empty assignment resets the list.
-        let mut effective: Vec<String> = Vec::new();
-        for v in values {
-            if v.is_empty() {
-                effective.clear();
-            } else {
-                effective.push(v);
-            }
-        }
-
-        let checked_s = checked.to_string_lossy().to_string();
-        if std::env::var("GRIT_DEBUG_SAFE_DIR").is_ok() {
-            eprintln!("debug-safe-directory values={:?}", effective);
-        }
-        if effective
-            .iter()
-            .any(|v| safe_directory_matches(v, &checked_s))
-        {
-            return Ok(());
-        }
-
-        Err(Error::DubiousOwnership(checked_s))
     }
 }
 

--- a/grit/src/commands/clone.rs
+++ b/grit/src/commands/clone.rs
@@ -863,11 +863,14 @@ fn resolve_revision_in_source(source: &Repository, revision: &str) -> Result<Str
 fn open_source_repo(path: &Path) -> Result<Repository> {
     // Try as-is first (might be a bare repo or .git dir)
     if let Ok(repo) = Repository::open(path, None) {
+        repo.verify_safe_for_clone_source()?;
         return Ok(repo);
     }
     // Try path/.git for non-bare repos
     let git_dir = path.join(".git");
-    Repository::open(&git_dir, Some(path)).map_err(Into::into)
+    let repo = Repository::open(&git_dir, Some(path)).map_err(anyhow::Error::from)?;
+    repo.verify_safe_for_clone_source()?;
+    Ok(repo)
 }
 
 /// Write an alternates file pointing to the source and reference repos' object stores.

--- a/logs/2026-04-08-t0034-root-safe-directory.md
+++ b/logs/2026-04-08-t0034-root-safe-directory.md
@@ -1,0 +1,21 @@
+# t0034-root-safe-directory
+
+## Problem
+
+- Discovery only enforced `safe.directory` when `GIT_TEST_ASSUME_DIFFERENT_OWNER` was set, so real root-owned repos were not rejected like Git.
+- `clone` opened source repos without `safe.directory` / ownership checks (t0033 clone tests).
+- Harness skipped t0034: missing `NOT_ROOT` lazy prereq, broken `SUDO` check (`sudo command` vs shell builtin, PATH for grit wrapper), empty `TEST_SHELL_PATH` in `run_with_sudo`.
+
+## Changes
+
+- `grit-lib`: Unix `ensure_valid_ownership` (root + `SUDO_UID` like `git-compat-util.h`), run on discovery when not using test hook; refactored `safe.directory` matching; `verify_safe_for_clone_source` for clone.
+- `grit clone`: call verify after opening source.
+- `tests/t0034-root-safe-directory.sh`: `NOT_ROOT` prereq, fix `SUDO` lazy prereq.
+- `tests/lib-sudo.sh`: default shell + `PATH` for sudo.
+- `scripts/run-tests.sh`: set `GIT_TEST_ALLOW_SUDO=YES` for t0034 only.
+
+## Verification
+
+- `./scripts/run-tests.sh t0033-safe-directory.sh` (with env) — 22/22
+- `./scripts/run-tests.sh t0034-root-safe-directory.sh` — 8/8
+- `cargo test -p grit-lib --lib`

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -160,10 +160,15 @@ run_one() {
     local f="$1"
     local base="${f%.sh}"
     local output summary total pass fail status ef
+    local git_test_allow_sudo=
+    if [[ "$f" == "t0034-root-safe-directory.sh" ]]; then
+        git_test_allow_sudo=YES
+    fi
     output=$(
         cd "$TESTS_DIR" &&
             EDITOR=: VISUAL=: LC_ALL=C LANG=C _prereq_DEFAULT_REPO_FORMAT=set GRIT_TEST_LIB_SUMMARY=1 GUST_BIN="$(pwd)/grit" \
             GIT_SOURCE_DIR="$REPO/git" \
+            GIT_TEST_ALLOW_SUDO="${git_test_allow_sudo:-}" \
             "${TIMEOUT_PREFIX[@]}" bash "$f" 2>&1
     ) || true
     summary=$(echo "$output" | grep "^# Tests:" | tail -1) || true

--- a/tests/lib-sudo.sh
+++ b/tests/lib-sudo.sh
@@ -4,11 +4,12 @@
 run_with_sudo () {
 	local ret
 	local RUN="$TEST_DIRECTORY/$$.sh"
-	write_script "$RUN" "$TEST_SHELL_PATH"
+	local shell="${TEST_SHELL_PATH:-/bin/sh}"
+	write_script "$RUN" "$shell"
 	# avoid calling "$RUN" directly so sudo doesn't get a chance to
 	# override the shell, add additional restrictions or even reject
 	# running the script because its security policy deem it unsafe
-	sudo "$TEST_SHELL_PATH" -c "\"$RUN\""
+	sudo env PATH="$PATH" "$shell" -c "\"$RUN\""
 	ret=$?
 	rm -f "$RUN"
 	return $ret

--- a/tests/t0034-root-safe-directory.sh
+++ b/tests/t0034-root-safe-directory.sh
@@ -5,6 +5,13 @@ test_description='verify safe.directory checks while running as root'
 . ./test-lib.sh
 . "$TEST_DIRECTORY"/lib-sudo.sh
 
+# Upstream defines this in git/t/test-lib.sh; keep it here so we do not rely on
+# a full test-lib port.
+test_lazy_prereq NOT_ROOT '
+	uid=$(id -u) &&
+	test "$uid" != 0
+'
+
 if [ "$GIT_TEST_ALLOW_SUDO" != "YES" ]
 then
 	skip_all="You must set env var GIT_TEST_ALLOW_SUDO=YES in order to run this test"
@@ -22,7 +29,7 @@ test_lazy_prereq SUDO '
 	id -u root >r &&
 	test_cmp u r &&
 	command -v git >u &&
-	sudo command -v git >r &&
+	sudo env PATH="$PATH" sh -c "command -v git" >r &&
 	test_cmp u r
 '
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible `safe.directory` / ownership behavior for normal (non-test-hook) discovery, enforces the same checks when opening a **clone source**, and fixes the **t0034** harness so it actually runs under passwordless sudo.

## Details

- **Discovery (Unix):** After finding a repo, verify ownership of gitfile (when present), worktree, and gitdir using effective UID with root + `SUDO_UID` semantics (matching upstream `is_path_owned_by_current_uid`). If unsafe, consult protected `safe.directory` config like Git.
- **`GIT_TEST_ASSUME_DIFFERENT_OWNER`:** Still forces the config-only path for **t0033** and similar harness tests.
- **Clone:** `open_source_repo` calls `Repository::verify_safe_for_clone_source()` so local clone refuses unlisted sources (t0033 clone cases).
- **t0034 harness:** Add missing `NOT_ROOT` lazy prereq; fix `SUDO` prereq (`command` is a shell builtin; preserve `PATH` so sudo sees the grit wrapper); fix `run_with_sudo` when `TEST_SHELL_PATH` is unset; `run-tests.sh` sets `GIT_TEST_ALLOW_SUDO=YES` only for `t0034-root-safe-directory.sh`.

## Verification

- `./scripts/run-tests.sh t0033-safe-directory.sh` (with `GIT_TEST_ASSUME_DIFFERENT_OWNER=1`): 22/22
- `./scripts/run-tests.sh t0034-root-safe-directory.sh`: 8/8
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6ccde9f-5a6f-4868-9efa-198d783d8b1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6ccde9f-5a6f-4868-9efa-198d783d8b1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

