### PR TITLE
fix: make t8350-checkout-index-force fully pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1327,7 +1327,7 @@ t8310-for-each-ref-format-deep	t8	yes	32	32	0	true	ok	0
 t8320-config-global-local	t8	yes	34	34	0	true	ok	0
 t8330-switch-track	t8	yes	30	2	28	false	ok	0
 t8340-restore-staged	t8	yes	27	16	11	false	ok	0
-t8350-checkout-index-force	t8	yes	30	27	3	false	ok	0
+t8350-checkout-index-force	t8	yes	30	30	0	true	ok	0
 t8360-read-tree-twoway	t8	yes	25	18	7	false	ok	0
 t8370-mktree-roundtrip	t8	yes	26	24	2	false	ok	0
 t8380-name-rev-deep	t8	yes	31	31	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T03:10:03+00:00" class="gen-time" title="2026-04-08 03:10 UTC">2026-04-08 03:10 UTC</time> · <a href="https://github.com/schacon/grit/commit/301bdec24480022f1b3eeaca963492883de2ebc6" style="color:#58a6ff">301bdec</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T03:43:58+00:00" class="gen-time" title="2026-04-08 03:43 UTC">2026-04-08 03:43 UTC</time> · <a href="https://github.com/schacon/grit/commit/db9634d87d0d5e50df5e85697d43fd035ca7a5bf" style="color:#58a6ff">db9634d</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,475</div>
+      <div class="summary-big-val">29,478</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>608 files fully passing</span>
+    <span>609 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -267,11 +267,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t8</span>
         <span class="group-desc">Porcelainish commands concerning forensics</span>
-        <span class="group-meta">65/105 files · 0 skipped · 2,547/2,763 tests</span>
+        <span class="group-meta">66/105 files · 0 skipped · 2,550/2,763 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:92.2%"></div></div>
-        <span class="group-pct pct-green">92.2%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:92.3%"></div></div>
+        <span class="group-pct pct-green">92.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t9">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T03:10:03+00:00" class="gen-time" title="2026-04-08 03:10 UTC">2026-04-08 03:10 UTC</time> · <a href="https://github.com/schacon/grit/commit/301bdec24480022f1b3eeaca963492883de2ebc6" style="color:#58a6ff">301bdec</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T03:43:58+00:00" class="gen-time" title="2026-04-08 03:43 UTC">2026-04-08 03:43 UTC</time> · <a href="https://github.com/schacon/grit/commit/db9634d87d0d5e50df5e85697d43fd035ca7a5bf" style="color:#58a6ff">db9634d</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,745</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,475</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,478</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">67.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -13407,14 +13407,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:59.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t8" data-tests="30" data-passed="27">
+<tr class="" data-group="t8" data-tests="30" data-passed="30">
   <td class="mono">t8350-checkout-index-force</td>
   <td>t8</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">30</td>
-  <td class="right">27</td>
+  <td class="right">30</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t8" data-tests="25" data-passed="18">

--- a/grit/src/commands/checkout_index.rs
+++ b/grit/src/commands/checkout_index.rs
@@ -4,13 +4,16 @@ use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::config::ConfigSet;
 use grit_lib::crlf;
+use grit_lib::diff::stat_matches;
 use grit_lib::index::Index;
-use grit_lib::objects::ObjectKind;
+use grit_lib::objects::{ObjectId, ObjectKind};
+use grit_lib::odb::Odb;
 use std::io::{self, BufRead};
+use std::os::unix::fs::MetadataExt;
 use std::path::Component;
 use std::path::PathBuf;
 
-use grit_lib::index::{IndexEntry, MODE_EXECUTABLE, MODE_SYMLINK};
+use grit_lib::index::{IndexEntry, MODE_EXECUTABLE, MODE_REGULAR, MODE_SYMLINK};
 use grit_lib::repo::Repository;
 
 /// Stage selection for `--stage` (last occurrence wins).
@@ -212,7 +215,6 @@ pub fn run(args: Args) -> Result<()> {
     }
 
     let mut has_errors = false;
