### PR TITLE
Record t8930-rev-list-first-parent as fully passing

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1379,7 +1379,7 @@ t8860-add-intent-to-add	t8	yes	30	26	4	false	ok	0
 t8870-rm-directory-tree	t8	yes	27	27	0	true	ok	0
 t8880-mv-subdirectory	t8	yes	24	24	0	true	ok	0
 t8920-rev-parse-flags	t8	yes	31	31	0	true	ok	0
-t8930-rev-list-first-parent	t8	yes	32	26	6	false	ok	0
+t8930-rev-list-first-parent	t8	yes	32	32	0	true	ok	0
 t8940-for-each-ref-points-at	t8	yes	29	18	11	false	ok	0
 t8950-show-ref-patterns	t8	yes	29	16	13	false	ok	0
 t8960-update-ref-stdin-nul	t8	yes	31	15	16	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T05:46:53+00:00" class="gen-time" title="2026-04-08 05:46 UTC">2026-04-08 05:46 UTC</time> · <a href="https://github.com/schacon/grit/commit/0fd20fba5995dfb0a616022ee6ac00bef6171fd3" style="color:#58a6ff">0fd20fb</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T05:49:13+00:00" class="gen-time" title="2026-04-08 05:49 UTC">2026-04-08 05:49 UTC</time> · <a href="https://github.com/schacon/grit/commit/823b179835f7765a609fedce959d5b7cec2e17ed" style="color:#58a6ff">823b179</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,476</div>
+      <div class="summary-big-val">29,482</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>608 files fully passing</span>
+    <span>609 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -267,11 +267,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t8</span>
         <span class="group-desc">Porcelainish commands concerning forensics</span>
-        <span class="group-meta">65/105 files · 0 skipped · 2,548/2,763 tests</span>
+        <span class="group-meta">66/105 files · 0 skipped · 2,554/2,763 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:92.2%"></div></div>
-        <span class="group-pct pct-green">92.2%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:92.4%"></div></div>
+        <span class="group-pct pct-green">92.4%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t9">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T05:46:53+00:00" class="gen-time" title="2026-04-08 05:46 UTC">2026-04-08 05:46 UTC</time> · <a href="https://github.com/schacon/grit/commit/0fd20fba5995dfb0a616022ee6ac00bef6171fd3" style="color:#58a6ff">0fd20fb</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T05:49:13+00:00" class="gen-time" title="2026-04-08 05:49 UTC">2026-04-08 05:49 UTC</time> · <a href="https://github.com/schacon/grit/commit/823b179835f7765a609fedce959d5b7cec2e17ed" style="color:#58a6ff">823b179</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,745</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,476</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,482</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">67.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -13927,14 +13927,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t8" data-tests="32" data-passed="26">
+<tr class="" data-group="t8" data-tests="32" data-passed="32">
   <td class="mono">t8930-rev-list-first-parent</td>
   <td>t8</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">32</td>
-  <td class="right">26</td>
+  <td class="right">32</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:81.2%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t8" data-tests="29" data-passed="18">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`./scripts/run-tests.sh t8930-rev-list-first-parent.sh` reports **32/32** passing. The harness row for `t8930-rev-list-first-parent` in `data/test-files.csv` was still showing 6 failures from an older run; this updates the CSV and regenerated dashboards (`docs/index.html`, `docs/testfiles.html`) to match current behavior.

## Verification

```bash
cargo build --release -p grit-rs
./scripts/run-tests.sh t8930-rev-list-first-parent.sh
```

## Notes

No Rust changes were required: `rev-list --first-parent` is already wired through `RevListOptions` into `CommitGraph` in `grit-lib`, which truncates merge commits to the first parent during traversal.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-adfe794f-8ea6-4d2b-8fef-df6a53b45383"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-adfe794f-8ea6-4d2b-8fef-df6a53b45383"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

