### PR TITLE
fix: make t5621-clone-revision pass (clone --revision)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -616,7 +616,7 @@ commit → check it off → move on.
 - [ ] `t5582-fetch-negative-refspec` ████████░░░░░░░░░░░░ 7/16 (9 left) — 
 - [ ] `t5305-include-tag` ████████░░░░░░░░░░░░ 6/15 (9 left) — git pack-object --include-tag
 - [ ] `t5401-update-hooks` ██████░░░░░░░░░░░░░░ 4/13 (9 left) — Test the update hook infrastructure.
-- [ ] `t5621-clone-revision` █████░░░░░░░░░░░░░░░ 3/12 (9 left) — tests for git clone --revision
+- [x] `t5621-clone-revision` — tests for git clone --revision (12/12)
 - [ ] `t5530-upload-pack-error` ███░░░░░░░░░░░░░░░░░ 2/11 (9 left) — errors in upload-pack
 - [ ] `t5150-request-pull` ██░░░░░░░░░░░░░░░░░░ 1/10 (9 left) — Test workflows involving pull request.
 - [ ] `t5320-delta-islands` ██████░░░░░░░░░░░░░░ 5/15 (10 left) — exercise delta islands

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1015,7 +1015,7 @@ t5617-clone-submodules-remote	t5	yes	9	2	7	false	ok	0
 t5618-alternate-refs	t5	yes	6	2	4	false	ok	0
 t5619-clone-local-ambiguous-transport	t5	yes	2	0	2	false	ok	0
 t5620-backfill	t5	yes	10	2	8	false	ok	0
-t5621-clone-revision	t5	yes	12	3	9	false	ok	0
+t5621-clone-revision	t5	yes	12	12	0	true	ok	0
 t5700-protocol-v1	t5	yes	24	4	20	false	ok	0
 t5701-git-serve	t5	yes	25	25	0	true	ok	0
 t5702-protocol-v2	t5	yes	85	10	75	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T03:57:54+00:00" class="gen-time" title="2026-04-08 03:57 UTC">2026-04-08 03:57 UTC</time> · <a href="https://github.com/schacon/grit/commit/a9a7e9c8a9ab0f717ea1f0be3d4b518340747f3d" style="color:#58a6ff">a9a7e9c</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T04:18:27+00:00" class="gen-time" title="2026-04-08 04:18 UTC">2026-04-08 04:18 UTC</time> · <a href="https://github.com/schacon/grit/commit/09290c100b79448921e4faff6de7013a3030982b" style="color:#58a6ff">09290c1</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,476</div>
+      <div class="summary-big-val">29,485</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>608 files fully passing</span>
+    <span>609 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">28/167 files · 17 skipped · 1,432/4,315 tests</span>
+        <span class="group-meta">29/167 files · 17 skipped · 1,441/4,315 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.2%"></div></div>
-        <span class="group-pct pct-red">33.2%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.4%"></div></div>
+        <span class="group-pct pct-red">33.4%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T03:57:54+00:00" class="gen-time" title="2026-04-08 03:57 UTC">2026-04-08 03:57 UTC</time> · <a href="https://github.com/schacon/grit/commit/a9a7e9c8a9ab0f717ea1f0be3d4b518340747f3d" style="color:#58a6ff">a9a7e9c</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T04:18:27+00:00" class="gen-time" title="2026-04-08 04:18 UTC">2026-04-08 04:18 UTC</time> · <a href="https://github.com/schacon/grit/commit/09290c100b79448921e4faff6de7013a3030982b" style="color:#58a6ff">09290c1</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,745</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,476</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,485</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">67.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -10287,14 +10287,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:20.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="12" data-passed="3">
+<tr class="" data-group="t5" data-tests="12" data-passed="12">
   <td class="mono">t5621-clone-revision</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">12</td>
-  <td class="right">3</td>
+  <td class="right">12</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:25.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="24" data-passed="4">

