### PR TITLE
test: t0023-crlf-am fully passing — refresh harness data

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -19,7 +19,7 @@ t0019-json-writer	t0	yes	16	16	0	true	ok	0
 t0020-crlf	t0	yes	36	36	0	true	ok	0
 t0021-conversion	t0	yes	42	20	22	false	ok	0
 t0022-crlf-rename	t0	yes	2	2	0	true	ok	0
-t0023-crlf-am	t0	yes	2	1	1	false	ok	0
+t0023-crlf-am	t0	yes	2	2	0	true	ok	0
 t0024-crlf-archive	t0	yes	3	3	0	true	ok	0
 t0025-crlf-renormalize	t0	yes	3	3	0	true	ok	0
 t0026-eol-config	t0	yes	6	6	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,30 +141,30 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T05:50:14+00:00" class="gen-time" title="2026-04-08 05:50 UTC">2026-04-08 05:50 UTC</time> · <a href="https://github.com/schacon/grit/commit/0d52b5fcd0a869d69a694225d8e749af1b0dd201" style="color:#58a6ff">0d52b5f</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T06:55:22+00:00" class="gen-time" title="2026-04-08 06:55 UTC">2026-04-08 06:55 UTC</time> · <a href="https://github.com/schacon/grit/commit/97f740d8a013a8ff5a9878702946ebdafe52b3f4" style="color:#58a6ff">97f740d</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">67.4%</div>
+      <div class="summary-big-val pct-blue">67.9%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,476</div>
+      <div class="summary-big-val">29,734</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">43,745</div>
+      <div class="summary-big-val">43,761</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:67.4%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:67.9%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>609 files fully passing</span>
+    <span>630 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -179,7 +179,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t0</span>
         <span class="group-desc">Absolute basics and global stuff</span>
-        <span class="group-meta">39/63 files · 21 skipped · 3,432/5,057 tests</span>
+        <span class="group-meta">41/63 files · 21 skipped · 3,442/5,066 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:67.9%"></div></div>
@@ -190,11 +190,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">236/368 files · 8 skipped · 10,527/12,224 tests</span>
+        <span class="group-meta">238/368 files · 8 skipped · 10,550/12,227 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:86.1%"></div></div>
-        <span class="group-pct pct-green">86.1%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:86.3%"></div></div>
+        <span class="group-pct pct-green">86.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t2">
@@ -212,66 +212,66 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">29/141 files · 2 skipped · 3,438/5,297 tests</span>
+        <span class="group-meta">32/141 files · 2 skipped · 3,463/5,297 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.9%"></div></div>
-        <span class="group-pct pct-blue">64.9%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:65.4%"></div></div>
+        <span class="group-pct pct-blue">65.4%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">62/178 files · 2 skipped · 2,161/4,387 tests</span>
+        <span class="group-meta">65/178 files · 2 skipped · 2,209/4,391 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:49.3%"></div></div>
-        <span class="group-pct pct-orange">49.3%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:50.3%"></div></div>
+        <span class="group-pct pct-orange">50.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">29/167 files · 17 skipped · 1,440/4,315 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,461/4,315 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.4%"></div></div>
-        <span class="group-pct pct-red">33.4%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.9%"></div></div>
+        <span class="group-pct pct-red">33.9%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
       <div class="group-line1">
         <span class="group-id">t6</span>
         <span class="group-desc">Revision tree commands (e.g. merge-base)</span>
-        <span class="group-meta">48/105 files · 3 skipped · 1,178/2,376 tests</span>
-      </div>
-      <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:49.6%"></div></div>
-        <span class="group-pct pct-orange">49.6%</span>
-      </div>
-    </a>
-    <a class="group-card" href="testfiles.html?group=t7">
-      <div class="group-line1">
-        <span class="group-id">t7</span>
-        <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">35/126 files · 11 skipped · 1,873/3,607 tests</span>
+        <span class="group-meta">51/105 files · 3 skipped · 1,234/2,376 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-orange" style="width:51.9%"></div></div>
         <span class="group-pct pct-orange">51.9%</span>
       </div>
     </a>
