### PR TITLE
fix: git diff -R path swap for additions (t4122 apply symlink)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -791,7 +791,7 @@ t4118-apply-empty-context	t4	yes	3	3	0	true	ok	0
 t4119-apply-config	t4	yes	11	1	10	false	ok	0
 t4120-apply-popt	t4	yes	12	4	8	false	ok	0
 t4121-apply-diffs	t4	yes	2	2	0	true	ok	0
-t4122-apply-symlink-inside	t4	yes	7	6	1	false	ok	0
+t4122-apply-symlink-inside	t4	yes	7	7	0	true	ok	0
 t4123-apply-shrink	t4	yes	2	2	0	true	ok	0
 t4124-apply-ws-rule	t4	yes	85	12	73	false	ok	0
 t4125-apply-ws-fuzz	t4	yes	4	2	2	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T02:00:50+00:00" class="gen-time" title="2026-04-08 02:00 UTC">2026-04-08 02:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/13ac15fd1c2f4f821af0ebffc8e1a00c611dd08f" style="color:#58a6ff">13ac15f</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T02:29:15+00:00" class="gen-time" title="2026-04-08 02:29 UTC">2026-04-08 02:29 UTC</time> · <a href="https://github.com/schacon/grit/commit/0c937c3e5950d0fca757544342ffaeb937a7ecd7" style="color:#58a6ff">0c937c3</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,474</div>
+      <div class="summary-big-val">29,475</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>608 files fully passing</span>
+    <span>609 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -223,7 +223,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">62/178 files · 2 skipped · 2,161/4,387 tests</span>
+        <span class="group-meta">63/178 files · 2 skipped · 2,162/4,387 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-orange" style="width:49.3%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T02:00:50+00:00" class="gen-time" title="2026-04-08 02:00 UTC">2026-04-08 02:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/13ac15fd1c2f4f821af0ebffc8e1a00c611dd08f" style="color:#58a6ff">13ac15f</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T02:29:15+00:00" class="gen-time" title="2026-04-08 02:29 UTC">2026-04-08 02:29 UTC</time> · <a href="https://github.com/schacon/grit/commit/0c937c3e5950d0fca757544342ffaeb937a7ecd7" style="color:#58a6ff">0c937c3</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,739</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,474</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,475</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">67.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -8047,14 +8047,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="7" data-passed="6">
+<tr class="" data-group="t4" data-tests="7" data-passed="7">
   <td class="mono">t4122-apply-symlink-inside</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">7</td>
-  <td class="right">6</td>
+  <td class="right">7</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:85.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="2" data-passed="2">

--- a/grit/src/commands/diff.rs
+++ b/grit/src/commands/diff.rs
@@ -888,10 +888,10 @@ pub fn run(mut args: Args) -> Result<()> {
             .map(|mut e| {
                 std::mem::swap(&mut e.old_oid, &mut e.new_oid);
                 std::mem::swap(&mut e.old_mode, &mut e.new_mode);
-                if let Some(ref op) = e.old_path.clone() {
-                    e.old_path = e.new_path.take();
-                    e.new_path = Some(op.clone());
-                }
+                // Swap paths for every entry, including additions/deletions where one side
+                // is `None`. The previous `if let Some(old_path)` branch skipped Added files
+                // and produced invalid patches (`--- /dev/null` + `+++ /dev/null`).
+                std::mem::swap(&mut e.old_path, &mut e.new_path);
                 // Invert the status
                 e.status = match e.status {
                     grit_lib::diff::DiffStatus::Added => grit_lib::diff::DiffStatus::Deleted,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t4122-apply-symlink-inside` was failing on the last subtest because `git diff -R` produced an invalid delete patch for files that were **added** in the forward direction.

## Root cause

In `grit diff -R`, we inverted `DiffStatus::Added` → `Deleted` but only swapped `old_path` / `new_path` when `old_path` was `Some`. For additions, `old_path` is `None`, so after reversal the entry stayed as “deleted” with no real path, and the unified diff emitted `--- /dev/null` and `+++ /dev/null` instead of Git’s `diff --git b/path a/path` + `deleted file mode` with no `---`/`+++` lines.

That broke `del_file.patch` in t4122 (built via `git diff -R HEAD`), so `git apply` failed with `failed to read : No such file` instead of the expected symlink guard message.

## Fix

Swap `old_path` and `new_path` with `std::mem::swap` for every entry when reversing, so a forward “add file” becomes a proper reverse “delete that path”.

## Validation

- `./scripts/run-tests.sh t4122-apply-symlink-inside.sh` → **7/7**
- `cargo test -p grit-lib --lib` → pass
- Harness CSV + dashboards refreshed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb1b9578-b6c5-4beb-b145-88279ab7992e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb1b9578-b6c5-4beb-b145-88279ab7992e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

