### PR TITLE
test: t8610-checkout-index-modes harness refresh (27/27)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1351,7 +1351,7 @@ t8570-rev-parse-branch	t8	yes	35	33	2	false	ok	0
 t8580-rev-list-limit	t8	yes	30	30	0	true	ok	0
 t8590-for-each-ref-filter	t8	yes	30	30	0	true	ok	0
 t8600-update-ref-symref	t8	yes	28	20	8	false	ok	0
-t8610-checkout-index-modes	t8	yes	27	25	2	false	ok	0
+t8610-checkout-index-modes	t8	yes	27	27	0	true	ok	0
 t8630-ls-tree-format	t8	yes	29	29	0	true	ok	0
 t8640-ls-files-stage-unmerged	t8	yes	31	18	13	false	ok	0
 t8650-cat-file-batch-extra	t8	yes	27	26	1	false	ok	0
@@ -1599,7 +1599,7 @@ t9880-config-file-option	t9	yes	32	25	7	false	ok	0
 t9890-init-object-format	t9	yes	31	31	0	true	ok	0
 t9900-branch-verbose-all	t9	yes	33	33	0	true	ok	0
 t9901-git-web--browse	t9	yes	5	0	5	false	ok	0
-t9902-completion	t9	yes	263	15	245	false	ok	2
+t9902-completion	t9	yes	260	15	245	false	ok	2
 t9903-bash-prompt	t9	yes	67	1	66	false	ok	0
 t9910-tag-pattern-glob	t9	yes	32	32	0	true	ok	0
 t9920-commit-tree-author-env	t9	yes	26	25	1	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T07:02:06+00:00" class="gen-time" title="2026-04-08 07:02 UTC">2026-04-08 07:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/6c43d4f254c685cfbaaa45ad96a40e6de1c46be6" style="color:#58a6ff">6c43d4f</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T07:18:37+00:00" class="gen-time" title="2026-04-08 07:18 UTC">2026-04-08 07:18 UTC</time> · <a href="https://github.com/schacon/grit/commit/17f93bd8f022db368a6277f0351cdbfcc7ef02a2" style="color:#58a6ff">17f93bd</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,11 +150,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,725</div>
+      <div class="summary-big-val">29,745</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">43,529</div>
+      <div class="summary-big-val">43,526</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>631 files fully passing</span>
+    <span>633 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,11 +212,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">32/141 files · 2 skipped · 3,380/5,100 tests</span>
+        <span class="group-meta">33/141 files · 2 skipped · 3,398/5,100 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:66.3%"></div></div>
-        <span class="group-pct pct-blue">66.3%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:66.6%"></div></div>
+        <span class="group-pct pct-blue">66.6%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">
@@ -267,18 +267,18 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t8</span>
         <span class="group-desc">Porcelainish commands concerning forensics</span>
-        <span class="group-meta">66/105 files · 0 skipped · 2,554/2,763 tests</span>
+        <span class="group-meta">67/105 files · 0 skipped · 2,556/2,763 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:92.4%"></div></div>
-        <span class="group-pct pct-green">92.4%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:92.5%"></div></div>
+        <span class="group-pct pct-green">92.5%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t9">
       <div class="group-line1">
         <span class="group-id">t9</span>
         <span class="group-desc">Git tools</span>
-        <span class="group-meta">40/90 files · 127 skipped · 2,285/2,854 tests</span>
+        <span class="group-meta">40/90 files · 127 skipped · 2,285/2,851 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-green" style="width:80.1%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T07:02:06+00:00" class="gen-time" title="2026-04-08 07:02 UTC">2026-04-08 07:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/6c43d4f254c685cfbaaa45ad96a40e6de1c46be6" style="color:#58a6ff">6c43d4f</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T07:18:37+00:00" class="gen-time" title="2026-04-08 07:18 UTC">2026-04-08 07:18 UTC</time> · <a href="https://github.com/schacon/grit/commit/17f93bd8f022db368a6277f0351cdbfcc7ef02a2" style="color:#58a6ff">17f93bd</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">43,529</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,725</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n" id="sum-tests">43,526</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,745</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">68.3%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -5937,14 +5937,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:6.5%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="22" data-passed="4">
+<tr class="" data-group="t3" data-tests="22" data-passed="22">
   <td class="mono">t3310-notes-merge-manual-resolve</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">22</td>
-  <td class="right">4</td>
+  <td class="right">22</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:18.2%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="24" data-passed="1">
@@ -13647,14 +13647,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:71.4%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t8" data-tests="27" data-passed="25">
+<tr class="" data-group="t8" data-tests="27" data-passed="27">
   <td class="mono">t8610-checkout-index-modes</td>
   <td>t8</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">27</td>
-  <td class="right">25</td>
+  <td class="right">27</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:92.6%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t8" data-tests="29" data-passed="29">
@@ -16127,14 +16127,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t9" data-tests="263" data-passed="15">
+<tr class="" data-group="t9" data-tests="260" data-passed="15">
   <td class="mono">t9902-completion</td>
   <td>t9</td>
   <td></td>
-  <td class="right">263</td>
+  <td class="right">260</td>
   <td class="right">15</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">2</td>
 </tr>
 <tr class="" data-group="t9" data-tests="67" data-passed="1">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t8610-checkout-index-modes.sh` already passes all 27 tests against current `grit checkout-index` behavior (modes, `--prefix`, `--temp`, `--stdin`, `-f`, etc.).

This change refresifies harness metadata after a full run: `data/test-files.csv` and generated dashboards now show **27/27** passing with zero failures.

## Verification

```bash
./scripts/run-tests.sh t8610-checkout-index-modes.sh
```

## Notes

No Rust code changes were required; implementation in `grit/src/commands/checkout_index.rs` already satisfies the suite.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86192bb2-accf-459b-947a-5d180356c62a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86192bb2-accf-459b-947a-5d180356c62a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

