### PR TITLE
fix(tests): t1422 show-ref --exists harness (test_done)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -422,7 +422,7 @@ t1418-reflog-exists	t1	yes	6	6	0	true	ok	0
 t1419-exclude-refs	t1	skip	13	1	12	false	ok	0
 t1420-lost-found	t1	yes	2	2	0	true	ok	0
 t1421-reflog-write	t1	yes	10	5	5	false	ok	0
-t1422-show-ref-exists	t1	yes	0	0	0	false	timeout	0
+t1422-show-ref-exists	t1	yes	12	12	0	true	ok	0
 t1423-ref-backend	t1	skip	9	0	0	false	ok	0
 t1430-bad-ref-name	t1	yes	40	6	34	false	ok	2
 t1450-fsck	t1	skip	74	0	0	false	ok	0
@@ -431,7 +431,7 @@ t1450-fsck-flags	t1	yes	10	8	2	false	ok	0
 t1451-fsck-buffer	t1	yes	72	10	62	false	ok	0
 t1460-refs-migrate	t1	skip	22	0	0	false	ok	0
 t1461-refs-list	t1	yes	0	0	0	false	timeout	0
-t1462-refs-exists	t1	yes	0	0	0	false	timeout	0
+t1462-refs-exists	t1	yes	12	3	9	false	ok	0
 t1463-refs-optimize	t1	yes	0	0	0	false	ok	0
 t1500-rev-parse	t1	yes	81	50	31	false	ok	0
 t1501-work-tree	t1	yes	39	21	18	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,30 +141,30 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T05:50:14+00:00" class="gen-time" title="2026-04-08 05:50 UTC">2026-04-08 05:50 UTC</time> · <a href="https://github.com/schacon/grit/commit/0d52b5fcd0a869d69a694225d8e749af1b0dd201" style="color:#58a6ff">0d52b5f</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T06:39:37+00:00" class="gen-time" title="2026-04-08 06:39 UTC">2026-04-08 06:39 UTC</time> · <a href="https://github.com/schacon/grit/commit/bdaf0a66eae425d8fb8c92be524910a8ef8fb60f" style="color:#58a6ff">bdaf0a6</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">67.4%</div>
+      <div class="summary-big-val pct-blue">67.8%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,476</div>
+      <div class="summary-big-val">29,660</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">43,745</div>
+      <div class="summary-big-val">43,776</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:67.4%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:67.8%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>609 files fully passing</span>
+    <span>621 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -190,11 +190,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">236/368 files · 8 skipped · 10,527/12,224 tests</span>
+        <span class="group-meta">239/368 files · 8 skipped · 10,565/12,251 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:86.1%"></div></div>
-        <span class="group-pct pct-green">86.1%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:86.2%"></div></div>
+        <span class="group-pct pct-green">86.2%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t2">
@@ -212,66 +212,66 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">29/141 files · 2 skipped · 3,438/5,297 tests</span>
+        <span class="group-meta">30/141 files · 2 skipped · 3,447/5,297 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.9%"></div></div>
-        <span class="group-pct pct-blue">64.9%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:65.1%"></div></div>
+        <span class="group-pct pct-blue">65.1%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">62/178 files · 2 skipped · 2,161/4,387 tests</span>
+        <span class="group-meta">63/178 files · 2 skipped · 2,189/4,391 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:49.3%"></div></div>
-        <span class="group-pct pct-orange">49.3%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:49.9%"></div></div>
+        <span class="group-pct pct-orange">49.9%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">29/167 files · 17 skipped · 1,440/4,315 tests</span>
+        <span class="group-meta">30/167 files · 17 skipped · 1,446/4,315 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.4%"></div></div>
-        <span class="group-pct pct-red">33.4%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.5%"></div></div>
+        <span class="group-pct pct-red">33.5%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
       <div class="group-line1">
         <span class="group-id">t6</span>
         <span class="group-desc">Revision tree commands (e.g. merge-base)</span>
-        <span class="group-meta">48/105 files · 3 skipped · 1,178/2,376 tests</span>
+        <span class="group-meta">50/105 files · 3 skipped · 1,216/2,376 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:49.6%"></div></div>
-        <span class="group-pct pct-orange">49.6%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:51.2%"></div></div>
+        <span class="group-pct pct-orange">51.2%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t7">
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">35/126 files · 11 skipped · 1,873/3,607 tests</span>
+        <span class="group-meta">36/126 files · 11 skipped · 1,910/3,607 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:51.9%"></div></div>
-        <span class="group-pct pct-orange">51.9%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:53.0%"></div></div>
+        <span class="group-pct pct-orange">53.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">
       <div class="group-line1">
         <span class="group-id">t8</span>
         <span class="group-desc">Porcelainish commands concerning forensics</span>
