### PR TITLE
fix: make t7517-per-repo-email fully pass

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -829,7 +829,7 @@ commit → check it off → move on.
 - [ ] `t7111-reset-table` ████████████████░░░░ 34/42 (8 left) — Tests to check that 
 - [ ] `t7814-grep-recurse-submodules` ███████████████░░░░░ 26/34 (8 left) — Test grep recurse-submodules feature
 
-- [ ] `t7517-per-repo-email` ██████████░░░░░░░░░░ 8/16 (8 left) — per-repo forced setting of email address
+- [x] `t7517-per-repo-email` — per-repo forced setting of email address (16/16)
 - [ ] `t7525-status-rename` █████████░░░░░░░░░░░ 7/15 (8 left) — git status rename detection options
 - [ ] `t7412-submodule-absorbgitdirs` ██████░░░░░░░░░░░░░░ 4/12 (8 left) — Test submodule absorbgitdirs
 

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1239,7 +1239,7 @@ t7514-commit-patch	t7	yes	3	1	2	false	ok	0
 t7514-interpret-trailers-options	t7	yes	10	10	0	true	ok	0
 t7515-status-symlinks	t7	yes	3	3	0	true	ok	0
 t7516-commit-races	t7	yes	2	0	2	false	ok	0
-t7517-per-repo-email	t7	yes	16	8	8	false	ok	0
+t7517-per-repo-email	t7	yes	16	16	0	true	ok	0
 t7518-ident-corner-cases	t7	yes	5	5	0	true	ok	0
 t7519-status-fsmonitor	t7	yes	33	14	19	false	ok	0
 t7520-ignored-hook-warning	t7	yes	5	4	1	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T04:18:34+00:00" class="gen-time" title="2026-04-08 04:18 UTC">2026-04-08 04:18 UTC</time> · <a href="https://github.com/schacon/grit/commit/b223cd1de47b87039799aa3a4a961ca232184ff6" style="color:#58a6ff">b223cd1</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T04:33:15+00:00" class="gen-time" title="2026-04-08 04:33 UTC">2026-04-08 04:33 UTC</time> · <a href="https://github.com/schacon/grit/commit/d4c2c1afcdf964ebd98540e25586834c14cfba96" style="color:#58a6ff">d4c2c1a</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,476</div>
+      <div class="summary-big-val">29,484</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>608 files fully passing</span>
+    <span>609 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -256,11 +256,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">35/126 files · 11 skipped · 1,873/3,607 tests</span>
+        <span class="group-meta">36/126 files · 11 skipped · 1,881/3,607 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:51.9%"></div></div>
-        <span class="group-pct pct-orange">51.9%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:52.1%"></div></div>
+        <span class="group-pct pct-orange">52.1%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T04:18:34+00:00" class="gen-time" title="2026-04-08 04:18 UTC">2026-04-08 04:18 UTC</time> · <a href="https://github.com/schacon/grit/commit/b223cd1de47b87039799aa3a4a961ca232184ff6" style="color:#58a6ff">b223cd1</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T04:33:15+00:00" class="gen-time" title="2026-04-08 04:33 UTC">2026-04-08 04:33 UTC</time> · <a href="https://github.com/schacon/grit/commit/d4c2c1afcdf964ebd98540e25586834c14cfba96" style="color:#58a6ff">d4c2c1a</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,745</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,476</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,484</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">67.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -12527,14 +12527,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="16" data-passed="8">
+<tr class="" data-group="t7" data-tests="16" data-passed="16">
   <td class="mono">t7517-per-repo-email</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">16</td>
-  <td class="right">8</td>
+  <td class="right">16</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="5" data-passed="5">

--- a/grit/src/commands/commit.rs
+++ b/grit/src/commands/commit.rs
@@ -16,6 +16,9 @@ use grit_lib::repo::Repository;
 use grit_lib::rev_parse::resolve_revision;
 use grit_lib::state::{resolve_head, HeadState};
 use grit_lib::write_tree::write_tree_from_index;
+
+use crate::ident::{resolve_email, resolve_name, IdentRole};
+
 use std::collections::BTreeSet;
 use std::fs;
 use std::io::{self, Write};
@@ -1154,27 +1157,10 @@ fn resolve_author(
         }
     }
 
