### PR TITLE
fix: post-checkout hook and clone default branch (t5403)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -625,7 +625,7 @@ commit → check it off → move on.
 - [ ] `t5003-archive-zip` █████████████████░░░ 71/82 (11 left) — git archive --format=zip test
 - [ ] `t5334-incremental-multi-pack-index` ██████░░░░░░░░░░░░░░ 5/16 (11 left) — incremental multi-pack-index
 - [ ] `t5607-clone-bundle` ██████░░░░░░░░░░░░░░ 5/16 (11 left) — some bundle related tests
-- [ ] `t5403-post-checkout-hook` ████░░░░░░░░░░░░░░░░ 3/14 (11 left) — Test the post-checkout hook.
+- [x] `t5403-post-checkout-hook` ████████████████████ 14/14 (0 left) — Test the post-checkout hook.
 - [ ] `t5610-clone-detached` ███░░░░░░░░░░░░░░░░░ 2/13 (11 left) — test cloning a repository with detached HEAD
 - [ ] `t5605-clone-local` █████████░░░░░░░░░░░ 11/23 (12 left) — test local clone
 - [ ] `t5325-reverse-index` █████░░░░░░░░░░░░░░░ 4/16 (12 left) — on-disk reverse index

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -907,7 +907,7 @@ t5351-unpack-large-objects	t5	yes	7	4	3	false	ok	0
 t5400-send-pack	t5	yes	17	10	7	false	ok	0
 t5401-update-hooks	t5	yes	13	4	9	false	ok	0
 t5402-post-merge-hook	t5	yes	7	3	4	false	ok	0
-t5403-post-checkout-hook	t5	yes	14	3	11	false	ok	0
+t5403-post-checkout-hook	t5	yes	14	14	0	true	ok	0
 t5404-tracking-branches	t5	yes	7	3	4	false	ok	0
 t5405-send-pack-rewind	t5	yes	3	1	2	false	ok	0
 t5406-remote-rejects	t5	yes	3	2	1	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T04:28:41+00:00" class="gen-time" title="2026-04-08 04:28 UTC">2026-04-08 04:28 UTC</time> · <a href="https://github.com/schacon/grit/commit/454a69c8fc171de2dd14bc6a655840211e4b3f3a" style="color:#58a6ff">454a69c</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T05:45:08+00:00" class="gen-time" title="2026-04-08 05:45 UTC">2026-04-08 05:45 UTC</time> · <a href="https://github.com/schacon/grit/commit/424189b46be6c4ca854443fbf3435557a2be2c9f" style="color:#58a6ff">424189b</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,476</div>
+      <div class="summary-big-val">29,487</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>608 files fully passing</span>
+    <span>609 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">28/167 files · 17 skipped · 1,432/4,315 tests</span>
+        <span class="group-meta">29/167 files · 17 skipped · 1,443/4,315 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.2%"></div></div>
-        <span class="group-pct pct-red">33.2%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.4%"></div></div>
+        <span class="group-pct pct-red">33.4%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T04:28:41+00:00" class="gen-time" title="2026-04-08 04:28 UTC">2026-04-08 04:28 UTC</time> · <a href="https://github.com/schacon/grit/commit/454a69c8fc171de2dd14bc6a655840211e4b3f3a" style="color:#58a6ff">454a69c</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T05:45:08+00:00" class="gen-time" title="2026-04-08 05:45 UTC">2026-04-08 05:45 UTC</time> · <a href="https://github.com/schacon/grit/commit/424189b46be6c4ca854443fbf3435557a2be2c9f" style="color:#58a6ff">424189b</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,745</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,476</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,487</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">67.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -9207,14 +9207,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:42.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="14" data-passed="3">
+<tr class="" data-group="t5" data-tests="14" data-passed="14">
   <td class="mono">t5403-post-checkout-hook</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">14</td>
-  <td class="right">3</td>
+  <td class="right">14</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:21.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="7" data-passed="3">

