### PR TITLE
fix: cat-file --filters and --textconv (t8010)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -914,7 +914,7 @@ commit → check it off → move on.
 - [ ] `t8008-blame-formats` ████████████████░░░░ 4/5 (1 left) — blame output in various formats on a simple case
 - [ ] `t8004-blame-with-conflicts` █████████████░░░░░░░ 2/3 (1 left) — git blame on conflicted files
 - [ ] `t8009-blame-vs-topicbranches` ██████████░░░░░░░░░░ 1/2 (1 left) — blaming through history with topic branches
-- [ ] `t8010-cat-file-filters` ████████░░░░░░░░░░░░ 4/9 (5 left) — git cat-file filters support
+- [x] `t8010-cat-file-filters` ████████████████████ 9/9 — git cat-file filters support
 - [ ] `t8015-blame-diff-algorithm` █████░░░░░░░░░░░░░░░ 2/7 (5 left) — git blame with specific diff algorithm
 - [ ] `t8007-cat-file-textconv` ████████████░░░░░░░░ 9/15 (6 left) — git cat-file textconv support
 - [ ] `t8011-blame-split-file` ████░░░░░░░░░░░░░░░░ 2/10 (8 left) — 

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1291,7 +1291,7 @@ t8007-cat-file-textconv	t8	yes	15	9	6	false	ok	0
 t8008-blame-formats	t8	yes	5	5	0	true	ok	0
 t8009-blame-vs-topicbranches	t8	yes	2	2	0	true	ok	0
 t8010-cat-file-batch	t8	yes	26	26	0	true	ok	0
-t8010-cat-file-filters	t8	yes	9	4	5	false	ok	0
+t8010-cat-file-filters	t8	yes	9	9	0	true	ok	0
 t8011-blame-split-file	t8	yes	10	10	0	true	ok	0
 t8012-blame-colors	t8	yes	4	0	4	false	ok	0
 t8013-blame-ignore-revs	t8	yes	19	19	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T03:57:54+00:00" class="gen-time" title="2026-04-08 03:57 UTC">2026-04-08 03:57 UTC</time> · <a href="https://github.com/schacon/grit/commit/a9a7e9c8a9ab0f717ea1f0be3d4b518340747f3d" style="color:#58a6ff">a9a7e9c</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T04:18:36+00:00" class="gen-time" title="2026-04-08 04:18 UTC">2026-04-08 04:18 UTC</time> · <a href="https://github.com/schacon/grit/commit/09290c100b79448921e4faff6de7013a3030982b" style="color:#58a6ff">09290c1</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,476</div>
+      <div class="summary-big-val">29,481</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>608 files fully passing</span>
+    <span>609 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -267,11 +267,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t8</span>
         <span class="group-desc">Porcelainish commands concerning forensics</span>
-        <span class="group-meta">65/105 files · 0 skipped · 2,548/2,763 tests</span>
+        <span class="group-meta">66/105 files · 0 skipped · 2,553/2,763 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:92.2%"></div></div>
-        <span class="group-pct pct-green">92.2%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:92.4%"></div></div>
+        <span class="group-pct pct-green">92.4%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t9">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T03:57:54+00:00" class="gen-time" title="2026-04-08 03:57 UTC">2026-04-08 03:57 UTC</time> · <a href="https://github.com/schacon/grit/commit/a9a7e9c8a9ab0f717ea1f0be3d4b518340747f3d" style="color:#58a6ff">a9a7e9c</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T04:18:36+00:00" class="gen-time" title="2026-04-08 04:18 UTC">2026-04-08 04:18 UTC</time> · <a href="https://github.com/schacon/grit/commit/09290c100b79448921e4faff6de7013a3030982b" style="color:#58a6ff">09290c1</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,745</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,476</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,481</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">67.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -13047,14 +13047,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t8" data-tests="9" data-passed="4">
+<tr class="" data-group="t8" data-tests="9" data-passed="9">
   <td class="mono">t8010-cat-file-filters</td>
   <td>t8</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">9</td>
-  <td class="right">4</td>
+  <td class="right">9</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:44.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t8" data-tests="10" data-passed="10">

