### PR TITLE
fix: pathspec wildcards for diff-tree (t4010)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -682,7 +682,7 @@ t4006-diff-mode	t4	yes	7	6	1	false	ok	0
 t4007-rename-3	t4	yes	13	11	2	false	ok	0
 t4008-diff-break-rewrite	t4	yes	14	5	9	false	ok	0
 t4009-diff-rename-4	t4	yes	7	4	3	false	ok	0
-t4010-diff-pathspec	t4	yes	17	12	5	false	ok	0
+t4010-diff-pathspec	t4	yes	17	17	0	true	ok	0
 t4011-diff-symlink	t4	yes	8	7	1	false	ok	0
 t4011-diff-tree	t4	yes	110	109	1	false	ok	0
 t4012-diff-binary	t4	yes	13	4	9	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T03:04:11+00:00" class="gen-time" title="2026-04-08 03:04 UTC">2026-04-08 03:04 UTC</time> · <a href="https://github.com/schacon/grit/commit/38be921337edde8e2232c8b6269032490a02ba1f" style="color:#58a6ff">38be921</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T03:23:07+00:00" class="gen-time" title="2026-04-08 03:23 UTC">2026-04-08 03:23 UTC</time> · <a href="https://github.com/schacon/grit/commit/976111a3c66fad1837e41552a0479b8a8beee056" style="color:#58a6ff">976111a</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,475</div>
+      <div class="summary-big-val">29,480</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>608 files fully passing</span>
+    <span>609 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -223,11 +223,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">62/178 files · 2 skipped · 2,161/4,387 tests</span>
+        <span class="group-meta">63/178 files · 2 skipped · 2,166/4,387 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:49.3%"></div></div>
-        <span class="group-pct pct-orange">49.3%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:49.4%"></div></div>
+        <span class="group-pct pct-orange">49.4%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T03:04:11+00:00" class="gen-time" title="2026-04-08 03:04 UTC">2026-04-08 03:04 UTC</time> · <a href="https://github.com/schacon/grit/commit/38be921337edde8e2232c8b6269032490a02ba1f" style="color:#58a6ff">38be921</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T03:23:07+00:00" class="gen-time" title="2026-04-08 03:23 UTC">2026-04-08 03:23 UTC</time> · <a href="https://github.com/schacon/grit/commit/976111a3c66fad1837e41552a0479b8a8beee056" style="color:#58a6ff">976111a</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,745</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,475</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,480</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">67.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -6957,14 +6957,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:57.1%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="17" data-passed="12">
+<tr class="" data-group="t4" data-tests="17" data-passed="17">
   <td class="mono">t4010-diff-pathspec</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">17</td>
-  <td class="right">12</td>
+  <td class="right">17</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.6%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="8" data-passed="7">

--- a/grit-lib/src/lib.rs
+++ b/grit-lib/src/lib.rs
@@ -39,6 +39,7 @@ pub mod odb;
 pub mod pack;
 pub mod parse_options_test_tool;
 pub mod patch_ids;
+pub mod pathspec;
 pub mod prune_packed;
 pub mod reflog;
 pub mod refs;

