### PR TITLE
fix: make t7509-commit-authorship fully pass

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -846,7 +846,7 @@ commit → check it off → move on.
 - [ ] `t7031-verify-tag-signed-ssh` █████░░░░░░░░░░░░░░░ 4/14 (10 left) — signed tag tests
 - [ ] `t7010-setup` ██████░░░░░░░░░░░░░░ 5/16 (11 left) — setup taking and sanitizing funny paths
 - [ ] `t7424-submodule-mixed-ref-formats` ████░░░░░░░░░░░░░░░░ 3/14 (11 left) — submodules handle mixed ref storage formats
-- [ ] `t7509-commit-authorship` █░░░░░░░░░░░░░░░░░░░ 1/12 (11 left) — commit tests of various authorhip options. 
+- [x] `t7509-commit-authorship` ████████████████████ 12/12 (0 left) — commit tests of various authorhip options. 
 - [ ] `t7521-ignored-mode` █░░░░░░░░░░░░░░░░░░░ 1/12 (11 left) — git status ignored modes
 - [ ] `t7005-editor` ░░░░░░░░░░░░░░░░░░░░ 0/11 (11 left) — GIT_EDITOR, core.editor, and stuff
 - [ ] `t7107-reset-pathspec-file` ░░░░░░░░░░░░░░░░░░░░ 0/11 (11 left) — reset --pathspec-from-file

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1230,7 +1230,7 @@ t7505-prepare-commit-msg-hook	t7	yes	23	5	18	false	ok	0
 t7506-status-submodule	t7	yes	40	4	36	false	ok	0
 t7507-commit-verbose	t7	yes	45	19	26	false	ok	0
 t7508-status	t7	yes	126	38	88	false	ok	0
-t7509-commit-authorship	t7	yes	12	5	7	false	ok	0
+t7509-commit-authorship	t7	yes	12	12	0	true	ok	0
 t7510-signed-commit	t7	skip	28	0	0	false	ok	0
 t7511-status-index	t7	yes	24	24	0	true	ok	0
 t7512-status-help	t7	yes	47	7	40	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T03:45:02+00:00" class="gen-time" title="2026-04-08 03:45 UTC">2026-04-08 03:45 UTC</time> · <a href="https://github.com/schacon/grit/commit/d4a4b1fd1e3811409fa5ea547f24f06765ebda1a" style="color:#58a6ff">d4a4b1f</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T03:56:12+00:00" class="gen-time" title="2026-04-08 03:56 UTC">2026-04-08 03:56 UTC</time> · <a href="https://github.com/schacon/grit/commit/1dfff49460b0d6780cbf0f8be79c11b5125d0732" style="color:#58a6ff">1dfff49</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,476</div>
+      <div class="summary-big-val">29,483</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>608 files fully passing</span>
+    <span>609 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -256,11 +256,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">35/126 files · 11 skipped · 1,873/3,607 tests</span>
+        <span class="group-meta">36/126 files · 11 skipped · 1,880/3,607 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:51.9%"></div></div>
-        <span class="group-pct pct-orange">51.9%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:52.1%"></div></div>
+        <span class="group-pct pct-orange">52.1%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T03:45:02+00:00" class="gen-time" title="2026-04-08 03:45 UTC">2026-04-08 03:45 UTC</time> · <a href="https://github.com/schacon/grit/commit/d4a4b1fd1e3811409fa5ea547f24f06765ebda1a" style="color:#58a6ff">d4a4b1f</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T03:56:12+00:00" class="gen-time" title="2026-04-08 03:56 UTC">2026-04-08 03:56 UTC</time> · <a href="https://github.com/schacon/grit/commit/1dfff49460b0d6780cbf0f8be79c11b5125d0732" style="color:#58a6ff">1dfff49</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,745</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,476</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,483</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">67.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -12437,14 +12437,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:30.2%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="12" data-passed="5">
+<tr class="" data-group="t7" data-tests="12" data-passed="12">
   <td class="mono">t7509-commit-authorship</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">12</td>
-  <td class="right">5</td>
+  <td class="right">12</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:41.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="row-skip" data-group="t7" data-tests="28" data-passed="0">

--- a/grit/src/commands/commit.rs
+++ b/grit/src/commands/commit.rs
@@ -191,6 +191,10 @@ pub fn run(args: Args) -> Result<()> {
         bail!("Only one of -m, -F, -C, -c can be used.");
     }
 