--- a/grit-lib/src/merge_diff.rs
+++ b/grit-lib/src/merge_diff.rs
@@ -64,16 +64,17 @@ pub fn is_binary_for_diff(git_dir: &Path, path: &str, blob: &[u8]) -> bool {
     crate::crlf::is_binary(blob)
 }
 
-/// Run `diff.<driver>.textconv` feeding `input` on stdin; returns UTF-8 lossy text on success.
-pub fn run_textconv(
+/// Run `diff.<driver>.textconv` feeding `input` on stdin; returns raw stdout on success.
+///
+/// Matches Git's `run_textconv` stdin-based drivers (config lines ending with ` <` are
+/// normalized the same way as [`run_textconv`]).
+pub fn run_textconv_raw(
     git_dir: &Path,
     config: &ConfigSet,
     driver: &str,
     input: &[u8],
-) -> Option<String> {
+) -> Option<Vec<u8>> {
     let mut cmd_line = config.get(&format!("diff.{driver}.textconv"))?;
-    // Git's config often ends with ` <` meaning "read from stdin"; our child already
-    // receives blob bytes on stdin, so drop a trailing shell redirect token.
     cmd_line = cmd_line.trim_end().to_string();
     if cmd_line.ends_with('<') {
         let t = cmd_line.trim_end_matches('<').trim_end();
@@ -96,7 +97,41 @@ pub fn run_textconv(
     if !out.status.success() {
         return None;
     }
-    Some(String::from_utf8_lossy(&out.stdout).into_owned())
+    Some(out.stdout)
+}
+
+/// Run `diff.<driver>.textconv` feeding `input` on stdin; returns UTF-8 lossy text on success.
+pub fn run_textconv(
+    git_dir: &Path,
+    config: &ConfigSet,
+    driver: &str,
+    input: &[u8],
+) -> Option<String> {
+    run_textconv_raw(git_dir, config, driver, input)
+        .map(|b| String::from_utf8_lossy(&b).into_owned())
+}
+
+/// Blob bytes after smudge/EOL conversion for `path`, using the same rules as checkout.
+///
+/// `index` is used to pick up `.gitattributes` from the index when the worktree file is
+/// missing; pass `None` to use only on-disk `.gitattributes` under `work_tree`.
+pub fn convert_blob_to_worktree_for_path(
+    git_dir: &Path,
+    work_tree: &Path,
+    index: Option<&crate::index::Index>,
+    odb: &Odb,
+    path: &str,
+    blob: &[u8],
+    oid_hex: Option<&str>,
+) -> std::io::Result<Vec<u8>> {
+    let config = ConfigSet::load(Some(git_dir), true).unwrap_or_default();
+    let conv = crate::crlf::ConversionConfig::from_config(&config);
+    let rules = match index {
+        Some(idx) => crate::crlf::load_gitattributes_for_checkout(work_tree, path, idx, odb),
+        None => crate::crlf::load_gitattributes(work_tree),
+    };
+    let file_attrs = crate::crlf::get_file_attrs(&rules, path, &config);
+    crate::crlf::convert_to_worktree(blob, path, &conv, &file_attrs, oid_hex)
 }
 
 /// Prepare blob bytes for diff: optional textconv when `use_textconv` and `diff=<driver>`.

--- a/grit/src/commands/cat_file.rs
+++ b/grit/src/commands/cat_file.rs
@@ -3,7 +3,9 @@
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::config::ConfigSet;
+use grit_lib::crlf::{self, DiffAttr};
 use grit_lib::error::Error as LibError;
+use grit_lib::merge_diff::{convert_blob_to_worktree_for_path, run_textconv_raw};
 use grit_lib::pack;
 use grit_lib::rev_list::{self, ObjectFilter};
 use std::io::{self, BufRead, Write};
@@ -234,6 +236,10 @@ pub fn run(args: Args) -> Result<()> {
         return Ok(());
     }
 
+    if args.textconv || args.filters {
+        return cat_file_emit_transformed(&repo, &args, &oid, &obj, obj_str);
+    }
+
     if let Some(kind) = expected_kind {
         // Dereference tags/commits to reach the requested object type.
         let mut _current_oid = oid;
@@ -364,12 +370,20 @@ fn validate_args(args: &Args) -> Result<()> {
     }
 
     // --batch-all-objects conflicts with mode flags as a cmdmode
-    if args.batch_all_objects && !cmdmodes.is_empty() {
-        let mode = cmdmodes[0];
-        usage_error(&format!(
-            "error: {} cannot be used together with --batch-all-objects",
-            mode
-        ));
+    if args.batch_all_objects {
+        if args.textconv {
+            usage_error("error: --textconv is incompatible with --batch-all-objects");
+        }
+        if args.filters {
+            usage_error("error: --filters is incompatible with --batch-all-objects");
+        }
+        if !cmdmodes.is_empty() {
+            let mode = cmdmodes[0];
+            usage_error(&format!(
+                "error: {} cannot be used together with --batch-all-objects",
+                mode
+            ));
+        }
     }
 
     // Check mutual exclusivity of cmdmode flags
@@ -385,12 +399,8 @@ fn validate_args(args: &Args) -> Result<()> {
     let has_mode = !cmdmodes.is_empty();
     let mode_name = cmdmodes.first().copied().unwrap_or("");
 
-    // --path requires --textconv or --filters (not batch)
+    // --path requires --textconv or --filters
     if args.path.is_some() && !args.textconv && !args.filters {
-        if is_batch {
-            usage_error("fatal: '--path=<path|tree-ish>' needs '--filters' or '--textconv'");
-        }
-        // --path without --textconv/--filters in non-batch mode
         usage_error("fatal: '--path=<path|tree-ish>' needs '--filters' or '--textconv'");
     }
 
@@ -411,16 +421,14 @@ fn validate_args(args: &Args) -> Result<()> {
         usage_error("fatal: '-Z' requires a batch mode");
     }
 
-    // Mode flags are incompatible with batch mode
-    if has_mode && is_batch {
+    // Mode flags are incompatible with batch mode, except --textconv/--filters (Git allows
+    // those together with --batch for per-line conversion).
+    if has_mode && is_batch && !args.textconv && !args.filters {
         usage_error(&format!(
             "fatal: '{}' is incompatible with batch mode",
             mode_name
         ));
     }
-
-    // Mode flags are incompatible with --follow-symlinks (a batch-only option)
-    // (already handled above since --follow-symlinks requires batch mode)
 
     // --textconv/--filters require an object argument (unless in batch mode)
     if (args.textconv || args.filters) && !is_batch && args.type_or_object.is_none() {
@@ -485,6 +493,12 @@ fn validate_args(args: &Args) -> Result<()> {
 
     if args.no_filter && !is_batch {
         usage_error("fatal: '--no-filter' requires a batch mode");
+    }
+
+    let batch_transform = args.textconv || args.filters;
+    if is_batch && batch_transform && args.path.is_some() {
+        eprintln!("fatal: missing path");
+        std::process::exit(128);
     }
 
     Ok(())
@@ -603,6 +617,8 @@ struct BatchWriteOpts<'a> {
     follow_symlinks: bool,
     apply_object_filter: bool,
     objects_filter: Option<&'a ObjectFilter>,
+    batch_textconv: bool,
+    batch_filters: bool,
 }
 
 fn loose_object_file(objects_dir: &Path, oid: &ObjectId) -> PathBuf {
@@ -665,15 +681,24 @@ fn run_batch(repo: &Repository, args: &Args) -> Result<()> {
         Some(ObjectFilter::parse(spec).map_err(|e| anyhow::anyhow!("invalid object filter: {e}"))?)
     };
 
+    let batch_transform = args.textconv || args.filters;
+
     let write_opts = BatchWriteOpts {
         ignore_replace: args.batch_all_objects,
         follow_symlinks: args.follow_symlinks,
         apply_object_filter: !args.batch_all_objects && objects_filter.is_some(),
         objects_filter: objects_filter.as_ref(),
+        batch_textconv: args.textconv,
+        batch_filters: args.filters,
     };
 
     let mut handle_line = |line: &str| -> Result<()> {
         let trimmed = line.trim();
+        let (display_spec, object_spec, path_suffix) = if batch_transform {
+            split_batch_object_field_and_rest(trimmed)
+        } else {
+            (trimmed, trimmed, None)
+        };
 
         if args.batch_command.is_some() {
             if trimmed.is_empty() {
@@ -692,11 +717,17 @@ fn run_batch(repo: &Repository, args: &Args) -> Result<()> {
                         eprintln!("fatal: contents requires arguments");
                         std::process::exit(128);
                     }
+                    let (d, o, ps) = if batch_transform {
+                        split_batch_object_field_and_rest(obj_str)
+                    } else {
+                        (obj_str, obj_str, None)
+                    };
                     if use_app_buffer {
                         print_batch_entry(
                             repo,
-                            obj_str,
-                            obj_str,
+                            d,
+                            o,
+                            ps,
                             true,
                             format,
                             nul_output,
@@ -707,8 +738,9 @@ fn run_batch(repo: &Repository, args: &Args) -> Result<()> {
                     } else {
                         print_batch_entry(
                             repo,
-                            obj_str,
-                            obj_str,
+                            d,
+                            o,
+                            ps,
                             true,
                             format,
                             nul_output,
@@ -727,11 +759,17 @@ fn run_batch(repo: &Repository, args: &Args) -> Result<()> {
                         eprintln!("fatal: info requires arguments");
                         std::process::exit(128);
                     }
+                    let (d, o, ps) = if batch_transform {
+                        split_batch_object_field_and_rest(obj_str)
+                    } else {
+                        (obj_str, obj_str, None)
+                    };
                     if use_app_buffer {
                         print_batch_entry(
                             repo,
-                            obj_str,
-                            obj_str,
+                            d,
+                            o,
+                            ps,
                             false,
                             format,
                             nul_output,
@@ -742,8 +780,9 @@ fn run_batch(repo: &Repository, args: &Args) -> Result<()> {
                     } else {
                         print_batch_entry(
                             repo,
-                            obj_str,
-                            obj_str,
+                            d,
+                            o,
+                            ps,
                             false,
                             format,
                             nul_output,
@@ -780,8 +819,9 @@ fn run_batch(repo: &Repository, args: &Args) -> Result<()> {
             let include_content = args.batch_includes_content();
             print_batch_entry(
                 repo,
-                trimmed,
-                trimmed,
+                display_spec,
+                object_spec,
+                path_suffix,
                 include_content,
                 format,
                 nul_output,
@@ -912,6 +952,7 @@ fn emit_batch_object_lines(
     nul_output: bool,
     packed_sizes: Option<&HashMap<ObjectId, u64>>,
     rest: &str,
+    content_override: Option<&[u8]>,
     out: &mut impl Write,
 ) -> Result<()> {
     let eol: &[u8] = if nul_output { b"\0" } else { b"\n" };
@@ -952,7 +993,8 @@ fn emit_batch_object_lines(
     }
     out.write_all(eol)?;
     if include_content {
-        out.write_all(&obj.data)?;
+        let payload = content_override.unwrap_or(obj.data.as_slice());
+        out.write_all(payload)?;
         out.write_all(eol)?;
     }
     Ok(())
@@ -996,6 +1038,7 @@ fn print_batch_follow_symlinks(
                             nul_output,
                             packed_sizes,
                             rest,
+                            None,
                             out,
                         )?;
                     }
@@ -1044,6 +1087,7 @@ fn print_batch_follow_symlinks(
                 nul_output,
                 packed_sizes,
                 rest,
+                None,
                 out,
             )?;
         }
@@ -1065,6 +1109,51 @@ fn print_batch_follow_symlinks(
         }
     }
     Ok(())
+}
+
+/// Smudge / textconv for `cat-file --batch` blob output (Git matches checkout + textconv order).
+fn cat_file_batch_blob_payload(
+    repo: &Repository,
+    path: &str,
+    blob: &[u8],
+    oid_hex: &str,
+    opts: BatchWriteOpts<'_>,
+) -> Result<Vec<u8>> {
+    let config = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+    let work_tree = repo
+        .work_tree
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("no working tree"))?;
+    let index = repo.load_index().ok();
+    let smudged = convert_blob_to_worktree_for_path(
+        &repo.git_dir,
+        work_tree,
+        index.as_ref(),
+        &repo.odb,
+        path,
+        blob,
+        Some(oid_hex),
+    )
+    .map_err(|e| anyhow::anyhow!("could not convert '{oid_hex}' {path}: {e}"))?;
+    if opts.batch_filters {
+        return Ok(smudged);
+    }
+    let rules = match index.as_ref() {
+        Some(idx) => crlf::load_gitattributes_for_checkout(work_tree, path, idx, &repo.odb),
+        None => crlf::load_gitattributes(work_tree),
+    };
+    let fa = crlf::get_file_attrs(&rules, path, &config);
+    let driver = match &fa.diff_attr {
+        DiffAttr::Driver(d) => d.as_str(),
+        _ => return Ok(smudged),
+    };
+    match run_textconv_raw(&repo.git_dir, &config, driver, &smudged) {
+        Some(b) => Ok(b),
+        None => {
+            eprintln!("fatal: unable to read files to diff");
+            std::process::exit(128);
+        }
+    }
 }
 
 fn write_excluded_line(
@@ -1101,6 +1190,7 @@ fn print_batch_entry(
     repo: &Repository,
     display_spec: &str,
     object_spec: &str,
+    path_suffix: Option<&str>,
     include_content: bool,
     format: &str,
     nul_output: bool,
@@ -1110,6 +1200,7 @@ fn print_batch_entry(
 ) -> Result<()> {
     let (obj_str, rest) = parse_batch_input(object_spec, format);
     let eol: &[u8] = if nul_output { b"\0" } else { b"\n" };
+    let batch_transform = opts.batch_textconv || opts.batch_filters;
 
     if obj_str.is_empty() {
         out.write_all(b" missing")?;
@@ -1152,6 +1243,7 @@ fn print_batch_entry(
                     nul_output,
                     packed_sizes,
                     rest,
+                    None,
                     out,
                 )?;
             }
@@ -1188,6 +1280,77 @@ fn print_batch_entry(
                         }
                     }
                 }
+
+                if batch_transform && obj.kind == ObjectKind::Blob && include_content {
+                    let path_for_attrs = path_suffix.map(|s| s.replace('\\', "/")).or_else(|| {
+                        obj_str.find(':').map(|i| {
+                            let tail = &obj_str[i + 1..];
+                            tail.replace('\\', "/")
+                        })
+                    });
+
+                    let need_path = opts.batch_filters;
+                    if need_path && path_for_attrs.is_none() {
+                        emit_batch_object_lines(
+                            repo,
+                            oid,
+                            &obj,
+                            mode,
+                            false,
+                            format,
+                            nul_output,
+                            packed_sizes,
+                            rest,
+                            None,
+                            out,
+                        )?;
+                        eprintln!("fatal: missing path for '{}'", oid.to_hex());
+                        std::process::exit(128);
+                    }
+
+                    if let Some(ref p) = path_for_attrs {
+                        if repo.work_tree.is_none() {
+                            emit_batch_object_lines(
+                                repo,
+                                oid,
+                                &obj,
+                                mode,
+                                false,
+                                format,
+                                nul_output,
+                                packed_sizes,
+                                rest,
+                                None,
+                                out,
+                            )?;
+                            let flag = if opts.batch_textconv {
+                                "--textconv"
+                            } else {
+                                "--filters"
+                            };
+                            eprintln!("fatal: <rev> required with '{flag}'");
+                            std::process::exit(129);
+                        }
+                        let oid_hex = oid.to_string();
+                        let payload =
+                            cat_file_batch_blob_payload(repo, p, &obj.data, &oid_hex, opts)?;
+                        emit_batch_object_lines(
+                            repo,
+                            oid,
+                            &obj,
+                            mode,
+                            true,
+                            format,
+                            nul_output,
+                            packed_sizes,
+                            rest,
+                            Some(payload.as_slice()),
+                            out,
+                        )?;
+                        return Ok(());
+                    }
+                }
+
                 emit_batch_object_lines(
                     repo,
                     oid,
@@ -1198,6 +1361,7 @@ fn print_batch_entry(
                     nul_output,
                     packed_sizes,
                     rest,
+                    None,
                     out,
                 )?;
             }
@@ -1348,6 +1512,125 @@ fn pretty_print(kind: &ObjectKind, data: &[u8]) -> Result<()> {
 /// Uses the full rev-parse machinery for resolution.
 fn resolve_object(repo: &Repository, obj_str: &str) -> Result<ObjectId> {
     rev_parse::resolve_revision(repo, obj_str).map_err(|e| anyhow::anyhow!("{}", e))
+}
+
+/// Emit `--textconv` / `--filters` output for a single object (non-batch).
+fn cat_file_emit_transformed(
+    repo: &Repository,
+    args: &Args,
+    oid: &ObjectId,
+    obj: &grit_lib::objects::Object,
+    obj_spec: &str,
+) -> Result<()> {
+    let path = cat_file_transform_path(args, obj_spec)?;
+    let config = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+
+    if obj.kind != ObjectKind::Blob {
+        eprintln!("fatal: <object>:<path> required, only <object> '{obj_spec}' given");
+        std::process::exit(128);
+    }
+
+    let work_tree = match repo.work_tree.as_deref() {
+        Some(wt) => wt,
+        None => {
+            eprintln!(
+                "fatal: <rev> required with '{}'",
+                mode_flag_for_transform(args)
+            );
+            std::process::exit(129);
+        }
+    };
+
+    let index = repo.load_index().ok();
+    let oid_hex = format!("{oid}");
+    let smudged = convert_blob_to_worktree_for_path(
+        &repo.git_dir,
+        work_tree,
+        index.as_ref(),
+        &repo.odb,
+        &path,
+        &obj.data,
+        Some(&oid_hex),
+    )
+    .map_err(|e| anyhow::anyhow!("could not convert '{oid_hex}' {path}: {e}"))?;
+
+    let data = if args.filters {
+        smudged
+    } else {
+        let rules = match index.as_ref() {
+            Some(idx) => crlf::load_gitattributes_for_checkout(work_tree, &path, idx, &repo.odb),
+            None => crlf::load_gitattributes(work_tree),
+        };
+        let fa = crlf::get_file_attrs(&rules, &path, &config);
+        let driver = match &fa.diff_attr {
+            DiffAttr::Driver(d) => d.as_str(),
+            _ => {
+                let stdout = io::stdout();
+                let mut out = stdout.lock();
+                out.write_all(&smudged)?;
+                return Ok(());
+            }
+        };
+        match run_textconv_raw(&repo.git_dir, &config, driver, &smudged) {
+            Some(b) => b,
+            None => {
+                eprintln!("fatal: unable to read files to diff");
+                std::process::exit(128);
+            }
+        }
+    };
+
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
+    out.write_all(&data)?;
+    Ok(())
+}
+
+fn mode_flag_for_transform(args: &Args) -> &'static str {
+    if args.textconv {
+        "--textconv"
+    } else {
+        "--filters"
+    }
+}
+
+/// Path string for attribute lookup: `--path` if set, else the path from `<rev>:path`.
+fn cat_file_transform_path(args: &Args, obj_spec: &str) -> Result<String> {
+    if let Some(p) = args.path.as_deref() {
+        return Ok(p.replace('\\', "/"));
+    }
+    let Some(colon) = obj_spec.find(':') else {
+        eprintln!("fatal: <object>:<path> required, only <object> '{obj_spec}' given");
+        std::process::exit(128);
+    };
+    let path_part = &obj_spec[colon + 1..];
+    if path_part.is_empty() {
+        eprintln!("fatal: <object>:<path> required, only <object> '{obj_spec}' given");
+        std::process::exit(128);
+    }
+    Ok(path_part.replace('\\', "/"))
+}
+
+/// Split batch input when `--textconv` / `--filters` is active: object id is the first token;
+/// optional path is the remainder of the line (Git nulls the first run of spaces).
+fn split_batch_object_field_and_rest(line: &str) -> (&str, &str, Option<&str>) {
+    let trimmed = line.trim();
+    let bytes = trimmed.as_bytes();
+    for i in 0..bytes.len() {
+        if bytes[i].is_ascii_whitespace() {
+            let obj = trimmed[..i].trim_end();
+            let mut j = i;
+            while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+                j += 1;
+            }
+            let path = trimmed[j..].trim_end();
+            if path.is_empty() {
+                return (obj, obj, None);
+            }
+            return (obj, obj, Some(path));
+        }
+    }
+    (trimmed, trimmed, None)
 }
 
 /// Resolve an object reference and also return the file mode if the reference

--- a/logs/2026-04-08_t8010-cat-file-filters.md
+++ b/logs/2026-04-08_t8010-cat-file-filters.md
@@ -1,0 +1,20 @@
+# t8010-cat-file-filters
+
+## Goal
+
+Make `tests/t8010-cat-file-filters.sh` pass (9/9).
+
+## Changes
+
+- **`grit-lib`**: `merge_diff::run_textconv_raw` + `convert_blob_to_worktree_for_path` (reuse checkout smudge/EOL pipeline with optional index for `.gitattributes`).
+- **`grit cat-file`**: Non-batch `--filters` / `--textconv` output; `--batch` + `--textconv`/`--filters` with first-token OID + optional path suffix; size line uses stored blob size, content line uses transformed bytes; Git-compatible errors (`missing path`, bare `<rev> required`, `--batch-all-objects` incompatibility).
+
+## Verification
+
+```bash
+cargo build --release -p grit-rs
+./scripts/run-tests.sh t8010-cat-file-filters.sh
+cargo test -p grit-lib --lib
+```
+
+All green.

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   226 |
+| Completed   |   227 |
 | In progress |     2 |
-| Remaining   |   540 |
+| Remaining   |   539 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 226 completed (`[x]`), 2 in progress (`[~]`), 540 remaining (`[ ]`).
+Task lines in `PLAN.md`: 227 completed (`[x]`), 2 in progress (`[~]`), 539 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t8010-cat-file-filters` — 9/9 tests pass (`cat-file --filters` / `--textconv`: smudge + EOL via checkout-style attributes; `--batch` + `--textconv` with per-line path; validation aligned with Git for `--path`, bare repo, and `--batch-all-objects`)
 - `t7509-commit-authorship` — 12/12 tests pass (`commit`: `--reset-author` with `-C`/`-c`/`--amend` and when `CHERRY_PICK_HEAD`/`REBASE_HEAD` exists; author from `CHERRY_PICK_HEAD` when finishing cherry-pick with `MERGE_MSG`; `--author` now formats full ident with current date; amend rejects empty/malformed prior author; mutual exclusion with `--reset-author`)
 - `t4026-color` — 34/34 tests pass (Git-compatible `config::parse_color` per `git/color.c`; `git config --get-color` merges argv after the slot into one default and uses `--` when the default begins with `-` so clap accepts `-1 black`)
 - `t3704-add-pathspec-file` — 11/11 tests pass (`git add --pathspec-from-file` / `--pathspec-file-nul`: raw bytes + CRLF/LF/NUL splitting, C-quoted lines, conflict checks vs `--interactive`/`--patch`/`--edit`/pathspecs; shared `pathspec::parse_pathspecs_from_file`; error text matches grep expectations)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible `grit cat-file --filters` and `--textconv` so `t8010-cat-file-filters` passes (9/9).

## Details

- **Library** (`grit-lib`): `run_textconv_raw` returns raw stdout from `diff.<driver>.textconv`; `convert_blob_to_worktree_for_path` runs the same smudge/EOL path as checkout (optional index for in-tree `.gitattributes`).
- **CLI** (`grit cat-file`): Standalone mode applies filters/textconv using `--path` or `<rev>:path`; `--batch` combines with `--textconv`/`--filters` using first-token OID + optional path suffix; header size stays the stored blob size; content is transformed. Validation aligned with Git for `--path`, bare repos, and `--batch-all-objects`.

## Testing

- `./scripts/run-tests.sh t8010-cat-file-filters.sh`
- `./scripts/run-tests.sh t8010-cat-file-batch.sh` (regression)
- `cargo test -p grit-lib --lib`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc65d7b2-1506-4c1b-8e31-630d100989c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc65d7b2-1506-4c1b-8e31-630d100989c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

