### PR TITLE
fix: make t10560-switch-create-detach fully pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -153,7 +153,7 @@ t10520-commit-date-author	t1	yes	31	31	0	true	ok	0
 t10530-add-verbose-dry-run	t1	yes	32	32	0	true	ok	0
 t10540-rm-ignore-unmatch	t1	yes	31	31	0	true	ok	0
 t10550-mv-verbose-dry-run	t1	yes	28	28	0	true	ok	0
-t10560-switch-create-detach	t1	yes	28	6	22	false	ok	0
+t10560-switch-create-detach	t1	yes	28	28	0	true	ok	0
 t10570-restore-worktree-only	t1	yes	28	28	0	true	ok	0
 t10580-reset-path-mixed	t1	yes	25	25	0	true	ok	0
 t1060-object-corruption	t1	yes	16	12	4	false	ok	1
@@ -1599,7 +1599,7 @@ t9880-config-file-option	t9	yes	32	25	7	false	ok	0
 t9890-init-object-format	t9	yes	31	31	0	true	ok	0
 t9900-branch-verbose-all	t9	yes	33	33	0	true	ok	0
 t9901-git-web--browse	t9	yes	5	0	5	false	ok	0
-t9902-completion	t9	yes	263	15	245	false	ok	2
+t9902-completion	t9	yes	260	15	245	false	ok	2
 t9903-bash-prompt	t9	yes	67	1	66	false	ok	0
 t9910-tag-pattern-glob	t9	yes	32	32	0	true	ok	0
 t9920-commit-tree-author-env	t9	yes	26	25	1	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T07:02:06+00:00" class="gen-time" title="2026-04-08 07:02 UTC">2026-04-08 07:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/6c43d4f254c685cfbaaa45ad96a40e6de1c46be6" style="color:#58a6ff">6c43d4f</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T07:11:09+00:00" class="gen-time" title="2026-04-08 07:11 UTC">2026-04-08 07:11 UTC</time> · <a href="https://github.com/schacon/grit/commit/fde941c1be4a3669ac8369942b44c2e14dbaa1d7" style="color:#58a6ff">fde941c</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,11 +150,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,725</div>
+      <div class="summary-big-val">29,747</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">43,529</div>
+      <div class="summary-big-val">43,526</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>631 files fully passing</span>
+    <span>632 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -190,11 +190,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">239/368 files · 8 skipped · 10,596/12,227 tests</span>
+        <span class="group-meta">240/368 files · 8 skipped · 10,618/12,227 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:86.7%"></div></div>
-        <span class="group-pct pct-green">86.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:86.8%"></div></div>
+        <span class="group-pct pct-green">86.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t2">
@@ -278,7 +278,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t9</span>
         <span class="group-desc">Git tools</span>
-        <span class="group-meta">40/90 files · 127 skipped · 2,285/2,854 tests</span>
+        <span class="group-meta">40/90 files · 127 skipped · 2,285/2,851 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-green" style="width:80.1%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T07:02:06+00:00" class="gen-time" title="2026-04-08 07:02 UTC">2026-04-08 07:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/6c43d4f254c685cfbaaa45ad96a40e6de1c46be6" style="color:#58a6ff">6c43d4f</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T07:11:09+00:00" class="gen-time" title="2026-04-08 07:11 UTC">2026-04-08 07:11 UTC</time> · <a href="https://github.com/schacon/grit/commit/fde941c1be4a3669ac8369942b44c2e14dbaa1d7" style="color:#58a6ff">fde941c</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">43,529</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,725</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n" id="sum-tests">43,526</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,747</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">68.3%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1667,14 +1667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="28" data-passed="6">
+<tr class="" data-group="t1" data-tests="28" data-passed="28">
   <td class="mono">t10560-switch-create-detach</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">28</td>
-  <td class="right">6</td>
+  <td class="right">28</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:21.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="28" data-passed="28">
@@ -16127,14 +16127,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t9" data-tests="263" data-passed="15">
+<tr class="" data-group="t9" data-tests="260" data-passed="15">
   <td class="mono">t9902-completion</td>
   <td>t9</td>
   <td></td>
-  <td class="right">263</td>
+  <td class="right">260</td>
   <td class="right">15</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">2</td>
 </tr>
 <tr class="" data-group="t9" data-tests="67" data-passed="1">

--- a/grit/src/commands/checkout.rs
+++ b/grit/src/commands/checkout.rs
@@ -12,6 +12,7 @@ use clap::Args as ClapArgs;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
+use grit_lib::check_ref_format::{check_refname_format, RefNameOptions};
 use grit_lib::config::ConfigSet;
 use grit_lib::crlf;
 use grit_lib::diff::zero_oid;