-        <span class="group-meta">65/105 files · 0 skipped · 2,548/2,763 tests</span>
+        <span class="group-meta">66/105 files · 0 skipped · 2,553/2,763 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:92.2%"></div></div>
-        <span class="group-pct pct-green">92.2%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:92.4%"></div></div>
+        <span class="group-pct pct-green">92.4%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t9">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,13 +84,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T05:50:14+00:00" class="gen-time" title="2026-04-08 05:50 UTC">2026-04-08 05:50 UTC</time> · <a href="https://github.com/schacon/grit/commit/0d52b5fcd0a869d69a694225d8e749af1b0dd201" style="color:#58a6ff">0d52b5f</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T06:39:37+00:00" class="gen-time" title="2026-04-08 06:39 UTC">2026-04-08 06:39 UTC</time> · <a href="https://github.com/schacon/grit/commit/bdaf0a66eae425d8fb8c92be524910a8ef8fb60f" style="color:#58a6ff">bdaf0a6</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">43,745</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,476</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">67.4%</div><div class="lbl">Pass rate</div></div>
+  <div class="card"><div class="n" id="sum-tests">43,776</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,660</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">67.8%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -4357,14 +4357,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="0" data-passed="0">
+<tr class="" data-group="t1" data-tests="12" data-passed="12">
   <td class="mono">t1422-show-ref-exists</td>
   <td>t1</td>
-  <td></td>
-  <td class="right">0</td>
-  <td class="right">0</td>
-  <td class="right">timeout</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td><span class="badge ok">full pass</span></td>
+  <td class="right">12</td>
+  <td class="right">12</td>
+  <td class="right">ok</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="row-skip" data-group="t1" data-tests="9" data-passed="0">
@@ -4447,14 +4447,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="0" data-passed="0">
+<tr class="" data-group="t1" data-tests="12" data-passed="3">
   <td class="mono">t1462-refs-exists</td>
   <td>t1</td>
   <td></td>
-  <td class="right">0</td>
-  <td class="right">0</td>
-  <td class="right">timeout</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="right">12</td>
+  <td class="right">3</td>
+  <td class="right">ok</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:25.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="0" data-passed="0">
@@ -4597,15 +4597,15 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:64.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="35" data-passed="16">
+<tr class="" data-group="t1" data-tests="38" data-passed="38">
   <td class="mono">t1512-rev-parse-disambiguation</td>
   <td>t1</td>
-  <td></td>
-  <td class="right">35</td>
-  <td class="right">16</td>
+  <td><span class="badge ok">full pass</span></td>
+  <td class="right">38</td>
+  <td class="right">38</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.7%"></div></div></td>
-  <td class="right small">3</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="11" data-passed="11">
   <td class="mono">t1513-rev-parse-prefix</td>
@@ -5727,14 +5727,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="24" data-passed="15">
+<tr class="" data-group="t3" data-tests="24" data-passed="24">
   <td class="mono">t3201-branch-contains</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">24</td>
-  <td class="right">15</td>
+  <td class="right">24</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:62.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="27" data-passed="4">
@@ -12317,14 +12317,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:14.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="57" data-passed="20">
+<tr class="" data-group="t7" data-tests="57" data-passed="57">
   <td class="mono">t7500-commit-template-squash-signoff</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">57</td>
-  <td class="right">20</td>
+  <td class="right">57</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:35.1%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="146" data-passed="140">
@@ -13047,14 +13047,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t8" data-tests="9" data-passed="4">
+<tr class="" data-group="t8" data-tests="9" data-passed="9">
   <td class="mono">t8010-cat-file-filters</td>
   <td>t8</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">9</td>
-  <td class="right">4</td>
+  <td class="right">9</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:44.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t8" data-tests="10" data-passed="10">

--- a/logs/2026-04-08_t1422-show-ref-exists-test_done.md
+++ b/logs/2026-04-08_t1422-show-ref-exists-test_done.md
@@ -1,0 +1,13 @@
+# t1422-show-ref-exists
+
+## Issue
+
+`tests/show-ref-exists-tests.sh` (sourced by `t1422-show-ref-exists.sh` and `t1462-refs-exists.sh`) did not call `test_done` at the end. The harness (`scripts/run-tests.sh`) parses `# Tests: …` from TAP output emitted only in `test_done`; without it the CSV showed `timeout` and `0/0` even when all expectations passed.
+
+## Fix
+
+Append `test_done` to `tests/show-ref-exists-tests.sh`, matching upstream `git/t/show-ref-exists-tests.sh`.
+
+## Verification
+
+`./scripts/run-tests.sh t1422-show-ref-exists.sh` → ✓ 12/12.

--- a/tests/show-ref-exists-tests.sh
+++ b/tests/show-ref-exists-tests.sh
@@ -71,3 +71,5 @@ test_expect_success '--exists succeeds for refs/heads/master' '
 	cd repo &&
 	${git_show_ref_exists} refs/heads/master
 '
+
+test_done


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t1422-show-ref-exists` was running all expectations successfully, but `scripts/run-tests.sh` reported **0/0** and **timeout** because the shared `tests/show-ref-exists-tests.sh` never called `test_done`, so the TAP summary line (`# Tests: …`) was never emitted.

## Changes

- Append `test_done` to `tests/show-ref-exists-tests.sh` (matches upstream `git/t/show-ref-exists-tests.sh`).
- Refresh `data/test-files.csv` and dashboards from `./scripts/run-tests.sh t1422-show-ref-exists.sh` (now **12/12**).
- Log: `logs/2026-04-08_t1422-show-ref-exists-test_done.md`.

## Verification

```bash
./scripts/run-tests.sh t1422-show-ref-exists.sh
# ✓ t1422-show-ref-exists (12/12)
```

**Note:** `t1462-refs-exists.sh` sources the same file; it still has unrelated failures (3/12) against current `git refs exists` — not addressed here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e149cf4-433a-496c-923d-d99e0e6b867c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e149cf4-433a-496c-923d-d99e0e6b867c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

