### PR TITLE
fix: t4114 apply-typechange — correct git rm pathspec for symlinks

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -783,7 +783,7 @@ t4110-apply-scan	t4	yes	1	1	0	true	ok	0
 t4111-apply-subdir	t4	yes	10	3	7	false	ok	0
 t4112-apply-renames	t4	yes	2	2	0	true	ok	0
 t4113-apply-ending	t4	yes	3	1	2	false	ok	0
-t4114-apply-typechange	t4	yes	12	3	9	false	ok	0
+t4114-apply-typechange	t4	yes	12	12	0	true	ok	0
 t4115-apply-symlink	t4	yes	8	2	6	false	ok	0
 t4116-apply-reverse	t4	yes	7	7	0	true	ok	0
 t4117-apply-reject	t4	yes	8	8	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T03:04:11+00:00" class="gen-time" title="2026-04-08 03:04 UTC">2026-04-08 03:04 UTC</time> · <a href="https://github.com/schacon/grit/commit/38be921337edde8e2232c8b6269032490a02ba1f" style="color:#58a6ff">38be921</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T03:09:12+00:00" class="gen-time" title="2026-04-08 03:09 UTC">2026-04-08 03:09 UTC</time> · <a href="https://github.com/schacon/grit/commit/976111a3c66fad1837e41552a0479b8a8beee056" style="color:#58a6ff">976111a</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,475</div>
+      <div class="summary-big-val">29,484</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>608 files fully passing</span>
+    <span>609 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -223,11 +223,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">62/178 files · 2 skipped · 2,161/4,387 tests</span>
+        <span class="group-meta">63/178 files · 2 skipped · 2,170/4,387 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:49.3%"></div></div>
-        <span class="group-pct pct-orange">49.3%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:49.5%"></div></div>
+        <span class="group-pct pct-orange">49.5%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T03:04:11+00:00" class="gen-time" title="2026-04-08 03:04 UTC">2026-04-08 03:04 UTC</time> · <a href="https://github.com/schacon/grit/commit/38be921337edde8e2232c8b6269032490a02ba1f" style="color:#58a6ff">38be921</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T03:09:12+00:00" class="gen-time" title="2026-04-08 03:09 UTC">2026-04-08 03:09 UTC</time> · <a href="https://github.com/schacon/grit/commit/976111a3c66fad1837e41552a0479b8a8beee056" style="color:#58a6ff">976111a</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,745</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,475</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,484</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">67.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -7967,14 +7967,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:33.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="12" data-passed="3">
+<tr class="" data-group="t4" data-tests="12" data-passed="12">
   <td class="mono">t4114-apply-typechange</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">12</td>
-  <td class="right">3</td>
+  <td class="right">12</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:25.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="8" data-passed="2">

--- a/grit/src/commands/rm.rs
+++ b/grit/src/commands/rm.rs
@@ -604,9 +604,17 @@ fn resolve_rel(pathspec: &str, work_tree: &Path) -> Result<String> {
 
     let p = Path::new(pathspec_clean);
     if p.is_absolute() {
-        let abs = p
-            .canonicalize()
-            .unwrap_or_else(|_| lexical_normalize_path(p));
+        // Resolve lexically first so a symlink as the final component is not followed:
+        // `git rm foo` must remove path `foo`, not the symlink target (matches Git).
+        let abs_lex = lexical_normalize_path(p);
+        if let Ok(rel) = abs_lex.strip_prefix(&wt_canon) {
+            let s = rel.to_string_lossy().into_owned();
+            if s == "." || s.is_empty() {
+                return Ok(String::new());
+            }
+            return Ok(s);
+        }
+        let abs = abs_lex.canonicalize().unwrap_or(abs_lex);
         let rel = abs
             .strip_prefix(&wt_canon)
             .map_err(|_| anyhow::anyhow!("path '{}' is outside the work tree", pathspec))?;
@@ -615,10 +623,9 @@ fn resolve_rel(pathspec: &str, work_tree: &Path) -> Result<String> {
 
     let cwd = std::env::current_dir()?;
     let cwd_canon = cwd.canonicalize().unwrap_or(cwd);
-    let abs = lexical_resolve_under_cwd(pathspec_clean, &cwd_canon);
-    let abs_resolved = abs.canonicalize().unwrap_or(abs);
+    let abs_lex = lexical_resolve_under_cwd(pathspec_clean, &cwd_canon);
 
-    if let Ok(rel) = abs_resolved.strip_prefix(&wt_canon) {
+    if let Ok(rel) = abs_lex.strip_prefix(&wt_canon) {
         let s = rel.to_string_lossy().into_owned();
         if s == "." || s.is_empty() {
             return Ok(String::new());
@@ -628,8 +635,7 @@ fn resolve_rel(pathspec: &str, work_tree: &Path) -> Result<String> {
 
     // Pathspec relative to worktree root (e.g. when cwd is not under the repo).
     let from_root = lexical_normalize_path(&wt_canon.join(pathspec_clean));
-    let from_root_resolved = from_root.canonicalize().unwrap_or(from_root);
-    if let Ok(rel) = from_root_resolved.strip_prefix(&wt_canon) {
+    if let Ok(rel) = from_root.strip_prefix(&wt_canon) {
         let s = rel.to_string_lossy().into_owned();
         if s == "." || s.is_empty() {
             return Ok(String::new());


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t4114-apply-typechange` was failing because setup never completed: `git rm -f foo` removed `bar` when `foo` was a symlink to `bar`.

## Root cause

`grit rm`’s `resolve_rel` used `Path::canonicalize()` before stripping the work tree prefix. Canonicalization follows the final path component, so the pathspec `foo` became the real path `bar`.

## Fix

Resolve pathspecs lexically first and strip the work tree prefix from that path (so the final symlink is not followed). For absolute pathspecs, try lexical resolution under the work tree before falling back to full canonicalization.

## Validation

- `./scripts/run-tests.sh t4114-apply-typechange.sh` — 12/12
- `cargo test -p grit-lib --lib`
- `cargo clippy -p grit-rs --fix --allow-dirty`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73f94d8c-7a1b-4192-9016-f5878e65edb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73f94d8c-7a1b-4192-9016-f5878e65edb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