--- a/grit/src/commands/clone.rs
+++ b/grit/src/commands/clone.rs
@@ -7,6 +7,7 @@ use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::config::{ConfigFile, ConfigScope};
 use grit_lib::objects::{parse_commit, parse_tag, parse_tree, ObjectId, ObjectKind};
+use grit_lib::refs;
 use grit_lib::repo::{init_repository, init_repository_separate_git_dir, Repository};
 use std::collections::{HashSet, VecDeque};
 use std::fs;
@@ -423,13 +424,6 @@ pub fn run(args: Args) -> Result<()> {
         }
     }
 
-    // Handle shallow depth — write .git/shallow with boundary commits
-    if let Some(depth) = args.depth {
-        if depth > 0 {
-            write_shallow_boundary(&dest, depth)?;
-        }
-    }
-
     // Apply -c config values
     if !args.config.is_empty() {
         apply_clone_config(&dest.git_dir, &args.config).context("applying -c config")?;
@@ -451,13 +445,20 @@ pub fn run(args: Args) -> Result<()> {
             .context("initializing partial-clone promisor state")?;
     }
 
-    // Handle --revision: resolve the specified ref in the source repo and set
-    // the destination to a detached HEAD at that commit.
+    // Handle --revision: detached HEAD at the resolved commit, no local refs,
+    // and no remote.fetch (matches git clone --revision).
     if let Some(ref revision) = args.revision {
-        let rev_oid = resolve_revision_in_source(&source, revision)
-            .with_context(|| format!("cannot resolve --revision '{}'", revision))?;
-        // Set HEAD to the resolved OID directly (detached)
+        let rev_oid = resolve_revision_for_clone(&source, revision, remote_name)?;
+        strip_refs_under(&dest.git_dir.join("refs"))?;
         fs::write(dest.git_dir.join("HEAD"), format!("{}\n", rev_oid))?;
+        remove_revision_clone_remote_config(&dest.git_dir, remote_name)?;
+    }
+
+    // Shallow boundary must be computed from the final HEAD (after --revision).
+    if let Some(depth) = args.depth {
+        if depth > 0 {
+            write_shallow_boundary(&dest, depth)?;
+        }
     }
 
     // Checkout working tree unless --bare or --no-checkout
@@ -659,12 +660,6 @@ fn run_ssh_clone(args: Args) -> Result<()> {
         }
     }
 
-    if let Some(depth) = args.depth {
-        if depth > 0 {
-            write_shallow_boundary(&dest, depth)?;
-        }
-    }
-
     if !args.config.is_empty() {
         apply_clone_config(&dest.git_dir, &args.config).context("applying -c config")?;
     }
