### PR TITLE
fix: pass t5704 protocol violations (upload-pack v2, ls-remote --upload-pack)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -570,7 +570,7 @@ commit → check it off → move on.
 - [ ] `t5536-fetch-conflicts` ███████████░░░░░░░░░ 4/7 (3 left) — fetch handles conflicting refspecs correctly
 - [ ] `t5308-pack-detect-duplicates` ██████████░░░░░░░░░░ 3/6 (3 left) — handling of duplicate objects in incoming packfiles
 - [ ] `t5549-fetch-push-http` ░░░░░░░░░░░░░░░░░░░░ 0/3 (3 left) — fetch/push functionality using the HTTP protocol
-- [ ] `t5704-protocol-violations` ░░░░░░░░░░░░░░░░░░░░ 0/3 (3 left) — Test responses to violations of the network protocol. In most
+- [x] `t5704-protocol-violations` ████████████████████ 3/3 — Test responses to violations of the network protocol. In most
 
 - [ ] `t5002-archive-attr-pattern` ███████████████░░░░░ 15/19 (4 left) — git archive attribute pattern tests
 - [ ] `t5004-archive-corner-cases` ██████████████░░░░░░ 10/14 (4 left) — test corner cases of git-archive

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1020,7 +1020,7 @@ t5700-protocol-v1	t5	yes	24	4	20	false	ok	0
 t5701-git-serve	t5	yes	25	25	0	true	ok	0
 t5702-protocol-v2	t5	yes	85	10	75	false	ok	0
 t5703-upload-pack-ref-in-want	t5	yes	26	4	22	false	ok	0
-t5704-protocol-violations	t5	yes	3	0	3	false	ok	0
+t5704-protocol-violations	t5	yes	3	3	0	true	ok	0
 t5705-session-id-in-capabilities	t5	yes	17	2	15	false	ok	0
 t5710-promisor-remote-capability	t5	yes	22	1	21	false	ok	0
 t5730-protocol-v2-bundle-uri-file	t5	yes	8	2	6	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T03:57:54+00:00" class="gen-time" title="2026-04-08 03:57 UTC">2026-04-08 03:57 UTC</time> · <a href="https://github.com/schacon/grit/commit/a9a7e9c8a9ab0f717ea1f0be3d4b518340747f3d" style="color:#58a6ff">a9a7e9c</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T04:17:46+00:00" class="gen-time" title="2026-04-08 04:17 UTC">2026-04-08 04:17 UTC</time> · <a href="https://github.com/schacon/grit/commit/09290c100b79448921e4faff6de7013a3030982b" style="color:#58a6ff">09290c1</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,476</div>
+      <div class="summary-big-val">29,479</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>608 files fully passing</span>
+    <span>609 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">28/167 files · 17 skipped · 1,432/4,315 tests</span>
+        <span class="group-meta">29/167 files · 17 skipped · 1,435/4,315 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.2%"></div></div>
-        <span class="group-pct pct-red">33.2%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.3%"></div></div>
+        <span class="group-pct pct-red">33.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T03:57:54+00:00" class="gen-time" title="2026-04-08 03:57 UTC">2026-04-08 03:57 UTC</time> · <a href="https://github.com/schacon/grit/commit/a9a7e9c8a9ab0f717ea1f0be3d4b518340747f3d" style="color:#58a6ff">a9a7e9c</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T04:17:46+00:00" class="gen-time" title="2026-04-08 04:17 UTC">2026-04-08 04:17 UTC</time> · <a href="https://github.com/schacon/grit/commit/09290c100b79448921e4faff6de7013a3030982b" style="color:#58a6ff">09290c1</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,745</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,476</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,479</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">67.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -10337,14 +10337,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:15.4%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="3" data-passed="0">
+<tr class="" data-group="t5" data-tests="3" data-passed="3">
   <td class="mono">t5704-protocol-violations</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">3</td>
-  <td class="right">0</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="17" data-passed="2">