-    let name = std::env::var("GIT_AUTHOR_NAME")
-        .ok()
-        .or_else(|| config.get("user.name"));
-    let name = match name {
-        Some(n) if n.is_empty() => {
-            eprintln!("Author identity unknown");
-            bail!("empty ident name (for <author>) not allowed");
-        }
-        Some(n) => n,
-        None => {
-            eprintln!("Author identity unknown");
-            bail!("Author identity unknown\n\nPlease tell me who you are.\n\n\
-                 Run\n\n  git config user.email \"you@example.com\"\n  git config user.name \"Your Name\"");
-        }
-    };
+    let name = resolve_name(config, IdentRole::Author)?;
     validate_ident_name(&name, "author")?;
 
-    let email = std::env::var("GIT_AUTHOR_EMAIL")
-        .ok()
-        .or_else(|| config.get("user.email"))
-        .unwrap_or_default();
+    let email = resolve_email(config, IdentRole::Author)?;
 
     let date_str = args
         .date
@@ -1192,23 +1178,10 @@ fn resolve_author(
 
 /// Resolve the committer identity from env and config.
 fn resolve_committer(config: &ConfigSet, now: OffsetDateTime) -> Result<String> {
-    let name = std::env::var("GIT_COMMITTER_NAME")
-        .ok()
-        .or_else(|| config.get("user.name"));
-    let name = match name {
-        Some(n) if n.is_empty() => {
-            eprintln!("Committer identity unknown");
-            bail!("empty ident name (for <committer>) not allowed");
-        }
-        Some(n) => n,
-        None => "Unknown".to_owned(),
-    };
+    let name = resolve_name(config, IdentRole::Committer)?;
     validate_ident_name(&name, "committer")?;
 
-    let email = std::env::var("GIT_COMMITTER_EMAIL")
-        .ok()
-        .or_else(|| config.get("user.email"))
-        .unwrap_or_default();
+    let email = resolve_email(config, IdentRole::Committer)?;
 
     let date_str = std::env::var("GIT_COMMITTER_DATE").ok();
     let timestamp = match date_str {

--- a/grit/src/commands/rebase.rs
+++ b/grit/src/commands/rebase.rs
@@ -31,6 +31,8 @@ use grit_lib::rev_parse::resolve_revision;
 use grit_lib::state::{resolve_head, HeadState};
 use grit_lib::write_tree::write_tree_from_index;
 
+use crate::ident::{resolve_email, resolve_name, IdentRole};
+
 #[derive(Clone, Copy)]
 enum RebaseBackend {
     Merge,
@@ -283,17 +285,8 @@ fn print_branch_up_to_date(head: &HeadState) {
 }
 
 fn reflog_identity(repo: &Repository) -> String {
-    let config = ConfigSet::load(Some(&repo.git_dir), true).ok();
-    let name = std::env::var("GIT_COMMITTER_NAME")
-        .ok()
-        .or_else(|| std::env::var("GIT_AUTHOR_NAME").ok())
-        .or_else(|| config.as_ref().and_then(|c| c.get("user.name")))
-        .unwrap_or_else(|| "Unknown".to_owned());
-    let email = std::env::var("GIT_COMMITTER_EMAIL")
-        .ok()
-        .or_else(|| std::env::var("GIT_AUTHOR_EMAIL").ok())
-        .or_else(|| config.as_ref().and_then(|c| c.get("user.email")))
-        .unwrap_or_default();
+    let config = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+    let (name, email) = crate::ident::resolve_loose_committer_parts(&config);
     let now = time::OffsetDateTime::now_utc();
     let epoch = now.unix_timestamp();
     let offset = now.offset();
@@ -469,7 +462,8 @@ fn do_rebase(args: Args) -> Result<()> {
             let subject = commit.message.lines().next().unwrap_or("");
             println!("pick {} {}", &oid.to_hex()[..7], subject);
         }
-        return Ok(());
+        // Git runs the sequence editor then proceeds with the replay; we have no editor
+        // integration yet, so continue into the same replay path as non-interactive rebase.
     }
 
     if !args.no_ff && commits.is_empty() {
@@ -1021,6 +1015,20 @@ fn cherry_pick_for_rebase(
     let head_commit = parse_commit(&head_obj.data)?;
     let head_tree_oid = head_commit.tree;
 
+    // Already at the picked commit's parent tip — nothing to replay (matches Git's noop pick).
+    if head_oid == *parent_oid {
+        let old_index = load_index(repo)?;
+        let mut idx = Index::new();
+        idx.entries = tree_to_index_entries(repo, &commit_tree_oid, "")?;
+        idx.sort();
+        repo.write_index(&mut idx)?;
+        if let Some(wt) = &repo.work_tree {
+            checkout_merged_index(repo, wt, &old_index, &idx)?;
+        }
+        fs::write(git_dir.join("HEAD"), format!("{}\n", commit_oid.to_hex()))?;
+        return Ok(());
+    }
+
     // Three-way merge: base=parent_tree, ours=HEAD_tree, theirs=commit_tree
     let base_entries = tree_to_map(tree_to_index_entries(repo, &parent_tree_oid, "")?);
     let ours_entries = tree_to_map(tree_to_index_entries(repo, &head_tree_oid, "")?);
@@ -1449,19 +1457,11 @@ fn load_index(repo: &Repository) -> Result<Index> {
 }
 
 fn resolve_identity(config: &ConfigSet, kind: &str) -> Result<(String, String)> {
-    let name_var = format!("GIT_{kind}_NAME");
-    let email_var = format!("GIT_{kind}_EMAIL");
-
-    let name = std::env::var(&name_var)
-        .ok()
-        .or_else(|| config.get("user.name"))
-        .unwrap_or_else(|| "Unknown".to_owned());
-    let email = std::env::var(&email_var)
-        .ok()
-        .or_else(|| config.get("user.email"))
-        .unwrap_or_default();
-
-    Ok((name, email))
+    let role = match kind {
+        "AUTHOR" => IdentRole::Author,
+        _ => IdentRole::Committer,
+    };
+    Ok((resolve_name(config, role)?, resolve_email(config, role)?))
 }
 
 fn format_ident(ident: &(String, String), now: time::OffsetDateTime) -> String {

--- a/grit/src/commands/var.rs
+++ b/grit/src/commands/var.rs
@@ -11,6 +11,8 @@ use grit_lib::config::ConfigSet;
 use std::io::{self, Write};
 use time::OffsetDateTime;
 
+use crate::ident::{peek_name, resolve_email_lenient, IdentRole};
+
 /// Arguments for `grit var`.
 #[derive(Debug, ClapArgs)]
 #[command(about = "Show a Git logical variable")]
@@ -122,12 +124,12 @@ fn read_var(name: &str, config: &ConfigSet, strict: bool) -> Result<Option<Strin
 
 /// Build the author identity string from env/config.
 fn author_ident(config: &ConfigSet, strict: bool) -> Result<Option<String>> {
-    let env_name = std::env::var("GIT_AUTHOR_NAME").ok();
-    let env_email = std::env::var("GIT_AUTHOR_EMAIL").ok();
-    let name = env_name.or_else(|| config.get("user.name"));
-    let email = env_email
-        .or_else(|| config.get("user.email"))
-        .unwrap_or_default();
+    let name = peek_name(config, IdentRole::Author);
+    let email = if strict {
+        crate::ident::resolve_email(config, IdentRole::Author)?
+    } else {
+        resolve_email_lenient(config, IdentRole::Author)
+    };
     let date = std::env::var("GIT_AUTHOR_DATE")
         .ok()
         .unwrap_or_else(|| format_git_timestamp(OffsetDateTime::now_utc()));
@@ -137,12 +139,12 @@ fn author_ident(config: &ConfigSet, strict: bool) -> Result<Option<String>> {
 
 /// Build the committer identity string from env/config.
 fn committer_ident(config: &ConfigSet, strict: bool) -> Result<Option<String>> {
-    let env_name = std::env::var("GIT_COMMITTER_NAME").ok();
-    let env_email = std::env::var("GIT_COMMITTER_EMAIL").ok();
-    let name = env_name.or_else(|| config.get("user.name"));
-    let email = env_email
-        .or_else(|| config.get("user.email"))
-        .unwrap_or_default();
+    let name = peek_name(config, IdentRole::Committer);
+    let email = if strict {
+        crate::ident::resolve_email(config, IdentRole::Committer)?
+    } else {
+        resolve_email_lenient(config, IdentRole::Committer)
+    };
     let date = std::env::var("GIT_COMMITTER_DATE")
         .ok()
         .unwrap_or_else(|| format_git_timestamp(OffsetDateTime::now_utc()));
@@ -161,7 +163,7 @@ fn build_ident(
     let name = name.map(|n| n.trim().to_owned()).filter(|n| !n.is_empty());
     let email = email.trim().to_owned();
 
-    if strict && (name.is_none() || email.is_empty()) {
+    if strict && name.is_none() {
         bail!(
                 "*** Please tell me who you are.\n\n\
                  Run\n\n  git config user.email \"you@example.com\"\n  git config user.name \"Your Name\"\n\n\

--- a/grit/src/ident.rs
+++ b/grit/src/ident.rs
@@ -1,0 +1,245 @@
+//! Git-compatible author/committer identity resolution (see upstream `ident.c`).
+//!
+//! Handles `user.useConfigOnly`, per-role `author.*` / `committer.*` overrides,
+//! and the `EMAIL` environment fallback when auto-detection is allowed.
+
+use anyhow::{bail, Result};
+use grit_lib::config::ConfigSet;
+
+/// Author vs committer for `GIT_*` / `author.*` / `committer.*` lookup.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IdentRole {
+    Author,
+    Committer,
+}
+
+impl IdentRole {
+    fn env_name_key(self) -> &'static str {
+        match self {
+            IdentRole::Author => "GIT_AUTHOR_NAME",
+            IdentRole::Committer => "GIT_COMMITTER_NAME",
+        }
+    }
+
+    fn env_email_key(self) -> &'static str {
+        match self {
+            IdentRole::Author => "GIT_AUTHOR_EMAIL",
+            IdentRole::Committer => "GIT_COMMITTER_EMAIL",
+        }
+    }
+
+    fn config_name_key(self) -> &'static str {
+        match self {
+            IdentRole::Author => "author.name",
+            IdentRole::Committer => "committer.name",
+        }
+    }
+
+    fn config_email_key(self) -> &'static str {
+        match self {
+            IdentRole::Author => "author.email",
+            IdentRole::Committer => "committer.email",
+        }
+    }
+
+    fn missing_email_hint(self) -> &'static str {
+        match self {
+            IdentRole::Author => "Author identity unknown",
+            IdentRole::Committer => "Committer identity unknown",
+        }
+    }
+}
+
+fn use_config_only(config: &ConfigSet) -> bool {
+    match config.get_bool("user.useConfigOnly") {
+        Some(Ok(b)) => b,
+        Some(Err(_)) => false,
+        None => false,
+    }
+}
+
+/// True if any of `user.email`, `author.email`, or `committer.email` is set to a non-empty value.
+fn config_mail_given(config: &ConfigSet) -> bool {
+    for key in ["user.email", "author.email", "committer.email"] {
+        if let Some(v) = config.get(key) {
+            if !v.trim().is_empty() {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn synthetic_email() -> String {
+    let user = std::env::var("USER")
+        .or_else(|_| std::env::var("USERNAME"))
+        .unwrap_or_else(|_| "unknown".to_owned());
+    let host = std::env::var("HOSTNAME").unwrap_or_else(|_| "unknown".to_owned());
+    let domain = if host.contains('.') {
+        host
+    } else {
+        format!("{host}.(none)")
+    };
+    format!("{user}@{domain}")
+}
+
+fn resolve_email_inner(
+    config: &ConfigSet,
+    role: IdentRole,
+    honor_use_config_only: bool,
+) -> Result<String> {
+    if let Ok(v) = std::env::var(role.env_email_key()) {
+        let t = v.trim();
+        if !t.is_empty() {
+            return Ok(t.to_owned());
+        }
+    }
+
+    if let Some(v) = config.get(role.config_email_key()) {
+        let t = v.trim();
+        if !t.is_empty() {
+            return Ok(t.to_owned());
+        }
+    }
+
+    if let Some(v) = config.get("user.email") {
+        let t = v.trim();
+        if !t.is_empty() {
+            return Ok(t.to_owned());
+        }
+    }
+
+    if honor_use_config_only && use_config_only(config) && !config_mail_given(config) {
+        eprintln!("{}", role.missing_email_hint());
+        bail!(
+            "no email was given and auto-detection is disabled\n\n\
+*** Please tell me who you are.\n\n\
+Run\n\n\
+  git config --global user.email \"you@example.com\"\n\
+  git config --global user.name \"Your Name\"\n\n\
+to set your account's default identity.\n\
+Omit --global to set the identity only in this repository.\n"
+        );
+    }
+
+    if let Ok(v) = std::env::var("EMAIL") {
+        let t = v.trim();
+        if !t.is_empty() {
+            return Ok(t.to_owned());
+        }
+    }
+
+    Ok(synthetic_email())
+}
+
+/// Resolve email for a role when creating commits (honors `user.useConfigOnly`).
+pub fn resolve_email(config: &ConfigSet, role: IdentRole) -> Result<String> {
+    resolve_email_inner(config, role, true)
+}
+
+/// Resolve email without failing on `user.useConfigOnly` (e.g. `git var -l`, reflog-style).
+#[must_use]
+pub fn resolve_email_lenient(config: &ConfigSet, role: IdentRole) -> String {
+    resolve_email_inner(config, role, false).unwrap_or_else(|_| synthetic_email())
+}
+
+/// Name from env and config without erroring (for `git var -l`).
+#[must_use]
+pub fn peek_name(config: &ConfigSet, role: IdentRole) -> Option<String> {
+    if let Ok(v) = std::env::var(role.env_name_key()) {
+        let t = v.trim();
+        if !t.is_empty() {
+            return Some(t.to_owned());
+        }
+    }
+    if let Some(v) = config.get(role.config_name_key()) {
+        let t = v.trim();
+        if !t.is_empty() {
+            return Some(t.to_owned());
+        }
+    }
+    config
+        .get("user.name")
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+}
+
+/// Resolve name for a role when creating commits.
+pub fn resolve_name(config: &ConfigSet, role: IdentRole) -> Result<String> {
+    if let Some(n) = peek_name(config, role) {
+        return Ok(n);
+    }
+
+    match role {
+        IdentRole::Author => {
+            eprintln!("Author identity unknown");
+            bail!(
+                "Author identity unknown\n\n\
+Please tell me who you are.\n\n\
+Run\n\n\
+  git config user.email \"you@example.com\"\n\
+  git config user.name \"Your Name\""
+            );
+        }
+        IdentRole::Committer => Ok("Unknown".to_owned()),
+    }
+}
+
+/// Committer name/email for reflog and other non-strict contexts: never errors; always has an email.
+pub fn resolve_loose_committer_parts(config: &ConfigSet) -> (String, String) {
+    let name = std::env::var("GIT_COMMITTER_NAME")
+        .ok()
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            std::env::var("GIT_AUTHOR_NAME")
+                .ok()
+                .map(|s| s.trim().to_owned())
+                .filter(|s| !s.is_empty())
+        })
+        .or_else(|| {
+            config
+                .get("committer.name")
+                .map(|s| s.trim().to_owned())
+                .filter(|s| !s.is_empty())
+        })
+        .or_else(|| {
+            config
+                .get("user.name")
+                .map(|s| s.trim().to_owned())
+                .filter(|s| !s.is_empty())
+        })
+        .unwrap_or_else(|| "Unknown".to_owned());
+
+    let email = std::env::var("GIT_COMMITTER_EMAIL")
+        .ok()
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            std::env::var("GIT_AUTHOR_EMAIL")
+                .ok()
+                .map(|s| s.trim().to_owned())
+                .filter(|s| !s.is_empty())
+        })
+        .or_else(|| {
+            config
+                .get("committer.email")
+                .map(|s| s.trim().to_owned())
+                .filter(|s| !s.is_empty())
+        })
+        .or_else(|| {
+            config
+                .get("user.email")
+                .map(|s| s.trim().to_owned())
+                .filter(|s| !s.is_empty())
+        })
+        .or_else(|| {
+            std::env::var("EMAIL")
+                .ok()
+                .map(|s| s.trim().to_owned())
+                .filter(|s| !s.is_empty())
+        })
+        .unwrap_or_else(synthetic_email);
+
+    (name, email)
+}

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -18,6 +18,7 @@ mod dotfile;
 mod git_commit_encoding;
 mod git_path;
 mod grit_exe;
+mod ident;
 pub mod pathspec;
 pub mod pkt_line;
 pub mod protocol;

--- a/logs/2026-04-08_t7517-per-repo-email.md
+++ b/logs/2026-04-08_t7517-per-repo-email.md
@@ -1,0 +1,18 @@
+# t7517-per-repo-email
+
+## Goal
+
+Make `tests/t7517-per-repo-email.sh` fully pass (Git `user.useConfigOnly`, `author.*` / `committer.*`, rebase ident behavior).
+
+## Changes
+
+- Added `grit/src/ident.rs`: Git-style identity resolution (env → role-specific config → `user.*`, `user.useConfigOnly` blocks `EMAIL` / synthetic fallback unless any of `user.email` / `author.email` / `committer.email` is set; loose committer helper for reflog).
+- `commit.rs`: `resolve_author` / `resolve_committer` use the shared resolver.
+- `rebase.rs`: same for cherry-pick committer; interactive rebase prints picks then continues replay (no sequence editor yet); `cherry_pick_for_rebase` fast-path when `HEAD == parent` (noop pick, no new commit / no committer needed).
+- `var.rs`: strict `GIT_*_IDENT` uses the same email rules; non-strict listing uses lenient email.
+
+## Validation
+
+- `cargo fmt`, `cargo clippy -p grit-rs --fix --allow-dirty`
+- `cargo test -p grit-lib --lib`
+- `./scripts/run-tests.sh t7517-per-repo-email.sh` → 16/16

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   227 |
+| Completed   |   228 |
 | In progress |     2 |
-| Remaining   |   539 |
+| Remaining   |   538 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 227 completed (`[x]`), 2 in progress (`[~]`), 539 remaining (`[ ]`).
+Task lines in `PLAN.md`: 228 completed (`[x]`), 2 in progress (`[~]`), 538 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t7517-per-repo-email` — 16/16 tests pass (`user.useConfigOnly` strict email; `author.*`/`committer.*` overrides; rebase `-i` continues into replay; noop pick when HEAD is already the parent)
 - `t5704-protocol-violations` — 3/3 tests pass (`upload-pack` honors `GIT_PROTOCOL=version=2` with flush-after-args validation for `ls-refs`/`fetch`; `ls-remote --upload-pack` parses v0 ref ads with space/NUL-separated fields and v2 `ls-refs` responses; `serve-v2` default loop fixed)
 - `t7509-commit-authorship` — 12/12 tests pass (`commit`: `--reset-author` with `-C`/`-c`/`--amend` and when `CHERRY_PICK_HEAD`/`REBASE_HEAD` exists; author from `CHERRY_PICK_HEAD` when finishing cherry-pick with `MERGE_MSG`; `--author` now formats full ident with current date; amend rejects empty/malformed prior author; mutual exclusion with `--reset-author`)
 - `t4026-color` — 34/34 tests pass (Git-compatible `config::parse_color` per `git/color.c`; `git config --get-color` merges argv after the slot into one default and uses `--` when the default begins with `-` so clap accepts `-1 black`)

--- a/test-results.md
+++ b/test-results.md
@@ -2,6 +2,7 @@
 
 **Updated:** 2026-04-08
 
+- `./scripts/run-tests.sh t7517-per-repo-email.sh`: 16/16 passing (`user.useConfigOnly`, per-role ident config, rebase noop pick; harness CSV/dashboards refreshed).
 - `./scripts/run-tests.sh t5704-protocol-violations.sh`: 3/3 passing (`upload-pack` v2 via `GIT_PROTOCOL`, strict flush-after-args; `ls-remote --upload-pack` v0/v2 parsing; harness CSV/dashboards refreshed).
 - `cargo test -p grit-lib --lib`: 105/105 passing.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible identity handling for `user.useConfigOnly`, per-role `author.*` / `committer.*` config, and `EMAIL` only when auto-detection is allowed (matching upstream `ident.c` semantics). Updates `commit`, `rebase` cherry-pick committer resolution, and `var` strict/lenient paths.

## Rebase

- `rebase -i` now prints the pick list then continues into the same replay path as non-interactive rebase (sequence editor not integrated yet).
- When cherry-picking during rebase, if `HEAD` is already the picked commit's parent, skip creating a new commit and fast-forward HEAD to the existing commit (noop interactive rebase / ident-free path).

## Test

- `./scripts/run-tests.sh t7517-per-repo-email.sh` → 16/16
- `cargo test -p grit-lib --lib`

Also refreshes `data/test-files.csv`, dashboards, `PLAN.md`, `progress.md`, `test-results.md`, and adds `logs/2026-04-08_t7517-per-repo-email.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d8399af-95e8-4d1c-af24-c1e6b5bd48ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d8399af-95e8-4d1c-af24-c1e6b5bd48ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

