### PR TITLE
fix: make t1512-rev-parse-disambiguation fully pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -446,7 +446,7 @@ t1508-at-combinations	t1	yes	35	30	5	false	ok	0
 t1509-root-work-tree	t1	yes	0	0	0	false	ok	0
 t1510-repo-setup	t1	yes	109	13	96	false	ok	0
 t1511-rev-parse-caret	t1	yes	17	11	6	false	ok	0
-t1512-rev-parse-disambiguation	t1	yes	35	16	19	false	ok	3
+t1512-rev-parse-disambiguation	t1	yes	38	38	0	true	ok	0
 t1513-rev-parse-prefix	t1	yes	11	11	0	true	ok	0
 t1514-rev-parse-push	t1	yes	9	4	5	false	ok	0
 t1515-rev-parse-outside-repo	t1	yes	4	4	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T03:57:54+00:00" class="gen-time" title="2026-04-08 03:57 UTC">2026-04-08 03:57 UTC</time> · <a href="https://github.com/schacon/grit/commit/a9a7e9c8a9ab0f717ea1f0be3d4b518340747f3d" style="color:#58a6ff">a9a7e9c</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T05:14:48+00:00" class="gen-time" title="2026-04-08 05:14 UTC">2026-04-08 05:14 UTC</time> · <a href="https://github.com/schacon/grit/commit/09290c100b79448921e4faff6de7013a3030982b" style="color:#58a6ff">09290c1</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,11 +150,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,476</div>
+      <div class="summary-big-val">29,498</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">43,745</div>
+      <div class="summary-big-val">43,748</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>608 files fully passing</span>
+    <span>609 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -190,11 +190,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">235/368 files · 8 skipped · 10,526/12,224 tests</span>
+        <span class="group-meta">236/368 files · 8 skipped · 10,548/12,227 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:86.1%"></div></div>
-        <span class="group-pct pct-green">86.1%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:86.3%"></div></div>
+        <span class="group-pct pct-green">86.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t2">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T03:57:54+00:00" class="gen-time" title="2026-04-08 03:57 UTC">2026-04-08 03:57 UTC</time> · <a href="https://github.com/schacon/grit/commit/a9a7e9c8a9ab0f717ea1f0be3d4b518340747f3d" style="color:#58a6ff">a9a7e9c</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T05:14:48+00:00" class="gen-time" title="2026-04-08 05:14 UTC">2026-04-08 05:14 UTC</time> · <a href="https://github.com/schacon/grit/commit/09290c100b79448921e4faff6de7013a3030982b" style="color:#58a6ff">09290c1</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">43,745</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,476</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n" id="sum-tests">43,748</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,498</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">67.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -4597,15 +4597,15 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:64.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="35" data-passed="16">
+<tr class="" data-group="t1" data-tests="38" data-passed="38">
   <td class="mono">t1512-rev-parse-disambiguation</td>
   <td>t1</td>
-  <td></td>
-  <td class="right">35</td>
-  <td class="right">16</td>
+  <td><span class="badge ok">full pass</span></td>
+  <td class="right">38</td>
+  <td class="right">38</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.7%"></div></div></td>
-  <td class="right small">3</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="11" data-passed="11">
   <td class="mono">t1513-rev-parse-prefix</td>

--- a/grit-lib/src/rev_list.rs
+++ b/grit-lib/src/rev_list.rs
@@ -14,7 +14,7 @@ use crate::error::{Error, Result};
 use crate::objects::{parse_commit, parse_tag, parse_tree, ObjectId, ObjectKind};
 use crate::refs;
 use crate::repo::Repository;
