### PR TITLE
fix: t6434 merge-recursive rename options and diff -M parsing

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -757,7 +757,7 @@ commit → check it off → move on.
 - [ ] `t6411-merge-filemode` █░░░░░░░░░░░░░░░░░░░ 1/19 (18 left) — merge: handle file mode
 - [ ] `t6500-gc` ████████░░░░░░░░░░░░ 15/35 (20 left) — basic git gc tests
 
-- [ ] `t6434-merge-recursive-rename-options` ███░░░░░░░░░░░░░░░░░ 5/27 (22 left) — merge-recursive rename options
+- [x] `t6434-merge-recursive-rename-options` ████████████████████ 27/27 (0 left) — merge-recursive rename options
 
 - [ ] `t6007-rev-list-cherry-pick-file` ░░░░░░░░░░░░░░░░░░░░ 1/23 (22 left) — test git rev-list --cherry-pick -- file
 - [ ] `t6050-replace` ██████░░░░░░░░░░░░░░ 12/37 (25 left) — Tests replace refs functionality

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1131,7 +1131,7 @@ t6431-merge-criscross	t6	yes	2	2	0	true	ok	0
 t6432-merge-recursive-rename-options	t6	yes	3	3	0	true	ok	0
 t6432-merge-recursive-space-options	t6	yes	11	11	0	true	ok	0
 t6433-merge-toplevel	t6	yes	15	15	0	true	ok	0
-t6434-merge-recursive-rename-options	t6	yes	27	8	19	false	ok	0
+t6434-merge-recursive-rename-options	t6	yes	27	27	0	true	ok	0
 t6434-merge-with-no-common-ancestor	t6	yes	3	3	0	true	ok	0
 t6435-merge-sparse	t6	yes	6	6	0	true	ok	0
 t6435-merge-sparse-directory	t6	yes	2	2	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T04:18:34+00:00" class="gen-time" title="2026-04-08 04:18 UTC">2026-04-08 04:18 UTC</time> · <a href="https://github.com/schacon/grit/commit/b223cd1de47b87039799aa3a4a961ca232184ff6" style="color:#58a6ff">b223cd1</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T04:26:57+00:00" class="gen-time" title="2026-04-08 04:26 UTC">2026-04-08 04:26 UTC</time> · <a href="https://github.com/schacon/grit/commit/d4c2c1afcdf964ebd98540e25586834c14cfba96" style="color:#58a6ff">d4c2c1a</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,476</div>
+      <div class="summary-big-val">29,495</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>608 files fully passing</span>
+    <span>609 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -245,11 +245,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t6</span>
         <span class="group-desc">Revision tree commands (e.g. merge-base)</span>
-        <span class="group-meta">47/105 files · 3 skipped · 1,164/2,376 tests</span>
+        <span class="group-meta">48/105 files · 3 skipped · 1,183/2,376 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:49.0%"></div></div>
-        <span class="group-pct pct-orange">49.0%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:49.8%"></div></div>
+        <span class="group-pct pct-orange">49.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t7">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T04:18:34+00:00" class="gen-time" title="2026-04-08 04:18 UTC">2026-04-08 04:18 UTC</time> · <a href="https://github.com/schacon/grit/commit/b223cd1de47b87039799aa3a4a961ca232184ff6" style="color:#58a6ff">b223cd1</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T04:26:57+00:00" class="gen-time" title="2026-04-08 04:26 UTC">2026-04-08 04:26 UTC</time> · <a href="https://github.com/schacon/grit/commit/d4c2c1afcdf964ebd98540e25586834c14cfba96" style="color:#58a6ff">d4c2c1a</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,745</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,476</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,495</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">67.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -11447,14 +11447,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t6" data-tests="27" data-passed="8">
+<tr class="" data-group="t6" data-tests="27" data-passed="27">
   <td class="mono">t6434-merge-recursive-rename-options</td>
   <td>t6</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">27</td>
-  <td class="right">8</td>
+  <td class="right">27</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:29.6%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t6" data-tests="3" data-passed="3">