--- a/grit-lib/src/pathspec.rs
+++ b/grit-lib/src/pathspec.rs
@@ -1,0 +1,159 @@
+//! Git-style pathspec matching for command-line path arguments.
+//!
+//! Wildcards use [`crate::wildmatch`] in Git’s default (non-`:(glob)`) mode:
+//! `*` may match across `/` unless `**` pathname rules apply inside the pattern.
+
+use crate::wildmatch::{wildmatch, WM_CASEFOLD, WM_PATHNAME};
+
+/// Optional path metadata for literal pathspecs with a trailing `/`.
+///
+/// Git treats `dir/` as “directory or git submodule only”: a regular file `dir`
+/// does not match, but a tree entry `dir` or gitlink `dir` does.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PathspecMatchContext {
+    /// The index/tree entry is a directory (mode `040000`).
+    pub is_directory: bool,
+    /// The entry is a git submodule / gitlink (`160000`).
+    pub is_git_submodule: bool,
+}
+
+/// Returns whether `path` matches the pathspec `spec` with default (file) context.
+///
+/// For pathspecs ending in `/`, a path equal to the prefix matches only when
+/// [PathspecMatchContext] indicates a directory or submodule; see
+/// [`matches_pathspec_with_context`].
+#[must_use]
+pub fn matches_pathspec(spec: &str, path: &str) -> bool {
+    matches_pathspec_with_context(spec, path, PathspecMatchContext::default())
+}
+
+/// Like [`matches_pathspec`], but uses `ctx` for trailing-`/` literal pathspecs.
+#[must_use]
+pub fn matches_pathspec_with_context(spec: &str, path: &str, ctx: PathspecMatchContext) -> bool {
+    let trimmed = spec.strip_prefix("./").unwrap_or(spec);
+    if trimmed == "." || trimmed.is_empty() {
+        return true;
+    }
+
+    if trimmed.contains('*') || trimmed.contains('?') || trimmed.contains('[') {
+        let flags = if trimmed.contains("**") {
+            WM_PATHNAME
+        } else {
+            0
+        };
+        if wildmatch(trimmed.as_bytes(), path.as_bytes(), flags) {
+            return true;
+        }
+        // `tree-walk.c` match_entry: a directory matches a pattern whose next
+        // character after the entry name is `/` (e.g. `path1/f*` matches tree
+        // entry `path1` before recursion).
+        if (ctx.is_directory || ctx.is_git_submodule)
+            && !path.is_empty()
+            && trimmed.len() > path.len()
+            && trimmed.as_bytes().get(path.len()) == Some(&b'/')
+            && trimmed.starts_with(path)
+        {
+            return true;
+        }
+        return false;
+    }
+
+    if let Some(prefix) = trimmed.strip_suffix('/') {
+        if path.starts_with(&format!("{prefix}/")) {
+            return true;
+        }
+        if path == prefix {
+            return ctx.is_directory || ctx.is_git_submodule;
+        }
+        return false;
+    }
+
+    path == trimmed || path.starts_with(&format!("{trimmed}/"))
+}
+
+/// Parse a Git mode string (e.g. `100644`, `040000`) into a [`PathspecMatchContext`].
+#[must_use]
+pub fn context_from_mode_octal(mode: &str) -> PathspecMatchContext {
+    let Ok(bits) = u32::from_str_radix(mode, 8) else {
+        return PathspecMatchContext::default();
+    };
+    context_from_mode_bits(bits)
+}
+
+/// Classify a raw Git mode (e.g. from an index or tree entry) for pathspec matching.
+#[must_use]
+pub fn context_from_mode_bits(mode: u32) -> PathspecMatchContext {
+    let ty = mode & 0o170000;
+    PathspecMatchContext {
+        is_directory: ty == 0o040000,
+        is_git_submodule: ty == 0o160000,
+    }
+}
+
+#[must_use]
+/// Returns wildmatch flags for `:(icase)` / `:(glob)`-style patterns when those
+/// appear as explicit magic (not used by default CLI pathspecs).
+pub fn wildmatch_flags_icase_glob(icase: bool, glob: bool) -> u32 {
+    let mut f = if glob { WM_PATHNAME } else { 0 };
+    if icase {
+        f |= WM_CASEFOLD;
+    }
+    f
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn literal_prefix_and_exact() {
+        assert!(matches_pathspec("path1", "path1/file1"));
+        assert!(matches_pathspec_with_context(
+            "path1/",
+            "path1/file1",
+            PathspecMatchContext::default()
+        ));
+        assert!(matches_pathspec("file0", "file0"));
+        assert!(!matches_pathspec("path", "path1/file1"));
+    }
+
+    #[test]
+    fn wildcards_cross_slash_by_default() {
+        assert!(matches_pathspec("f*", "file0"));
+        assert!(matches_pathspec("*file1", "path1/file1"));
+        assert!(matches_pathspec_with_context(
+            "path1/f*",
+            "path1",
+            PathspecMatchContext {
+                is_directory: true,
+                ..Default::default()
+            }
+        ));
+        assert!(matches_pathspec("path1/*file1", "path1/file1"));
+    }
+
+    #[test]
+    fn trailing_slash_directory_only() {
+        assert!(!matches_pathspec_with_context(
+            "file0/",
+            "file0",
+            PathspecMatchContext::default()
+        ));
+        assert!(matches_pathspec_with_context(
+            "file0/",
+            "file0",
+            PathspecMatchContext {
+                is_directory: true,
+                ..Default::default()
+            }
+        ));
+        assert!(matches_pathspec_with_context(
+            "submod/",
+            "submod",
+            PathspecMatchContext {
+                is_git_submodule: true,
+                ..Default::default()
+            }
+        ));
+    }
+}

