### PR TITLE
fix: pass t3434-rebase-i18n (i18n commit encoding + rebase-merge)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -620,7 +620,7 @@ t3430-rebase-merges	t3	yes	34	1	33	false	ok	0
 t3431-rebase-fork-point	t3	yes	26	7	19	false	ok	0
 t3432-rebase-fast-forward	t3	yes	219	213	6	false	ok	0
 t3433-rebase-across-mode-change	t3	yes	4	4	0	true	ok	0
-t3434-rebase-i18n	t3	yes	0	0	0	false	ok	0
+t3434-rebase-i18n	t3	yes	6	6	0	true	ok	0
 t3435-rebase-gpg-sign	t3	skip	11	0	0	false	ok	0
 t3436-rebase-more-options	t3	yes	19	2	17	false	ok	0
 t3437-rebase-fixup-options	t3	yes	13	0	13	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T02:29:57+00:00" class="gen-time" title="2026-04-08 02:29 UTC">2026-04-08 02:29 UTC</time> · <a href="https://github.com/schacon/grit/commit/940cdd164911541ed04aae766b3993652003ff61" style="color:#58a6ff">940cdd1</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T03:02:51+00:00" class="gen-time" title="2026-04-08 03:02 UTC">2026-04-08 03:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/28d1bcebc85bac517d48d3e4a1bae3ce0d145c77" style="color:#58a6ff">28d1bce</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,11 +150,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,474</div>
+      <div class="summary-big-val">29,480</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">43,739</div>
+      <div class="summary-big-val">43,745</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>608 files fully passing</span>
+    <span>609 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,7 +212,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">29/141 files · 2 skipped · 3,437/5,291 tests</span>
+        <span class="group-meta">30/141 files · 2 skipped · 3,443/5,297 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:65.0%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T02:29:57+00:00" class="gen-time" title="2026-04-08 02:29 UTC">2026-04-08 02:29 UTC</time> · <a href="https://github.com/schacon/grit/commit/940cdd164911541ed04aae766b3993652003ff61" style="color:#58a6ff">940cdd1</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T03:02:51+00:00" class="gen-time" title="2026-04-08 03:02 UTC">2026-04-08 03:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/28d1bcebc85bac517d48d3e4a1bae3ce0d145c77" style="color:#58a6ff">28d1bce</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">43,739</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,474</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n" id="sum-tests">43,745</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,480</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">67.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -6337,14 +6337,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="0" data-passed="0">
+<tr class="" data-group="t3" data-tests="6" data-passed="6">
   <td class="mono">t3434-rebase-i18n</td>
   <td>t3</td>
-  <td></td>
-  <td class="right">0</td>
-  <td class="right">0</td>
+  <td><span class="badge ok">full pass</span></td>
+  <td class="right">6</td>
+  <td class="right">6</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="row-skip" data-group="t3" data-tests="11" data-passed="0">

