### PR TITLE
chore: verify t13010-rm-ignore-unmatch (30/30)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -352,7 +352,7 @@ t12990-commit-reuse-message	t1	yes	32	32	0	true	ok	0
 t1300-config	t1	yes	497	265	232	false	ok	0
 t13000-add-bulk-paths	t1	yes	31	31	0	true	ok	0
 t1301-shared-repo	t1	yes	22	2	20	false	ok	0
-t13010-rm-ignore-unmatch	t1	yes	30	29	1	false	ok	0
+t13010-rm-ignore-unmatch	t1	yes	30	30	0	true	ok	0
 t1302-repo-version	t1	yes	18	18	0	true	ok	0
 t13020-mv-force-overwrite	t1	yes	30	29	1	false	ok	0
 t1303-wacky-config	t1	yes	11	11	0	true	ok	0
@@ -1599,7 +1599,7 @@ t9880-config-file-option	t9	yes	32	25	7	false	ok	0
 t9890-init-object-format	t9	yes	31	31	0	true	ok	0
 t9900-branch-verbose-all	t9	yes	33	33	0	true	ok	0
 t9901-git-web--browse	t9	yes	5	0	5	false	ok	0
-t9902-completion	t9	yes	263	15	245	false	ok	2
+t9902-completion	t9	yes	260	15	245	false	ok	2
 t9903-bash-prompt	t9	yes	67	1	66	false	ok	0
 t9910-tag-pattern-glob	t9	yes	32	32	0	true	ok	0
 t9920-commit-tree-author-env	t9	yes	26	25	1	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T07:02:06+00:00" class="gen-time" title="2026-04-08 07:02 UTC">2026-04-08 07:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/6c43d4f254c685cfbaaa45ad96a40e6de1c46be6" style="color:#58a6ff">6c43d4f</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T07:13:38+00:00" class="gen-time" title="2026-04-08 07:13 UTC">2026-04-08 07:13 UTC</time> · <a href="https://github.com/schacon/grit/commit/fde941c1be4a3669ac8369942b44c2e14dbaa1d7" style="color:#58a6ff">fde941c</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,11 +150,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,725</div>
+      <div class="summary-big-val">29,726</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">43,529</div>
+      <div class="summary-big-val">43,526</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>631 files fully passing</span>
+    <span>632 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -190,7 +190,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">239/368 files · 8 skipped · 10,596/12,227 tests</span>
+        <span class="group-meta">240/368 files · 8 skipped · 10,597/12,227 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-green" style="width:86.7%"></div></div>
@@ -278,7 +278,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t9</span>
         <span class="group-desc">Git tools</span>
-        <span class="group-meta">40/90 files · 127 skipped · 2,285/2,854 tests</span>
+        <span class="group-meta">40/90 files · 127 skipped · 2,285/2,851 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-green" style="width:80.1%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T07:02:06+00:00" class="gen-time" title="2026-04-08 07:02 UTC">2026-04-08 07:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/6c43d4f254c685cfbaaa45ad96a40e6de1c46be6" style="color:#58a6ff">6c43d4f</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T07:13:38+00:00" class="gen-time" title="2026-04-08 07:13 UTC">2026-04-08 07:13 UTC</time> · <a href="https://github.com/schacon/grit/commit/fde941c1be4a3669ac8369942b44c2e14dbaa1d7" style="color:#58a6ff">fde941c</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">43,529</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,725</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n" id="sum-tests">43,526</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,726</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">68.3%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -3657,14 +3657,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:9.1%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="30" data-passed="29">
+<tr class="" data-group="t1" data-tests="30" data-passed="30">
   <td class="mono">t13010-rm-ignore-unmatch</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">30</td>
-  <td class="right">29</td>
+  <td class="right">30</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:96.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="18" data-passed="18">
@@ -16127,14 +16127,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t9" data-tests="263" data-passed="15">
+<tr class="" data-group="t9" data-tests="260" data-passed="15">
   <td class="mono">t9902-completion</td>
   <td>t9</td>
   <td></td>