--- a/grit-lib/src/rev_list.rs
+++ b/grit-lib/src/rev_list.rs
@@ -2020,9 +2020,18 @@ fn commit_touches_paths(
         if sparse {
             return Ok(true);
         }
-        return Ok(commit_map
-            .keys()
-            .any(|path| paths.iter().any(|spec| pathspec_matches(spec, path))));
+        return Ok(commit_map.keys().any(|path| {
+            paths.iter().any(|spec| {
+                crate::pathspec::matches_pathspec_with_context(
+                    spec,
+                    path,
+                    crate::pathspec::PathspecMatchContext {
+                        is_directory: false,
+                        is_git_submodule: false,
+                    },
+                )
+            })
+        }));
     }
 
     // Single-parent commit: include only when requested paths changed.
@@ -2078,7 +2087,10 @@ fn path_differs_for_specs(
     paths.extend(parent.keys().cloned());
 
     for path in &paths {
-        if !specs.iter().any(|spec| pathspec_matches(spec, path)) {
+        if !specs
+            .iter()
+            .any(|spec| crate::pathspec::matches_pathspec(spec, path))
+        {
             continue;
         }
         if current.get(path) != parent.get(path) {
@@ -2086,27 +2098,6 @@ fn path_differs_for_specs(
         }
     }
     false
-}
-
-fn pathspec_matches(spec: &str, path: &str) -> bool {
-    let normalized = spec.strip_prefix("./").unwrap_or(spec);
-    if normalized == "." || normalized.is_empty() {
-        return true;
-    }
-
-    if normalized.contains('*') || normalized.contains('?') || normalized.contains('[') {
-        return crate::wildmatch::wildmatch(
-            normalized.as_bytes(),
-            path.as_bytes(),
-            crate::wildmatch::WM_PATHNAME,
-        );
-    }
-
-    if let Some(prefix) = normalized.strip_suffix('/') {
-        return path == prefix || path.starts_with(&format!("{prefix}/"));
-    }
-
-    path == normalized || path.starts_with(&format!("{normalized}/"))
 }
 
 fn load_commit(repo: &Repository, oid: ObjectId) -> Result<crate::objects::CommitData> {

--- a/grit/src/commands/diff_index.rs
+++ b/grit/src/commands/diff_index.rs
@@ -10,6 +10,7 @@ use grit_lib::index::{
 };
 use grit_lib::objects::{parse_commit, parse_tree, ObjectId, ObjectKind};
 use grit_lib::odb::Odb;
+use grit_lib::pathspec::{context_from_mode_bits, matches_pathspec_with_context};
 use grit_lib::repo::Repository;
 use grit_lib::rev_parse::{abbreviate_object_id, resolve_revision};
 use std::collections::{BTreeMap, BTreeSet};
@@ -44,12 +45,15 @@ pub fn run(args: Args) -> Result<()> {
             continue;
         }
         if let Ok(path) = String::from_utf8(entry.path.clone()) {
-            if matches_pathspec(&path, &options.pathspecs) {
+            let ctx = context_from_mode_bits(entry.mode);
+            if entry_matches_pathspecs(&path, &options.pathspecs, ctx) {
                 index_map.insert(path, Snapshot::from_index_entry(entry.mode, entry.oid));
             }
         }
     }
-    tree_map.retain(|path, _| matches_pathspec(path, &options.pathspecs));
+    tree_map.retain(|path, snap| {
+        entry_matches_pathspecs(path, &options.pathspecs, context_from_mode_bits(snap.mode))
+    });
 
     let changes = if options.cached {
         diff_tree_vs_index(&tree_map, &index_map)
@@ -794,54 +798,17 @@ fn canonicalize_mode(raw_mode: u32) -> u32 {
     }
 }
 
-fn matches_pathspec(path: &str, pathspecs: &[String]) -> bool {
+fn entry_matches_pathspecs(
+    path: &str,
+    pathspecs: &[String],
+    ctx: grit_lib::pathspec::PathspecMatchContext,
+) -> bool {
     if pathspecs.is_empty() {
         return true;
     }
-    pathspecs.iter().any(|spec| {
-        if spec.contains('*') || spec.contains('?') || spec.contains('[') {
-            // Glob pattern
-            glob_match_pathspec(spec, path)
-        } else if let Some(prefix) = spec.strip_suffix('/') {
-            path.starts_with(&format!("{prefix}/"))
-        } else {
-            path == spec || path.starts_with(&format!("{spec}/"))
-        }
-    })
-}
-
-/// Simple glob matching for pathspecs.
-fn glob_match_pathspec(pattern: &str, text: &str) -> bool {
-    let pat = pattern.as_bytes();
-    let txt = text.as_bytes();
-    let mut pi = 0;
-    let mut ti = 0;
-    let mut star_pi = usize::MAX;
-    let mut star_ti = 0;
-
-    while ti < txt.len() {
-        if pi < pat.len() && pat[pi] == b'?' && txt[ti] != b'/' {
-            pi += 1;
-            ti += 1;
-        } else if pi < pat.len() && pat[pi] == b'*' {
-            star_pi = pi;
-            star_ti = ti;
-            pi += 1;
-        } else if pi < pat.len() && pat[pi] == txt[ti] {
-            pi += 1;
-            ti += 1;
-        } else if star_pi != usize::MAX {
-            star_ti += 1;
-            ti = star_ti;
-            pi = star_pi + 1;
-        } else {
-            return false;
-        }
-    }
-    while pi < pat.len() && pat[pi] == b'*' {
-        pi += 1;
-    }
-    pi == pat.len()
+    pathspecs
+        .iter()
+        .any(|spec| matches_pathspec_with_context(spec, path, ctx))
 }
 
 fn effective_index_path(repo: &Repository) -> Result<PathBuf> {

--- a/grit/src/commands/diff_tree.rs
+++ b/grit/src/commands/diff_tree.rs
@@ -18,6 +18,7 @@ use grit_lib::merge_diff::{
 };
 use grit_lib::objects::{parse_commit, parse_tree, ObjectId, ObjectKind};
 use grit_lib::odb::Odb;
+use grit_lib::pathspec::{context_from_mode_octal, matches_pathspec_with_context};
 use grit_lib::repo::Repository;
 use grit_lib::rev_parse::resolve_revision;
 use std::io::{self, BufRead, Write};
@@ -312,12 +313,11 @@ fn parse_options(argv: &[String]) -> Result<Options> {
         i += 1;
     }
 
-    // Patch, stat, summary, name-only, name-status all imply recursion.
+    // Patch and stat imply recursion (Git shows nested file paths). `--name-only`
+    // and `--name-status` follow plain `diff-tree` rules: top-level entries only
+    // unless `-r` is given (see t4010-diff-pathspec).
     match opts.format {
-        OutputFormat::Patch
-        | OutputFormat::Stat
-        | OutputFormat::NameOnly
-        | OutputFormat::NameStatus => {
+        OutputFormat::Patch | OutputFormat::Stat => {
             opts.recursive = true;
         }
         _ => {}
@@ -1549,17 +1549,42 @@ fn filter_pathspecs(entries: Vec<DiffEntry>, pathspecs: &[String]) -> Vec<DiffEn
     }
     entries
         .into_iter()
-        .filter(|e| {
-            let path = e.path();
-            pathspecs.iter().any(|spec| {
-                if let Some(prefix) = spec.strip_suffix('/') {
-                    path == prefix || path.starts_with(&format!("{prefix}/"))
-                } else {
-                    path == spec || path.starts_with(&format!("{spec}/"))
-                }
-            })
-        })
+        .filter(|e| diff_entry_matches_pathspecs(e, pathspecs))
         .collect()
+}
+
+fn diff_entry_pathspec_context(entry: &DiffEntry) -> grit_lib::pathspec::PathspecMatchContext {
+    use grit_lib::pathspec::PathspecMatchContext;
+
+    match entry.status {
+        DiffStatus::Deleted => context_from_mode_octal(&entry.old_mode),
+        DiffStatus::Added => context_from_mode_octal(&entry.new_mode),
+        _ => {
+            let old = context_from_mode_octal(&entry.old_mode);
+            let new = context_from_mode_octal(&entry.new_mode);
+            PathspecMatchContext {
+                is_directory: old.is_directory || new.is_directory,
+                is_git_submodule: old.is_git_submodule || new.is_git_submodule,
+            }
+        }
+    }
+}
+
+fn diff_entry_matches_pathspecs(entry: &DiffEntry, pathspecs: &[String]) -> bool {
+    let ctx = diff_entry_pathspec_context(entry);
+    pathspecs.iter().any(|spec| {
+        if let Some(ref p) = entry.new_path {
+            if matches_pathspec_with_context(spec, p, ctx) {
+                return true;
+            }
+        }
+        if let Some(ref p) = entry.old_path {
+            if entry.new_path.as_ref() != Some(p) && matches_pathspec_with_context(spec, p, ctx) {
+                return true;
+            }
+        }
+        false
+    })
 }
 
 /// Parse a whitespace-separated list of OID strings.

--- a/logs/2026-04-08_t4010-diff-pathspec.md
+++ b/logs/2026-04-08_t4010-diff-pathspec.md
@@ -1,0 +1,18 @@
+# t4010-diff-pathspec
+
+## Problem
+
+`grit diff-tree` pathspec filtering used prefix-only logic (no real globs). Wildcard tests failed. `--name-only` / `--name-status` incorrectly implied `-r`, so non-recursive wildcard directory matches differed from Git.
+
+## Changes
+
+- Added `grit-lib::pathspec` with Git-aligned matching: default wildmatch without `WM_PATHNAME` (unless `**`), directory-prefix rule for wildcards, trailing `/` requiring directory or gitlink for exact path match.
+- `diff-tree`: filter `DiffEntry` paths with mode-aware context; stop implying recursion for name-only/name-status (still implied for `--patch` / `--stat`).
+- `diff-index`: reuse shared pathspec helper with index/tree mode context; removed duplicate glob matcher.
+- `rev_list`: root pathspec existence check uses `matches_pathspec_with_context` with file context (blob-only map).
+
+## Validation
+
+- `./scripts/run-tests.sh t4010-diff-pathspec.sh` → 17/17
+- `cargo test -p grit-lib --lib`, `cargo test --workspace`
+- `cargo check -p grit-rs -p grit-lib`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes `tests/t4010-diff-pathspec.sh` pass (17/17).

## Changes

- **`grit-lib::pathspec`**: Git-style CLI pathspec matching — default wildcards use `wildmatch` without `WM_PATHNAME` (so `*` can span `/`); `**` enables pathname mode; trailing `/` on literals matches only directories/gitlinks for the exact path; wildcard patterns use Git’s directory-prefix rule for tree entries.
- **`diff-tree`**: Filter diff entries with mode-aware context; stop implying `-r` for `--name-only` / `--name-status` (Git only recurses for `-p` / `--stat` / `-r`, etc.).
- **`diff-index`**: Reuse the shared pathspec helper with index/tree entry modes; remove duplicate glob implementation.
- **`rev_list`**: Root-commit pathspec existence check uses the shared matcher.

## Validation

- `./scripts/run-tests.sh t4010-diff-pathspec.sh`
- `cargo test -p grit-lib --lib`, `cargo test --workspace`, `cargo check -p grit-rs -p grit-lib`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89c0fdfd-2c4c-4a29-970c-a25729bc5671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89c0fdfd-2c4c-4a29-970c-a25729bc5671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