+    if args.reset_author && args.author.is_some() {
+        bail!("options '--reset-author' and '--author' cannot be used together");
+    }
+
     // -a and explicit pathspec don't mix
     if args.all && !args.pathspec.is_empty() {
         bail!(
@@ -205,6 +209,16 @@ pub fn run(args: Args) -> Result<()> {
     }
 
     let repo = Repository::discover(None).context("not a git repository")?;
+
+    let reset_author_allowed = args.amend
+        || args.reuse_message.is_some()
+        || args.reedit_message.is_some()
+        || repo.git_dir.join("CHERRY_PICK_HEAD").exists()
+        || repo.git_dir.join("REBASE_HEAD").exists();
+    if args.reset_author && !reset_author_allowed {
+        bail!("--reset-author can be used only with -C, -c or --amend.");
+    }
+
     let work_tree = repo.work_tree.as_deref();
 
     // If -a, stage all tracked file changes first
@@ -335,6 +349,7 @@ pub fn run(args: Args) -> Result<()> {
 
     // When amending, preserve original author unless explicitly overridden
     let amend_author = if args.amend
+        && !args.reset_author
         && args.author.is_none()
         && args.reuse_message.is_none()
         && args.reedit_message.is_none()
@@ -343,6 +358,7 @@ pub fn run(args: Args) -> Result<()> {
         if let Some(head_oid) = head.oid() {
             let obj = repo.odb.read(head_oid)?;
             let commit = grit_lib::objects::parse_commit(&obj.data)?;
+            validate_amend_source_author(&commit.author)?;
             Some(commit.author)
         } else {
             None
@@ -353,7 +369,7 @@ pub fn run(args: Args) -> Result<()> {
     let author = if let Some(preserved) = amend_author {
         preserved
     } else {
-        resolve_author(&args, &config, now)?
+        resolve_author(&args, &config, &repo, now)?
     };
     let committer = resolve_committer(&config, now)?;
 
@@ -982,7 +998,87 @@ fn build_message(args: &Args, repo: &Repository) -> Result<MessageResult> {
     bail!("no commit message provided (use -m or -F)");
 }
 
-/// Resolve the author identity from args, env, and config.
+/// Parse `git commit --author="Name <email>"` parameter into name and email.
+fn parse_force_author_parameter(author: &str) -> Result<(String, String)> {
+    let Some(lt) = author.find('<') else {
+        bail!("malformed --author parameter");
+    };
+    let Some(gt) = author.rfind('>') else {
+        bail!("malformed --author parameter");
+    };
+    if gt <= lt {
+        bail!("malformed --author parameter");
+    }
+    let name = author[..lt].trim_end();
+    let email = author[lt + 1..gt].trim();
+    if name.is_empty() {
+        bail!("empty ident name (for <author>) not allowed");
+    }
+    if email.is_empty() {
+        bail!("malformed --author parameter");
+    }
+    if lt > 0 && author.as_bytes()[lt - 1] != b' ' {
+        bail!("malformed --author parameter");
+    }
+    Ok((name.to_string(), email.to_string()))
+}
+
+/// Split a stored author line (`name <email> <epoch> <tz>`) into name, email, and optional date tail.
+fn split_stored_author_line(author: &str) -> Result<(String, String, Option<String>)> {
+    let Some(lt) = author.find('<') else {
+        bail!("malformed author line");
+    };
+    let Some(gt) = author.rfind('>') else {
+        bail!("malformed author line");
+    };
+    if gt <= lt {
+        bail!("malformed author line");
+    }
+    let name = author[..lt].trim_end();
+    let email = author[lt + 1..gt].trim();
+    let after_gt = author[gt + 1..].trim_start();
+    let date_tail = if after_gt.is_empty() {
+        None
+    } else {
+        Some(after_gt.to_string())
+    };
+    Ok((name.to_string(), email.to_string(), date_tail))
+}
+
+/// Reject empty/malformed author identity when amending (matches Git's strictness for t7509).
+fn validate_amend_source_author(author: &str) -> Result<()> {
+    let (name, email, date_tail) = split_stored_author_line(author)
+        .map_err(|_| anyhow::anyhow!("commit has malformed author line"))?;
+    if name.is_empty() {
+        bail!("empty ident name (for <author>) not allowed");
+    }
+    validate_ident_name(&name, "author")?;
+    if email.is_empty() {
+        bail!("empty ident name (for <author>) not allowed");
+    }
+    if date_tail.is_none() || date_tail.as_ref().is_some_and(|s| s.is_empty()) {
+        bail!("empty ident name (for <author>) not allowed");
+    }
+    Ok(())
+}
+
+fn read_cherry_pick_head_author(repo: &Repository) -> Result<Option<String>> {
+    let path = repo.git_dir.join("CHERRY_PICK_HEAD");
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content = fs::read_to_string(&path).context("read CHERRY_PICK_HEAD")?;
+    let hex = content.trim();
+    if hex.is_empty() {
+        return Ok(None);
+    }
+    let oid: ObjectId = hex
+        .parse()
+        .map_err(|_| anyhow::anyhow!("invalid CHERRY_PICK_HEAD"))?;
+    let obj = repo.odb.read(&oid)?;
+    let commit = grit_lib::objects::parse_commit(&obj.data)?;
+    Ok(Some(commit.author))
+}
 
 /// Check if an ident name is valid (not empty and not all special characters).
 fn validate_ident_name(name: &str, kind: &str) -> Result<()> {
@@ -1009,19 +1105,53 @@ fn validate_ident_name(name: &str, kind: &str) -> Result<()> {
     Ok(())
 }
 
-fn resolve_author(args: &Args, config: &ConfigSet, now: OffsetDateTime) -> Result<String> {
-    // --reuse-message / --reedit-message: reuse the original commit's author
-    let reuse_rev = args.reuse_message.as_ref().or(args.reedit_message.as_ref());
-    if let Some(rev) = reuse_rev {
-        let repo = Repository::discover(None)?;
-        let oid = resolve_revision(&repo, rev)?;
-        let obj = repo.odb.read(&oid)?;
-        let commit = grit_lib::objects::parse_commit(&obj.data)?;
-        return Ok(commit.author);
+fn resolve_author(
+    args: &Args,
+    config: &ConfigSet,
+    repo: &Repository,
+    now: OffsetDateTime,
+) -> Result<String> {
+    if let Some(ref author) = args.author {
+        let (name, email) = parse_force_author_parameter(author)?;
+        validate_ident_name(&name, "author")?;
+        let date_str = args
+            .date
+            .as_deref()
+            .map(String::from)
+            .or_else(|| std::env::var("GIT_AUTHOR_DATE").ok());
+        let timestamp = match date_str {
+            Some(d) => parse_date_to_git_timestamp(&d).unwrap_or(d),
+            None => format_git_timestamp(now),
+        };
+        return Ok(format!("{name} <{email}> {timestamp}"));
     }
 
-    if let Some(ref author) = args.author {
-        return Ok(author.clone());
+    let reuse_rev = args.reuse_message.as_ref().or(args.reedit_message.as_ref());
+    if let Some(rev) = reuse_rev {
+        if !args.reset_author {
+            let oid = resolve_revision(repo, rev)?;
+            let obj = repo.odb.read(&oid)?;
+            let commit = grit_lib::objects::parse_commit(&obj.data)?;
+            if let Some(ref d) = args.date {
+                let (name, email, _) = split_stored_author_line(&commit.author)?;
+                validate_ident_name(&name, "author")?;
+                let timestamp = parse_date_to_git_timestamp(d).unwrap_or_else(|| d.to_string());
+                return Ok(format!("{name} <{email}> {timestamp}"));
+            }
+            return Ok(commit.author);
+        }
+    }
+
+    if !args.reset_author {
+        if let Some(cp_author) = read_cherry_pick_head_author(repo)? {
+            if let Some(ref d) = args.date {
+                let (name, email, _) = split_stored_author_line(&cp_author)?;
+                validate_ident_name(&name, "author")?;
+                let timestamp = parse_date_to_git_timestamp(d).unwrap_or_else(|| d.to_string());
+                return Ok(format!("{name} <{email}> {timestamp}"));
+            }
+            return Ok(cp_author);
+        }
     }
 
     let name = std::env::var("GIT_AUTHOR_NAME")

--- a/logs/2026-04-08_t7509-commit-authorship.md
+++ b/logs/2026-04-08_t7509-commit-authorship.md
@@ -1,0 +1,16 @@
+# t7509-commit-authorship
+
+## Goal
+
+Make `tests/t7509-commit-authorship.sh` pass (12/12) under the harness.
+
+## Changes
+
+- `grit/src/commands/commit.rs`: Git-compatible author resolution for `-C`/`-c` with `--reset-author` (reuse message only); read author from `CHERRY_PICK_HEAD` when present unless `--reset-author`; `--author` parses `Name <email>` and appends timestamp like Git; validate amended HEAD author for empty/missing date; allow `--reset-author` when `CHERRY_PICK_HEAD` or `REBASE_HEAD` exists; error messages for incompatible `--reset-author`/`--author` and invalid `--reset-author` context.
+
+## Verification
+
+- `cargo build --release -p grit-rs`
+- `./scripts/run-tests.sh t7509-commit-authorship.sh` → 12/12
+- `cargo test -p grit-lib --lib`
+- `cargo clippy -p grit-rs --fix --allow-dirty`

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   225 |
+| Completed   |   226 |
 | In progress |     2 |
-| Remaining   |   541 |
+| Remaining   |   540 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 225 completed (`[x]`), 2 in progress (`[~]`), 541 remaining (`[ ]`).
+Task lines in `PLAN.md`: 226 completed (`[x]`), 2 in progress (`[~]`), 540 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t7509-commit-authorship` — 12/12 tests pass (`commit`: `--reset-author` with `-C`/`-c`/`--amend` and when `CHERRY_PICK_HEAD`/`REBASE_HEAD` exists; author from `CHERRY_PICK_HEAD` when finishing cherry-pick with `MERGE_MSG`; `--author` now formats full ident with current date; amend rejects empty/malformed prior author; mutual exclusion with `--reset-author`)
 - `t4026-color` — 34/34 tests pass (Git-compatible `config::parse_color` per `git/color.c`; `git config --get-color` merges argv after the slot into one default and uses `--` when the default begins with `-` so clap accepts `-1 black`)
 - `t3704-add-pathspec-file` — 11/11 tests pass (`git add --pathspec-from-file` / `--pathspec-file-nul`: raw bytes + CRLF/LF/NUL splitting, C-quoted lines, conflict checks vs `--interactive`/`--patch`/`--edit`/pathspecs; shared `pathspec::parse_pathspecs_from_file`; error text matches grep expectations)
 - `t5813-proto-disable-ssh` — 81/81 tests pass (`GIT_ALLOW_PROTOCOL` comma split, `protocol.*.allow=user` + `GIT_PROTOCOL_FROM_USER`, SSH URL validation, local SSH resolution via `TRASH_DIRECTORY` + absolute `ssh://` paths, pkt-line `upload-pack`/`receive-pack`, side-band pack streaming)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible `git commit` author semantics so `tests/t7509-commit-authorship.sh` passes 12/12.

## Changes

- **`--reset-author`**: With `-C`/`-c`/`--amend`, reuse only the message and take author from `GIT_AUTHOR_*`/config. Also allowed when `CHERRY_PICK_HEAD` or `REBASE_HEAD` exists (cherry-pick / rebase pick in progress).
- **`CHERRY_PICK_HEAD`**: When finishing a cherry-pick with message from `MERGE_MSG`, inherit author from the commit named by `CHERRY_PICK_HEAD` unless `--reset-author`.
- **`--author`**: Parse `Name <email>` and append the current (or `--date`/`GIT_AUTHOR_DATE`) timestamp so stored commits match Git’s full ident line.
- **`--amend`**: Reject commits whose current HEAD author line is empty or missing the date portion (matches upstream “empty ident” behavior for malformed parents).
- **Validation**: `--reset-author` and `--author` are mutually exclusive; bare `--reset-author` without `-C`/`-c`/`--amend` and without cherry-pick/rebase-head state is rejected.

## Verification

- `cargo build --release -p grit-rs`
- `./scripts/run-tests.sh t7509-commit-authorship.sh` → 12/12
- `cargo test -p grit-lib --lib`
- `cargo clippy -p grit-rs --fix --allow-dirty`

Also refreshed harness CSV/dashboards and marked `t7509-commit-authorship` complete in `PLAN.md` / `progress.md`; added `logs/2026-04-08_t7509-commit-authorship.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd88a30b-fffb-4510-a732-92372a70f782"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd88a30b-fffb-4510-a732-92372a70f782"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