@@ -680,9 +675,16 @@ fn run_ssh_clone(args: Args) -> Result<()> {
     }
 
     if let Some(ref revision) = args.revision {
-        let rev_oid = resolve_revision_in_source(&source, revision)
-            .with_context(|| format!("cannot resolve --revision '{}'", revision))?;
+        let rev_oid = resolve_revision_for_clone(&source, revision, remote_name)?;
+        strip_refs_under(&dest.git_dir.join("refs"))?;
         fs::write(dest.git_dir.join("HEAD"), format!("{}\n", rev_oid))?;
+        remove_revision_clone_remote_config(&dest.git_dir, remote_name)?;
+    }
+
+    if let Some(depth) = args.depth {
+        if depth > 0 {
+            write_shallow_boundary(&dest, depth)?;
+        }
     }
 
     if !args.bare && !args.no_checkout {
@@ -829,34 +831,116 @@ fn extract_remote_url(config: &str, remote_name: &str) -> Option<String> {
     None
 }
 
-/// Resolve a revision string (ref, OID, HEAD) in the source repository.
-/// For tags, peels to the commit. Returns the OID string.
-fn resolve_revision_in_source(source: &Repository, revision: &str) -> Result<String> {
-    use grit_lib::refs;
+/// Resolve `--revision` in the source repo to a **commit** OID (hex).
+///
+/// Stricter than general `rev-parse`: parent/ancestor syntax (`^`, `~`) is not
+/// accepted (Git's transport treats the revision as a refspec-like name).
+fn resolve_revision_for_clone(
+    source: &Repository,
+    revision: &str,
+    remote_name: &str,
+) -> Result<String> {
+    if revision.contains('^') || revision.contains('~') {
+        bail!("fatal: Remote revision {revision} not found in upstream {remote_name}");
+    }
 
-    // Try resolving as a ref first
-    if let Ok(oid) = refs::resolve_ref(&source.git_dir, revision) {
-        // If it's a tag, peel it to the commit
+    let git_dir = &source.git_dir;
+
+    let oid = if revision == "HEAD" {
+        refs::resolve_ref(git_dir, "HEAD").map_err(|_| {
+            anyhow::anyhow!("fatal: Remote revision HEAD not found in upstream {remote_name}")
+        })?
+    } else if let Ok(oid) = revision.parse::<ObjectId>() {
+        // Only full 40-hex IDs are accepted as raw object names (matches git's
+        // `--revision` transport behaviour; short OIDs are not resolved).
+        if revision.len() != 40 {
+            bail!("fatal: Remote revision {revision} not found in upstream {remote_name}");
+        }
+        if !source.odb.exists(&oid) {
+            bail!("fatal: Remote revision {revision} not found in upstream {remote_name}");
+        }
+        oid
+    } else if let Ok(oid) = refs::resolve_ref(git_dir, revision) {
+        oid
+    } else if let Ok(oid) = refs::resolve_ref(git_dir, &format!("refs/heads/{revision}")) {
+        oid
+    } else if let Ok(oid) = refs::resolve_ref(git_dir, &format!("refs/tags/{revision}")) {
+        oid
+    } else if let Ok(oid) = refs::resolve_ref(git_dir, &format!("refs/remotes/{revision}")) {
+        oid
+    } else if looks_like_hex_object_id(revision) {
+        bail!("fatal: Remote revision {revision} not found in upstream {remote_name}");
+    } else {
+        bail!("cannot resolve --revision '{revision}'");
+    };
+
+    let commit_oid = peel_revision_to_commit(source, oid)?;
+    Ok(commit_oid.to_hex())
+}
+
+/// Peel tags until `oid` names a commit; error if the result is a tree or blob.
+fn peel_revision_to_commit(source: &Repository, mut oid: ObjectId) -> Result<ObjectId> {
+    loop {
         let obj = source.odb.read(&oid)?;
-        if obj.kind == grit_lib::objects::ObjectKind::Tag {
-            // Parse tag to find the target object
-            let text = std::str::from_utf8(&obj.data).unwrap_or("");
-            if let Some(line) = text.lines().find(|l| l.starts_with("object ")) {
-                let target_hex = line.trim_start_matches("object ").trim();
-                return Ok(target_hex.to_string());
+        match obj.kind {
+            ObjectKind::Commit => return Ok(oid),
+            ObjectKind::Tag => {
+                let tag = parse_tag(&obj.data)?;
+                oid = tag.object;
+            }
+            ObjectKind::Tree => {
+                bail!("object {} is a tree, not a commit", oid.to_hex());
+            }
+            ObjectKind::Blob => {
+                bail!("object {} is a blob, not a commit", oid.to_hex());
             }
         }
-        return Ok(oid.to_hex());
     }
+}
 
-    // Try as a hex OID
-    if let Ok(oid) = ObjectId::from_hex(revision) {
-        if source.odb.exists(&oid) {
-            return Ok(oid.to_hex());
+fn looks_like_hex_object_id(s: &str) -> bool {
+    let len = s.len();
+    (4..=40).contains(&len) && s.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// Remove every ref under `refs/` (files and empty dirs), for revision-only clones.
+fn strip_refs_under(refs_root: &Path) -> Result<()> {
+    if !refs_root.exists() {
+        return Ok(());
+    }
+    for entry in fs::read_dir(refs_root)? {
+        let entry = entry?;
+        let path = entry.path();
+        if entry.file_type()?.is_dir() {
+            strip_refs_under(&path)?;
+            let _ = fs::remove_dir(&path);
+        } else {
+            let _ = fs::remove_file(&path);
         }
     }
+    Ok(())
+}
 
-    bail!("revision '{}' not found in source repository", revision);
+/// Drop `remote.<name>.fetch` and `branch.*` sections left over from init / clone setup.
+fn remove_revision_clone_remote_config(git_dir: &Path, remote_name: &str) -> Result<()> {
+    let config_path = git_dir.join("config");
+    let mut config = match ConfigFile::from_path(&config_path, ConfigScope::Local)? {
+        Some(c) => c,
+        None => ConfigFile::parse(&config_path, "", ConfigScope::Local)?,
+    };
+    let _ = config.unset(&format!("remote.{remote_name}.fetch"))?;
+    let to_remove: Vec<String> = config
+        .entries
+        .iter()
+        .filter(|e| e.key.starts_with("branch.") && e.key.contains(".remote"))
+        .filter(|e| e.value.as_deref() == Some(remote_name))
+        .filter_map(|e| e.key.rsplit_once('.').map(|(prefix, _)| prefix.to_string()))
+        .collect();
+    for branch_sec in to_remove {
+        let _ = config.remove_section(&branch_sec)?;
+    }
+    config.write().context("writing config")?;
+    Ok(())
 }
 
 /// Open a source repository (bare or non-bare).

--- a/logs/2026-04-08_t5621-clone-revision.md
+++ b/logs/2026-04-08_t5621-clone-revision.md
@@ -1,0 +1,21 @@
+# t5621-clone-revision
+
+## Goal
+
+Make `tests/t5621-clone-revision.sh` pass (12/12) against grit.
+
+## Changes
+
+1. **`tests/test-lib.sh`** — Added `--annotate` to `test_commit` (upstream parity): after commit, run `git tag -a -m "$message"` with optional `test_tick`, matching `git/t/test-lib-functions.sh`.
+
+2. **`grit/src/commands/clone.rs`** — `git clone --revision`:
+   - Resolve revision in source with rules aligned to Git transport: `HEAD`, full ref names, DWIM `refs/heads|tags|remotes/<name>`, full 40-char hex only as raw OID; reject `^`/`~` and ambiguous short hex with `fatal: Remote revision … not found in upstream origin`.
+   - Peel annotated tags to a commit; tree/blob → `error: object <id> is a tree|blob, not a commit` (single `error:` prefix from main).
+   - After resolution: remove everything under `refs/`, write detached `HEAD`, remove `remote.<name>.fetch` and `branch.*` tracking sections for that remote.
+   - Run `write_shallow_boundary` **after** applying `--revision` so `--depth` uses the final HEAD.
+
+## Verification
+
+- `cargo fmt`, `cargo clippy --fix --allow-dirty` (pre-existing warnings in `main.rs` unchanged)
+- `cargo test -p grit-lib --lib`
+- `./scripts/run-tests.sh t5621-clone-revision.sh` → 12/12

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   226 |
+| Completed   |   227 |
 | In progress |     2 |
-| Remaining   |   540 |
+| Remaining   |   539 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 226 completed (`[x]`), 2 in progress (`[~]`), 540 remaining (`[ ]`).
+Task lines in `PLAN.md`: 227 completed (`[x]`), 2 in progress (`[~]`), 539 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t5621-clone-revision` — 12/12 tests pass (`clone --revision`: detached HEAD, strip `refs/*`, drop `remote.origin.fetch` and branch tracking; shallow boundary from final HEAD; strict revision resolution with Git-style `fatal: Remote revision` / tree errors; `test_commit --annotate` in `tests/test-lib.sh` for annotated tags)
 - `t7509-commit-authorship` — 12/12 tests pass (`commit`: `--reset-author` with `-C`/`-c`/`--amend` and when `CHERRY_PICK_HEAD`/`REBASE_HEAD` exists; author from `CHERRY_PICK_HEAD` when finishing cherry-pick with `MERGE_MSG`; `--author` now formats full ident with current date; amend rejects empty/malformed prior author; mutual exclusion with `--reset-author`)
 - `t4026-color` — 34/34 tests pass (Git-compatible `config::parse_color` per `git/color.c`; `git config --get-color` merges argv after the slot into one default and uses `--` when the default begins with `-` so clap accepts `-1 black`)
 - `t3704-add-pathspec-file` — 11/11 tests pass (`git add --pathspec-from-file` / `--pathspec-file-nul`: raw bytes + CRLF/LF/NUL splitting, C-quoted lines, conflict checks vs `--interactive`/`--patch`/`--edit`/pathspecs; shared `pathspec::parse_pathspecs_from_file`; error text matches grep expectations)

--- a/tests/test-lib.sh
+++ b/tests/test-lib.sh
@@ -925,13 +925,14 @@ test_cmp_config () {
 }
 
 test_commit () {
-	local notick= signoff= indir= tag=yes message= file= contents= author=
+	local notick= signoff= indir= tag=light message= file= contents= author=
 	while test $# != 0
 	do
 		case "$1" in
 		--notick) notick=yes; shift ;;
 		--signoff) signoff="$1"; shift ;;
-		--no-tag) tag=; shift ;;
+		--no-tag) tag=none; shift ;;
+		--annotate) tag=annotate; shift ;;
 		--author) author="$2"; shift 2 ;;
 		-C) indir="$2"; shift 2 ;;
 		--append) shift ;; # accepted but ignored for compat
@@ -950,9 +951,16 @@ test_commit () {
 		printf '%s\n' "$contents" >"$file" &&
 		git add "$file" &&
 		git commit -q ${signoff:+$signoff} ${author:+--author "$author"} -m "$message" &&
-		if test -n "$tag"; then
-			git tag "${1:-$message}"
-		fi
+		case "$tag" in
+		none) ;;
+		light) git tag "${1:-$message}" ;;
+		annotate)
+			if test -z "$notick"; then
+				test_tick
+			fi &&
+			git tag -a -m "$message" "${1:-$message}"
+			;;
+		esac
 	)
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible `git clone --revision` behaviour so `tests/t5621-clone-revision.sh` passes 12/12.

### `grit clone --revision`

- Resolves the revision in the source repo with transport-like rules: `HEAD`, full ref paths, DWIM under `refs/heads/`, `refs/tags/`, `refs/remotes/`, and **only** full 40-character hex as a raw object id (short hex → `fatal: Remote revision … not found in upstream origin`, matching the test).
- Rejects `^` / `~` in the revision string with the same fatal line.
- Peels annotated tags to a commit; tree/blob targets emit `error: object <id> is a tree|blob, not a commit` (main adds a single `error:` prefix).
- After cloning: strips everything under `refs/`, sets detached `HEAD` to the commit, removes `remote.origin.fetch` and `branch.*` tracking for that remote.
- Writes shallow boundary **after** applying `--revision` so `--depth` is computed from the final HEAD.

### Harness

- Extended `tests/test-lib.sh` `test_commit` with `--annotate` (upstream parity: `git tag -a -m …`) so the t5621 setup creates annotated tag `v1.0`.

### Meta

- `PLAN.md`, `progress.md`, `data/test-files.csv`, dashboards, and `logs/2026-04-08_t5621-clone-revision.md` updated.

## Verification

- `cargo fmt`, `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t5621-clone-revision.sh` → 12/12
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-082e62bf-6e3a-4c15-a16d-e9ef1556ad59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-082e62bf-6e3a-4c15-a16d-e9ef1556ad59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