-use crate::rev_parse::resolve_revision;
+use crate::rev_parse::resolve_revision_for_range_end;
 
 /// User-facing output mode for `rev-list`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -713,7 +713,7 @@ pub fn rev_list(
 /// - `<rev>` => positive `<rev>`
 #[must_use]
 pub fn split_revision_token(token: &str) -> (Vec<String>, Vec<String>) {
-    if let Some((lhs, rhs)) = token.split_once("..") {
+    if let Some((lhs, rhs)) = crate::rev_parse::split_double_dot_range(token) {
         let positive = if rhs.is_empty() {
             "HEAD".to_owned()
         } else {
@@ -1765,7 +1765,7 @@ struct RootObject {
 fn resolve_specs(repo: &Repository, specs: &[String]) -> Result<Vec<ObjectId>> {
     let mut out = Vec::with_capacity(specs.len());
     for spec in specs {
-        let oid = resolve_revision(repo, spec)?;
+        let oid = resolve_revision_for_range_end(repo, spec)?;
         let commit_oid = peel_to_commit(repo, oid)?;
         out.push(commit_oid);
     }
@@ -1810,7 +1810,7 @@ fn resolve_specs_for_objects(
             continue;
         }
 
-        let oid = resolve_revision(repo, spec)?;
+        let oid = resolve_revision_for_range_end(repo, spec)?;
         match peel_to_commit(repo, oid) {
             Ok(commit_oid) => commits.push(commit_oid),
             Err(Error::CorruptObject(_)) | Err(Error::ObjectNotFound(_)) => {

--- a/grit-lib/src/rev_parse.rs
+++ b/grit-lib/src/rev_parse.rs
@@ -12,8 +12,12 @@ use std::path::{Component, Path, PathBuf};
 
 use regex::Regex;
 
+use std::collections::HashSet;
+
+use crate::config::ConfigSet;
 use crate::error::{Error, Result};
 use crate::objects::{parse_commit, parse_tree, ObjectId, ObjectKind};
+use crate::pack;
 use crate::reflog::read_reflog;
 use crate::refs;
 use crate::repo::Repository;
@@ -463,15 +467,82 @@ pub fn split_triple_dot_range(spec: &str) -> Option<(&str, &str)> {
 /// Like [`resolve_revision`], but does not treat a bare filename as an index path
 /// (matches `git rev-parse` / plumbing, where `file.txt` stays ambiguous).
 pub fn resolve_revision_without_index_dwim(repo: &Repository, spec: &str) -> Result<ObjectId> {
-    resolve_revision_impl(repo, spec, false)
+    resolve_revision_impl(repo, spec, false, false, true, false, false, false)
 }
 
 /// Resolve a revision string to an object ID.
 pub fn resolve_revision(repo: &Repository, spec: &str) -> Result<ObjectId> {
-    resolve_revision_impl(repo, spec, true)
+    resolve_revision_impl(repo, spec, true, false, true, false, false, false)
 }
 
-fn resolve_revision_impl(repo: &Repository, spec: &str, index_dwim: bool) -> Result<ObjectId> {
+/// Resolve `spec` when it appears as the end of a revision range (`A..B`, `A...B`, etc.):
+/// abbreviated hex and `core.disambiguate` prefer a commit (porcelain range parsing).
+pub fn resolve_revision_for_range_end(repo: &Repository, spec: &str) -> Result<ObjectId> {
+    resolve_revision_impl(repo, spec, true, true, true, false, false, false)
+}
+
+/// First argument to `commit-tree`: ambiguous short hex uses tree-ish rules (blob vs tree).
+pub fn resolve_revision_for_commit_tree_tree(repo: &Repository, spec: &str) -> Result<ObjectId> {
+    resolve_revision_impl(repo, spec, true, false, true, false, true, false)
+}
+
+/// Old blob OID from a patch `index <old>..<new>` line (`git apply --build-fake-ancestor`).
+pub fn resolve_revision_for_patch_old_blob(repo: &Repository, spec: &str) -> Result<ObjectId> {
+    resolve_revision_impl(repo, spec, true, false, true, false, false, true)
+}
+
+/// Resolve `spec` to a commit OID for porcelain history commands (`log`, `reset`, etc.).
+///
+/// Handles `A..B` / `..B` / `A..` (tip is the right side, defaulting to `HEAD`) and
+/// `A...B` symmetric diff (returns the merge base). Other specs are resolved and peeled
+/// to a commit (tags peeled, abbreviated hex disambiguated as commit-ish on range ends).
+pub fn resolve_revision_as_commit(repo: &Repository, spec: &str) -> Result<ObjectId> {
+    if let Some((left, right)) = split_triple_dot_range(spec) {
+        let left_tip = if left.is_empty() {
+            resolve_revision_for_range_end(repo, "HEAD")?
+        } else {
+            resolve_revision_for_range_end(repo, left)?
+        };
+        let right_tip = if right.is_empty() {
+            resolve_revision_for_range_end(repo, "HEAD")?
+        } else {
+            resolve_revision_for_range_end(repo, right)?
+        };
+        let left_c = peel_to_commit_for_merge_base(repo, left_tip)?;
+        let right_c = peel_to_commit_for_merge_base(repo, right_tip)?;
+        let bases = crate::merge_base::merge_bases_first_vs_rest(repo, left_c, &[right_c])?;
+        return bases
+            .into_iter()
+            .next()
+            .ok_or_else(|| Error::ObjectNotFound(format!("no merge base for '{spec}'")));
+    }
+    if let Some((left, right)) = split_double_dot_range(spec) {
+        if left.is_empty() {
+            peel_to_commit_for_merge_base(repo, resolve_revision_for_range_end(repo, "HEAD")?)?;
+        } else {
+            peel_to_commit_for_merge_base(repo, resolve_revision_for_range_end(repo, left)?)?;
+        }
+        let tip = if right.is_empty() {
+            resolve_revision_for_range_end(repo, "HEAD")?
+        } else {
+            resolve_revision_for_range_end(repo, right)?
+        };
+        return peel_to_commit_for_merge_base(repo, tip);
+    }
+    let oid = resolve_revision_for_range_end(repo, spec)?;
+    peel_to_commit_for_merge_base(repo, oid)
+}
+
+fn resolve_revision_impl(
+    repo: &Repository,
+    spec: &str,
+    index_dwim: bool,
+    commit_only_hex: bool,
+    use_disambiguate_config: bool,
+    treeish_colon_lhs: bool,
+    implicit_tree_abbrev: bool,
+    implicit_blob_abbrev: bool,
+) -> Result<ObjectId> {
     // Handle `:/message` early — it can contain any characters so must
     // not be confused with peel/nav syntax.
     if let Some(pattern) = spec.strip_prefix(":/") {
@@ -489,17 +560,53 @@ fn resolve_revision_impl(repo: &Repository, spec: &str, index_dwim: bool) -> Res
             let left_oid = peel_to_commit_for_merge_base(
                 repo,
                 if left_raw.is_empty() {
-                    resolve_revision_impl(repo, "HEAD", index_dwim)?
+                    resolve_revision_impl(
+                        repo,
+                        "HEAD",
+                        index_dwim,
+                        commit_only_hex,
+                        use_disambiguate_config,
+                        false,
+                        false,
+                        false,
+                    )?
                 } else {
-                    resolve_revision_impl(repo, left_raw, index_dwim)?
+                    resolve_revision_impl(
+                        repo,
+                        left_raw,
+                        index_dwim,
+                        commit_only_hex,
+                        use_disambiguate_config,
+                        false,
+                        false,
+                        false,
+                    )?
                 },
             )?;
             let right_oid = peel_to_commit_for_merge_base(
                 repo,
                 if right_raw.is_empty() {
-                    resolve_revision_impl(repo, "HEAD", index_dwim)?
+                    resolve_revision_impl(
+                        repo,
+                        "HEAD",
+                        index_dwim,
+                        commit_only_hex,
+                        use_disambiguate_config,
+                        false,
+                        false,
+                        false,
+                    )?
                 } else {
-                    resolve_revision_impl(repo, right_raw, index_dwim)?
+                    resolve_revision_impl(
+                        repo,
+                        right_raw,
+                        index_dwim,
+                        commit_only_hex,
+                        use_disambiguate_config,
+                        false,
+                        false,
+                        false,
+                    )?
                 },
             )?;
             let bases = crate::merge_base::merge_bases_first_vs_rest(repo, left_oid, &[right_oid])?;
@@ -516,7 +623,16 @@ fn resolve_revision_impl(repo: &Repository, spec: &str, index_dwim: bool) -> Res
     if let Some((before, after)) = split_treeish_colon(spec) {
         if !before.is_empty() && !spec.starts_with(":/") {
             // <rev>:<path> — resolve rev to tree, then navigate path
-            let rev_oid = match resolve_revision_impl(repo, before, index_dwim) {
+            let rev_oid = match resolve_revision_impl(
+                repo,
+                before,
+                index_dwim,
+                commit_only_hex,
+                use_disambiguate_config,
+                true,
+                false,
+                false,
+            ) {
                 Ok(o) => o,
                 Err(Error::ObjectNotFound(s)) if s == before => {
                     return Err(Error::Message(format!(
@@ -557,7 +673,19 @@ fn resolve_revision_impl(repo: &Repository, spec: &str, index_dwim: bool) -> Res
 
     let (base_with_nav, peel) = parse_peel_suffix(spec);
     let (base, nav_steps) = parse_nav_steps(base_with_nav);
-    let mut oid = resolve_base(repo, base, index_dwim)?;
+    let peel_for_hex = peel
+        .or(((treeish_colon_lhs || implicit_tree_abbrev) && peel.is_none()).then_some("tree"))
+        .or((implicit_blob_abbrev && peel.is_none()).then_some("blob"));
+    let mut oid = resolve_base(
+        repo,
+        base,
+        index_dwim,
+        commit_only_hex,
+        use_disambiguate_config,
+        peel_for_hex,
+        implicit_tree_abbrev,
+        implicit_blob_abbrev,
+    )?;
     for step in nav_steps {
         oid = apply_nav_step(repo, oid, step).map_err(|e| {
             if matches!(e, Error::ObjectNotFound(_)) {
@@ -833,10 +961,233 @@ pub fn to_relative_path(path: &Path, cwd: &Path) -> String {
     }
 }
 
-fn resolve_base(repo: &Repository, spec: &str, index_dwim: bool) -> Result<ObjectId> {
+fn object_storage_dirs_for_abbrev(repo: &Repository) -> Result<Vec<PathBuf>> {
+    let mut dirs = Vec::new();
+    let primary = repo.odb.objects_dir().to_path_buf();
+    dirs.push(primary.clone());
+    if let Ok(alts) = pack::read_alternates_recursive(&primary) {
+        for alt in alts {
+            if !dirs.iter().any(|d| d == &alt) {
+                dirs.push(alt);
+            }
+        }
+    }
+    Ok(dirs)
+}
+
+fn collect_pack_oids_with_prefix(objects_dir: &Path, prefix: &str) -> Result<Vec<ObjectId>> {
+    let mut out = Vec::new();
+    for idx in pack::read_local_pack_indexes(objects_dir)? {
+        for e in idx.entries {
+            if e.oid.to_hex().starts_with(prefix) {
+                out.push(e.oid);
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn disambiguate_kind_rank(kind: ObjectKind) -> u8 {
+    match kind {
+        ObjectKind::Tag => 0,
+        ObjectKind::Commit => 1,
+        ObjectKind::Tree => 2,
+        ObjectKind::Blob => 3,
+    }
+}
+
+fn oid_satisfies_peel_filter(repo: &Repository, oid: ObjectId, peel_inner: &str) -> bool {
+    apply_peel(repo, oid, Some(peel_inner)).is_ok()
+}
+
+/// Lines for `hint:` output when a short object id is ambiguous (type order, then hex).
+pub fn ambiguous_object_hint_lines(
+    repo: &Repository,
+    short_prefix: &str,
+    peel_filter: Option<&str>,
+) -> Result<Vec<String>> {
+    let mut typed: Vec<(u8, String, &'static str)> = Vec::new();
+    let mut bad_hex: Vec<String> = Vec::new();
+    for oid in list_all_abbrev_matches(repo, short_prefix)? {
+        let hex = oid.to_hex();
+        match repo.odb.read(&oid) {
+            Ok(obj) => {
+                let ok = peel_filter.is_none_or(|p| oid_satisfies_peel_filter(repo, oid, p));
+                if ok {
+                    typed.push((disambiguate_kind_rank(obj.kind), hex, obj.kind.as_str()));
+                }
+            }
+            Err(_) => bad_hex.push(hex),
+        }
+    }
+    if typed.is_empty() && peel_filter.is_some() {
+        return ambiguous_object_hint_lines(repo, short_prefix, None);
+    }
+    bad_hex.sort();
+    typed.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+    let mut out = Vec::new();
+    for h in bad_hex {
+        out.push(format!("hint:   {h} [bad object]"));
+    }
+    for (_, hex, kind) in typed {
+        out.push(format!("hint:   {hex} {kind}"));
+    }
+    Ok(out)
+}
+
+fn read_core_disambiguate(repo: &Repository) -> Option<&'static str> {
+    let config = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_else(|_| ConfigSet::new());
+    let v = config.get("core.disambiguate")?;
+    match v.to_ascii_lowercase().as_str() {
+        "committish" | "commit" => Some("commit"),
+        "treeish" | "tree" => Some("tree"),
+        "blob" => Some("blob"),
+        "tag" => Some("tag"),
+        "none" => None,
+        _ => None,
+    }
+}
+
+fn disambiguate_hex_by_peel(
+    repo: &Repository,
+    spec: &str,
+    matches: &[ObjectId],
+    peel: &str,
+) -> Result<ObjectId> {
+    let peel_some = Some(peel);
+    let filtered: Vec<ObjectId> = matches
+        .iter()
+        .copied()
+        .filter(|oid| apply_peel(repo, *oid, peel_some).is_ok())
+        .collect();
+    if filtered.len() == 1 {
+        return Ok(filtered[0]);
+    }
+    if filtered.is_empty() {
+        return Err(Error::InvalidRef(format!(
+            "short object ID {spec} is ambiguous"
+        )));
+    }
+    let mut peeled_targets: HashSet<ObjectId> = HashSet::new();
+    for oid in &filtered {
+        if let Ok(p) = apply_peel(repo, *oid, peel_some) {
+            peeled_targets.insert(p);
+        }
+    }
+    if peeled_targets.len() == 1 {
+        // Several objects (e.g. commit + tag) may peel to the same commit; any representative
+        // is valid for subsequent `apply_peel` in `resolve_revision_impl`.
+        let mut sorted = filtered;
+        sorted.sort_by_key(|o| o.to_hex());
+        return Ok(sorted[0]);
+    }
+    Err(Error::InvalidRef(format!(
+        "short object ID {spec} is ambiguous"
+    )))
+}
+
+fn commit_reachable_closure(repo: &Repository, start: ObjectId) -> Result<HashSet<ObjectId>> {
+    use std::collections::VecDeque;
+    let mut seen = HashSet::new();
+    let mut q = VecDeque::from([start]);
+    while let Some(oid) = q.pop_front() {
+        if !seen.insert(oid) {
+            continue;
+        }
+        let obj = match repo.odb.read(&oid) {
+            Ok(o) => o,
+            Err(_) => continue,
+        };
+        if obj.kind != ObjectKind::Commit {
+            continue;
+        }
+        let commit = match parse_commit(&obj.data) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        for p in &commit.parents {
+            q.push_back(*p);
+        }
+    }
+    Ok(seen)
+}
+
+/// `git rev-list --count <tag>..<head>` — commits reachable from `head` but not from `tag`.
+fn describe_generation_count(
+    repo: &Repository,
+    head: ObjectId,
+    tag_commit: ObjectId,
+) -> Result<usize> {
+    let from_tag = commit_reachable_closure(repo, tag_commit)?;
+    let from_head = commit_reachable_closure(repo, head)?;
+    Ok(from_head.difference(&from_tag).count())
+}
+
+fn try_resolve_describe_name(repo: &Repository, spec: &str) -> Result<Option<ObjectId>> {
+    let re = Regex::new(r"(?i)^(.+)-(\d+)-g([0-9a-fA-F]+)$")
+        .map_err(|_| Error::Message("internal: describe regex".to_owned()))?;
+    let Some(caps) = re.captures(spec) else {
+        return Ok(None);
+    };
+    let tag_name = caps.get(1).map(|m| m.as_str()).unwrap_or("");
+    let gen: usize = caps
+        .get(2)
+        .and_then(|m| m.as_str().parse().ok())
+        .unwrap_or(0);
+    let hex_abbrev = caps.get(3).map(|m| m.as_str()).unwrap_or("");
+    if tag_name.is_empty() || hex_abbrev.is_empty() {
+        return Ok(None);
+    }
+    let hex_lower = hex_abbrev.to_ascii_lowercase();
+    let tag_oid = match refs::resolve_ref(&repo.git_dir, &format!("refs/tags/{tag_name}"))
+        .or_else(|_| refs::resolve_ref(&repo.git_dir, tag_name))
+    {
+        Ok(o) => o,
+        Err(_) => return Ok(None),
+    };
+    let tag_commit = peel_to_commit_for_merge_base(repo, tag_oid)?;
+    let mut candidates: Vec<ObjectId> = find_abbrev_matches(repo, &hex_lower)?
+        .into_iter()
+        .filter(|oid| {
+            repo.odb
+                .read(oid)
+                .map(|o| o.kind == ObjectKind::Commit)
+                .unwrap_or(false)
+                && describe_generation_count(repo, *oid, tag_commit).ok() == Some(gen)
+        })
+        .collect();
+    candidates.sort_by_key(|o| o.to_hex());
+    match candidates.len() {
+        0 => Err(Error::ObjectNotFound(spec.to_owned())),
+        1 => Ok(Some(candidates[0])),
+        _ => Err(Error::InvalidRef(format!(
+            "short object ID {hex_abbrev} is ambiguous"
+        ))),
+    }
+}
+
+fn resolve_base(
+    repo: &Repository,
+    spec: &str,
+    index_dwim: bool,
+    commit_only_hex: bool,
+    use_disambiguate_config: bool,
+    peel_for_disambig: Option<&str>,
+    implicit_tree_abbrev: bool,
+    implicit_blob_abbrev: bool,
+) -> Result<ObjectId> {
     // Standalone `@` is an alias for `HEAD` in revision parsing.
     if spec == "@" {
-        return resolve_base(repo, "HEAD", index_dwim);
+        return resolve_base(
+            repo,
+            "HEAD",
+            index_dwim,
+            commit_only_hex,
+            use_disambiguate_config,
+            peel_for_disambig,
+            implicit_tree_abbrev,
+            implicit_blob_abbrev,
+        );
     }
 
     // `@{-N}` must run before reflog parsing so `@{-1}@{1}` is not misread as `@{-1}` + `@{1}`.
@@ -853,7 +1204,16 @@ fn resolve_base(repo: &Repository, spec: &str, index_dwim: bool) -> Result<Objec
                     } else {
                         let branch = resolve_at_minus_to_branch(repo, n)?;
                         let new_spec = format!("{branch}{suffix}");
-                        return resolve_base(repo, &new_spec, index_dwim);
+                        return resolve_base(
+                            repo,
+                            &new_spec,
+                            index_dwim,
+                            commit_only_hex,
+                            use_disambiguate_config,
+                            peel_for_disambig,
+                            implicit_tree_abbrev,
+                            implicit_blob_abbrev,
+                        );
                     }
                 }
             }
@@ -932,14 +1292,41 @@ fn resolve_base(repo: &Repository, spec: &str, index_dwim: bool) -> Result<Objec
     }
 
     if let Some((treeish, path)) = split_treeish_spec(spec) {
-        let root_oid = resolve_revision_impl(repo, treeish, index_dwim)?;
+        let root_oid = resolve_revision_impl(
+            repo,
+            treeish,
+            index_dwim,
+            commit_only_hex,
+            use_disambiguate_config,
+            false,
+            false,
+            false,
+        )?;
         return resolve_treeish_path(repo, root_oid, path);
     }
 
     if let Ok(oid) = spec.parse::<ObjectId>() {
         // A full 40-hex OID is always accepted, even if the object
         // doesn't exist in the ODB (matches git behavior).
+        let rn = format!("refs/heads/{spec}");
+        if refs::resolve_ref(&repo.git_dir, &rn).is_ok() {
+            eprintln!("warning: refname '{spec}' is ambiguous.");
+        }
         return Ok(oid);
+    }
+
+    match try_resolve_describe_name(repo, spec) {
+        Ok(Some(oid)) => return Ok(oid),
+        Err(e) => return Err(e),
+        Ok(None) => {}
+    }
+
+    if is_hex_prefix(spec) && spec.len() < 40 {
+        let branch_ref = format!("refs/heads/{spec}");
+        if let Ok(oid) = refs::resolve_ref(&repo.git_dir, &branch_ref) {
+            eprintln!("warning: refname '{spec}' is ambiguous.");
+            return Ok(oid);
+        }
     }
 
     if is_hex_prefix(spec) {
@@ -948,6 +1335,19 @@ fn resolve_base(repo: &Repository, spec: &str, index_dwim: bool) -> Result<Objec
             return Ok(matches[0]);
         }
         if matches.len() > 1 {
+            if commit_only_hex {
+                return disambiguate_hex_by_peel(repo, spec, &matches, "commit");
+            }
+            if let Some(p) = peel_for_disambig {
+                return disambiguate_hex_by_peel(repo, spec, &matches, p);
+            }
+            if use_disambiguate_config {
+                if let Some(pref) = read_core_disambiguate(repo) {
+                    if let Ok(oid) = disambiguate_hex_by_peel(repo, spec, &matches, pref) {
+                        return Ok(oid);
+                    }
+                }
+            }
             return Err(Error::InvalidRef(format!(
                 "short object ID {} is ambiguous",
                 spec
@@ -1700,7 +2100,9 @@ fn apply_peel(repo: &Repository, mut oid: ObjectId, peel: Option<&str>) -> Resul
     }
 }
 
-fn parse_peel_suffix(spec: &str) -> (&str, Option<&str>) {
+/// Split `spec` into `(base, peel_inner)` for `^{...}` / `^0` suffixes (same rules as revision parsing).
+#[must_use]
+pub fn parse_peel_suffix(spec: &str) -> (&str, Option<&str>) {
     if let Some(base) = spec.strip_suffix("^{}") {
         return (base, Some(""));
     }
@@ -1782,21 +2184,35 @@ fn find_abbrev_matches(repo: &Repository, prefix: &str) -> Result<Vec<ObjectId>>
     if !is_hex_prefix(prefix) || !(4..=40).contains(&prefix.len()) {
         return Ok(Vec::new());
     }
-    let all = collect_loose_object_ids(repo)?;
+    let mut seen = HashSet::new();
     let mut matches = Vec::new();
-    for candidate in all {
-        if candidate.starts_with(prefix) {
-            matches.push(candidate.parse::<ObjectId>()?);
+    for objects_dir in object_storage_dirs_for_abbrev(repo)? {
+        for hex in collect_loose_object_ids_in_dir(&objects_dir)? {
+            if hex.starts_with(prefix) {
+                let oid = hex.parse::<ObjectId>()?;
+                if seen.insert(oid) {
+                    matches.push(oid);
+                }
+            }
+        }
+        for oid in collect_pack_oids_with_prefix(&objects_dir, prefix)? {
+            if seen.insert(oid) {
+                matches.push(oid);
+            }
         }
     }
     Ok(matches)
 }
 
 fn collect_loose_object_ids(repo: &Repository) -> Result<Vec<String>> {
+    collect_loose_object_ids_in_dir(repo.odb.objects_dir())
+}
+
+fn collect_loose_object_ids_in_dir(objects_dir: &Path) -> Result<Vec<String>> {
     let mut ids = Vec::new();
-    let objects_dir = repo.odb.objects_dir();
     let read = match fs::read_dir(objects_dir) {
         Ok(read) => read,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(ids),
         Err(err) => return Err(Error::Io(err)),
     };
 
@@ -1934,7 +2350,12 @@ fn resolve_commit_message_search(
     Err(Error::ObjectNotFound(format!(":/{pattern}")))
 }
 
+/// All object IDs (loose and packed) whose hex form starts with `prefix`.
+pub fn list_all_abbrev_matches(repo: &Repository, prefix: &str) -> Result<Vec<ObjectId>> {
+    find_abbrev_matches(repo, prefix)
+}
+
 /// Public: find all object IDs whose hex prefix matches the given string.
 pub fn list_loose_abbrev_matches(repo: &Repository, prefix: &str) -> Result<Vec<ObjectId>> {
-    find_abbrev_matches(repo, prefix)
+    list_all_abbrev_matches(repo, prefix)
 }

--- a/grit/src/commands/apply.rs
+++ b/grit/src/commands/apply.rs
@@ -19,7 +19,6 @@ use grit_lib::crlf;
 use grit_lib::index::{Index, IndexEntry};
 use grit_lib::objects::ObjectKind;
 use grit_lib::repo::Repository;
-use grit_lib::rev_parse::resolve_revision;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fs;
@@ -1862,7 +1861,7 @@ fn build_fake_ancestor_file(patches: &[FilePatch], args: &Args, out_path: &Path)
         }
 
         let resolved = if let Some(old_oid) = fp.old_oid.as_deref() {
-            let oid = resolve_revision(&repo, old_oid)
+            let oid = grit_lib::rev_parse::resolve_revision_for_patch_old_blob(&repo, old_oid)
                 .with_context(|| format!("resolving old blob id `{old_oid}` for `{adjusted}`"))?;
             let mode = fp.old_mode.as_deref().map(parse_mode).unwrap_or(0o100644);
             Some((mode, oid))

--- a/grit/src/commands/cat_file.rs
+++ b/grit/src/commands/cat_file.rs
@@ -4,6 +4,7 @@ use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::config::ConfigSet;
 use grit_lib::error::Error as LibError;
+use grit_lib::error::Result as LibResult;
 use grit_lib::pack;
 use grit_lib::rev_list::{self, ObjectFilter};
 use std::io::{self, BufRead, Write};
@@ -1135,7 +1136,20 @@ fn print_batch_entry(
         }
     }
 
-    match resolve_object_with_mode(repo, obj_str) {
+    match resolve_object_with_mode_lib(repo, obj_str) {
+        Err(LibError::InvalidRef(ref msg)) if msg.contains("ambiguous") => {
+            write!(out, "{display_spec} ambiguous")?;
+            out.write_all(eol)?;
+            let treeish = obj_str.split(':').next().unwrap_or(obj_str).trim();
+            if treeish.chars().all(|c| c.is_ascii_hexdigit()) && (4..=40).contains(&treeish.len()) {
+                let (_, peel) = rev_parse::parse_peel_suffix(treeish);
+                if let Ok(lines) = rev_parse::ambiguous_object_hint_lines(repo, treeish, peel) {
+                    for line in lines {
+                        eprintln!("{line}");
+                    }
+                }
+            }
+        }
         Err(_) => {
             write!(out, "{display_spec} missing")?;
             out.write_all(eol)?;
@@ -1347,19 +1361,26 @@ fn pretty_print(kind: &ObjectKind, data: &[u8]) -> Result<()> {
 ///
 /// Uses the full rev-parse machinery for resolution.
 fn resolve_object(repo: &Repository, obj_str: &str) -> Result<ObjectId> {
-    rev_parse::resolve_revision(repo, obj_str).map_err(|e| anyhow::anyhow!("{}", e))
+    resolve_object_lib(repo, obj_str).map_err(|e| anyhow::anyhow!("{}", e))
+}
+
+fn resolve_object_lib(repo: &Repository, obj_str: &str) -> LibResult<ObjectId> {
+    rev_parse::resolve_revision(repo, obj_str)
 }
 
 /// Resolve an object reference and also return the file mode if the reference
 /// is a tree path (e.g., `HEAD:file` or `<tree_oid>:path`).
-fn resolve_object_with_mode(repo: &Repository, obj_str: &str) -> Result<(ObjectId, Option<u32>)> {
+fn resolve_object_with_mode_lib(
+    repo: &Repository,
+    obj_str: &str,
+) -> LibResult<(ObjectId, Option<u32>)> {
     // Check if this is a treeish:path reference
     if let Some(colon_pos) = obj_str.find(':') {
         let treeish_part = &obj_str[..colon_pos];
         let path_part = &obj_str[colon_pos + 1..];
         if !treeish_part.is_empty() && !path_part.is_empty() {
             // Resolve the treeish part
-            if let Ok(treeish_oid) = rev_parse::resolve_revision(repo, treeish_part) {
+            if let Ok(treeish_oid) = resolve_object_lib(repo, treeish_part) {
                 // Get the tree oid
                 let object = repo.odb.read(&treeish_oid)?;
                 let tree_oid = match object.kind {
@@ -1370,7 +1391,7 @@ fn resolve_object_with_mode(repo: &Repository, obj_str: &str) -> Result<(ObjectI
                     ObjectKind::Tree => treeish_oid,
                     _ => {
                         // Fall back to regular resolution
-                        let oid = resolve_object(repo, obj_str)?;
+                        let oid = resolve_object_lib(repo, obj_str)?;
                         return Ok((oid, None));
                     }
                 };
@@ -1396,6 +1417,10 @@ fn resolve_object_with_mode(repo: &Repository, obj_str: &str) -> Result<(ObjectI
     }
 
     // No tree path or couldn't resolve mode
-    let oid = resolve_object(repo, obj_str)?;
+    let oid = resolve_object_lib(repo, obj_str)?;
     Ok((oid, None))
+}
+
+fn resolve_object_with_mode(repo: &Repository, obj_str: &str) -> Result<(ObjectId, Option<u32>)> {
+    resolve_object_with_mode_lib(repo, obj_str).map_err(|e| anyhow::anyhow!("{}", e))
 }

--- a/grit/src/commands/commit_tree.rs
+++ b/grit/src/commands/commit_tree.rs
@@ -16,7 +16,7 @@ use time::{format_description, OffsetDateTime, PrimitiveDateTime, UtcOffset};
 
 use grit_lib::objects::{serialize_commit, CommitData, ObjectId, ObjectKind};
 use grit_lib::repo::Repository;
-use grit_lib::rev_parse::resolve_revision;
+use grit_lib::rev_parse::{resolve_revision_for_commit_tree_tree, resolve_revision_for_range_end};
 
 /// Arguments for `grit commit-tree`.
 #[derive(Debug, ClapArgs)]
@@ -45,13 +45,15 @@ pub struct Args {
 pub fn run(args: Args) -> Result<()> {
     let repo = Repository::discover(None).context("not a git repository")?;
 
-    let tree_oid = resolve_tree_ish(&repo, &args.tree)?;
+    let tree_oid = resolve_revision_for_commit_tree_tree(&repo, &args.tree)
+        .with_context(|| format!("not a valid object name: '{}'", args.tree))?;
 
     // Git omits duplicate parents (e.g. `-p P -p P` records P once).
     let mut parent_oids: Vec<ObjectId> = Vec::new();
     let mut seen: HashSet<ObjectId> = HashSet::new();
     for p in &args.parents {
-        let oid = resolve_tree_ish(&repo, p)?;
+        let oid = resolve_revision_for_range_end(&repo, p)
+            .with_context(|| format!("not a valid object name: '{p}'"))?;
         if seen.insert(oid) {
             parent_oids.push(oid);
         }
@@ -246,9 +248,4 @@ fn current_unix_timestamp() -> String {
 fn local_tz_string() -> String {
     // Simple: always UTC for now; a full implementation would read localtime
     "+0000".to_owned()
-}
-
-fn resolve_tree_ish(repo: &Repository, s: &str) -> Result<ObjectId> {
-    // Try full rev-parse first (handles HEAD^{tree}, tags, etc.)
-    resolve_revision(repo, s).with_context(|| format!("not a valid object name: '{s}'"))
 }

--- a/grit/src/commands/log.rs
+++ b/grit/src/commands/log.rs
@@ -15,6 +15,7 @@ use grit_lib::repo::Repository;
 use grit_lib::rev_list::{
     collect_revision_specs_with_stdin, rev_list, OrderingMode, RevListOptions,
 };
+use grit_lib::rev_parse::resolve_revision_as_commit;
 use grit_lib::state::{resolve_head, HeadState};
 use regex::{Regex, RegexBuilder};
 use std::collections::{HashMap, HashSet};
@@ -402,20 +403,20 @@ fn run_graph_log(repo: &Repository, args: &Args) -> Result<()> {
             continue;
         }
         if let Some(stripped) = rev.strip_prefix('^') {
-            match resolve_revision(repo, stripped) {
+            match resolve_revision_as_commit(repo, stripped) {
                 Ok(_) => revision_specs.push(rev.clone()),
                 Err(_err) if is_likely_pathspec_during_rev_parse(stripped) => {
                     implied_pathspecs.push(stripped.to_owned())
                 }
-                Err(err) => return Err(err),
+                Err(err) => return Err(err.into()),
             }
         } else {
-            match resolve_revision(repo, rev) {
+            match resolve_revision_as_commit(repo, rev) {
                 Ok(_) => revision_specs.push(rev.clone()),
                 Err(_err) if is_likely_pathspec_during_rev_parse(rev) => {
                     implied_pathspecs.push(rev.clone())
                 }
-                Err(err) => return Err(err),
+                Err(err) => return Err(err.into()),
             }
         }
     }
@@ -1637,15 +1638,15 @@ pub fn run(mut args: Args) -> Result<()> {
         let mut excludes = Vec::new();
         for rev in &args.revisions {
             if let Some(stripped) = rev.strip_prefix('^') {
-                let oid = resolve_revision(&repo, stripped)?;
+                let oid = resolve_revision_as_commit(&repo, stripped)?;
                 excludes.push(oid);
             } else {
-                match resolve_revision(&repo, rev) {
+                match resolve_revision_as_commit(&repo, rev) {
                     Ok(oid) => oids.push(oid),
                     Err(_err) if is_likely_pathspec_during_rev_parse(rev) => {
                         implied_pathspecs.push(rev.clone());
                     }
-                    Err(err) => return Err(err),
+                    Err(err) => return Err(err.into()),
                 }
             }
         }
@@ -2168,7 +2169,7 @@ pub fn run_no_walk(repo: &Repository, args: &Args) -> Result<()> {
         }
     } else {
         for rev in &args.revisions {
-            let oid = resolve_revision(repo, rev)?;
+            let oid = resolve_revision_as_commit(repo, rev)?;
             oids.push(oid);
         }
     }

--- a/grit/src/commands/reset.rs
+++ b/grit/src/commands/reset.rs
@@ -21,7 +21,7 @@ use grit_lib::objects::{parse_commit, parse_tree, ObjectId, ObjectKind};
 use grit_lib::odb::Odb;
 use grit_lib::refs::{append_reflog, write_ref};
 use grit_lib::repo::Repository;
-use grit_lib::rev_parse::{abbreviate_object_id, resolve_revision};
+use grit_lib::rev_parse::{abbreviate_object_id, resolve_revision_as_commit};
 use grit_lib::state::{resolve_head, HeadState};
 
 /// The zero OID for reflog entries when there is no previous value.
@@ -195,10 +195,7 @@ fn split_commit_and_paths(repo: &Repository, rest: &[String]) -> (String, Vec<St
     let first = &rest[0];
     // Attempt to resolve first arg as a commit-ish.
     // Must actually resolve to a commit (not just any object like a blob).
-    let first_is_commit = resolve_revision(repo, first)
-        .ok()
-        .and_then(|oid| peel_to_commit(repo, oid).ok())
-        .is_some();
+    let first_is_commit = resolve_revision_as_commit(repo, first).is_ok();
 
     if first_is_commit {
         // First arg is the commit; remaining args are paths (may be empty).
@@ -885,9 +882,7 @@ fn print_head_message(repo: &Repository, oid: &ObjectId) -> Result<()> {
 
 /// Resolve a revision spec to a commit OID, peeling through tags.
 fn resolve_to_commit(repo: &Repository, spec: &str) -> Result<ObjectId> {
-    let oid =
-        resolve_revision(repo, spec).with_context(|| format!("unknown revision: '{spec}'"))?;
-    peel_to_commit(repo, oid)
+    resolve_revision_as_commit(repo, spec).with_context(|| format!("unknown revision: '{spec}'"))
 }
 
 /// Peel an OID to a commit (follows tag chains).

--- a/grit/src/commands/rev_parse.rs
+++ b/grit/src/commands/rev_parse.rs
@@ -7,9 +7,10 @@ use grit_lib::merge_base;
 use grit_lib::refs;
 use grit_lib::repo::Repository;
 use grit_lib::rev_parse::{
-    abbreviate_object_id, abbreviate_ref_name, discover_optional, is_inside_git_dir,
-    is_inside_work_tree, list_loose_abbrev_matches, peel_to_commit_for_merge_base,
-    resolve_revision, resolve_revision_without_index_dwim, show_prefix, split_double_dot_range,
+    abbreviate_object_id, abbreviate_ref_name, ambiguous_object_hint_lines, discover_optional,
+    is_inside_git_dir, is_inside_work_tree, list_all_abbrev_matches, parse_peel_suffix,
+    peel_to_commit_for_merge_base, resolve_revision, resolve_revision_for_range_end,
+    resolve_revision_without_index_dwim, show_prefix, split_double_dot_range,
     split_triple_dot_range, symbolic_full_name,
 };
 use std::env;
@@ -84,6 +85,7 @@ pub fn run(args: Args) -> Result<()> {
         ForcedPath(String),
         PathSeparator,
         Literal(String),
+        Disambiguate(String),
     }
 
     let mut actions: Vec<Action> = Vec::new();
@@ -234,6 +236,15 @@ pub fn run(args: Args) -> Result<()> {
                 sq_quote = true;
             } else if arg == "--sq" {
                 sq_output = true;
+            } else if let Some(pfx) = arg.strip_prefix("--disambiguate=") {
+                actions.push(Action::Disambiguate(pfx.to_owned()));
+            } else if arg == "--disambiguate" {
+                i += 1;
+                let pfx = args
+                    .args
+                    .get(i)
+                    .ok_or_else(|| anyhow::anyhow!("--disambiguate requires a prefix argument"))?;
+                actions.push(Action::Disambiguate(pfx.clone()));
             } else if arg == "--local-env-vars" {
                 actions.push(Action::LocalEnvVars);
             } else if arg == "--resolve-git-dir" {
@@ -313,20 +324,20 @@ pub fn run(args: Args) -> Result<()> {
         let spec = rev_list[0];
         if let Some((left, right)) = split_double_dot_range(spec) {
             let left_oid = match if left.is_empty() {
-                resolve_revision(current, "HEAD")
+                resolve_revision_for_range_end(current, "HEAD")
             } else {
-                resolve_revision(current, left)
+                resolve_revision_for_range_end(current, left)
             } {
                 Ok(oid) => oid,
-                Err(e) => return fail_verify_resolve(quiet, &e),
+                Err(e) => return fail_verify_resolve(quiet, &e, Some(current)),
             };
             let right_oid = match if right.is_empty() {
-                resolve_revision(current, "HEAD")
+                resolve_revision_for_range_end(current, "HEAD")
             } else {
-                resolve_revision(current, right)
+                resolve_revision_for_range_end(current, right)
             } {
                 Ok(oid) => oid,
-                Err(e) => return fail_verify_resolve(quiet, &e),
+                Err(e) => return fail_verify_resolve(quiet, &e, Some(current)),
             };
             if let Some(mut len) = short_len {
                 if len == 0 {
@@ -348,14 +359,14 @@ pub fn run(args: Args) -> Result<()> {
         }
         if let Some((left, right)) = split_triple_dot_range(spec) {
             let left_tip = if left.is_empty() {
-                resolve_revision(current, "HEAD")?
+                resolve_revision_for_range_end(current, "HEAD")?
             } else {
-                resolve_revision(current, left)?
+                resolve_revision_for_range_end(current, left)?
             };
             let right_tip = if right.is_empty() {
-                resolve_revision(current, "HEAD")?
+                resolve_revision_for_range_end(current, "HEAD")?
             } else {
-                resolve_revision(current, right)?
+                resolve_revision_for_range_end(current, right)?
             };
             let left_commit = peel_to_commit_for_merge_base(current, left_tip)?;
             let right_commit = peel_to_commit_for_merge_base(current, right_tip)?;
@@ -386,7 +397,7 @@ pub fn run(args: Args) -> Result<()> {
         }
         let oid = match resolve_revision(current, spec) {
             Ok(oid) => oid,
-            Err(e) => return fail_verify_resolve(quiet, &e),
+            Err(e) => return fail_verify_resolve(quiet, &e, Some(current)),
         };
         if let Some(mut len) = short_len {
             if len == 0 {
@@ -456,6 +467,17 @@ pub fn run(args: Args) -> Result<()> {
         match action {
             Action::Literal(s) => {
                 println!("{s}");
+            }
+            Action::Disambiguate(pfx) => {
+                let Some(current) = repo.as_ref() else {
+                    bail!("not a git repository (or any of the parent directories)");
+                };
+                let mut oids = list_all_abbrev_matches(current, pfx)?;
+                oids.sort_by_key(|o| o.to_hex());
+                oids.dedup();
+                for oid in oids {
+                    println!("{}", oid.to_hex());
+                }
             }
             Action::ShowIsInsideWorkTree => {
                 let inside = repo
@@ -944,14 +966,14 @@ Use 'git <command> -- <path>...' to specify paths that do not exist locally."
                         continue;
                     }
                     let left_tip = if left.is_empty() {
-                        resolve_revision_without_index_dwim(current, "HEAD")?
+                        resolve_revision_for_range_end(current, "HEAD")?
                     } else {
-                        resolve_revision_without_index_dwim(current, left)?
+                        resolve_revision_for_range_end(current, left)?
                     };
                     let right_tip = if right.is_empty() {
-                        resolve_revision_without_index_dwim(current, "HEAD")?
+                        resolve_revision_for_range_end(current, "HEAD")?
                     } else {
-                        resolve_revision_without_index_dwim(current, right)?
+                        resolve_revision_for_range_end(current, right)?
                     };
                     let left_commit = peel_to_commit_for_merge_base(current, left_tip)?;
                     let right_commit = peel_to_commit_for_merge_base(current, right_tip)?;
@@ -979,14 +1001,14 @@ Use 'git <command> -- <path>...' to specify paths that do not exist locally."
                         continue;
                     }
                     let left_oid = if left.is_empty() {
-                        resolve_revision_without_index_dwim(current, "HEAD")?
+                        resolve_revision_for_range_end(current, "HEAD")?
                     } else {
-                        resolve_revision_without_index_dwim(current, left)?
+                        resolve_revision_for_range_end(current, left)?
                     };
                     let right_oid = if right.is_empty() {
-                        resolve_revision_without_index_dwim(current, "HEAD")?
+                        resolve_revision_for_range_end(current, "HEAD")?
                     } else {
-                        resolve_revision_without_index_dwim(current, right)?
+                        resolve_revision_for_range_end(current, right)?
                     };
                     if left.is_empty() && right.is_empty() {
                         println!("..");
@@ -1057,12 +1079,12 @@ Use 'git <command> -- <path>...' to specify paths that do not exist locally."
                             deferred_fatal_stderr = Some(msg);
                             continue;
                         }
-                        if matches!(&e, LibError::Message(_) | LibError::InvalidRef(_)) {
-                            return Err(e.into());
-                        }
                         let amb_prefix = parse_ambiguous_short_oid(&msg);
                         if let Some(ref pfx) = amb_prefix {
                             print_ambiguous_short_oid_error(current, rev, pfx)?;
+                        }
+                        if matches!(&e, LibError::Message(_) | LibError::InvalidRef(_)) {
+                            return Err(e.into());
                         }
                         if msg.contains("ambiguous") {
                             return Err(anyhow::anyhow!("{msg}"));
@@ -1122,13 +1144,25 @@ fn fail_verify(quiet: bool, is_reflog_selector: bool) -> Result<()> {
     }
 }
 
-fn fail_verify_resolve(quiet: bool, err: &LibError) -> Result<()> {
+fn fail_verify_resolve(
+    quiet: bool,
+    err: &LibError,
+    repo: Option<&grit_lib::repo::Repository>,
+) -> Result<()> {
     if quiet {
         std::process::exit(1);
     }
     let msg = err.to_string();
     if msg.contains("only has") && msg.contains("entries") {
         bail!("{msg}");
+    }
+    if let (LibError::ObjectNotFound(spec), Some(r)) = (err, repo) {
+        if spec.contains("-g") && spec.matches('-').count() >= 2 {
+            if let Ok(oid) = resolve_revision(r, spec) {
+                println!("{oid}");
+                return Ok(());
+            }
+        }
     }
     if matches!(err, LibError::InvalidRef(_) | LibError::Message(_)) {
         bail!("{msg}");
@@ -1186,7 +1220,7 @@ fn print_ambiguous_short_oid_error(
     rev: &str,
     short_prefix: &str,
 ) -> Result<()> {
-    let candidates = list_loose_abbrev_matches(repo, short_prefix)?;
+    let candidates = list_all_abbrev_matches(repo, short_prefix)?;
     if candidates.is_empty() {
         return Err(anyhow::anyhow!(
             "invalid ref: short object ID {} is ambiguous",
@@ -1194,19 +1228,19 @@ fn print_ambiguous_short_oid_error(
         ));
     }
 
-    let mut typed_candidates: Vec<(String, String)> = Vec::new();
+    let mut typed_count = 0usize;
     let mut bad_oids: Vec<String> = Vec::new();
-    for oid in candidates {
+    for oid in &candidates {
         let oid_hex = oid.to_hex();
-        match repo.odb.read(&oid) {
-            Ok(obj) => typed_candidates.push((oid_hex, obj.kind.as_str().to_owned())),
+        match repo.odb.read(oid) {
+            Ok(_) => typed_count += 1,
             Err(_) => bad_oids.push(oid_hex),
         }
     }
 
     eprintln!("error: short object ID {} is ambiguous", short_prefix);
 
-    if typed_candidates.is_empty() {
+    if typed_count == 0 {
         eprintln!("fatal: invalid object type");
         std::process::exit(128);
     }
@@ -1220,15 +1254,10 @@ fn print_ambiguous_short_oid_error(
         }
     }
 
-    let mut all_candidates: Vec<(String, String)> = bad_oids
-        .into_iter()
-        .map(|oid| (oid, "[bad object]".to_owned()))
-        .collect();
-    all_candidates.extend(typed_candidates);
-
+    let peel_filter = parse_peel_suffix(rev).1;
     eprintln!("hint: The candidates are:");
-    for (oid_hex, kind) in all_candidates {
-        eprintln!("hint:   {} {}", oid_hex, kind);
+    for line in ambiguous_object_hint_lines(repo, short_prefix, peel_filter)? {
+        eprintln!("{line}");
     }
 
     eprintln!(

--- a/logs/2026-04-08_t1512-rev-parse-disambiguation.md
+++ b/logs/2026-04-08_t1512-rev-parse-disambiguation.md
@@ -1,0 +1,14 @@
+# t1512-rev-parse-disambiguation
+
+- Fixed `rev-parse` handling of ambiguous short OIDs: parse `InvalidRef` before early return so full hint output matches Git.
+- `grit-lib` `rev_parse`: pack-aware abbreviation matching; treeish/blob/commit context disambiguation; `resolve_revision_for_range_end`, `resolve_revision_as_commit`, describe-name parsing using `rev-list`-style generation count; peel-collapse for semi-ambiguous cases; `core.disambiguate` via `ConfigSet` (honours `-c`); branch ref wins over ambiguous hex with warning; `ambiguous_object_hint_lines` for sorted type-filtered hints; exported `parse_peel_suffix`.
+- `commit-tree`: tree arg uses implicit tree-ish abbrev; parents use range-style commit-preferring resolution.
+- `apply --build-fake-ancestor`: old blob index lines resolve with implicit blob abbrev.
+- `log` / `reset`: use `resolve_revision_as_commit` for ranges and single revs.
+- `rev_list` `split_revision_token`: use `split_double_dot_range` so `...` is not split as `..`.
+- `rev-parse`: `--disambiguate`, verify fallback for describe strings, range ends use `resolve_revision_for_range_end`.
+- `cat-file` batch: emit `ambiguous` + hints on ambiguous OID.
+- `tests/lib-loose.sh`: set SHA1 prereq when default hash is sha1 so t1512 runs past early skip.
+- `tests/t1512-rev-parse-disambiguation.sh`: `test_expect_failure` → `test_expect_success` for semi-ambiguous and describe-generation cases now implemented.
+
+Validation: `./scripts/run-tests.sh t1512-rev-parse-disambiguation.sh` → 38/38; `cargo test -p grit-lib --lib`.

--- a/tests/lib-loose.sh
+++ b/tests/lib-loose.sh
@@ -4,6 +4,12 @@
 # and tests that configure extensions.objectformat work.
 test_hash_algo=${test_hash_algo:-sha1}
 export test_hash_algo
+# test-lib.sh does not set upstream-style hash prereqs; satisfy `test_have_prereq SHA1`
+# for scripts that source this helper (e.g. t1512) when using the default algorithm.
+if test "$test_hash_algo" = sha1
+then
+	test_set_prereq SHA1
+fi
 
 # Match git/t/oid-info entries used by t1006 et al. for $(test_oid deadbeef).
 if test -n "${TEST_OID_CACHE_FILE:-}" && test -d "$(dirname "$TEST_OID_CACHE_FILE")"

--- a/tests/t1512-rev-parse-disambiguation.sh
+++ b/tests/t1512-rev-parse-disambiguation.sh
@@ -226,7 +226,7 @@ test_expect_success 'first tag' '
 	git tag -a -m j7cp83um v1.0.0
 '
 
-test_expect_failure 'two semi-ambiguous commit-ish' '
+test_expect_success 'two semi-ambiguous commit-ish' '
 	# At this point, we have a tag 0000000000f8f that points
 	# at a commit 0000000000e4f, and a tree and a blob that
 	# share 0000000000 prefix with these tag and commit.
@@ -247,7 +247,7 @@ test_expect_failure 'two semi-ambiguous commit-ish' '
 	git log 0000000000...
 '
 
-test_expect_failure 'three semi-ambiguous tree-ish' '
+test_expect_success 'three semi-ambiguous tree-ish' '
 	# Likewise for tree-ish.  HEAD, v1.0.0 and HEAD^{tree} share
 	# the prefix but peeling them to tree yields the same thing
 	git rev-parse --verify 0000000000^{tree}
@@ -311,7 +311,7 @@ test_expect_success 'more history' '
 
 '
 
-test_expect_failure 'parse describe name taking advantage of generation' '
+test_expect_success 'parse describe name taking advantage of generation' '
 	# ambiguous at the object name level, but there is only one
 	# such commit at generation 0
 	git rev-parse --verify v1.0.0-0-g000000000 &&


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible object-name disambiguation and related `rev-parse` / porcelain behavior so **`tests/t1512-rev-parse-disambiguation.sh` passes all 38 cases** (harness updated).

## Key changes

- **`grit-lib` `rev_parse`**: pack + loose abbreviation matching; context disambiguation (treeish `rev:path`, implicit tree/blob for `commit-tree` / `apply --build-fake-ancestor`); `resolve_revision_for_range_end` and `resolve_revision_as_commit` for `..` / `...` and `log`/`reset`; describe-style names with generation count matching `git describe`; peel-collapse when multiple objects peel to the same target; `core.disambiguate` via layered `ConfigSet` (honours `-c`); branch ref preferred over ambiguous hex with warning; sorted/type-filtered ambiguity hints (`ambiguous_object_hint_lines`); exported `parse_peel_suffix`.
- **`grit`**: `rev-parse` `--disambiguate`, verify fallback for describe strings, ordered hint printing; **`cat-file` batch** prints `ambiguous` + hints; **`commit-tree`** parent/tree resolution fixes; **`apply`** fake-ancestor blob resolution; **`log`/`reset`** use commit-oriented resolution; **`rev_list`** `split_revision_token` uses `split_double_dot_range`.
- **Tests**: `lib-loose.sh` sets SHA1 prereq when using default sha1; t1512 `test_expect_failure` → `test_expect_success` for cases now implemented (semi-ambiguous + describe generation).

## Validation

- `./scripts/run-tests.sh t1512-rev-parse-disambiguation.sh` → **38/38**
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7027dee-6dbf-4f5c-804b-9a2f6e43f5d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7027dee-6dbf-4f5c-804b-9a2f6e43f5d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

