### PR TITLE
fix: make t3201-branch-contains fully pass

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -294,7 +294,7 @@ commit → check it off → move on.
 - [ ] `t3902-quoted` ███████░░░░░░░░░░░░░ 5/13 (8 left) — quoted output
 - [ ] `t3306-notes-prune` ██████░░░░░░░░░░░░░░ 4/12 (8 left) — Test git notes prune
 - [ ] `t3438-rebase-broken-files` ██░░░░░░░░░░░░░░░░░░ 1/9 (8 left) — rebase behavior when on-disk files are broken
-- [ ] `t3201-branch-contains` ████████████░░░░░░░░ 15/24 (9 left) — branch --contains <commit>, --no-contains <commit> --merged, and --no-merged
+- [x] `t3201-branch-contains` ████████████████████ 24/24 (done) — branch --contains <commit>, --no-contains <commit> --merged, and --no-merged
 - [ ] `t3104-ls-tree-format` ██████████░░░░░░░░░░ 10/19 (9 left) — ls-tree --format
 - [ ] `t3204-branch-name-interpretation` ████████░░░░░░░░░░░░ 7/16 (9 left) — interpreting exotic branch name arguments
 

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -559,7 +559,7 @@ t3103-ls-tree-misc	t3	yes	10	10	0	true	ok	0
 t3104-ls-tree-format	t3	yes	19	16	3	false	ok	0
 t3105-ls-tree-output	t3	yes	60	22	38	false	ok	0
 t3200-branch	t3	yes	167	84	83	false	ok	0
-t3201-branch-contains	t3	yes	24	15	9	false	ok	0
+t3201-branch-contains	t3	yes	24	24	0	true	ok	0
 t3202-show-branch	t3	yes	27	4	23	false	ok	0
 t3203-branch-output	t3	yes	41	15	26	false	ok	0
 t3204-branch-name-interpretation	t3	yes	16	9	7	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T03:10:03+00:00" class="gen-time" title="2026-04-08 03:10 UTC">2026-04-08 03:10 UTC</time> · <a href="https://github.com/schacon/grit/commit/301bdec24480022f1b3eeaca963492883de2ebc6" style="color:#58a6ff">301bdec</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T03:54:53+00:00" class="gen-time" title="2026-04-08 03:54 UTC">2026-04-08 03:54 UTC</time> · <a href="https://github.com/schacon/grit/commit/db9634d87d0d5e50df5e85697d43fd035ca7a5bf" style="color:#58a6ff">db9634d</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,475</div>
+      <div class="summary-big-val">29,484</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>608 files fully passing</span>
+    <span>609 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,11 +212,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">29/141 files · 2 skipped · 3,438/5,297 tests</span>
+        <span class="group-meta">30/141 files · 2 skipped · 3,447/5,297 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.9%"></div></div>
-        <span class="group-pct pct-blue">64.9%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:65.1%"></div></div>
+        <span class="group-pct pct-blue">65.1%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T03:10:03+00:00" class="gen-time" title="2026-04-08 03:10 UTC">2026-04-08 03:10 UTC</time> · <a href="https://github.com/schacon/grit/commit/301bdec24480022f1b3eeaca963492883de2ebc6" style="color:#58a6ff">301bdec</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T03:54:53+00:00" class="gen-time" title="2026-04-08 03:54 UTC">2026-04-08 03:54 UTC</time> · <a href="https://github.com/schacon/grit/commit/db9634d87d0d5e50df5e85697d43fd035ca7a5bf" style="color:#58a6ff">db9634d</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,745</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,475</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,484</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">67.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -5727,14 +5727,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="24" data-passed="15">
+<tr class="" data-group="t3" data-tests="24" data-passed="24">
   <td class="mono">t3201-branch-contains</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">24</td>
-  <td class="right">15</td>
+  <td class="right">24</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:62.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="27" data-passed="4">

--- a/grit/src/commands/branch.rs
+++ b/grit/src/commands/branch.rs
@@ -4,10 +4,11 @@ use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::config::{ConfigFile, ConfigScope, ConfigSet};
 use grit_lib::merge_base::is_ancestor;
-use grit_lib::objects::{parse_commit, ObjectId};
+use grit_lib::objects::{parse_commit, ObjectId, ObjectKind};
 use grit_lib::repo::Repository;
 use grit_lib::rev_parse::{resolve_revision, resolve_upstream_symbolic_name, symbolic_full_name};
 use grit_lib::state::{resolve_head, HeadState};