--- a/grit-lib/src/objects.rs
+++ b/grit-lib/src/objects.rs
@@ -346,58 +346,68 @@ pub struct CommitData {
 ///
 /// Returns [`Error::CorruptObject`] if required headers are missing.
 pub fn parse_commit(data: &[u8]) -> Result<CommitData> {
-    // Use lossy UTF-8 conversion so commits with non-UTF-8 encoded
-    // messages (e.g. iso-8859-7 with an `encoding` header) can still
-    // be parsed.  The header fields are always ASCII-safe.
-    let text = String::from_utf8_lossy(data);
-
+    // Headers are ASCII; the message body may be in another encoding (see
+    // `encoding` header). Find the blank line that separates headers from the
+    // body without interpreting body bytes as UTF-8.
+    let mut pos = 0usize;
     let mut tree = None;
     let mut parents = Vec::new();
     let mut author = None;
     let mut committer = None;
     let mut encoding = None;
-    let mut message = String::new();
-    let mut in_message = false;
 
-    for line in text.split('\n') {
-        if in_message {
-            message.push_str(line);
-            message.push('\n');
-            continue;
+    while pos < data.len() {
+        let line_start = pos;
+        let mut line_end = pos;
+        while line_end < data.len() && data[line_end] != b'\n' {
+            line_end += 1;
         }
+        let line = &data[line_start..line_end];
+        let after_nl = line_end.saturating_add(1);
         if line.is_empty() {
-            in_message = true;
-            continue;
+            // Blank line: remainder is the message body (may be non-UTF-8).
+            let body = data.get(after_nl..).unwrap_or_default();
+            let mut raw_body = body.to_vec();
+            if raw_body.ends_with(b"\n") {
+                raw_body.pop();
+            }
+            let message = String::from_utf8_lossy(&raw_body).into_owned();
+            let raw_message = std::str::from_utf8(&raw_body).is_err().then_some(raw_body);
+            return Ok(CommitData {
+                tree: tree
+                    .ok_or_else(|| Error::CorruptObject("commit missing tree header".to_owned()))?,
+                parents,
+                author: author.ok_or_else(|| {
+                    Error::CorruptObject("commit missing author header".to_owned())
+                })?,
+                committer: committer.ok_or_else(|| {
+                    Error::CorruptObject("commit missing committer header".to_owned())
+                })?,
+                encoding,
+                message,
+                raw_message,
+            });
         }
-        if let Some(rest) = line.strip_prefix("tree ") {
+        let line_str = std::str::from_utf8(line).map_err(|_| {
+            Error::CorruptObject("commit header line is not valid UTF-8".to_owned())
+        })?;
+        if let Some(rest) = line_str.strip_prefix("tree ") {
             tree = Some(rest.trim().parse::<ObjectId>()?);
-        } else if let Some(rest) = line.strip_prefix("parent ") {
+        } else if let Some(rest) = line_str.strip_prefix("parent ") {
             parents.push(rest.trim().parse::<ObjectId>()?);
-        } else if let Some(rest) = line.strip_prefix("author ") {
+        } else if let Some(rest) = line_str.strip_prefix("author ") {
             author = Some(rest.to_owned());
-        } else if let Some(rest) = line.strip_prefix("committer ") {
+        } else if let Some(rest) = line_str.strip_prefix("committer ") {
             committer = Some(rest.to_owned());
-        } else if let Some(rest) = line.strip_prefix("encoding ") {
+        } else if let Some(rest) = line_str.strip_prefix("encoding ") {
             encoding = Some(rest.to_owned());
         }
+        pos = after_nl;
     }
 
-    // Strip one trailing newline that split adds
-    if message.ends_with('\n') {
-        message.pop();
-    }
-
-    Ok(CommitData {
-        tree: tree.ok_or_else(|| Error::CorruptObject("commit missing tree header".to_owned()))?,
-        parents,
-        author: author
-            .ok_or_else(|| Error::CorruptObject("commit missing author header".to_owned()))?,
-        committer: committer
-            .ok_or_else(|| Error::CorruptObject("commit missing committer header".to_owned()))?,
-        encoding,
-        message,
-        raw_message: None,
-    })
+    Err(Error::CorruptObject(
+        "commit missing blank line before message".to_owned(),
+    ))
 }
 
 /// Parsed representation of an annotated tag object.
@@ -510,12 +520,18 @@ pub fn serialize_commit(c: &CommitData) -> Vec<u8> {
     out.push(b'\n');
     // Use raw_message bytes if available (for non-UTF-8 commit messages),
     // otherwise fall back to the UTF-8 message field.
-    // Callers are responsible for trailing newlines (commit-tree preserves
-    // stdin exactly; other callers use ensure_trailing_newline).
+    // Git's commit object format ends the message body with a newline when the
+    // body is non-empty (matches `git commit` and upstream tests).
     if let Some(raw) = &c.raw_message {
         out.extend_from_slice(raw);
-    } else {
+        if !raw.is_empty() && !raw.ends_with(b"\n") {
+            out.push(b'\n');
+        }
+    } else if !c.message.is_empty() {
         out.extend_from_slice(c.message.as_bytes());
+        if !c.message.ends_with('\n') {
+            out.push(b'\n');
+        }
     }
     out
 }

--- a/grit/src/commands/merge.rs
+++ b/grit/src/commands/merge.rs
@@ -1043,11 +1043,9 @@ fn do_real_merge(
 
     // Create merge commit
     let tree_oid = write_tree_from_index(&repo.odb, &merge_result.index, "")?;
+    let config = ConfigSet::load(Some(&repo.git_dir), true)?;
     let effective_custom_msg = if let Some(ref file_path) = args.file {
-        Some(
-            fs::read_to_string(file_path)
-                .with_context(|| format!("could not read merge message file: {file_path}"))?,
-        )
+        Some(read_merge_message_from_file(Path::new(file_path), &config)?)
     } else {
         args.message.clone()
     };
@@ -1071,7 +1069,6 @@ fn do_real_merge(
         }
     }
 
-    let config = ConfigSet::load(Some(&repo.git_dir), true)?;
     let now = OffsetDateTime::now_utc();
     let author = resolve_ident(&config, "author", now)?;
     let committer = resolve_ident(&config, "committer", now)?;
@@ -1093,14 +1090,15 @@ fn do_real_merge(
         msg = cleanup_message(&msg, mode);
     }
 
+    let finalized = finalize_merge_commit_message(msg, &config);
     let commit_data = CommitData {
         tree: tree_oid,
         parents: vec![head_oid, merge_oid],
         author,
         committer,
-        encoding: None,
-        message: msg,
-        raw_message: None,
+        encoding: finalized.encoding,
+        message: finalized.message,
+        raw_message: finalized.raw_message,
     };
 
     let commit_bytes = serialize_commit(&commit_data);
@@ -4438,6 +4436,64 @@ fn append_signoff(msg: &str, name: &str, email: &str) -> String {
     }
     let trimmed = msg.trim_end();
     format!("{}\n\n{}\n", trimmed, trailer)
+}
+
+/// UTF-8 merge message plus optional raw bytes and `encoding` header for the commit object.
+struct MergeCommitMessage {
+    message: String,
+    encoding: Option<String>,
+    raw_message: Option<Vec<u8>>,
+}
+
+fn read_merge_message_from_file(path: &Path, config: &ConfigSet) -> Result<String> {
+    let bytes =
+        fs::read(path).with_context(|| format!("could not read merge message file: {path:?}"))?;
+    if let Ok(s) = String::from_utf8(bytes.clone()) {
+        return Ok(s);
+    }
+    let enc_name = config
+        .get("i18n.commitEncoding")
+        .or_else(|| config.get("i18n.commitencoding"));
+    Ok(crate::git_commit_encoding::decode_bytes(
+        enc_name.as_deref(),
+        &bytes,
+    ))
+}
+
+fn finalize_merge_commit_message(msg: String, config: &ConfigSet) -> MergeCommitMessage {
+    let commit_enc = config
+        .get("i18n.commitEncoding")
+        .or_else(|| config.get("i18n.commitencoding"));
+    let is_utf8 = match commit_enc.as_deref() {
+        None => true,
+        Some(e) => e.eq_ignore_ascii_case("utf-8") || e.eq_ignore_ascii_case("utf8"),
+    };
+    if is_utf8 {
+        return MergeCommitMessage {
+            message: msg,
+            encoding: None,
+            raw_message: None,
+        };
+    }
+    let Some(label) = commit_enc else {
+        return MergeCommitMessage {
+            message: msg,
+            encoding: None,
+            raw_message: None,
+        };
+    };
+    let Some(raw) = crate::git_commit_encoding::encode_unicode(&label, &msg) else {
+        return MergeCommitMessage {
+            message: msg,
+            encoding: None,
+            raw_message: None,
+        };
+    };
+    MergeCommitMessage {
+        message: msg,
+        encoding: Some(label),
+        raw_message: Some(raw),
+    }
 }
 
 fn build_merge_message(

--- a/grit/src/commands/pull.rs
+++ b/grit/src/commands/pull.rs
@@ -214,6 +214,7 @@ fn do_merge_or_rebase(
             exec: None,
             merge: false,
             apply: false,
+            rebase_merges: false,
             no_ff: false,
             keep_base: false,
             fork_point: false,

--- a/grit/src/commands/rebase.rs
+++ b/grit/src/commands/rebase.rs
@@ -112,6 +112,10 @@ pub struct Args {
     #[arg(long = "apply")]
     pub apply: bool,
 
+    /// Rebase merge commits (accepted for compatibility; uses `rebase-merge/` state layout when set).
+    #[arg(long = "rebase-merges", alias = "r")]
+    pub rebase_merges: bool,
+
     /// Force rebase even if the current branch is up to date.
     #[arg(long = "no-ff", alias = "force-rebase")]
     pub no_ff: bool,
@@ -160,6 +164,10 @@ pub struct Args {
 /// Run the `rebase` command.
 pub fn run(mut args: Args) -> Result<()> {
     validate_compat_options(&args)?;
+
+    if args.rebase_merges {
+        args.merge = true;
+    }
 
     if args.abort {
         return do_abort();
@@ -294,12 +302,24 @@ fn reflog_identity(repo: &Repository) -> String {
     format!("{name} <{email}> {epoch} {hours:+03}{minutes:02}")
 }
 
-fn rebase_dir(git_dir: &Path) -> std::path::PathBuf {
+fn rebase_apply_dir(git_dir: &Path) -> std::path::PathBuf {
     git_dir.join("rebase-apply")
 }
 
+fn rebase_merge_dir(git_dir: &Path) -> std::path::PathBuf {
+    git_dir.join("rebase-merge")
+}
+
+fn rebase_dir(git_dir: &Path) -> std::path::PathBuf {
+    if rebase_merge_dir(git_dir).exists() {
+        rebase_merge_dir(git_dir)
+    } else {
+        rebase_apply_dir(git_dir)
+    }
+}
+
 fn is_rebase_in_progress(git_dir: &Path) -> bool {
-    rebase_dir(git_dir).exists()
+    rebase_apply_dir(git_dir).exists() || rebase_merge_dir(git_dir).exists()
 }
 
 fn choose_rebase_backend(args: &Args) -> RebaseBackend {
@@ -484,7 +504,11 @@ fn do_rebase(args: Args) -> Result<()> {
     }
 
     let backend = choose_rebase_backend(&args);
-    let rb_dir = rebase_dir(git_dir);
+    let rb_dir = if args.merge {
+        rebase_merge_dir(git_dir)
+    } else {
+        rebase_apply_dir(git_dir)
+    };
     fs::create_dir_all(&rb_dir)?;
 
     let head_name = match &head {
@@ -973,6 +997,7 @@ fn cherry_pick_for_rebase(
 
     let commit_obj = repo.odb.read(commit_oid)?;
     let commit = parse_commit(&commit_obj.data)?;
+    let config = ConfigSet::load(Some(git_dir), true)?;
 
     // Parent tree (base for the cherry-pick)
     let parent_oid = commit
@@ -1029,26 +1054,25 @@ fn cherry_pick_for_rebase(
     }
 
     if has_conflicts {
-        // Save MERGE_MSG for --continue
-        fs::write(git_dir.join("MERGE_MSG"), &commit.message)?;
+        write_rebase_conflict_message(git_dir, &commit, &config)?;
         bail!("conflicts during cherry-pick of {}", commit_oid.to_hex());
     }
 
     // Create the rebased commit, preserving the original author
     let tree_oid = write_tree_from_index(&repo.odb, &merged_index, "")?;
 
-    let config = ConfigSet::load(Some(git_dir), true)?;
     let now = time::OffsetDateTime::now_utc();
     let committer = resolve_identity(&config, "COMMITTER")?;
 
+    let (message, encoding, raw_message) = transcoded_replayed_message(&commit, &config);
     let commit_data = CommitData {
         tree: tree_oid,
         parents: vec![head_oid],
         author: commit.author.clone(), // preserve original author
         committer: format_ident(&committer, now),
-        encoding: commit.encoding.clone(),
-        message: commit.message.clone(),
-        raw_message: None,
+        encoding,
+        message,
+        raw_message,
     };
 
     let commit_bytes = serialize_commit(&commit_data);
@@ -1137,7 +1161,7 @@ fn do_continue() -> Result<()> {
     let git_dir = &repo.git_dir;
 
     if !is_rebase_in_progress(git_dir) {
-        bail!("error: no rebase in progress");
+        bail!("no rebase in progress");
     }
 
     let rb_dir = rebase_dir(git_dir);
@@ -1159,11 +1183,9 @@ fn do_continue() -> Result<()> {
     let commit_obj = repo.odb.read(&current_oid)?;
     let original_commit = parse_commit(&commit_obj.data)?;
 
-    // Read message (might have been edited)
-    let message = match fs::read_to_string(git_dir.join("MERGE_MSG")) {
-        Ok(m) => m,
-        Err(_) => original_commit.message.clone(),
-    };
+    let config = ConfigSet::load(Some(git_dir), true)?;
+    let (message, encoding, raw_message) =
+        read_rebase_continue_message(git_dir, &original_commit, &config)?;
 
     let head = resolve_head(git_dir)?;
     let head_oid = head
@@ -1172,7 +1194,6 @@ fn do_continue() -> Result<()> {
         .to_owned();
 
     let tree_oid = write_tree_from_index(&repo.odb, &index, "")?;
-    let config = ConfigSet::load(Some(git_dir), true)?;
     let now = time::OffsetDateTime::now_utc();
     let committer = resolve_identity(&config, "COMMITTER")?;
 
@@ -1181,9 +1202,9 @@ fn do_continue() -> Result<()> {
         parents: vec![head_oid],
         author: original_commit.author.clone(),
         committer: format_ident(&committer, now),
-        encoding: original_commit.encoding.clone(),
+        encoding,
         message,
-        raw_message: None,
+        raw_message,
     };
 
     let commit_bytes = serialize_commit(&commit_data);
@@ -1192,6 +1213,7 @@ fn do_continue() -> Result<()> {
     // Update HEAD (detached)
     fs::write(git_dir.join("HEAD"), format!("{}\n", new_oid.to_hex()))?;
     let _ = fs::remove_file(git_dir.join("MERGE_MSG"));
+    let _ = fs::remove_file(rb_dir.join("message"));
 
     let subject = original_commit.message.lines().next().unwrap_or("");
     eprintln!("Applying: {}", subject);
@@ -1219,7 +1241,7 @@ fn do_skip() -> Result<()> {
     let git_dir = &repo.git_dir;
 
     if !is_rebase_in_progress(git_dir) {
-        bail!("error: no rebase in progress");
+        bail!("no rebase in progress");
     }
 
     let _rb_dir = rebase_dir(git_dir);
@@ -1258,7 +1280,7 @@ fn do_abort() -> Result<()> {
     let git_dir = &repo.git_dir;
 
     if !is_rebase_in_progress(git_dir) {
-        bail!("error: no rebase in progress");
+        bail!("no rebase in progress");
     }
 
     let rb_dir = rebase_dir(git_dir);
@@ -1332,9 +1354,92 @@ fn do_abort() -> Result<()> {
 // ── Cleanup ─────────────────────────────────────────────────────────
 
 fn cleanup_rebase_state(git_dir: &Path) {
-    let rb_dir = rebase_dir(git_dir);
-    let _ = fs::remove_dir_all(&rb_dir);
+    let _ = fs::remove_dir_all(rebase_apply_dir(git_dir));
+    let _ = fs::remove_dir_all(rebase_merge_dir(git_dir));
     let _ = fs::remove_file(git_dir.join("MERGE_MSG"));
+}
+
+fn commit_message_unicode(commit: &CommitData) -> String {
+    if let Some(raw) = &commit.raw_message {
+        return crate::git_commit_encoding::decode_bytes(commit.encoding.as_deref(), raw);
+    }
+    commit.message.clone()
+}
+
+fn finalize_message_for_commit_encoding(
+    unicode: String,
+    config: &ConfigSet,
+) -> (String, Option<String>, Option<Vec<u8>>) {
+    let commit_enc = config
+        .get("i18n.commitEncoding")
+        .or_else(|| config.get("i18n.commitencoding"));
+    let is_utf8 = match commit_enc.as_deref() {
+        None => true,
+        Some(e) => e.eq_ignore_ascii_case("utf-8") || e.eq_ignore_ascii_case("utf8"),
+    };
+    if is_utf8 {
+        return (unicode, None, None);
+    }
+    let Some(label) = commit_enc else {
+        return (unicode, None, None);
+    };
+    let Some(raw) = crate::git_commit_encoding::encode_unicode(&label, &unicode) else {
+        return (unicode, None, None);
+    };
+    (unicode, Some(label), Some(raw))
+}
+
+fn transcoded_replayed_message(
+    commit: &CommitData,
+    config: &ConfigSet,
+) -> (String, Option<String>, Option<Vec<u8>>) {
+    finalize_message_for_commit_encoding(commit_message_unicode(commit), config)
+}
+
+fn write_rebase_conflict_message(
+    git_dir: &Path,
+    commit: &CommitData,
+    config: &ConfigSet,
+) -> Result<()> {
+    let (unicode, _enc, raw_opt) = transcoded_replayed_message(commit, config);
+    let merge_msg = git_dir.join("MERGE_MSG");
+    let bytes = raw_opt.unwrap_or_else(|| unicode.into_bytes());
+    fs::write(&merge_msg, &bytes)?;
+    if rebase_merge_dir(git_dir).exists() {
+        fs::write(rebase_merge_dir(git_dir).join("message"), bytes)?;
+    }
+    Ok(())
+}
+
+fn read_rebase_continue_message(
+    git_dir: &Path,
+    original: &CommitData,
+    config: &ConfigSet,
+) -> Result<(String, Option<String>, Option<Vec<u8>>)> {
+    let rb = rebase_dir(git_dir);
+    let from_state = rb.join("message");
+    let bytes = if from_state.exists() {
+        fs::read(&from_state)?
+    } else {
+        let merge_msg = git_dir.join("MERGE_MSG");
+        if merge_msg.exists() {
+            fs::read(&merge_msg)?
+        } else {
+            return Ok(transcoded_replayed_message(original, config));
+        }
+    };
+    let enc_name = config
+        .get("i18n.commitEncoding")
+        .or_else(|| config.get("i18n.commitencoding"));
+    let unicode = match enc_name.as_deref() {
+        Some(e) if !e.eq_ignore_ascii_case("utf-8") && !e.eq_ignore_ascii_case("utf8") => {
+            crate::git_commit_encoding::decode_bytes(Some(e), &bytes)
+        }
+        _ => String::from_utf8(bytes.clone()).unwrap_or_else(|_| {
+            crate::git_commit_encoding::decode_bytes(enc_name.as_deref(), &bytes)
+        }),
+    };
+    Ok(finalize_message_for_commit_encoding(unicode, config))
 }
 
 // ── Helpers (mirrored from revert.rs) ───────────────────────────────

--- a/grit/src/git_commit_encoding.rs
+++ b/grit/src/git_commit_encoding.rs
@@ -1,0 +1,92 @@
+//! Map Git `i18n.commitEncoding` / commit `encoding` header names to codecs.
+//!
+//! Git's `ISO-8859-1` is strict Latin-1; `encoding_rs` maps that label to Windows-1252.
+
+use encoding_rs::Encoding;
+
+fn is_iso_8859_1(label: &str) -> bool {
+    matches!(
+        label.trim().to_ascii_lowercase().as_str(),
+        "iso-8859-1" | "iso8859-1" | "latin1" | "latin-1"
+    )
+}
+
+fn decode_latin1(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len());
+    for &b in bytes {
+        s.push(char::from_u32(u32::from(b)).unwrap_or('\u{FFFD}'));
+    }
+    s
+}
+
+fn encode_latin1_lossy(unicode: &str) -> Vec<u8> {
+    unicode
+        .chars()
+        .map(|c| {
+            let cp = u32::from(c);
+            if cp <= 0xFF {
+                cp as u8
+            } else {
+                b'?'
+            }
+        })
+        .collect()
+}
+
+/// Git stores the commit message body with a trailing newline when non-empty.
+#[must_use]
+pub fn ensure_body_trailing_newline(mut bytes: Vec<u8>) -> Vec<u8> {
+    if !bytes.is_empty() && !bytes.ends_with(b"\n") {
+        bytes.push(b'\n');
+    }
+    bytes
+}
+
+/// Resolve an encoding label the way Git uses it in config and commit objects.
+///
+/// Git accepts names like `eucJP` that `encoding_rs::Encoding::for_label` does not recognize.
+/// ISO-8859-1 is handled separately (strict Latin-1).
+#[must_use]
+pub fn resolve(label: &str) -> Option<&'static Encoding> {
+    let t = label.trim();
+    if t.is_empty() || is_iso_8859_1(t) {
+        return None;
+    }
+    let normalized = t.replace('_', "-");
+    let lower = normalized.to_ascii_lowercase();
+    let mapped = match lower.as_str() {
+        "eucjp" => "euc-jp",
+        "cp932" | "mskanji" | "sjis" => "shift_jis",
+        _ => normalized.as_str(),
+    };
+    Encoding::for_label(mapped.as_bytes()).or_else(|| Encoding::for_label(t.as_bytes()))
+}
+
+/// Encode `unicode` for storage in a commit using Git's encoding name.
+#[must_use]
+pub fn encode_unicode(label: &str, unicode: &str) -> Option<Vec<u8>> {
+    let t = label.trim();
+    let raw = if is_iso_8859_1(t) {
+        encode_latin1_lossy(unicode)
+    } else {
+        let enc = resolve(t)?;
+        let (cow, _, _) = enc.encode(unicode);
+        cow.into_owned()
+    };
+    Some(ensure_body_trailing_newline(raw))
+}
+
+/// Decode `bytes` using Git's encoding name, or lossy UTF-8 if unknown.
+#[must_use]
+pub fn decode_bytes(label: Option<&str>, bytes: &[u8]) -> String {
+    if let Some(l) = label {
+        if is_iso_8859_1(l) {
+            return decode_latin1(bytes);
+        }
+        if let Some(enc) = resolve(l) {
+            let (cow, _) = enc.decode_without_bom_handling(bytes);
+            return cow.into_owned();
+        }
+    }
+    String::from_utf8_lossy(bytes).into_owned()
+}

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -15,6 +15,7 @@ use std::path::{Path, PathBuf};
 mod alias;
 mod commands;
 mod dotfile;
+mod git_commit_encoding;
 mod git_path;
 mod grit_exe;
 pub mod pathspec;

--- a/logs/2026-04-08-t3434-rebase-i18n.md
+++ b/logs/2026-04-08-t3434-rebase-i18n.md
@@ -1,0 +1,15 @@
+# t3434-rebase-i18n
+
+## Summary
+
+- Registered `ICONV` lazy prereq in `tests/test-lib.sh` (matches upstream Git test-lib) so the suite runs instead of skipping when `iconv` exists.
+- `parse_commit` now splits headers from the message body on raw bytes; non-UTF-8 bodies populate `raw_message`.
+- `serialize_commit` appends a trailing newline on non-empty bodies (Git object format).
+- `merge -F`: read binary message files using `i18n.commitEncoding`; write `encoding` + `raw_message` when committing in a non-UTF-8 encoding (Git label normalization for `eucJP`, strict ISO-8859-1).
+- `rebase`: `--rebase-merges` / `-m` use `.git/rebase-merge/`; replay commits transcoding message from commit `encoding` to current `i18n.commitEncoding`; conflict/`--continue` paths use `rebase-merge/message` with correct decoding.
+
+## Validation
+
+- `./scripts/run-tests.sh t3434-rebase-i18n.sh` — 6/6
+- `cargo test -p grit-lib --lib` — pass
+- `cargo clippy -p grit-rs -p grit-lib` — clean

--- a/tests/test-lib.sh
+++ b/tests/test-lib.sh
@@ -825,6 +825,11 @@ test_lazy_prereq () {
 	fi
 }
 
+test_lazy_prereq ICONV '
+	test -z "$NO_ICONV" &&
+	iconv -f utf8 -t utf8 </dev/null
+'
+
 # write_script FILE [INTERPRETER] — write a script from stdin
 write_script () {
 	{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes `t3434-rebase-i18n` pass all 6 cases.

### Test harness
- Register `ICONV` lazy prereq in `tests/test-lib.sh` (same check as upstream Git: `iconv -f utf8 -t utf8`) so i18n tests run when `iconv` is available instead of skipping with 0 tests.

### Grit
- **`parse_commit`**: Split headers from message on raw bytes; non-UTF-8 bodies set `raw_message` so EUC-JP / ISO-2022-JP merge messages round-trip.
- **`serialize_commit`**: Append a final newline on non-empty message bodies (Git object format).
- **`merge -F`**: Read message files as bytes and decode with `i18n.commitEncoding`; when committing in a non-UTF-8 encoding, set `encoding` + `raw_message`. Added `git_commit_encoding.rs` for Git label quirks (`eucJP` → EUC-JP, strict ISO-8859-1 vs Windows-1252).
- **`rebase`**: Accept `--rebase-merges` / `-r`; use `.git/rebase-merge/` when merge backend is selected; transcode replayed commit messages from the commit `encoding` header to the current `i18n.commitEncoding`; write/read `rebase-merge/message` for conflicts and `--continue`; avoid double `error:` prefix on `rebase --abort` when no rebase is in progress.
- **`pull`**: Initialize new `rebase_merges` field on `rebase::Args`.

### Verification
- `./scripts/run-tests.sh t3434-rebase-i18n.sh` → 6/6
- `cargo test -p grit-lib --lib`
- `cargo clippy -p grit-rs -p grit-lib`

Work log: `logs/2026-04-08-t3434-rebase-i18n.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7eb89999-3a3e-4b8d-830a-ae57611c5e6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7eb89999-3a3e-4b8d-830a-ae57611c5e6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