--- a/grit/src/commands/checkout.rs
+++ b/grit/src/commands/checkout.rs
@@ -14,6 +14,8 @@ use std::path::Path;
 
 use grit_lib::config::ConfigSet;
 use grit_lib::crlf;
+use grit_lib::diff::zero_oid;
+use grit_lib::hooks::{run_hook, HookResult};
 use grit_lib::index::{Index, IndexEntry, MODE_EXECUTABLE, MODE_SYMLINK};
 use grit_lib::merge_file::{self, ConflictStyle, MergeFavor, MergeInput};
 use grit_lib::objects::{parse_commit, parse_tree, ObjectId, ObjectKind};
@@ -699,6 +701,33 @@ fn split_target_and_paths(
 // Branch switching
 // ---------------------------------------------------------------------------
 
+/// Run Git's `post-checkout` hook: `<old-oid> <new-oid> <flag>` where `flag` is `1` for a branch
+/// checkout and `0` for a path (file) checkout. Missing `old_oid` uses the null OID (clone-style).
+///
+/// # Errors
+///
+/// Returns an error when the hook exits with a non-zero status.
+fn run_post_checkout_hook(
+    repo: &Repository,
+    old_oid: Option<&ObjectId>,
+    new_oid: &ObjectId,
+    is_branch_checkout: bool,
+) -> Result<()> {
+    let z = zero_oid();
+    let old_hex = old_oid.unwrap_or(&z).to_hex();
+    let new_hex = new_oid.to_hex();
+    let flag = if is_branch_checkout { "1" } else { "0" };
+    if let HookResult::Failed(code) = run_hook(
+        repo,
+        "post-checkout",
+        &[old_hex.as_str(), new_hex.as_str(), flag],
+        None,
+    ) {
+        bail!("post-checkout hook exited with status {code}");
+    }
+    Ok(())
+}
+
 /// Switch HEAD to an existing branch, updating the working tree and index.
 fn switch_branch(
     repo: &Repository,
@@ -723,6 +752,11 @@ fn switch_branch(
                 let target_tree = commit_to_tree(repo, &target_oid)?;
                 return force_reset_to_tree(repo, &target_tree);
             }
+            let tip = head
+                .oid()
+                .copied()
+                .ok_or_else(|| anyhow::anyhow!("HEAD has no commit"))?;
+            run_post_checkout_hook(repo, Some(&tip), &tip, true)?;
             return Ok(());
         }
     }