+    <a class="group-card" href="testfiles.html?group=t7">
+      <div class="group-line1">
+        <span class="group-id">t7</span>
+        <span class="group-desc">Porcelainish commands concerning the working tree</span>
+        <span class="group-meta">38/126 files · 11 skipped · 1,920/3,607 tests</span>
+      </div>
+      <div class="group-line2">
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:53.2%"></div></div>
+        <span class="group-pct pct-orange">53.2%</span>
+      </div>
+    </a>
     <a class="group-card" href="testfiles.html?group=t8">
       <div class="group-line1">
         <span class="group-id">t8</span>
         <span class="group-desc">Porcelainish commands concerning forensics</span>
-        <span class="group-meta">65/105 files · 0 skipped · 2,548/2,763 tests</span>
+        <span class="group-meta">66/105 files · 0 skipped · 2,553/2,763 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:92.2%"></div></div>
-        <span class="group-pct pct-green">92.2%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:92.4%"></div></div>
+        <span class="group-pct pct-green">92.4%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t9">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,13 +84,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T05:50:14+00:00" class="gen-time" title="2026-04-08 05:50 UTC">2026-04-08 05:50 UTC</time> · <a href="https://github.com/schacon/grit/commit/0d52b5fcd0a869d69a694225d8e749af1b0dd201" style="color:#58a6ff">0d52b5f</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T06:55:22+00:00" class="gen-time" title="2026-04-08 06:55 UTC">2026-04-08 06:55 UTC</time> · <a href="https://github.com/schacon/grit/commit/97f740d8a013a8ff5a9878702946ebdafe52b3f4" style="color:#58a6ff">97f740d</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">43,745</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,476</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">67.4%</div><div class="lbl">Pass rate</div></div>
+  <div class="card"><div class="n" id="sum-tests">43,761</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,734</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">67.9%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -327,14 +327,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t0" data-tests="2" data-passed="1">
+<tr class="" data-group="t0" data-tests="2" data-passed="2">
   <td class="mono">t0023-crlf-am</td>
   <td>t0</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">2</td>
-  <td class="right">1</td>
+  <td class="right">2</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t0" data-tests="3" data-passed="3">
@@ -487,14 +487,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t0" data-tests="0" data-passed="0">
+<tr class="" data-group="t0" data-tests="9" data-passed="9">
   <td class="mono">t0052-simple-ipc</td>
   <td>t0</td>
-  <td></td>
-  <td class="right">0</td>
-  <td class="right">0</td>
+  <td><span class="badge ok">full pass</span></td>
+  <td class="right">9</td>
+  <td class="right">9</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t0" data-tests="3" data-passed="3">
@@ -4597,15 +4597,15 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:64.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="35" data-passed="16">
+<tr class="" data-group="t1" data-tests="38" data-passed="38">
   <td class="mono">t1512-rev-parse-disambiguation</td>
   <td>t1</td>
-  <td></td>
-  <td class="right">35</td>
-  <td class="right">16</td>
+  <td><span class="badge ok">full pass</span></td>
+  <td class="right">38</td>
+  <td class="right">38</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.7%"></div></div></td>
-  <td class="right small">3</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="11" data-passed="11">
   <td class="mono">t1513-rev-parse-prefix</td>
@@ -5727,14 +5727,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="24" data-passed="15">
+<tr class="" data-group="t3" data-tests="24" data-passed="24">
   <td class="mono">t3201-branch-contains</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">24</td>
-  <td class="right">15</td>
+  <td class="right">24</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:62.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="27" data-passed="4">
@@ -6127,14 +6127,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="25" data-passed="13">
+<tr class="" data-group="t3" data-tests="25" data-passed="25">
   <td class="mono">t3412-rebase-root</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">25</td>
-  <td class="right">13</td>
+  <td class="right">25</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:52.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="15" data-passed="5">
@@ -6187,14 +6187,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:20.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="8" data-passed="4">
+<tr class="" data-group="t3" data-tests="8" data-passed="8">
   <td class="mono">t3419-rebase-patch-id</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">8</td>