+use std::collections::HashSet;
 use std::fs;
 use std::io::{self, Write};
 use std::path::Path;
@@ -72,13 +73,23 @@ pub struct Args {
     #[arg(long = "no-contains", action = clap::ArgAction::Append)]
     pub no_contains: Vec<String>,
 
-    /// Show branches merged into this commit (default: HEAD).
-    #[arg(long = "merged", num_args = 0..=1, default_missing_value = "")]
-    pub merged: Option<String>,
+    /// Show branches merged into this commit (default: HEAD). Repeat for intersection.
+    #[arg(
+        long = "merged",
+        action = clap::ArgAction::Append,
+        num_args = 0..=1,
+        default_missing_value = ""
+    )]
+    pub merged: Vec<String>,
 
-    /// Show branches not merged into this commit (default: HEAD).
-    #[arg(long = "no-merged", num_args = 0..=1, default_missing_value = "")]
-    pub no_merged: Option<String>,
+    /// Show branches not merged into this commit (default: HEAD). Repeat for intersection.
+    #[arg(
+        long = "no-merged",
+        action = clap::ArgAction::Append,
+        num_args = 0..=1,
+        default_missing_value = ""
+    )]
+    pub no_merged: Vec<String>,
 
     /// Force creation (overwrite existing branch).
     #[arg(short = 'f', long = "force")]
@@ -204,6 +215,26 @@ pub fn run(args: Args) -> Result<()> {
         }
     }
 