-    let mut has_conflicts = false;
     for (path, display) in selected {
         let entry = index
             .get(&path, target_stage)
@@ -230,9 +232,6 @@ pub fn run(args: Args) -> Result<()> {
             &display,
         ) {
             Ok(outcome) => {
-                if outcome.had_conflict {
-                    has_conflicts = true;
-                }
                 if let Some(updated) = outcome.updated_entry {
                     index.add_or_replace(updated);
                     index_needs_write = true;
@@ -252,7 +251,7 @@ pub fn run(args: Args) -> Result<()> {
             .context("writing index")?;
     }
 
-    if has_errors || has_conflicts {
+    if has_errors {
         std::process::exit(1);
     }
 
@@ -424,14 +423,39 @@ fn checkout_entry(
     }
 
     let existing_meta = std::fs::symlink_metadata(&abs_path).ok();
-    let should_skip_existing =
-        existing_meta.is_some() && !args.force && !args.ignore_skip_worktree_bits;
-    if should_skip_existing {
-        if !args.quiet {
-            eprintln!("warning: '{rel_path}' already exists, skipping (use --force to override)");
+    if let Some(ref meta) = existing_meta {
+        if !args.force && !args.ignore_skip_worktree_bits {
+            let unchanged = if entry.mode == MODE_SYMLINK && symlinks_enabled {
+                meta.file_type().is_symlink()
+                    && std::fs::read_link(&abs_path).ok().is_some_and(|t| {
+                        use std::os::unix::ffi::OsStrExt;
+                        t.as_os_str().as_bytes() == obj.data.as_slice()
+                    })
+            } else if !meta.file_type().is_symlink() && entry.mode != MODE_SYMLINK {
+                let wt_mode = worktree_mode_from_metadata(meta);
+                if wt_mode != entry.mode {
+                    false
+                } else if stat_matches(entry, meta) {
+                    true
+                } else {
+                    worktree_clean_blob_oid_matches(
+                        repo, index, work_tree, &path_str, &abs_path, &entry.oid,
+                    )
+                    .unwrap_or(false)
+                }
+            } else {
+                false
+            };
+            if unchanged {
+                return Ok(outcome);
+            }
+            if !args.quiet {
+                eprintln!(
+                    "warning: '{rel_path}' already exists, skipping (use --force to override)"
+                );
+            }
+            return Ok(outcome);
         }
-        outcome.had_conflict = true;
-        return Ok(outcome);
     }
 
     if let Some(parent) = abs_path.parent() {
@@ -597,7 +621,40 @@ fn checkout_all_unmerged_stages(
 struct CheckoutOutcome {
     updated_entry: Option<grit_lib::index::IndexEntry>,
     temp_output: Option<String>,
-    had_conflict: bool,
+}
+
+fn worktree_mode_from_metadata(meta: &std::fs::Metadata) -> u32 {
+    if meta.file_type().is_symlink() {
+        MODE_SYMLINK
+    } else if meta.mode() & 0o111 != 0 {
+        MODE_EXECUTABLE
+    } else {
+        MODE_REGULAR
+    }
+}
+
+/// When cached stat does not match the file (e.g. index not refreshed after `commit`), still treat
+/// the path as up to date if the cleaned working-tree content hashes to the same blob as the index
+/// (matches Git `ie_match_stat` / `hash_stat_data` behavior).
+fn worktree_clean_blob_oid_matches(
+    repo: &Repository,
+    index: &Index,
+    work_tree: &std::path::Path,
+    path_str: &str,
+    abs_path: &std::path::Path,
+    index_oid: &ObjectId,
+) -> Result<bool> {
+    let raw = match std::fs::read(abs_path) {
+        Ok(b) => b,
+        Err(_) => return Ok(false),
+    };
+    let config = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+    let conv = crlf::ConversionConfig::from_config(&config);
+    let attrs = crlf::load_gitattributes_for_checkout(work_tree, path_str, index, &repo.odb);
+    let file_attrs = crlf::get_file_attrs(&attrs, path_str, &config);
+    let cleaned = crlf::convert_to_git(&raw, path_str, &conv, &file_attrs).unwrap_or(raw);
+    let wt_oid = Odb::hash_object_data(ObjectKind::Blob, &cleaned);
+    Ok(wt_oid == *index_oid)
 }
 
 fn read_stdin_paths(null_terminated: bool) -> Result<Vec<PathBuf>> {

--- a/logs/2026-04-08_t8350-checkout-index-force.md
+++ b/logs/2026-04-08_t8350-checkout-index-force.md
@@ -1,0 +1,14 @@
+# t8350-checkout-index-force
+
+## Issue
+
+Harness showed 28/30 passing: (1) exit code 1 when skipping an existing dirty file without `--force` (test expected 0); (2) `--no-create --all` then `checkout-index --all` failed because unchanged files still had stale index stat cache vs disk.
+
+## Fix (`grit/src/commands/checkout_index.rs`)
+
+- Removed treating “skipped existing file” as a fatal conflict (`had_conflict` + `exit(1)`). Git returns 0 when checkout is skipped.
+- When a path exists and `--force` is off: if symlink target matches index blob, or cached stat matches, or cleaned worktree content hashes to the index OID (Git-style stat/content match), treat as up to date with no warning; otherwise warn and skip without failing.
+
+## Verification
+
+- `./scripts/run-tests.sh t8350-checkout-index-force.sh` → 30/30.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates `checkout-index` so behavior matches Git for existing paths and stale index stat cache.

## Changes

- **Exit code:** Skipping an existing file without `--force` no longer sets a conflict flag or forces `exit(1)` (Git exits 0).
- **Up-to-date detection:** When not forcing, treat a path as unchanged if symlink target matches the index blob, or if `stat_matches` agrees, or if cleaned worktree content hashes to the same blob OID as the index (covers post-commit index stat drift).

## Testing

- `./scripts/run-tests.sh t8350-checkout-index-force.sh` → 30/30
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-028c60be-c610-46b2-bf2b-2a1887827e4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-028c60be-c610-46b2-bf2b-2a1887827e4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