-  <td class="right">4</td>
+  <td class="right">8</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="52" data-passed="3">
@@ -6957,14 +6957,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:57.1%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="17" data-passed="12">
+<tr class="" data-group="t4" data-tests="17" data-passed="17">
   <td class="mono">t4010-diff-pathspec</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">17</td>
-  <td class="right">12</td>
+  <td class="right">17</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.6%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="8" data-passed="7">
@@ -7647,14 +7647,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:94.1%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="16" data-passed="1">
+<tr class="" data-group="t4" data-tests="16" data-passed="16">
   <td class="mono">t4069-remerge-diff</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">16</td>
-  <td class="right">1</td>
+  <td class="right">16</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:6.2%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="7" data-passed="2">
@@ -10137,14 +10137,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:47.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="21" data-passed="6">
+<tr class="" data-group="t5" data-tests="21" data-passed="21">
   <td class="mono">t5606-clone-options</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">21</td>
-  <td class="right">6</td>
+  <td class="right">21</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:28.6%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="16" data-passed="5">
@@ -11017,14 +11017,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t6" data-tests="25" data-passed="7">
+<tr class="" data-group="t6" data-tests="25" data-passed="25">
   <td class="mono">t6137-pathspec-wildcards-literal</td>
   <td>t6</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">25</td>
-  <td class="right">7</td>
+  <td class="right">25</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:28.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t6" data-tests="34" data-passed="31">
@@ -12147,14 +12147,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:25.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="3" data-passed="1">
+<tr class="" data-group="t7" data-tests="3" data-passed="3">
   <td class="mono">t7409-submodule-detached-work-tree</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">3</td>
-  <td class="right">1</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:33.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="20" data-passed="2">
@@ -12317,14 +12317,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:14.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="57" data-passed="20">
+<tr class="" data-group="t7" data-tests="57" data-passed="57">
   <td class="mono">t7500-commit-template-squash-signoff</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">57</td>
-  <td class="right">20</td>
+  <td class="right">57</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:35.1%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="146" data-passed="140">
@@ -12527,14 +12527,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="16" data-passed="8">
+<tr class="" data-group="t7" data-tests="16" data-passed="16">
   <td class="mono">t7517-per-repo-email</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">16</td>
-  <td class="right">8</td>
+  <td class="right">16</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="5" data-passed="5">
@@ -13047,14 +13047,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t8" data-tests="9" data-passed="4">
+<tr class="" data-group="t8" data-tests="9" data-passed="9">
   <td class="mono">t8010-cat-file-filters</td>
   <td>t8</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">9</td>
-  <td class="right">4</td>
+  <td class="right">9</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:44.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t8" data-tests="10" data-passed="10">

--- a/logs/2026-04-08_t0023-crlf-am.md
+++ b/logs/2026-04-08_t0023-crlf-am.md
@@ -1,0 +1,4 @@
+# t0023-crlf-am
+
+- Ran `./scripts/run-tests.sh t0023-crlf-am.sh`: 2/2 pass (`git am -3` with `core.autocrlf true`, clean `git diff-files`).
+- Refreshed `data/test-files.csv` and dashboards (row previously showed 1 failure; current grit passes).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t0023-crlf-am.sh` already passes against current grit (2/2): `git am -3` with `core.autocrlf true` leaves a clean index/worktree (`git diff-files --exit-code`).

This change refreshes harness artifacts so `data/test-files.csv` matches the latest run.

## Changes

- Update `data/test-files.csv` row for `t0023-crlf-am` to 2/2 pass, `fully_passing=true`
- Regenerate `docs/index.html` and `docs/testfiles.html` via `scripts/run-tests.sh`
- Add `logs/2026-04-08_t0023-crlf-am.md`

## Verification

- `./scripts/run-tests.sh t0023-crlf-am.sh`
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-138791b2-169f-4c7b-9e39-a3ec354067db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-138791b2-169f-4c7b-9e39-a3ec354067db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