--- a/grit/src/commands/diff.rs
+++ b/grit/src/commands/diff.rs
@@ -367,6 +367,10 @@ pub struct Args {
     #[arg(skip)]
     pub pickaxe_grep: Option<String>,
 
+    /// Filter diff output by change type (e.g. `R` for renames only). Parsed from trailing args.
+    #[arg(skip)]
+    pub diff_filter: Option<String>,
+
     /// Treat the string given to -S as a POSIX extended regex.
     #[arg(long = "pickaxe-regex")]
     pub pickaxe_regex: bool,
@@ -509,9 +513,14 @@ pub fn run(mut args: Args) -> Result<()> {
                     args.line_prefix =
                         Some(s.strip_prefix("--line-prefix=").unwrap_or("").to_owned());
                 }
+                s if s.starts_with("--diff-filter=") => {
+                    args.diff_filter =
+                        Some(s.strip_prefix("--diff-filter=").unwrap_or("").to_owned());
+                }
                 s if s == "-M"
-                    || s.starts_with("-M")
-                        && s[2..].bytes().all(|b| b.is_ascii_digit() || b == b'%') =>
+                    || (s.starts_with("-M")
+                        && s.len() > 2
+                        && s[2..].bytes().all(|b| b.is_ascii_digit() || b == b'%')) =>
                 {
                     let val = if s.len() > 2 { &s[2..] } else { "50" };
                     args.find_renames = Some(val.to_owned());
@@ -683,7 +692,7 @@ pub fn run(mut args: Args) -> Result<()> {
 
     // Apply rename detection if requested (explicit -M flag or diff.renames config).
     let rename_threshold: Option<u32> = if let Some(ref threshold_str) = args.find_renames {
-        Some(threshold_str.parse().unwrap_or(50))
+        Some(parse_diff_rename_threshold(threshold_str))
     } else {
         // Check diff.renames config.
         use grit_lib::config::ConfigSet;
@@ -717,6 +726,16 @@ pub fn run(mut args: Args) -> Result<()> {
                 e.old_mode != "160000" && e.new_mode != "160000"
             })
             .collect()
+    } else {
+        entries
+    };
+
+    let entries = if let Some(ref df) = args.diff_filter {
+        if df.is_empty() {
+            entries
+        } else {
+            apply_diff_filter(entries, df)
+        }
     } else {
         entries
     };
@@ -1473,6 +1492,42 @@ fn glob_match(pattern: &str, text: &str) -> bool {
 /// If `--` is present, everything before is revisions, everything after is paths.
 /// Otherwise, we try each arg: if it exists as a file, treat it (and all
 /// subsequent args) as paths rather than revisions.
+/// Parse `-M` / `--find-renames` similarity: optional trailing `%`, capped at 100 (Git truncates).
+fn parse_diff_rename_threshold(raw: &str) -> u32 {
+    let t = raw.trim();
+    let num = t.strip_suffix('%').unwrap_or(t);
+    num.parse::<u32>().unwrap_or(50).min(100)
+}
+
+/// Apply `--diff-filter` (include uppercase status letters, exclude lowercase).
+fn apply_diff_filter(entries: Vec<DiffEntry>, filter: &str) -> Vec<DiffEntry> {
+    let mut include: Option<std::collections::HashSet<char>> = None;
+    let mut exclude: std::collections::HashSet<char> = std::collections::HashSet::new();
+    for c in filter.chars() {
+        if c == '*' {
+            continue;
+        }
+        if c.is_ascii_uppercase() {
+            include.get_or_insert_with(Default::default).insert(c);
+        } else if c.is_ascii_lowercase() {
+            exclude.insert(c.to_ascii_uppercase());
+        }
+    }
+    entries
+        .into_iter()
+        .filter(|e| {
+            let ch = e.status.letter();
+            if exclude.contains(&ch) {
+                return false;
+            }
+            if let Some(ref inc) = include {
+                return inc.contains(&ch);
+            }
+            true
+        })
+        .collect()
+}
+
 fn parse_rev_and_paths(args: &[String], has_separator: bool) -> (Vec<String>, Vec<String>) {
     if let Some(sep) = args.iter().position(|a| a == "--") {
         let revs = args[..sep].to_vec();

--- a/grit/src/commands/merge.rs
+++ b/grit/src/commands/merge.rs
@@ -643,6 +643,7 @@ fn create_virtual_merge_base(
             false,
             false,
             MergeDirectoryRenamesMode::FromConfig,
+            MergeRenameOptions::from_config(repo),
         )?;
 
         // Build a tree from the merged index:
@@ -939,6 +940,7 @@ fn do_real_merge(
         false,
         false,
         MergeDirectoryRenamesMode::FromConfig,
+        MergeRenameOptions::from_config(repo),
     )?;
 
     // Refuse merges that would overwrite local changes or untracked files.
@@ -1635,6 +1637,7 @@ fn do_octopus_merge(
             false,
             false,
             MergeDirectoryRenamesMode::FromConfig,
+            MergeRenameOptions::from_config(repo),
         )?;
 
         if merge_result.has_conflicts {
@@ -2577,6 +2580,48 @@ fn parse_conflict_marker_size(
     }
 }
 
+/// Rename detection settings for tree merge (CLI and `merge.renames` / `diff.renames`).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct MergeRenameOptions {
+    /// When false, skip all rename detection (exact and similarity-based).
+    pub detect: bool,
+    /// Minimum similarity percentage (0–100) for similarity-based renames.
+    pub threshold: u32,
+}
+
+impl MergeRenameOptions {
+    /// Load defaults from config: `merge.renames` overrides `diff.renames`; threshold is 50%.
+    pub fn from_config(repo: &Repository) -> Self {
+        let config = ConfigSet::load(Some(&repo.git_dir), true).ok();
+        let detect = merge_renames_enabled_from_config(config.as_ref());
+        Self {
+            detect,
+            threshold: 50,
+        }
+    }
+}
+
+fn merge_renames_enabled_from_config(config: Option<&ConfigSet>) -> bool {
+    let Some(c) = config else {
+        return true;
+    };
+    if let Some(v) = c.get("merge.renames") {
+        return config_value_enables_renames(&v);
+    }
+    if let Some(v) = c.get("diff.renames") {
+        return config_value_enables_renames(&v);
+    }
+    true
+}
+
+fn config_value_enables_renames(val: &str) -> bool {
+    let lowered = val.trim().to_ascii_lowercase();
+    matches!(
+        lowered.as_str(),
+        "true" | "yes" | "on" | "1" | "" | "copies" | "copy"
+    )
+}
+
 /// Build rename maps from base to each side.
 ///
 /// Detects renames by looking for base blobs that appear at different paths
@@ -2590,8 +2635,12 @@ fn detect_merge_renames(
     base: &HashMap<Vec<u8>, IndexEntry>,
     ours: &HashMap<Vec<u8>, IndexEntry>,
     theirs: &HashMap<Vec<u8>, IndexEntry>,
+    rename_opts: MergeRenameOptions,
 ) -> (HashMap<Vec<u8>, Vec<u8>>, HashMap<Vec<u8>, Vec<u8>>) {
-    let threshold = 50u32;
+    if !rename_opts.detect {
+        return (HashMap::new(), HashMap::new());
+    }
+    let threshold = rename_opts.threshold.min(100);
     // Read merge.renamelimit or fall back to diff.renamelimit
     let rename_limit: usize = {
         let config = grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true).ok();
@@ -2951,9 +3000,11 @@ fn merge_trees(
     ignore_space_at_eol: bool,
     ignore_cr_at_eol: bool,
     merge_directory_renames_mode: MergeDirectoryRenamesMode,
+    rename_options: MergeRenameOptions,
 ) -> Result<MergeResult> {
     // Detect renames on each side
-    let (mut ours_renames, mut theirs_renames) = detect_merge_renames(repo, base, ours, theirs);
+    let (mut ours_renames, mut theirs_renames) =
+        detect_merge_renames(repo, base, ours, theirs, rename_options);
     let mut ours_entries = ours.clone();
     let mut theirs_entries = theirs.clone();
 
@@ -3715,6 +3766,7 @@ pub(crate) fn merge_trees_for_replay(
     ignore_space_at_eol: bool,
     ignore_cr_at_eol: bool,
     merge_directory_renames_mode: MergeDirectoryRenamesMode,
+    rename_options: MergeRenameOptions,
 ) -> Result<ReplayTreeMergeResult> {
     let head = HeadState::Invalid;
     let result = merge_trees(
@@ -3733,6 +3785,7 @@ pub(crate) fn merge_trees_for_replay(
         ignore_space_at_eol,
         ignore_cr_at_eol,
         merge_directory_renames_mode,
+        rename_options,
     )?;
     Ok(ReplayTreeMergeResult {
         index: result.index,

--- a/grit/src/commands/merge_recursive.rs
+++ b/grit/src/commands/merge_recursive.rs
@@ -13,7 +13,7 @@ use grit_lib::repo::Repository;
 use std::collections::HashMap;
 use std::path::Path;
 
-use super::merge::{merge_trees_for_replay, MergeDirectoryRenamesMode};
+use super::merge::{merge_trees_for_replay, MergeDirectoryRenamesMode, MergeRenameOptions};
 
 /// Arguments for `grit merge-recursive`.
 #[derive(Debug, ClapArgs)]
@@ -27,7 +27,11 @@ pub struct Args {
 /// Run `grit merge-recursive`.
 pub fn run(args: Args) -> Result<()> {
     let repo = Repository::discover(None).context("not a git repository")?;
-    let (ws, positional) = parse_args(&args.args)?;
+    let MergeRecursiveParsed {
+        ws,
+        rename_options,
+        positional,
+    } = parse_args(&repo, &args.args)?;
     if positional.len() != 3 {
         bail!("usage: git merge-recursive [<options>] <base> -- <head> <remote> [<base>...]");
     }
@@ -61,6 +65,7 @@ pub fn run(args: Args) -> Result<()> {
         ws.ignore_space_at_eol,
         ws.ignore_cr_at_eol,
         MergeDirectoryRenamesMode::FromConfig,
+        rename_options,
     )?;
 
     repo.write_index(&mut merge_result.index)?;
@@ -110,8 +115,31 @@ struct WhitespaceOptions {
     ignore_cr_at_eol: bool,
 }
 
-fn parse_args(args: &[String]) -> Result<(WhitespaceOptions, Vec<String>)> {
+struct MergeRecursiveParsed {
+    ws: WhitespaceOptions,
+    rename_options: MergeRenameOptions,
+    positional: Vec<String>,
+}
+
+/// Parse `--find-renames` / `--rename-threshold` percentage like Git (optional `%`, capped at 100).
+fn parse_merge_rename_percent(raw: &str) -> Result<u32> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        bail!("invalid similarity index: {raw}");
+    }
+    let num = trimmed.strip_suffix('%').unwrap_or(trimmed);
+    let value: i64 = num
+        .parse()
+        .map_err(|_| anyhow::anyhow!("invalid similarity index: {raw}"))?;
+    if value < 0 {
+        bail!("invalid similarity index: {raw}");
+    }
+    Ok((value as u32).min(100))
+}
+
+fn parse_args(repo: &Repository, args: &[String]) -> Result<MergeRecursiveParsed> {
     let mut ws = WhitespaceOptions::default();
+    let mut rename_options = MergeRenameOptions::from_config(repo);
     let mut positional = Vec::new();
     let mut end_of_options = false;
 
@@ -132,10 +160,25 @@ fn parse_args(args: &[String]) -> Result<(WhitespaceOptions, Vec<String>)> {
                 "--ignore-cr-at-eol" => ws.ignore_cr_at_eol = true,
                 "--patience" | "--histogram" | "--minimal" => { /* accepted, ignored */ }
                 "--renormalize" | "--no-renormalize" => { /* accepted, ignored for now */ }
-                "--no-renames" | "--find-renames" => { /* accepted, ignored for now */ }
-                _ if arg.starts_with("--find-renames=")
-                    || arg.starts_with("--rename-threshold=") =>
-                { /* accepted */ }
+                "--no-renames" => {
+                    rename_options.detect = false;
+                }
+                "--find-renames" => {
+                    rename_options.detect = true;
+                    rename_options.threshold = 50;
+                }
+                _ if arg.starts_with("--find-renames=") => {
+                    let val = &arg["--find-renames=".len()..];
+                    rename_options.detect = true;
+                    rename_options.threshold = parse_merge_rename_percent(val)
+                        .with_context(|| format!("bad --find-renames argument: {val}"))?;
+                }
+                _ if arg.starts_with("--rename-threshold=") => {
+                    let val = &arg["--rename-threshold=".len()..];
+                    rename_options.detect = true;
+                    rename_options.threshold = parse_merge_rename_percent(val)
+                        .with_context(|| format!("bad --rename-threshold argument: {val}"))?;
+                }
                 _ => bail!("unknown option: {arg}"),
             }
             i += 1;
@@ -146,7 +189,11 @@ fn parse_args(args: &[String]) -> Result<(WhitespaceOptions, Vec<String>)> {
         i += 1;
     }
 
-    Ok((ws, positional))
+    Ok(MergeRecursiveParsed {
+        ws,
+        rename_options,
+        positional,
+    })
 }
 
 fn resolve_commit_oid(repo: &Repository, spec: &str) -> Result<ObjectId> {

--- a/grit/src/commands/replay.rs
+++ b/grit/src/commands/replay.rs
@@ -4,7 +4,9 @@
 //! tree merging for each replayed commit and printing an `update-ref --stdin`
 //! command for the updated branch.
 
-use crate::commands::merge::{merge_trees_for_replay, MergeDirectoryRenamesMode};
+use crate::commands::merge::{
+    merge_trees_for_replay, MergeDirectoryRenamesMode, MergeRenameOptions,
+};
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::config::ConfigSet;
@@ -176,6 +178,7 @@ pub fn run(args: Args) -> Result<()> {
             false,
             false,
             MergeDirectoryRenamesMode::Disabled,
+            MergeRenameOptions::from_config(&repo),
         )?;
         if merge_result.has_conflicts {
             let reason = merge_result

--- a/logs/2026-04-08_t6434-merge-recursive-rename-options.md
+++ b/logs/2026-04-08_t6434-merge-recursive-rename-options.md
@@ -1,0 +1,32 @@
+# t6434-merge-recursive-rename-options
+
+## Summary
+
+Made `tests/t6434-merge-recursive-rename-options.sh` fully pass (27/27).
+
+## Changes
+
+1. **`grit merge-recursive`** (`grit/src/commands/merge_recursive.rs`)
+   - Parse `--find-renames`, `--find-renames=<pct>`, `--rename-threshold=<pct>`, `--no-renames` with last-wins semantics.
+   - Reject negative / non-numeric similarity values (e.g. `-25`, `0xf`).
+   - Truncate percentages >100 to 100 (matches Git).
+   - Build `MergeRenameOptions` from config (`merge.renames` overrides `diff.renames`) then apply CLI overrides.
+
+2. **Merge core** (`grit/src/commands/merge.rs`)
+   - Added `MergeRenameOptions { detect, threshold }` and `from_config`.
+   - `detect_merge_renames` takes options; skips similarity detection when disabled; uses configurable threshold.
+   - `merge_trees` / `merge_trees_for_replay` take `rename_options` (merge/replay pass `from_config`; merge-recursive passes parsed CLI).
+
+3. **`grit diff`** (`grit/src/commands/diff.rs`)
+   - Fixed trailing-arg handling: `-M25%` is recognized as rename option (require digits/`%` after `-M`), not a third revision.
+   - `--diff-filter=R` support for assumption test.
+   - Parse `-M` / `--find-renames` percentages with optional `%` and cap at 100.
+
+## Verification
+
+```bash
+cargo fmt
+cargo clippy -p grit-rs --fix --allow-dirty
+cargo test -p grit-lib --lib
+./scripts/run-tests.sh t6434-merge-recursive-rename-options.sh
+```

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   227 |
+| Completed   |   228 |
 | In progress |     2 |
-| Remaining   |   539 |
+| Remaining   |   538 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 227 completed (`[x]`), 2 in progress (`[~]`), 539 remaining (`[ ]`).
+Task lines in `PLAN.md`: 228 completed (`[x]`), 2 in progress (`[~]`), 538 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t6434-merge-recursive-rename-options` — 27/27 tests pass (`merge-recursive`: `--find-renames` / `--rename-threshold` with `%`, truncation, last-flag wins vs `--no-renames`, invalid args; config `merge.renames` / `diff.renames`; merge core threads `MergeRenameOptions` into `detect_merge_renames`; `diff`: `-M<n>%` no longer misparsed as a revision, `--diff-filter`, percentage threshold parsing)
 - `t5704-protocol-violations` — 3/3 tests pass (`upload-pack` honors `GIT_PROTOCOL=version=2` with flush-after-args validation for `ls-refs`/`fetch`; `ls-remote --upload-pack` parses v0 ref ads with space/NUL-separated fields and v2 `ls-refs` responses; `serve-v2` default loop fixed)
 - `t7509-commit-authorship` — 12/12 tests pass (`commit`: `--reset-author` with `-C`/`-c`/`--amend` and when `CHERRY_PICK_HEAD`/`REBASE_HEAD` exists; author from `CHERRY_PICK_HEAD` when finishing cherry-pick with `MERGE_MSG`; `--author` now formats full ident with current date; amend rejects empty/malformed prior author; mutual exclusion with `--reset-author`)
 - `t4026-color` — 34/34 tests pass (Git-compatible `config::parse_color` per `git/color.c`; `git config --get-color` merges argv after the slot into one default and uses `--` when the default begins with `-` so clap accepts `-1 black`)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes `t6434-merge-recursive-rename-options` pass (27/27).

## Changes

- **`merge-recursive`**: Parse `--find-renames`, `--find-renames=<n>`, `--rename-threshold=<n>`, and `--no-renames` with Git-style last-wins behavior; reject invalid similarity values; cap percentages at 100. Honor `merge.renames` (over `diff.renames`) from config when CLI does not override.
- **Merge core**: Introduce `MergeRenameOptions` and thread it through `merge_trees` / `merge_trees_for_replay` / `detect_merge_renames` so similarity threshold and on/off are configurable.
- **`diff`**: Fix trailing-arg parsing so `-M25%` is not treated as a third revision; add `--diff-filter` (used by the test setup); parse optional `%` on rename thresholds.

## Verification

- `cargo fmt`, `cargo clippy -p grit-rs --fix --allow-dirty`
- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t6434-merge-recursive-rename-options.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37d156b9-25d1-42cb-a160-08b8f8750db9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37d156b9-25d1-42cb-a160-08b8f8750db9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