+    let filter_active = !args.contains.is_empty()
+        || !args.no_contains.is_empty()
+        || !args.merged.is_empty()
+        || !args.no_merged.is_empty();
+    let implicit_list = filter_active && !args.list;
+    if implicit_list
+        && (args.delete
+            || args.force_delete
+            || args.rename
+            || args.force_rename
+            || args.copy
+            || args.force_copy)
+    {
+        eprintln!(
+            "fatal: options such as --contains, --no-contains, --merged, and --no-merged\n\
+             require branch listing; incompatible with branch modification"
+        );
+        std::process::exit(129);
+    }
+
     if args.show_current {
         if let Some(name) = head.branch_name() {
             println!("{name}");
@@ -236,8 +267,8 @@ pub fn run(args: Args) -> Result<()> {
         if !args.list
             && args.contains.is_empty()
             && args.no_contains.is_empty()
-            && args.merged.is_none()
-            && args.no_merged.is_none()
+            && args.merged.is_empty()
+            && args.no_merged.is_empty()
         {
             // Reject invalid branch names
             if name == "HEAD" || name.starts_with('-') {
@@ -323,39 +354,55 @@ fn list_branches(repo: &Repository, head: &HeadState, args: &Args) -> Result<()>
         }
     }
 
-    // Apply --merged filter
-    if let Some(ref merged_val) = args.merged {
-        let target_oid = if merged_val.is_empty() {
-            *head
-                .oid()
-                .ok_or_else(|| anyhow::anyhow!("HEAD does not point to a valid commit"))?
-        } else {
-            resolve_revision(repo, merged_val)?
-        };
-        branches.retain(|b| is_ancestor(repo, b.oid, target_oid).unwrap_or(false));
+    // Apply --merged filter: with multiple `--merged`, Git unions (OR) the results.
+    if !args.merged.is_empty() {
+        let mut keep = HashSet::new();
+        for merged_val in &args.merged {
+            let target_oid = if merged_val.is_empty() {
+                *head
+                    .oid()
+                    .ok_or_else(|| anyhow::anyhow!("HEAD does not point to a valid commit"))?
+            } else {
+                resolve_revision_must_be_commit(repo, merged_val)?
+            };
+            for b in &branches {
+                if is_ancestor(repo, b.oid, target_oid).unwrap_or(false) {
+                    keep.insert(b.name.clone());
+                }
+            }
+        }
+        branches.retain(|b| keep.contains(&b.name));
     }
 
-    // Apply --no-merged filter
-    if let Some(ref no_merged_val) = args.no_merged {
+    // Apply --no-merged filters: repeated `--no-merged` intersects (AND), unlike `--merged`.
+    for no_merged_val in &args.no_merged {
         let target_oid = if no_merged_val.is_empty() {
             *head
                 .oid()
                 .ok_or_else(|| anyhow::anyhow!("HEAD does not point to a valid commit"))?
         } else {
-            resolve_revision(repo, no_merged_val)?
+            resolve_revision_must_be_commit(repo, no_merged_val)?
         };
         branches.retain(|b| !is_ancestor(repo, b.oid, target_oid).unwrap_or(true));
     }
 
-    // Apply --contains filter (all must match)
-    for contains_rev in &args.contains {
-        let contains_oid = resolve_revision(repo, contains_rev)?;
-        branches.retain(|b| is_ancestor(repo, contains_oid, b.oid).unwrap_or(false));
+    // Apply --contains filter: with multiple `--contains`, Git unions (OR) the results.
+    if !args.contains.is_empty() {
+        let contain_oids: Vec<ObjectId> = args
+            .contains
+            .iter()
+            .map(|r| resolve_revision_must_be_commit(repo, r))
+            .collect::<Result<_>>()?;
+        branches.retain(|b| {
+            contain_oids
+                .iter()
+                .any(|&c| is_ancestor(repo, c, b.oid).unwrap_or(false))
+        });
     }
 
     // Apply --no-contains filter
     for no_contains_rev in &args.no_contains {
-        let no_contains_oid = resolve_revision(repo, no_contains_rev)?;
+        let no_contains_oid = resolve_revision_must_be_commit(repo, no_contains_rev)?;
         branches.retain(|b| !is_ancestor(repo, no_contains_oid, b.oid).unwrap_or(true));
     }
 
@@ -438,20 +485,23 @@ fn list_branches(repo: &Repository, head: &HeadState, args: &Args) -> Result<()>
             let subject = commit_subject(&repo.odb, &b.oid).unwrap_or_default();
             let padded_name = format!("{:<width$}", b.name, width = max_name_len);
 
-            if args.verbose >= 2 && !b.is_remote {
-                // -vv: show tracking info
-                let tracking = get_tracking_info(repo, &b.name)?;
-                if let Some(ref track_str) = tracking {
-                    writeln!(
-                        out,
-                        "{prefix}{color}{padded_name}{reset} {short_oid} [{track_str}] {subject}"
-                    )?;
-                } else {
-                    writeln!(
-                        out,
-                        "{prefix}{color}{padded_name}{reset} {short_oid} {subject}"
-                    )?;
+            if !b.is_remote {
+                let track = resolve_branch_tracking(repo, &b.name)?;
+                let v1 = track.as_ref().and_then(|t| t.verbose1_inner.as_deref());
+                let v2 = track.as_ref().and_then(|t| t.verbose2_inner.as_deref());
+                write!(out, "{prefix}{color}{padded_name}{reset} {short_oid}")?;
+                if args.verbose >= 2 {
+                    if let Some(i2) = v2 {
+                        write!(out, " [{i2}]")?;
+                    } else if let Some(i1) = v1 {
+                        write!(out, " [{i1}]")?;
+                    }
+                } else if args.verbose == 1 {
+                    if let Some(i1) = v1 {
+                        write!(out, " [{i1}]")?;
+                    }
                 }
+                writeln!(out, " {subject}")?;
             } else {
                 writeln!(
                     out,
@@ -464,6 +514,24 @@ fn list_branches(repo: &Repository, head: &HeadState, args: &Args) -> Result<()>
     }
 
     Ok(())
+}
+
+/// Resolve a revision and require the peeled object to be a commit (Git `branch --contains` rules).
+///
+/// On failure, prints Git-compatible messages to stderr and exits with code 129.
+fn resolve_revision_must_be_commit(repo: &Repository, spec: &str) -> Result<ObjectId> {
+    let oid = resolve_revision(repo, spec)?;
+    let object = repo.odb.read(&oid)?;
+    let hex = oid.to_hex();
+    let kind_msg = match object.kind {
+        ObjectKind::Commit => return Ok(oid),
+        ObjectKind::Tree => "tree",
+        ObjectKind::Blob => "blob",
+        ObjectKind::Tag => "tag",
+    };
+    eprintln!("error: object {hex} is a {kind_msg}, not a commit");
+    eprintln!("error: no such commit {hex}");
+    std::process::exit(129);
 }
 
 /// Sort branches by the given key.
@@ -519,8 +587,20 @@ fn sort_branches(
     Ok(())
 }
 
-/// Get the tracking info string for a local branch, e.g. "origin/main: ahead 1, behind 2".
-fn get_tracking_info(repo: &Repository, branch_name: &str) -> Result<Option<String>> {
+/// Parsed upstream / ahead-behind display for a local branch (`git branch -v` / `-vv`).
+struct BranchTracking {
+    /// Inner text for `-v` brackets, e.g. `ahead 1` or `origin/main: ahead 1`.
+    verbose1_inner: Option<String>,
+    /// Inner text for `-vv` brackets (includes remote ref prefix when Git does).
+    verbose2_inner: Option<String>,
+    /// Short upstream name for `%(upstream:short)` (e.g. `main` or `origin/main`).
+    upstream_short: String,
+    /// Full ref for `%(upstream)` (`refs/heads/...` or `refs/remotes/...`).
+    upstream_ref_full: String,
+}
+
+/// Resolve configured upstream and ahead/behind for a local branch.
+fn resolve_branch_tracking(repo: &Repository, branch_name: &str) -> Result<Option<BranchTracking>> {
     let config_path = repo.git_dir.join("config");
     let config_file = match ConfigFile::from_path(&config_path, ConfigScope::Local)? {
         Some(c) => c,
@@ -540,43 +620,99 @@ fn get_tracking_info(repo: &Repository, branch_name: &str) -> Result<Option<Stri
         .get(&remote_key)
         .unwrap_or_else(|| "origin".to_string());
 
-    // Strip refs/heads/ prefix from merge to get the upstream branch name
-    let upstream_branch = merge.strip_prefix("refs/heads/").unwrap_or(&merge);
+    let upstream_branch = merge
+        .strip_prefix("refs/heads/")
+        .unwrap_or(&merge)
+        .to_string();
+    let track_local = remote == ".";
 
-    let upstream_display = format!("{remote}/{upstream_branch}");
+    let local_ref_path = repo.git_dir.join("refs/heads").join(branch_name);
+    let local_oid = match fs::read_to_string(&local_ref_path) {
+        Ok(c) => ObjectId::from_hex(c.trim()).ok(),
+        Err(_) => None,
+    };
+    let Some(local_oid) = local_oid else {
+        return Ok(None);
+    };
 
-    // Try to compute ahead/behind
-    let upstream_ref_path = repo
-        .git_dir
-        .join("refs/remotes")
-        .join(&remote)
-        .join(upstream_branch);
+    let short_label = if track_local {
+        upstream_branch.clone()
+    } else {
+        format!("{remote}/{upstream_branch}")
+    };
+    let upstream_ref_full = if track_local {
+        format!("refs/heads/{upstream_branch}")
+    } else {
+        format!("refs/remotes/{remote}/{upstream_branch}")
+    };
 
-    if let Ok(content) = fs::read_to_string(&upstream_ref_path) {
-        if let Ok(upstream_oid) = ObjectId::from_hex(content.trim()) {
-            // Read local branch OID
-            let local_ref_path = repo.git_dir.join("refs/heads").join(branch_name);
-            if let Ok(local_content) = fs::read_to_string(&local_ref_path) {
-                if let Ok(local_oid) = ObjectId::from_hex(local_content.trim()) {
-                    let (ahead, behind) = count_ahead_behind(repo, local_oid, upstream_oid)?;
-                    if ahead == 0 && behind == 0 {
-                        return Ok(Some(upstream_display));
-                    }
-                    let mut parts = Vec::new();
-                    if ahead > 0 {
-                        parts.push(format!("ahead {ahead}"));
-                    }
-                    if behind > 0 {
-                        parts.push(format!("behind {behind}"));
-                    }
-                    return Ok(Some(format!("{upstream_display}: {}", parts.join(", "))));
-                }
-            }
+    let upstream_oid = if track_local {
+        let p = repo.git_dir.join("refs/heads").join(&upstream_branch);
+        match fs::read_to_string(&p) {
+            Ok(c) => ObjectId::from_hex(c.trim()).ok(),
+            Err(_) => None,
         }
+    } else {
+        let upstream_ref_path = repo
+            .git_dir
+            .join("refs/remotes")
+            .join(&remote)
+            .join(&upstream_branch);
+        match fs::read_to_string(&upstream_ref_path) {
+            Ok(c) => ObjectId::from_hex(c.trim()).ok(),
+            Err(_) => None,
+        }
+    };
+
+    let Some(upstream_oid) = upstream_oid else {
+        return Ok(Some(BranchTracking {
+            verbose1_inner: Some("gone".to_string()),
+            verbose2_inner: Some(format!("{short_label}: gone")),
+            upstream_short: short_label.clone(),
+            upstream_ref_full,
+        }));
+    };
+
+    let (ahead, behind) = count_ahead_behind(repo, local_oid, upstream_oid)?;
+    if ahead == 0 && behind == 0 {
+        return Ok(Some(BranchTracking {
+            verbose1_inner: None,
+            verbose2_inner: None,
+            upstream_short: short_label,
+            upstream_ref_full,
+        }));
     }
 
-    // Upstream ref doesn't exist locally — just show the name with "gone"
-    Ok(Some(format!("{upstream_display}: gone")))
+    let mut parts = Vec::new();
+    if ahead > 0 {
+        parts.push(format!("ahead {ahead}"));
+    }
+    if behind > 0 {
+        parts.push(format!("behind {behind}"));
+    }
+    let detail = parts.join(", ");
+
+    let (verbose1_inner, verbose2_inner) = if track_local {
+        (
+            Some(detail.clone()),
+            Some(format!("{}: {detail}", upstream_branch)),
+        )
+    } else if ahead > 0 && behind == 0 {
+        let s = format!("{short_label}: {detail}");
+        (Some(s.clone()), Some(s))
+    } else {
+        (
+            Some(detail.clone()),
+            Some(format!("{short_label}: {detail}")),
+        )
+    };
+
+    Ok(Some(BranchTracking {
+        verbose1_inner,
+        verbose2_inner,
+        upstream_short: short_label,
+        upstream_ref_full,
+    }))
 }
 
 /// Count how many commits local is ahead of and behind upstream.
@@ -777,21 +913,17 @@ fn format_branch(
 
     // %(upstream:short) before %(upstream)
     if result.contains("%(upstream") {
-        let tracking = get_tracking_info(repo, &branch.name)?;
-        let upstream_name = if let Some(ref t) = tracking {
-            t.split(':').next().unwrap_or(t).trim().to_string()
-        } else {
-            String::new()
-        };
-        result = result.replace("%(upstream:short)", &upstream_name);
-        result = result.replace(
-            "%(upstream)",
-            &if upstream_name.is_empty() {
-                String::new()
-            } else {
-                format!("refs/remotes/{upstream_name}")
-            },
-        );
+        let track = resolve_branch_tracking(repo, &branch.name)?;
+        let upstream_name = track
+            .as_ref()
+            .map(|t| t.upstream_short.as_str())
+            .unwrap_or("");
+        let upstream_full = track
+            .as_ref()
+            .map(|t| t.upstream_ref_full.as_str())
+            .unwrap_or("");
+        result = result.replace("%(upstream:short)", upstream_name);
+        result = result.replace("%(upstream)", upstream_full);
     }
 
     // %(subject) — commit message first line
@@ -904,21 +1036,19 @@ fn create_branch(
         let _ = fs::write(&reflog_path, entry);
     }
 
-    // Set up tracking if --track was used or start_point is a remote tracking branch
-    if args.track.is_some() || (!args.no_track && start_point.is_some()) {
-        if let Some(sp) = start_point {
-            // Try to parse as remote tracking branch: origin/branch or refs/remotes/origin/branch
-            let remote_ref = if sp.starts_with("refs/remotes/") {
-                Some(sp.to_string())
-            } else if grit_lib::refs::resolve_ref(&repo.git_dir, &format!("refs/remotes/{sp}"))
-                .is_ok()
-            {
-                Some(format!("refs/remotes/{sp}"))
-            } else {
-                None
-            };
+    // Set up tracking for `--track`, or when the start point is a remote-tracking ref (Git default).
+    if let Some(sp) = start_point {
+        let remote_ref = if sp.starts_with("refs/remotes/") {
+            Some(sp.to_string())
+        } else if grit_lib::refs::resolve_ref(&repo.git_dir, &format!("refs/remotes/{sp}")).is_ok()
+        {
+            Some(format!("refs/remotes/{sp}"))
+        } else {
+            None
+        };
+        let want_tracking = args.track.is_some() || (!args.no_track && remote_ref.is_some());
+        if want_tracking {
             if let Some(rref) = remote_ref {
-                // Parse remote/branch from refs/remotes/remote/branch
                 let stripped = rref.strip_prefix("refs/remotes/").unwrap_or(&rref);
                 if let Some(slash) = stripped.find('/') {
                     let remote = &stripped[..slash];
@@ -930,22 +1060,33 @@ fn create_branch(
                     cfg.push_str(&format!("\n\tmerge = refs/heads/{}\n", branch));
                     std::fs::write(&config_path, cfg)?;
                 }
-            } else if let Ok(full) = resolve_upstream_symbolic_name(repo, sp) {
-                let config_path = repo.git_dir.join("config");
-                let mut cfg = std::fs::read_to_string(&config_path).unwrap_or_default();
-                cfg.push_str(&format!("\n[branch \"{}\"]", name));
-                if let Some(rest) = full.strip_prefix("refs/remotes/") {
-                    if let Some(slash) = rest.find('/') {
-                        let remote = &rest[..slash];
-                        let branch = &rest[slash + 1..];
-                        cfg.push_str(&format!("\n\tremote = {}", remote));
-                        cfg.push_str(&format!("\n\tmerge = refs/heads/{}\n", branch));
+            } else if args.track.is_some() {
+                if let Ok(full) = resolve_upstream_symbolic_name(repo, sp) {
+                    let config_path = repo.git_dir.join("config");
+                    let mut cfg = std::fs::read_to_string(&config_path).unwrap_or_default();
+                    cfg.push_str(&format!("\n[branch \"{}\"]", name));
+                    if let Some(rest) = full.strip_prefix("refs/remotes/") {
+                        if let Some(slash) = rest.find('/') {
+                            let remote = &rest[..slash];
+                            let branch = &rest[slash + 1..];
+                            cfg.push_str(&format!("\n\tremote = {}", remote));
+                            cfg.push_str(&format!("\n\tmerge = refs/heads/{}\n", branch));
+                        }
+                    } else if full.starts_with("refs/heads/") {
+                        cfg.push_str("\n\tremote = .");
+                        cfg.push_str(&format!("\n\tmerge = {}\n", full));
                     }
-                } else if full.starts_with("refs/heads/") {
+                    std::fs::write(&config_path, cfg)?;
+                } else if let Some(full) =
+                    symbolic_full_name(repo, sp).filter(|f| f.starts_with("refs/heads/"))
+                {
+                    let config_path = repo.git_dir.join("config");
+                    let mut cfg = std::fs::read_to_string(&config_path).unwrap_or_default();
+                    cfg.push_str(&format!("\n[branch \"{}\"]", name));
                     cfg.push_str("\n\tremote = .");
-                    cfg.push_str(&format!("\n\tmerge = {}\n", full));
+                    cfg.push_str(&format!("\n\tmerge = {full}\n"));
+                    std::fs::write(&config_path, cfg)?;
                 }
-                std::fs::write(&config_path, cfg)?;
             }
         }
     }

--- a/logs/2026-04-08_t3201-branch-contains.md
+++ b/logs/2026-04-08_t3201-branch-contains.md
@@ -1,0 +1,18 @@
+# t3201-branch-contains
+
+## Goal
+
+Make `tests/t3201-branch-contains.sh` pass entirely (24/24).
+
+## Changes (grit `branch`)
+
+- **Filter + modification conflict:** When listing filters are active implicitly (`--contains`, `--no-contains`, `--merged`, `--no-merged`) and the user also passes `-d`/`-m`/`-c`/`-C`, exit 129 with Git-style fatal message (before `-m foo` could succeed).
+- **Commit-only revisions:** `--contains` / `--no-contains` / `--merged` / `--no-merged` arguments must peel to commits; tree/blob emit the two-line `error:` messages and exit 129.
+- **Multiple flags:** `--merged` and `--contains` repeat with **OR** (union). `--no-merged` repeats with **AND** (intersection). Clap `Append` for `--merged` / `--no-merged`.
+- **Upstream on create:** `--track topic main` writes `remote = .` + `merge = refs/heads/main`. Plain `branch zzz topic` does **not** set tracking (matches Git).
+- **Verbose listing:** `-v` shows `[ahead 1]` for local upstream when only ahead; `-vv` shows `[main: ahead 1]`. Remote tracking uses `[remote/branch: …]` forms matching Git. `gone` / behind-only cases aligned with observed Git output.
+
+## Verification
+
+- `./scripts/run-tests.sh t3201-branch-contains.sh` → 24/24
+- `cargo fmt`, `cargo check -p grit-rs`, `cargo clippy -p grit-rs --fix --allow-dirty`, `cargo test -p grit-lib --lib`

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   225 |
+| Completed   |   226 |
 | In progress |     2 |
-| Remaining   |   541 |
+| Remaining   |   540 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 225 completed (`[x]`), 2 in progress (`[~]`), 541 remaining (`[ ]`).
+Task lines in `PLAN.md`: 226 completed (`[x]`), 2 in progress (`[~]`), 540 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t3201-branch-contains` — 24/24 tests pass (`branch`: OR semantics for repeated `--contains` / `--merged`, AND for repeated `--no-merged`; reject filter options with `-d`/`-m`/`-c`; commit-only `--contains` errors; `Append` for `--merged`/`--no-merged`; `--track` writes local upstream; `-v`/`-vv` tracking brackets match Git; no tracking for `branch zzz topic` without `--track`)
 - `t4026-color` — 34/34 tests pass (Git-compatible `config::parse_color` per `git/color.c`; `git config --get-color` merges argv after the slot into one default and uses `--` when the default begins with `-` so clap accepts `-1 black`)
 - `t3704-add-pathspec-file` — 11/11 tests pass (`git add --pathspec-from-file` / `--pathspec-file-nul`: raw bytes + CRLF/LF/NUL splitting, C-quoted lines, conflict checks vs `--interactive`/`--patch`/`--edit`/pathspecs; shared `pathspec::parse_pathspecs_from_file`; error text matches grep expectations)
 - `t5813-proto-disable-ssh` — 81/81 tests pass (`GIT_ALLOW_PROTOCOL` comma split, `protocol.*.allow=user` + `GIT_PROTOCOL_FROM_USER`, SSH URL validation, local SSH resolution via `TRASH_DIRECTORY` + absolute `ssh://` paths, pkt-line `upload-pack`/`receive-pack`, side-band pack streaming)

--- a/test-results.md
+++ b/test-results.md
@@ -1,5 +1,10 @@
 # Test Results
 
+**Updated:** 2026-04-08
+
+- `./scripts/run-tests.sh t3201-branch-contains.sh`: 24/24 passing (`branch` filters, multi-flag OR/AND semantics, tracking + `-v`/`-vv`; harness CSV/dashboards refreshed).
+- `cargo test -p grit-lib --lib`: 105/105 passing.
+
 **Updated:** 2026-04-07
 
 - `./scripts/run-tests.sh t5813-proto-disable-ssh.sh`: 81/81 passing (SSH protocol allow/deny, `GIT_ALLOW_PROTOCOL` comma lists, `protocol.*.allow=user` + `GIT_PROTOCOL_FROM_USER`, pkt-line `upload-pack`/`receive-pack` with side-band pack; harness CSV/dashboards refreshed).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible `git branch` behavior for `t3201-branch-contains.sh` (24/24).

### Behavior fixes

- **Implicit list vs modification:** Combining `--contains` / `--no-contains` / `--merged` / `--no-merged` with `-d`, `-m`, or `-c`/`-C` now fails with exit **129** and Git-style messaging (so e.g. `branch --contains=main -m foo` does not rename).
- **Filter revisions must be commits:** Tree/blob targets emit the two-line `error:` format and exit **129**.
- **Multiple flags:** Repeated `--contains` and `--merged` use **OR** (union). Repeated `--no-merged` uses **AND** (intersection). `--merged` / `--no-merged` use clap `Append`.
- **Upstream on branch creation:** `branch --track topic main` writes `remote = .` + `merge = refs/heads/main`. Creating `zzz` from `topic` without `--track` does **not** copy tracking (matches Git).
- **Verbose listing:** `-v` / `-vv` upstream brackets match Git for local vs remote tracking, including `gone`, ahead-only, and behind cases.

### Housekeeping

- Harness: `./scripts/run-tests.sh t3201-branch-contains.sh` → 24/24; CSV + dashboards refreshed.
- `PLAN.md` / `progress.md` / `test-results.md` and `logs/2026-04-08_t3201-branch-contains.md` updated.

### Validation

- `cargo fmt`, `cargo check -p grit-rs`, `cargo clippy -p grit-rs --fix --allow-dirty`
- `cargo test -p grit-lib --lib` (105/105)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1696ab74-5cdb-45aa-8a1d-239d6f1f2d3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1696ab74-5cdb-45aa-8a1d-239d6f1f2d3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