@@ -780,6 +814,8 @@ fn switch_branch(
     let target_oid = refs::resolve_ref(&repo.git_dir, branch_ref)
         .with_context(|| format!("cannot resolve branch '{branch_name}'"))?;
 
+    let old_head_commit = head.oid().copied();
+
     // If target commit is the same as current HEAD, just re-attach
     // without touching the working tree or index (preserves dirty state).
     // But with -f, always rebuild.
@@ -792,10 +828,7 @@ fn switch_branch(
     }
 
     // Write reflog entries before updating HEAD
-    let old_oid = head
-        .oid()
-        .copied()
-        .unwrap_or_else(|| ObjectId::from_bytes(&[0u8; 20]).unwrap());
+    let old_oid = old_head_commit.unwrap_or_else(|| ObjectId::from_bytes(&[0u8; 20]).unwrap());
     let from_desc = match &head {
         HeadState::Branch { short_name, .. } => short_name.clone(),
         HeadState::Detached { oid } => oid.to_hex()[..7].to_string(),
@@ -806,6 +839,8 @@ fn switch_branch(
 
     // Update HEAD to point to the branch
     std::fs::write(repo.git_dir.join("HEAD"), format!("ref: {branch_ref}\n"))?;
+
+    run_post_checkout_hook(repo, old_head_commit.as_ref(), &target_oid, true)?;
 
     checkout_eprintln!("Switched to branch '{}'", branch_name);
     Ok(())
@@ -836,6 +871,7 @@ fn create_and_switch_branch(
 
     // Resolve start point (default: HEAD)
     let head = resolve_head(&repo.git_dir)?;
+    let old_head_commit = head.oid().copied();
     let start_oid = match start {
         Some(s) => resolve_to_commit(repo, s)?,
         None => {
@@ -863,6 +899,8 @@ fn create_and_switch_branch(
     };
     if head.oid() != Some(&start_oid) || force || worktree_is_empty {
         switch_to_tree(repo, &head, &target_tree, force)?;
+    } else {
+        run_post_checkout_hook(repo, old_head_commit.as_ref(), &start_oid, true)?;
     }
 
     // Create the branch ref
@@ -883,6 +921,10 @@ fn create_and_switch_branch(
 
     // Update HEAD to point to the new branch
     std::fs::write(repo.git_dir.join("HEAD"), format!("ref: {branch_ref}\n"))?;
+
+    if head.oid() != Some(&start_oid) || force || worktree_is_empty {
+        run_post_checkout_hook(repo, old_head_commit.as_ref(), &start_oid, true)?;
+    }
 
     checkout_eprintln!("Switched to a new branch '{}'", name);
     Ok(())
@@ -982,18 +1024,18 @@ fn force_create_and_switch_branch(
     };
 
     let head = resolve_head(&repo.git_dir)?;
+    let old_head_commit = head.oid().copied();
     let target_tree = commit_to_tree(repo, &start_oid)?;
 
     // Update working tree if start point differs from current HEAD, or if force
     if head.oid() != Some(&start_oid) || force {
         switch_to_tree(repo, &head, &target_tree, force)?;
+    } else {
+        run_post_checkout_hook(repo, old_head_commit.as_ref(), &start_oid, true)?;
     }
 
     // Write reflog before updating refs
-    let old_oid = head
-        .oid()
-        .copied()
-        .unwrap_or_else(|| ObjectId::from_bytes(&[0u8; 20]).unwrap());
+    let old_oid = old_head_commit.unwrap_or_else(|| ObjectId::from_bytes(&[0u8; 20]).unwrap());
     let from_desc = match &head {
         HeadState::Branch { short_name, .. } => short_name.clone(),
         HeadState::Detached { oid } => oid.to_hex()[..7].to_string(),
@@ -1007,6 +1049,10 @@ fn force_create_and_switch_branch(
 
     // Update HEAD to point to the new branch
     std::fs::write(repo.git_dir.join("HEAD"), format!("ref: {branch_ref}\n"))?;
+
+    if head.oid() != Some(&start_oid) || force {
+        run_post_checkout_hook(repo, old_head_commit.as_ref(), &start_oid, true)?;
+    }
 
     if branch_existed {
         checkout_eprintln!("Switched to and reset branch '{}'", name);
@@ -1205,18 +1251,18 @@ pub(crate) fn detach_head(repo: &Repository, oid: &ObjectId, force: bool) -> Res
 
 fn detach_head_inner(repo: &Repository, oid: &ObjectId, force: bool, explicit: bool) -> Result<()> {
     let head = resolve_head(&repo.git_dir)?;
+    let old_head_commit = head.oid().copied();
 
     let already_at_target = head.oid() == Some(oid);
     if !already_at_target || force {
         let target_tree = commit_to_tree(repo, oid)?;
         switch_to_tree(repo, &head, &target_tree, force)?;
+    } else {
+        run_post_checkout_hook(repo, old_head_commit.as_ref(), oid, true)?;
     }
 
     // Write reflog entries
-    let old_oid = head
-        .oid()
-        .copied()
-        .unwrap_or_else(|| ObjectId::from_bytes(&[0u8; 20]).unwrap());
+    let old_oid = old_head_commit.unwrap_or_else(|| ObjectId::from_bytes(&[0u8; 20]).unwrap());
     let from_desc = match &head {
         HeadState::Branch { short_name, .. } => short_name.clone(),
         HeadState::Detached { oid } => oid.to_hex()[..7].to_string(),
@@ -1228,6 +1274,12 @@ fn detach_head_inner(repo: &Repository, oid: &ObjectId, force: bool, explicit: b
 
     // Write detached HEAD
     std::fs::write(repo.git_dir.join("HEAD"), format!("{oid}\n"))?;
+
+    if already_at_target && !force {
+        // post-checkout already ran for same-commit detach
+    } else {
+        run_post_checkout_hook(repo, old_head_commit.as_ref(), oid, true)?;
+    }
 
     if explicit {
         print_detached_head_message_explicit(repo, oid)?;
@@ -2015,6 +2067,11 @@ fn checkout_paths(
             }
         }
     }
+
+    let head_state = resolve_head(&repo.git_dir)?;
+    let tip = head_state.oid().copied();
+    let new_tip = tip.unwrap_or_else(zero_oid);
+    run_post_checkout_hook(repo, tip.as_ref(), &new_tip, false)?;
 
     Ok(())
 }

--- a/grit/src/commands/clone.rs
+++ b/grit/src/commands/clone.rs
@@ -6,6 +6,8 @@
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::config::{ConfigFile, ConfigScope};
+use grit_lib::diff::zero_oid;
+use grit_lib::hooks::{run_hook, HookResult};
 use grit_lib::objects::{parse_commit, parse_tag, parse_tree, ObjectId, ObjectKind};
 use grit_lib::repo::{init_repository, init_repository_separate_git_dir, Repository};
 use std::collections::{HashSet, VecDeque};
@@ -289,7 +291,8 @@ pub fn run(args: Args) -> Result<()> {
     let source_head_branch = determine_head_branch(&source.git_dir, None)?;
     // Determine which branch to checkout (user override or source HEAD)
     let head_branch = determine_head_branch(&source.git_dir, args.branch.as_deref())?;
-    let initial_branch = head_branch.as_deref().unwrap_or("master");
+    let default_branch = default_initial_branch_for_clone();
+    let initial_branch = head_branch.as_deref().unwrap_or(&default_branch);
 
     // Initialize the target repository
     fs::create_dir_all(&target_path)
@@ -368,7 +371,7 @@ pub fn run(args: Args) -> Result<()> {
 
         // Set up remote "origin" in config
         let refspec = if args.single_branch {
-            let branch = head_branch.as_deref().unwrap_or("master");
+            let branch = head_branch.as_deref().unwrap_or(default_branch.as_str());
             format!("+refs/heads/{branch}:refs/remotes/{remote_name}/{branch}")
         } else {
             format!("+refs/heads/*:refs/remotes/{remote_name}/*")
@@ -463,6 +466,7 @@ pub fn run(args: Args) -> Result<()> {
     // Checkout working tree unless --bare or --no-checkout
     if !args.bare && !args.no_checkout {
         checkout_head(&dest).context("checking out HEAD")?;
+        run_post_checkout_after_clone(&dest)?;
     }
 
     if !args.quiet {
@@ -545,7 +549,8 @@ fn run_ssh_clone(args: Args) -> Result<()> {
 
     let source_head_branch = determine_head_branch(&source.git_dir, None)?;
     let head_branch = determine_head_branch(&source.git_dir, args.branch.as_deref())?;
-    let initial_branch = head_branch.as_deref().unwrap_or("master");
+    let default_branch = default_initial_branch_for_clone();
+    let initial_branch = head_branch.as_deref().unwrap_or(&default_branch);
 
     fs::create_dir_all(&target_path)
         .with_context(|| format!("cannot create directory '{}'", target_path.display()))?;
@@ -612,7 +617,7 @@ fn run_ssh_clone(args: Args) -> Result<()> {
         copy_refs_as_remote(&source.git_dir, &dest.git_dir, remote_name, args.no_tags)
             .context("copying refs")?;
         let refspec = if args.single_branch {
-            let branch = head_branch.as_deref().unwrap_or("master");
+            let branch = head_branch.as_deref().unwrap_or(default_branch.as_str());
             format!("+refs/heads/{branch}:refs/remotes/{remote_name}/{branch}")
         } else {
             format!("+refs/heads/*:refs/remotes/{remote_name}/*")
@@ -687,6 +692,7 @@ fn run_ssh_clone(args: Args) -> Result<()> {
 
     if !args.bare && !args.no_checkout {
         checkout_head(&dest).context("checking out HEAD")?;
+        run_post_checkout_after_clone(&dest)?;
     }
 
     if !args.quiet {
@@ -1384,6 +1390,64 @@ fn collect_tree_blob_oids(
     Ok(())
 }
 
+/// Default name for `refs/heads/<name>` when cloning (matches `git init` test override).
+fn default_initial_branch_for_clone() -> String {
+    std::env::var("GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME").unwrap_or_else(|_| "master".to_string())
+}
+
+/// Pick a local branch to check out when the source `HEAD` is detached or unknown.
+fn pick_clone_branch_from_heads(src_git_dir: &Path) -> Result<Option<String>> {
+    let heads = grit_lib::refs::list_refs(src_git_dir, "refs/heads/")
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    if heads.is_empty() {
+        return Ok(None);
+    }
+    if heads.len() == 1 {
+        let name = heads[0]
+            .0
+            .strip_prefix("refs/heads/")
+            .unwrap_or(&heads[0].0)
+            .to_string();
+        return Ok(Some(name));
+    }
+    let default = default_initial_branch_for_clone();
+    if let Some((r, _)) = heads
+        .iter()
+        .find(|(r, _)| r.strip_prefix("refs/heads/").unwrap_or(r) == default.as_str())
+    {
+        return Ok(Some(r.strip_prefix("refs/heads/").unwrap_or(r).to_string()));
+    }
+    if let Some((r, _)) = heads.iter().find(|(r, _)| r.ends_with("/main")) {
+        return Ok(Some(r.strip_prefix("refs/heads/").unwrap_or(r).to_string()));
+    }
+    if let Some((r, _)) = heads.iter().find(|(r, _)| r.ends_with("/master")) {
+        return Ok(Some(r.strip_prefix("refs/heads/").unwrap_or(r).to_string()));
+    }
+    let (r, _) = &heads[0];
+    Ok(Some(r.strip_prefix("refs/heads/").unwrap_or(r).to_string()))
+}
+
+/// Run `post-checkout` after clone: null old OID, new HEAD commit, branch flag `1`.
+fn run_post_checkout_after_clone(repo: &Repository) -> Result<()> {
+    let head_content = fs::read_to_string(repo.git_dir.join("HEAD")).context("reading HEAD")?;
+    let head = head_content.trim();
+    let new_oid = if let Some(refname) = head.strip_prefix("ref: ") {
+        let oid_str = fs::read_to_string(repo.git_dir.join(refname))
+            .with_context(|| format!("reading ref {refname}"))?;
+        ObjectId::from_hex(oid_str.trim()).with_context(|| format!("invalid OID in {refname}"))?
+    } else {
+        ObjectId::from_hex(head).context("invalid OID in HEAD")?
+    };
+    let z = zero_oid();
+    let old_hex = z.to_hex();
+    let new_hex = new_oid.to_hex();
+    let args = [old_hex.as_str(), new_hex.as_str(), "1"];
+    if let HookResult::Failed(code) = run_hook(repo, "post-checkout", &args, None) {
+        bail!("post-checkout hook exited with status {code}");
+    }
+    Ok(())
+}
+
 /// Determine which branch HEAD should point to.
 fn determine_head_branch(src_git_dir: &Path, requested: Option<&str>) -> Result<Option<String>> {
     if let Some(branch) = requested {
@@ -1397,10 +1461,20 @@ fn determine_head_branch(src_git_dir: &Path, requested: Option<&str>) -> Result<
         if let Some(refname) = content.strip_prefix("ref: refs/heads/") {
             return Ok(Some(refname.to_string()));
         }
+        if let Ok(oid) = ObjectId::from_hex(content) {
+            let heads = grit_lib::refs::list_refs(src_git_dir, "refs/heads/")
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            for (r, tip) in &heads {
+                if *tip == oid {
+                    let name = r.strip_prefix("refs/heads/").unwrap_or(r);
+                    return Ok(Some(name.to_string()));
+                }
+            }
+            return pick_clone_branch_from_heads(src_git_dir);
+        }
     }
 
-    // Default to master
-    Ok(Some("master".to_string()))
+    pick_clone_branch_from_heads(src_git_dir)
 }
 
 /// Perform a basic checkout of HEAD into the working tree.
@@ -1715,7 +1789,7 @@ fn run_bundle_clone(args: Args) -> Result<()> {
                     .map(|(r, _)| r.strip_prefix("refs/heads/").unwrap_or(r).to_string())
             }
         })
-        .unwrap_or_else(|| "master".to_string());
+        .unwrap_or_else(default_initial_branch_for_clone);
 
     // Initialize target repo
     fs::create_dir_all(&target_path)?;

--- a/grit/src/commands/rebase.rs
+++ b/grit/src/commands/rebase.rs
@@ -17,9 +17,9 @@ use std::fs;
 use std::path::Path;
 
 use grit_lib::config::ConfigSet;
-use grit_lib::index::{Index, IndexEntry, MODE_EXECUTABLE, MODE_SYMLINK};
-
 use grit_lib::diff::{self, count_changes, DiffEntry};
+use grit_lib::hooks::{run_hook, HookResult};
+use grit_lib::index::{Index, IndexEntry, MODE_EXECUTABLE, MODE_SYMLINK};
 use grit_lib::merge_base::{is_ancestor, merge_bases_first_vs_rest};
 use grit_lib::merge_file::{merge, ConflictStyle, MergeInput};
 use grit_lib::objects::{
@@ -272,6 +272,16 @@ fn validate_compat_options(args: &Args) -> Result<()> {
 
 fn rebase_reflog_action() -> String {
     std::env::var("GIT_REFLOG_ACTION").unwrap_or_else(|_| "rebase".to_owned())
+}
+
+fn run_post_checkout_hook(repo: &Repository, old_oid: &ObjectId, new_oid: &ObjectId) -> Result<()> {
+    let old_hex = old_oid.to_hex();
+    let new_hex = new_oid.to_hex();
+    let args = [old_hex.as_str(), new_hex.as_str(), "1"];
+    if let HookResult::Failed(code) = run_hook(repo, "post-checkout", &args, None) {
+        bail!("post-checkout hook exited with status {code}");
+    }
+    Ok(())
 }
 
 fn print_branch_up_to_date(head: &HeadState) {
@@ -570,6 +580,8 @@ fn do_rebase(args: Args) -> Result<()> {
         checkout_merged_index(&repo, wt, &old_index, &idx)?;
     }
 
+    run_post_checkout_hook(&repo, &head_oid, &onto_oid)?;
+
     eprintln!(
         "rebasing {} commits onto {}",
         total,
@@ -621,6 +633,8 @@ fn fast_forward_rebase(
     if let Some(wt) = &repo.work_tree {
         checkout_merged_index(repo, wt, &old_index, &idx)?;
     }
+
+    run_post_checkout_hook(repo, &head_oid, &onto_oid)?;
 
     let branch_disp = head
         .branch_name()

--- a/logs/2026-04-08_t5403-post-checkout-hook.md
+++ b/logs/2026-04-08_t5403-post-checkout-hook.md
@@ -1,0 +1,25 @@
+# t5403-post-checkout-hook
+
+## Goal
+
+Make `tests/t5403-post-checkout-hook.sh` pass (14/14).
+
+## Changes
+
+- **`grit/src/commands/checkout.rs`**
+  - Added `run_post_checkout_hook` using `grit_lib::hooks::run_hook` with args `<old-hex> <new-hex> <0|1>`.
+  - Branch switches: `switch_branch`, `create_and_switch_branch`, `force_create_and_switch_branch`, `detach_head_inner` — run hook after HEAD update; special case “already on branch” with same commit still runs hook (Git behavior).
+  - Path checkout: `checkout_paths` — flag `0`, old=new=current HEAD commit.
+- **`grit/src/commands/rebase.rs`**
+  - After initial checkout onto `onto` (full rebase and fast-forward rebase), run `post-checkout` with old=head before rewind, new=onto, flag `1`.
+- **`grit/src/commands/clone.rs`**
+  - `determine_head_branch`: map detached HEAD OID to `refs/heads/*` tip when unique; else pick branch like Git (`GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME`, main/master heuristic).
+  - `default_initial_branch_for_clone` for init fallback instead of hardcoded `master`.
+  - After `checkout_head`, run clone `post-checkout` (null old OID, new HEAD, `1`).
+  - SSH clone path updated similarly.
+
+## Validation
+
+- `cargo fmt`, `cargo clippy -p grit-rs --fix --allow-dirty`
+- `cargo test -p grit-lib --lib`
+- `./scripts/run-tests.sh t5403-post-checkout-hook.sh` → 14/14

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   228 |
+| Completed   |   229 |
 | In progress |     2 |
-| Remaining   |   538 |
+| Remaining   |   537 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 228 completed (`[x]`), 2 in progress (`[~]`), 538 remaining (`[ ]`).
+Task lines in `PLAN.md`: 229 completed (`[x]`), 2 in progress (`[~]`), 537 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t5403-post-checkout-hook` — 14/14 tests pass (`checkout`/`rebase`/`clone`: `post-checkout` hook with Git-compatible args; clone resolves detached `HEAD` to the right local branch and honors `GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME`; harness CSV refreshed)
 - `t6434-merge-recursive-rename-options` — 27/27 tests pass (`merge-recursive`: `--find-renames` / `--rename-threshold` with `%`, truncation, last-flag wins vs `--no-renames`, invalid args; config `merge.renames` / `diff.renames`; merge core threads `MergeRenameOptions` into `detect_merge_renames`; `diff`: `-M<n>%` no longer misparsed as a revision, `--diff-filter`, percentage threshold parsing)
 - `t5704-protocol-violations` — 3/3 tests pass (`upload-pack` honors `GIT_PROTOCOL=version=2` with flush-after-args validation for `ls-refs`/`fetch`; `ls-remote --upload-pack` parses v0 ref ads with space/NUL-separated fields and v2 `ls-refs` responses; `serve-v2` default loop fixed)
 - `t7509-commit-authorship` — 12/12 tests pass (`commit`: `--reset-author` with `-C`/`-c`/`--amend` and when `CHERRY_PICK_HEAD`/`REBASE_HEAD` exists; author from `CHERRY_PICK_HEAD` when finishing cherry-pick with `MERGE_MSG`; `--author` now formats full ident with current date; amend rejects empty/malformed prior author; mutual exclusion with `--reset-author`)

--- a/test-results.md
+++ b/test-results.md
@@ -2,6 +2,7 @@
 
 **Updated:** 2026-04-08
 
+- `./scripts/run-tests.sh t5403-post-checkout-hook.sh`: 14/14 passing (`post-checkout` hook on checkout/rebase/clone; clone default branch resolution with detached `HEAD` and `GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME`; harness CSV/dashboards refreshed).
 - `./scripts/run-tests.sh t5704-protocol-violations.sh`: 3/3 passing (`upload-pack` v2 via `GIT_PROTOCOL`, strict flush-after-args; `ls-remote --upload-pack` v0/v2 parsing; harness CSV/dashboards refreshed).
 - `cargo test -p grit-lib --lib`: 105/105 passing.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible `post-checkout` hook invocation for `checkout`, `rebase` (initial onto checkout), and `clone`, and fixes local clone when the source repository has a detached `HEAD` so the correct branch is checked out (including `GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME` for tests).

## Test plan

- `./scripts/run-tests.sh t5403-post-checkout-hook.sh` → 14/14
- `cargo test -p grit-lib --lib` → 105/105
- `cargo clippy -p grit-rs`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d59c4844-e979-4035-ba90-2fe2cd745bf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d59c4844-e979-4035-ba90-2fe2cd745bf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