@@ -142,6 +143,10 @@ pub struct Args {
     /// Read pathspec from file.
     #[arg(long = "pathspec-from-file")]
     pub pathspec_from_file: Option<String>,
+
+    /// Internal: set by `grit switch` so `-- <name>` is interpreted as a branch, not a path.
+    #[arg(long = "__grit_switch_mode", hide = true, default_value_t = false)]
+    pub switch_mode: bool,
 
     /// Remaining positional arguments: `[<branch|commit>] [--] [<paths>...]`
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
@@ -317,7 +322,12 @@ pub fn run(mut args: Args) -> Result<()> {
     }
 
     // Parse rest into (target, paths) handling `--` separator
-    let (target, paths) = split_target_and_paths(&args.rest, has_separator, separator_at_end);
+    let (target, paths) = split_target_and_paths(
+        &args.rest,
+        has_separator,
+        separator_at_end,
+        args.switch_mode,
+    );
 
     // Resolve @{-N} in start point if present
     let target = target.map(|t| resolve_at_minus(&repo, &t).unwrap_or(t));
@@ -676,6 +686,7 @@ fn split_target_and_paths(
     rest: &[String],
     has_separator: bool,
     separator_at_end: bool,
+    switch_mode: bool,
 ) -> (Option<String>, Vec<String>) {
     if rest.is_empty() {
         return (None, vec![]);
@@ -695,6 +706,11 @@ fn split_target_and_paths(
             return (None, vec![]);
         }
         if separator_at_end {
+            return (Some(rest[0].clone()), vec![]);
+        }
+        // `git switch -- <branch>`: a single token after `--` is always the branch name, even if
+        // it matches a tracked path (`git switch -- file1.txt-branch`).
+        if switch_mode && rest.len() == 1 {
             return (Some(rest[0].clone()), vec![]);
         }
         return (None, rest.to_vec());
@@ -868,6 +884,18 @@ fn switch_branch(
     Ok(())
 }
 
+/// Reject branch names that cannot exist as `refs/heads/<name>` (matches `git switch -c`).
+fn validate_new_branch_name(name: &str) -> Result<()> {
+    let opts = RefNameOptions {
+        allow_onelevel: true,
+        ..Default::default()
+    };
+    if check_refname_format(name, &opts).is_err() {
+        bail!("'{name}' is not a valid branch name");
+    }
+    Ok(())
+}
+
 /// Create a new branch and switch to it.
 fn create_and_switch_branch(
     repo: &Repository,
@@ -875,6 +903,7 @@ fn create_and_switch_branch(
     start: Option<&str>,
     force: bool,
 ) -> Result<()> {
+    validate_new_branch_name(name)?;
     // Check for HEAD.lock (another process is writing)
     let head_lock = repo.git_dir.join("HEAD.lock");
     if head_lock.exists() {
@@ -959,6 +988,7 @@ fn force_create_and_switch_branch(
     start: Option<&str>,
     force: bool,
 ) -> Result<()> {
+    validate_new_branch_name(name)?;
     let branch_ref = format!("refs/heads/{name}");
 
     // Check if branch is checked out in another worktree (including main)
@@ -1089,6 +1119,7 @@ fn force_create_and_switch_branch(
 /// Sets HEAD to the new branch but does NOT create the ref (no commit yet).
 /// If a start_point is given, populates the index/worktree from that commit.
 fn create_orphan_branch(repo: &Repository, name: &str, start_point: Option<&str>) -> Result<()> {
+    validate_new_branch_name(name)?;
     let branch_ref = format!("refs/heads/{name}");
 
     // Re-creating an orphan branch name removes the old ref (matches `git switch --orphan`

--- a/grit/src/commands/switch.rs
+++ b/grit/src/commands/switch.rs
@@ -133,6 +133,7 @@ pub fn run(args: Args) -> Result<()> {
         std::process::exit(128);
     }
     checkout::run(checkout::Args {
+        switch_mode: true,
         rest: checkout_tail,
         ..Default::default()
     })

--- a/logs/2026-04-08_t10560-switch-create-detach.md
+++ b/logs/2026-04-08_t10560-switch-create-detach.md
@@ -1,0 +1,21 @@
+# t10560-switch-create-detach
+
+## Goal
+
+Make `tests/t10560-switch-create-detach.sh` pass (28 tests).
+
+## Failures (before)
+
+1. `switch -- file1.txt-branch` — checkout path treated `file1.txt-branch` as a pathspec (ambiguous with branch name containing `.`).
+2. `switch -c "bad branch name"` — should fail; grit accepted invalid branch names.
+
+## Changes
+
+- `checkout::Args.switch_mode` (hidden `--__grit_switch_mode`): `switch` sets this when delegating to checkout.
+- `split_target_and_paths`: when `switch_mode && has_separator && !separator_at_end && rest.len() == 1`, treat the lone arg as the switch target (branch/commit), not pathspecs.
+- `validate_new_branch_name`: `check_refname_format` with `allow_onelevel: true`; used in `create_and_switch_branch`, `force_create_and_switch_branch`, `create_orphan_branch`.
+
+## Verification
+
+- `cargo fmt`, `cargo check -p grit-rs`, `cargo clippy -p grit-rs --fix --allow-dirty`, `cargo test -p grit-lib --lib`
+- `./scripts/run-tests.sh t10560-switch-create-detach.sh` → 28/28 after release build

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   229 |
+| Completed   |   230 |
 | In progress |     2 |
-| Remaining   |   537 |
+| Remaining   |   536 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 229 completed (`[x]`), 2 in progress (`[~]`), 537 remaining (`[ ]`).
+Task lines in `PLAN.md`: 230 completed (`[x]`), 2 in progress (`[~]`), 536 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t10560-switch-create-detach` — 28/28 tests pass (`switch`: `-- <branch>` treats a single token as the branch even when it matches a tracked path; `-c`/`-C`/`--orphan` reject invalid ref names via `check_refname_format` with Git-style `is not a valid branch name`)
 - `t6137-pathspec-wildcards-literal` — 25/25 tests pass (Git-style pathspec glob boundaries with `\` escapes; `add`/`commit` pathspec expansion uses `wildmatch`, ignores `.git` for `*`/`**`, bracket patterns also pick up a literal `[abc]` file; `commit` with pathspec builds partial trees: merge with `HEAD^{tree}` or subset tree on root commit)
 - `t7517-per-repo-email` — 16/16 tests pass (`user.useConfigOnly` strict email; `author.*`/`committer.*` overrides; rebase `-i` continues into replay; noop pick when HEAD is already the parent)
 - `t7409-submodule-detached-work-tree` — 3/3 tests pass (submodule `clone --separate-git-dir` sets `core.worktree`; checkout populates work tree when index empty on same branch/detached OID; merge/checkout treat gitlinks as clean when submodule HEAD matches; nested grit subprocesses clear inherited `GIT_DIR`/`GIT_WORK_TREE`; harness clears those env vars per test)

--- a/t1-plan.md
+++ b/t1-plan.md
@@ -29,7 +29,7 @@
 - [ ] t10520-commit-date-author.sh
 - [ ] t10540-rm-ignore-unmatch.sh
 - [ ] t10550-mv-verbose-dry-run.sh
-- [ ] t10560-switch-create-detach.sh
+- [x] t10560-switch-create-detach.sh
 - [ ] t10570-restore-worktree-only.sh
 - [ ] t1060-object-corruption.sh                                                                        - [ ] t10610-show-ref-dereference-extra.sh
 - [ ] t10620-update-ref-nul-stdin.sh

--- a/test-results.md
+++ b/test-results.md
@@ -2,12 +2,13 @@
 
 **Updated:** 2026-04-08
 
+- `./scripts/run-tests.sh t10560-switch-create-detach.sh`: 28/28 passing (`switch -- <branch>` disambiguation; invalid `-c`/`-C`/`--orphan` branch names rejected like Git; harness CSV/dashboards refreshed).
+- `cargo test -p grit-lib --lib`: 110/110 passing.
 - `./scripts/run-tests.sh t5403-post-checkout-hook.sh`: 14/14 passing (`post-checkout` hook on checkout/rebase/clone; clone default branch resolution with detached `HEAD` and `GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME`; harness CSV/dashboards refreshed).
 - `./scripts/run-tests.sh t7517-per-repo-email.sh`: 16/16 passing (`user.useConfigOnly`, per-role ident config, rebase noop pick; harness CSV/dashboards refreshed).
 - `./scripts/run-tests.sh t5704-protocol-violations.sh`: 3/3 passing (`upload-pack` v2 via `GIT_PROTOCOL`, strict flush-after-args; `ls-remote --upload-pack` v0/v2 parsing; harness CSV/dashboards refreshed).
 - `./scripts/run-tests.sh t6130-pathspec-noglob.sh`: 21/21 passing (pathspec globals env + `:(glob)`/`:(literal)` / `wildmatch` semantics; harness CSV/dashboards refreshed).
 - `./scripts/run-tests.sh t3201-branch-contains.sh`: 24/24 passing (`branch` filters, multi-flag OR/AND semantics, tracking + `-v`/`-vv`; harness CSV/dashboards refreshed).
-- `cargo test -p grit-lib --lib`: 105/105 passing.
 
 **Updated:** 2026-04-07
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`tests/t10560-switch-create-detach.sh` now passes 28/28.

## Changes

1. **`git switch -- <name>`** — When `switch` delegates to checkout, a hidden `switch_mode` flag is set so that a single argument after `--` is treated as the branch (or commit-ish) to switch to, not as pathspecs. This matches Git and fixes branches whose names look like paths (e.g. `file1.txt-branch`).

2. **Invalid branch names** — New branches from `-c`/`-C` and `--orphan` are validated with `grit_lib::check_ref_format::check_refname_format` (`allow_onelevel: true`). Invalid names fail with Git-style `'<name>' is not a valid branch name` (e.g. spaces).

## Verification

- `cargo fmt`, `cargo check -p grit-rs`, `cargo clippy -p grit-rs --fix --allow-dirty`
- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t10560-switch-create-detach.sh` → 28/28
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2154d5e0-7dcd-4794-8f3b-167ebc87f069"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2154d5e0-7dcd-4794-8f3b-167ebc87f069"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