-  <td class="right">263</td>
+  <td class="right">260</td>
   <td class="right">15</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">2</td>
 </tr>
 <tr class="" data-group="t9" data-tests="67" data-passed="1">

--- a/logs/2026-04-08_t13010-rm-ignore-unmatch.md
+++ b/logs/2026-04-08_t13010-rm-ignore-unmatch.md
@@ -1,0 +1,14 @@
+# t13010-rm-ignore-unmatch
+
+**Date:** 2026-04-08
+
+## Goal
+
+Ensure `tests/t13010-rm-ignore-unmatch.sh` passes fully (30 tests).
+
+## Result
+
+- `cargo build --release -p grit-rs`
+- `./scripts/run-tests.sh t13010-rm-ignore-unmatch.sh` → **30/30** pass.
+- No Rust changes required; implementation in `grit/src/commands/rm.rs` already satisfies the suite.
+- Committed harness refresh: `data/test-files.csv`, `docs/index.html`, `docs/testfiles.html`, plus `t1-plan.md` / `progress.md` / this log.

--- a/progress.md
+++ b/progress.md
@@ -15,6 +15,7 @@ Task lines in `PLAN.md`: 229 completed (`[x]`), 2 in progress (`[~]`), 537 remai
 
 ## Recently completed
 
+- `t13010-rm-ignore-unmatch` — 30/30 tests pass (verified `grit rm`: `--ignore-unmatch`, `--cached`, `--force`, `-r`, dry-run, quiet, globs, subdir paths, symlinks; harness CSV/dashboards refreshed)
 - `t6137-pathspec-wildcards-literal` — 25/25 tests pass (Git-style pathspec glob boundaries with `\` escapes; `add`/`commit` pathspec expansion uses `wildmatch`, ignores `.git` for `*`/`**`, bracket patterns also pick up a literal `[abc]` file; `commit` with pathspec builds partial trees: merge with `HEAD^{tree}` or subset tree on root commit)
 - `t7517-per-repo-email` — 16/16 tests pass (`user.useConfigOnly` strict email; `author.*`/`committer.*` overrides; rebase `-i` continues into replay; noop pick when HEAD is already the parent)
 - `t7409-submodule-detached-work-tree` — 3/3 tests pass (submodule `clone --separate-git-dir` sets `core.worktree`; checkout populates work tree when index empty on same branch/detached OID; merge/checkout treat gitlinks as clean when submodule HEAD matches; nested grit subprocesses clear inherited `GIT_DIR`/`GIT_WORK_TREE`; harness clears those env vars per test)

--- a/t1-plan.md
+++ b/t1-plan.md
@@ -147,7 +147,7 @@
 - [ ] t12990-commit-reuse-message.sh
 - [ ] t1300-config.sh
 - [ ] t1301-shared-repo.sh
-- [ ] t13010-rm-ignore-unmatch.sh
+- [x] t13010-rm-ignore-unmatch.sh
 - [ ] t13020-mv-force-overwrite.sh
 - [ ] t13030-switch-quiet-verbose.sh
 - [ ] t13040-restore-quiet-progress.sh


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`tests/t13010-rm-ignore-unmatch.sh` already passes against current `grit rm` (no Rust changes).

## What changed

- Re-ran `./scripts/run-tests.sh t13010-rm-ignore-unmatch.sh` → **30/30** tests pass.
- Refreshed harness outputs: `data/test-files.csv`, `docs/index.html`, `docs/testfiles.html`.
- Marked `t13010-rm-ignore-unmatch.sh` complete in `t1-plan.md`.
- Added `logs/2026-04-08_t13010-rm-ignore-unmatch.md`.

## Verification

```bash
cargo build --release -p grit-rs
./scripts/run-tests.sh t13010-rm-ignore-unmatch.sh
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b5b3b65f-d564-4bb4-a726-144c47b188f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b5b3b65f-d564-4bb4-a726-144c47b188f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