--- a/grit-lib/src/ls_remote.rs
+++ b/grit-lib/src/ls_remote.rs
@@ -165,6 +165,13 @@ fn resolve_common_git_dir(git_dir: &Path) -> Option<PathBuf> {
 /// A match occurs when:
 /// - `refname == pattern` exactly, **or**
 /// - `refname` ends with `/<pattern>` (suffix component match).
+///
+/// Exposed for callers that need the same rules as `git ls-remote` without
+/// duplicating glob logic (for example protocol v2 `ls-refs` filtering).
+pub fn ref_matches_ls_remote_patterns(refname: &str, patterns: &[String]) -> bool {
+    pattern_matches(refname, patterns)
+}
+
 fn pattern_matches(refname: &str, patterns: &[String]) -> bool {
     if patterns.is_empty() {
         return true;

--- a/grit/src/commands/ls_remote.rs
+++ b/grit/src/commands/ls_remote.rs
@@ -3,12 +3,17 @@
 //! Only the **local path** transport is supported.  Network URLs are not
 //! handled in v1.
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
-use grit_lib::ls_remote::{ls_remote, Options};
+use grit_lib::ls_remote::{ls_remote, Options, RefEntry};
+use grit_lib::objects::ObjectId;
 use grit_lib::repo::Repository;
+use std::io::{Cursor, Read, Write};
 use std::path::Path;
 use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use crate::pkt_line;
 
 /// Arguments for `grit ls-remote`.
 #[derive(Debug, ClapArgs)]
@@ -54,15 +59,18 @@ pub struct Args {
 ///
 /// Exits with status 1 when no refs match (same behaviour as `git ls-remote`).
 pub fn run(args: Args) -> Result<()> {
-    // Accepted for compatibility; local-path implementation does not use it.
-    let _ = &args.upload_pack;
-
     // If the repository argument is a configured remote name, resolve its URL
     let effective_path = resolve_remote_or_path(&args.repository);
 
     // Check if the path is a bundle file
     if is_bundle_file(&effective_path) {
         return run_bundle_ls_remote(&effective_path, &args);
+    }
+
+    if let Some(upload_pack) = args.upload_pack.as_deref() {
+        if !upload_pack.is_empty() {
+            return run_ls_remote_via_upload_pack(&effective_path, upload_pack, &args);
+        }
     }
 
     let repo = open_local_repo(&effective_path)?;
@@ -95,6 +103,273 @@ pub fn run(args: Args) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn run_ls_remote_via_upload_pack(repo_path: &Path, upload_pack: &str, args: &Args) -> Result<()> {
+    let repo = open_local_repo(repo_path)?;
+    let repo_dir = repo
+        .work_tree
+        .clone()
+        .unwrap_or_else(|| repo.git_dir.clone());
+
+    let default_hash = std::env::var("GIT_DEFAULT_HASH").unwrap_or_else(|_| "sha1".to_owned());
+
+    let mut child = Command::new("sh")
+        .arg("-c")
+        .arg(upload_pack)
+        .arg(repo_dir.to_string_lossy().as_ref())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_context(|| format!("failed to run upload-pack via sh -c '{upload_pack}'"))?;
+
+    let mut stdin = child.stdin.take().context("upload-pack stdin")?;
+    let mut stdout = child.stdout.take().context("upload-pack stdout")?;
+    let mut stderr = child.stderr.take().context("upload-pack stderr")?;
+
+    let stderr_buf = std::thread::spawn(move || {
+        let mut v = Vec::new();
+        let _ = stderr.read_to_end(&mut v);
+        v
+    });
+
+    let entries = read_ls_remote_upload_pack_output(&mut stdin, &mut stdout, &default_hash, args)?;
+    drop(stdin);
+
+    let status = child.wait()?;
+    let err_bytes = stderr_buf.join().unwrap_or_default();
+    if !err_bytes.is_empty() {
+        let _ = std::io::stderr().write_all(&err_bytes);
+    }
+    if !status.success() {
+        bail!(
+            "upload-pack exited with status {}",
+            status.code().unwrap_or(-1)
+        );
+    }
+    if entries.is_empty() {
+        return Ok(());
+    }
+    if args.quiet {
+        return Ok(());
+    }
+    for entry in &entries {
+        if let Some(target) = &entry.symref_target {
+            println!("ref: {target}\t{}", entry.name);
+        }
+        println!("{}\t{}", entry.oid, entry.name);
+    }
+    Ok(())
+}
+
+fn read_ls_remote_upload_pack_output(
+    stdin: &mut impl Write,
+    stdout: &mut impl Read,
+    object_format: &str,
+    args: &Args,
+) -> Result<Vec<RefEntry>> {
+    let first = match pkt_line::read_packet(stdout).context("read upload-pack first packet")? {
+        None => bail!("unexpected EOF from upload-pack"),
+        Some(p) => p,
+    };
+
+    match first {
+        pkt_line::Packet::Data(ref line) if line == "version 2" => {
+            skip_rest_of_v2_capability_advertisement(stdout)?;
+            write_v2_ls_refs_request(stdin, object_format, args)?;
+            stdin.flush()?;
+            let mut buf = Vec::new();
+            stdout
+                .take(512 * 1024)
+                .read_to_end(&mut buf)
+                .context("read v2 ls-refs response")?;
+            parse_v2_ls_refs_output(&buf, args)
+        }
+        pkt_line::Packet::Data(line) => {
+            let mut entries = parse_v0_ref_advertisement_line(&line, args)?;
+            loop {
+                match pkt_line::read_packet(stdout)? {
+                    None => break,
+                    Some(pkt_line::Packet::Flush) => break,
+                    Some(pkt_line::Packet::Data(l)) => {
+                        entries.extend(parse_v0_ref_advertisement_line(&l, args)?);
+                    }
+                    Some(other) => bail!("unexpected packet in v0 ref advertisement: {other:?}"),
+                }
+            }
+            Ok(entries)
+        }
+        other => bail!("unexpected first packet from upload-pack: {other:?}"),
+    }
+}
+
+/// Consume pkt-lines after the initial `version 2` line until `0000` flush.
+fn skip_rest_of_v2_capability_advertisement(r: &mut impl Read) -> Result<()> {
+    loop {
+        match pkt_line::read_packet(r).context("read v2 capability packet")? {
+            None => bail!("unexpected EOF in v2 capability advertisement"),
+            Some(pkt_line::Packet::Flush) => return Ok(()),
+            Some(pkt_line::Packet::Data(_)) => {}
+            Some(other) => bail!("unexpected packet in v2 capability advertisement: {other:?}"),
+        }
+    }
+}
+
+fn symref_head_target_from_caps(caps: &str) -> Option<String> {
+    for word in caps.split_whitespace() {
+        if let Some(t) = word.strip_prefix("symref=HEAD:") {
+            return Some(t.to_owned());
+        }
+    }
+    None
+}
+
+/// Parse one v0/v1 ref advertisement pkt-line (`<oid>\t<ref>[\0<capabilities>]`).
+fn parse_v0_ref_advertisement_line(raw: &str, args: &Args) -> Result<Vec<RefEntry>> {
+    let (payload, caps_opt) = match raw.split_once('\0') {
+        Some((p, c)) => (p, Some(c)),
+        None => (raw, None),
+    };
+    let (oid_hex, refname) = payload
+        .split_once('\t')
+        .or_else(|| payload.split_once(' '))
+        .ok_or_else(|| anyhow::anyhow!("malformed v0 ref advertisement: {raw}"))?;
+    let refname = refname.split('\0').next().unwrap_or(refname).trim();
+    let oid = ObjectId::from_hex(oid_hex.trim())
+        .with_context(|| format!("bad oid in v0 ref advertisement: {oid_hex}"))?;
+
+    if args.heads && refname != "HEAD" && !refname.starts_with("refs/heads/") {
+        return Ok(vec![]);
+    }
+    if args.tags && !refname.starts_with("refs/tags/") {
+        return Ok(vec![]);
+    }
+    if args.refs_only && (refname == "HEAD" || refname.ends_with("^{}")) {
+        return Ok(vec![]);
+    }
+    if !grit_lib::ls_remote::ref_matches_ls_remote_patterns(refname, &args.patterns) {
+        return Ok(vec![]);
+    }
+
+    let symref_target = if args.symref && refname == "HEAD" {
+        caps_opt.and_then(symref_head_target_from_caps)
+    } else {
+        None
+    };
+
+    Ok(vec![RefEntry {
+        name: refname.to_owned(),
+        oid,
+        symref_target,
+    }])
+}
+
+fn write_v2_ls_refs_request(w: &mut impl Write, object_format: &str, args: &Args) -> Result<()> {
+    pkt_line::write_line(w, "command=ls-refs")?;
+    pkt_line::write_line(w, &format!("object-format={object_format}"))?;
+    pkt_line::write_delim(w)?;
+    if args.symref {
+        pkt_line::write_line(w, "symrefs")?;
+    }
+    if !args.refs_only {
+        pkt_line::write_line(w, "peel")?;
+    }
+    if args.heads {
+        pkt_line::write_line(w, "ref-prefix refs/heads/")?;
+    }
+    if args.tags {
+        pkt_line::write_line(w, "ref-prefix refs/tags/")?;
+    }
+    for p in &args.patterns {
+        pkt_line::write_line(w, &format!("ref-prefix {p}"))?;
+    }
+    pkt_line::write_flush(w)?;
+    Ok(())
+}
+
+fn parse_v2_ls_refs_output(data: &[u8], args: &Args) -> Result<Vec<RefEntry>> {
+    let mut cursor = Cursor::new(data);
+    let mut entries: Vec<RefEntry> = Vec::new();
+
+    loop {
+        let pkt = match pkt_line::read_packet(&mut cursor)? {
+            None => break,
+            Some(pkt_line::Packet::Flush) => break,
+            Some(pkt_line::Packet::Data(line)) => line,
+            Some(other) => bail!("unexpected pkt-line in ls-refs response: {other:?}"),
+        };
+
+        let (name, oid, peeled, symref_target) = parse_ls_refs_v2_line(&pkt)?;
+        if !grit_lib::ls_remote::ref_matches_ls_remote_patterns(&name, &args.patterns) {
+            continue;
+        }
+
+        entries.push(RefEntry {
+            name: name.clone(),
+            oid,
+            symref_target: symref_target.clone(),
+        });
+
+        if let Some(poid) = peeled {
+            if !args.refs_only {
+                entries.push(RefEntry {
+                    name: format!("{name}^{{}}"),
+                    oid: poid,
+                    symref_target: None,
+                });
+            }
+        }
+    }
+
+    entries.sort_by(|a, b| {
+        let rank = |n: &str| if n == "HEAD" { 0 } else { 1 };
+        match rank(&a.name).cmp(&rank(&b.name)) {
+            std::cmp::Ordering::Equal => a.name.cmp(&b.name),
+            o => o,
+        }
+    });
+
+    Ok(entries)
+}
+
+/// Parse one `ls-refs` v2 data line: `<oid> <ref> [peeled:<hex>] [symref-target:<path>]`.
+fn parse_ls_refs_v2_line(
+    line: &str,
+) -> Result<(String, ObjectId, Option<ObjectId>, Option<String>)> {
+    const PEEL: &str = " peeled:";
+    const SYM: &str = " symref-target:";
+
+    let (oid_hex, after_oid) = line
+        .split_once(' ')
+        .ok_or_else(|| anyhow::anyhow!("bad ls-refs line: {line}"))?;
+    let oid =
+        ObjectId::from_hex(oid_hex).with_context(|| format!("bad oid in ls-refs: {oid_hex}"))?;
+
+    let mut peeled = None;
+    let mut symref_target = None;
+
+    if let Some(pos) = after_oid.find(PEEL) {
+        let name = after_oid[..pos].to_owned();
+        let tail = &after_oid[pos + PEEL.len()..];
+        let hex_end = tail.find(' ').unwrap_or(tail.len());
+        let ph = &tail[..hex_end];
+        peeled = Some(ObjectId::from_hex(ph).with_context(|| format!("bad peeled oid: {ph}"))?);
+        let rest = tail[hex_end..].trim_start();
+        if let Some(s) = rest.strip_prefix("symref-target:") {
+            symref_target = Some(s.to_owned());
+        }
+        return Ok((name, oid, peeled, symref_target));
+    }
+
+    if let Some(pos) = after_oid.find(SYM) {
+        let name = after_oid[..pos].to_owned();
+        let target = after_oid[pos + SYM.len()..].to_owned();
+        symref_target = Some(target);
+        return Ok((name, oid, peeled, symref_target));
+    }
+
+    Ok((after_oid.to_owned(), oid, None, None))
 }
 
 /// Open a local repository given a user-supplied path.

--- a/grit/src/commands/serve_v2.rs
+++ b/grit/src/commands/serve_v2.rs
@@ -9,7 +9,7 @@ use clap::Args as ClapArgs;
 use grit_lib::objects::{self, ObjectKind};
 use grit_lib::refs;
 use grit_lib::repo::Repository;
-use std::io::{self, Write};
+use std::io::{self, Read, Write};
 use std::path::Path;
 
 use crate::pkt_line;
@@ -28,7 +28,7 @@ pub struct Args {
 }
 
 /// Known commands and their feature strings.
-struct ServerCaps {
+pub struct ServerCaps {
     agent: String,
     object_format: String,
     advertise_object_info: bool,
@@ -36,7 +36,8 @@ struct ServerCaps {
 }
 
 impl ServerCaps {
-    fn load(git_dir: &Path) -> Self {
+    /// Load advertised capabilities from repository config at `git_dir`.
+    pub fn load(git_dir: &Path) -> Self {
         let version = crate::version_string();
         let agent = format!("agent=git/{version}-");
 
@@ -52,7 +53,7 @@ impl ServerCaps {
     }
 
     /// Write the capability advertisement to `w` in pkt-line format.
-    fn advertise(&self, w: &mut impl Write) -> io::Result<()> {
+    pub fn advertise(&self, w: &mut impl Write) -> io::Result<()> {
         pkt_line::write_line(w, "version 2")?;
         pkt_line::write_line(w, &self.agent)?;
         pkt_line::write_line(w, "ls-refs=unborn")?;
@@ -69,7 +70,7 @@ impl ServerCaps {
         w.flush()
     }
 
-    fn is_valid_command(&self, cmd: &str) -> bool {
+    pub fn is_valid_command(&self, cmd: &str) -> bool {
         match cmd {
             "ls-refs" | "fetch" => true,
             "object-info" if self.advertise_object_info => true,
@@ -78,7 +79,7 @@ impl ServerCaps {
         }
     }
 
-    fn is_valid_capability(&self, cap: &str) -> bool {
+    pub fn is_valid_capability(&self, cap: &str) -> bool {
         // Capabilities that may appear in a request
         cap.starts_with("agent=")
             || cap.starts_with("object-format=")
@@ -98,41 +99,47 @@ pub fn run(args: Args) -> Result<()> {
     }
 
     if args.stateless_rpc {
-        return stateless_rpc(&git_dir, &caps);
+        let _ = process_one_v2_request(&mut io::stdin().lock(), &git_dir, &caps)?;
+        return Ok(());
     }
 
-    // Default: advertise + serve loop
+    // Default: advertise + serve loop (matches `git serve-v2` / upload-pack v2).
     let stdout = io::stdout();
     let mut out = stdout.lock();
     caps.advertise(&mut out)?;
     drop(out);
-    stateless_rpc(&git_dir, &caps)
+    serve_loop(&mut io::stdin().lock(), &git_dir, &caps)
 }
 
-fn stateless_rpc(git_dir: &Path, caps: &ServerCaps) -> Result<()> {
-    let stdin = io::stdin();
-    let mut input = stdin.lock();
-
-    // Read the request header (up to flush packet).
-    let (header_lines, terminator) = pkt_line::read_until_flush_or_delim(&mut input)?;
-
-    // Empty request (or EOF): just exit silently.
-    if header_lines.is_empty() {
-        if terminator.is_some() {
-            // Got a flush with no content — that's fine for stateless-rpc
-            return Ok(());
+/// Read requests from `input` until EOF or a headerless flush (client hang-up).
+pub fn serve_loop(input: &mut impl Read, git_dir: &Path, caps: &ServerCaps) -> Result<()> {
+    loop {
+        if process_one_v2_request(input, git_dir, caps)? {
+            break;
         }
-        // EOF with no data
-        return Ok(());
+    }
+    Ok(())
+}
+
+/// Process a single protocol v2 request from `input`.
+///
+/// Returns `Ok(true)` when the client ended the session (EOF or flush with no keys).
+pub fn process_one_v2_request(
+    input: &mut impl Read,
+    git_dir: &Path,
+    caps: &ServerCaps,
+) -> Result<bool> {
+    let (header_lines, terminator) = pkt_line::read_until_flush_or_delim(input)?;
+
+    if header_lines.is_empty() {
+        return Ok(matches!(terminator, Some(pkt_line::Packet::Flush) | None));
     }
 
-    // Parse command and capabilities from header lines.
     let mut command: Option<String> = None;
     let mut client_object_format: Option<String> = None;
 
     for line in &header_lines {
         if let Some(cmd) = line.strip_prefix("command=") {
-            // Reject command=value=extra
             if cmd.contains('=') {
                 bail!("invalid command '{cmd}'");
             }
@@ -140,7 +147,6 @@ fn stateless_rpc(git_dir: &Path, caps: &ServerCaps) -> Result<()> {
         } else if let Some(fmt) = line.strip_prefix("object-format=") {
             client_object_format = Some(fmt.to_owned());
         } else if caps.is_valid_capability(line) {
-            // valid capability, ignore
         } else {
             bail!("unknown capability '{line}'");
         }
@@ -151,7 +157,6 @@ fn stateless_rpc(git_dir: &Path, caps: &ServerCaps) -> Result<()> {
         None => bail!("no command requested"),
     };
 
-    // Validate object-format if provided
     if let Some(ref fmt) = client_object_format {
         if fmt != &caps.object_format {
             bail!(
@@ -161,16 +166,21 @@ fn stateless_rpc(git_dir: &Path, caps: &ServerCaps) -> Result<()> {
         }
     }
 
-    // Check that the command is valid
     if !caps.is_valid_command(&cmd) {
         eprintln!("fatal: invalid command '{cmd}'");
         std::process::exit(128);
     }
 
-    // Read arguments section (after delimiter, up to flush).
+    let flush_err = match cmd.as_str() {
+        "ls-refs" => "expected flush after ls-refs arguments",
+        "fetch" => "expected flush after fetch arguments",
+        "object-info" => "object-info: expected flush after arguments",
+        "bundle-uri" => "bundle-uri: expected flush after arguments",
+        _ => "expected flush after command arguments",
+    };
+
     let args = if terminator == Some(pkt_line::Packet::Delim) {
-        let (arg_lines, _) = pkt_line::read_until_flush_or_delim(&mut input)?;
-        arg_lines
+        pkt_line::read_data_lines_until_flush(input, flush_err).map_err(anyhow::Error::from)?
     } else {
         Vec::new()
     };
@@ -187,7 +197,7 @@ fn stateless_rpc(git_dir: &Path, caps: &ServerCaps) -> Result<()> {
     }
 
     out.flush()?;
-    Ok(())
+    Ok(false)
 }
 
 /// Handle the `ls-refs` command.

--- a/grit/src/commands/upload_pack.rs
+++ b/grit/src/commands/upload_pack.rs
@@ -13,6 +13,7 @@ use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
+use crate::commands::serve_v2::{serve_loop, ServerCaps};
 use crate::grit_exe::grit_executable;
 use crate::pkt_line;
 
@@ -36,6 +37,24 @@ pub fn run(args: Args) -> Result<()> {
             args.directory.display()
         )
     })?;
+
+    if server_protocol_version_from_env() == 2 {
+        let caps = ServerCaps::load(&repo.git_dir);
+        if args.advertise_refs {
+            let mut out = io::stdout();
+            caps.advertise(&mut out)?;
+            out.flush()?;
+            return Ok(());
+        }
+        let stdin = io::stdin();
+        let mut input = stdin.lock();
+        let stdout = io::stdout();
+        let mut out = stdout.lock();
+        caps.advertise(&mut out)?;
+        out.flush()?;
+        drop(out);
+        return serve_loop(&mut input, &repo.git_dir, &caps);
+    }
 
     if args.advertise_refs {
         return advertise_refs_with_caps(&repo);
@@ -227,6 +246,26 @@ fn list_all_refs(git_dir: &Path) -> Result<Vec<(String, ObjectId)>> {
 }
 
 /// Open a repository (bare or non-bare).
+/// Highest protocol version requested via `GIT_PROTOCOL` (`version=0`, `version=1`, `version=2`).
+///
+/// When unset, returns 0 so behaviour matches historical Git upload-pack defaults.
+fn server_protocol_version_from_env() -> u8 {
+    let Ok(raw) = std::env::var("GIT_PROTOCOL") else {
+        return 0;
+    };
+    let mut best = 0u8;
+    for part in raw.split(':') {
+        let Some(rest) = part.strip_prefix("version=") else {
+            continue;
+        };
+        let v = rest.parse::<u8>().unwrap_or(0);
+        if v > best {
+            best = v;
+        }
+    }
+    best
+}
+
 fn open_repo(path: &Path) -> Result<Repository> {
     if let Ok(repo) = Repository::open(path, None) {
         return Ok(repo);

--- a/grit/src/pkt_line.rs
+++ b/grit/src/pkt_line.rs
@@ -89,6 +89,35 @@ pub fn read_until_flush_or_delim(r: &mut impl Read) -> io::Result<(Vec<String>, 
     }
 }
 
+/// Read data pkt-lines until a flush packet, matching Git's command argument sections.
+///
+/// A delimiter or response-end packet is treated as a protocol violation and reported with
+/// `err_not_flush` (for example: `"expected flush after ls-refs arguments"`).
+pub fn read_data_lines_until_flush(
+    r: &mut impl Read,
+    err_not_flush: &str,
+) -> io::Result<Vec<String>> {
+    let mut lines = Vec::new();
+    loop {
+        match read_packet(r)? {
+            None => {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    err_not_flush.to_string(),
+                ));
+            }
+            Some(Packet::Flush) => return Ok(lines),
+            Some(Packet::Delim) | Some(Packet::ResponseEnd) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    err_not_flush.to_string(),
+                ));
+            }
+            Some(Packet::Data(s)) => lines.push(s),
+        }
+    }
+}
+
 /// `grit pkt-line pack`: read text lines from stdin, write pkt-line to stdout.
 pub fn cmd_pack() -> io::Result<()> {
     let stdin = io::stdin();

--- a/logs/2026-04-08_t5704-protocol-violations.md
+++ b/logs/2026-04-08_t5704-protocol-violations.md
@@ -1,0 +1,31 @@
+# t5704-protocol-violations
+
+## Goal
+
+Make `tests/t5704-protocol-violations.sh` pass under the grit harness (3 tests).
+
+## Changes
+
+1. **`grit upload-pack` + `GIT_PROTOCOL`**
+   - When `GIT_PROTOCOL` requests `version=2` (highest wins, colon-separated), run protocol v2: advertise capabilities, then serve loop like upstream `upload-pack`.
+   - Reused `serve_v2` capability/command handling.
+
+2. **Strict flush after command arguments**
+   - Added `pkt_line::read_data_lines_until_flush` so a second `0001` delim after args fails with Git’s messages (`expected flush after ls-refs arguments`, etc.).
+
+3. **`grit serve-v2`**
+   - Default mode now loops requests after advertising (was incorrectly calling `stateless_rpc` twice).
+   - Stateless RPC still handles one request.
+
+4. **`grit ls-remote --upload-pack`**
+   - Spawns `sh -c <upload-pack> <repo>` without forcing v2.
+   - First pkt-line `version 2` → v2 ls-refs client; otherwise parse v0 ref advertisement (tab or space between oid and ref; NUL before capabilities; `symref=HEAD:` for `--symref`).
+
+5. **`grit-lib`**
+   - Exported `ref_matches_ls_remote_patterns` for pattern filtering shared with protocol client.
+
+## Validation
+
+- `./scripts/run-tests.sh t5704-protocol-violations.sh` — 3/3
+- `cargo test -p grit-lib --lib`
+- `cargo clippy -p grit-rs -p grit-lib`

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   226 |
+| Completed   |   227 |
 | In progress |     2 |
-| Remaining   |   540 |
+| Remaining   |   539 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 226 completed (`[x]`), 2 in progress (`[~]`), 540 remaining (`[ ]`).
+Task lines in `PLAN.md`: 227 completed (`[x]`), 2 in progress (`[~]`), 539 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t5704-protocol-violations` — 3/3 tests pass (`upload-pack` honors `GIT_PROTOCOL=version=2` with flush-after-args validation for `ls-refs`/`fetch`; `ls-remote --upload-pack` parses v0 ref ads with space/NUL-separated fields and v2 `ls-refs` responses; `serve-v2` default loop fixed)
 - `t7509-commit-authorship` — 12/12 tests pass (`commit`: `--reset-author` with `-C`/`-c`/`--amend` and when `CHERRY_PICK_HEAD`/`REBASE_HEAD` exists; author from `CHERRY_PICK_HEAD` when finishing cherry-pick with `MERGE_MSG`; `--author` now formats full ident with current date; amend rejects empty/malformed prior author; mutual exclusion with `--reset-author`)
 - `t4026-color` — 34/34 tests pass (Git-compatible `config::parse_color` per `git/color.c`; `git config --get-color` merges argv after the slot into one default and uses `--` when the default begins with `-` so clap accepts `-1 black`)
 - `t3704-add-pathspec-file` — 11/11 tests pass (`git add --pathspec-from-file` / `--pathspec-file-nul`: raw bytes + CRLF/LF/NUL splitting, C-quoted lines, conflict checks vs `--interactive`/`--patch`/`--edit`/pathspecs; shared `pathspec::parse_pathspecs_from_file`; error text matches grep expectations)

--- a/test-results.md
+++ b/test-results.md
@@ -1,5 +1,10 @@
 # Test Results
 
+**Updated:** 2026-04-08
+
+- `./scripts/run-tests.sh t5704-protocol-violations.sh`: 3/3 passing (`upload-pack` v2 via `GIT_PROTOCOL`, strict flush-after-args; `ls-remote --upload-pack` v0/v2 parsing; harness CSV/dashboards refreshed).
+- `cargo test -p grit-lib --lib`: 105/105 passing.
+
 **Updated:** 2026-04-07
 
 - `./scripts/run-tests.sh t5813-proto-disable-ssh.sh`: 81/81 passing (SSH protocol allow/deny, `GIT_ALLOW_PROTOCOL` comma lists, `protocol.*.allow=user` + `GIT_PROTOCOL_FROM_USER`, pkt-line `upload-pack`/`receive-pack` with side-band pack; harness CSV/dashboards refreshed).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes `t5704-protocol-violations` pass (3/3) under the harness.

## Changes

- **`upload-pack`**: When `GIT_PROTOCOL` requests `version=2`, advertise v2 capabilities then run the same serve loop as `serve-v2`, including strict "flush after command arguments" validation (`expected flush after ls-refs arguments` / `fetch arguments`).
- **`serve-v2`**: Default mode now loops after capability advertisement (was incorrectly processing stdin twice). Exported `ServerCaps` and shared `process_one_v2_request` / `serve_loop`.
- **`pkt-line`**: Added `read_data_lines_until_flush` for argument sections terminated by `0000` only.
- **`ls-remote --upload-pack`**: Spawns the user command, detects v2 vs v0 from the first packet, sends v2 `ls-refs` when appropriate, or parses v0 ref advertisements (space or tab separator; NUL before capabilities; `symref=HEAD:` for `--symref`).
- **`grit-lib`**: `ref_matches_ls_remote_patterns` for shared pattern rules.

## Validation

- `./scripts/run-tests.sh t5704-protocol-violations.sh`
- `cargo test -p grit-lib --lib`
- `cargo fmt` / `cargo clippy`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2da4b885-957f-4816-b88f-ed46f4924bad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2da4b885-957f-4816-b88f-ed46f4924bad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

