### PR TITLE
fix: fast-import for t3206 and Git-style range-diff (partial)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,6 +333,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e780567ed7abc415d12fd464571d265eb4a5710ddc97cdb1a31a4c35bb479d"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,6 +503,7 @@ dependencies = [
  "flate2",
  "grit-lib",
  "hex",
+ "hungarian",
  "libc",
  "regex",
  "sha1",
@@ -583,6 +596,17 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hungarian"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb27c5eb724ea621d9181d877786a4d1ec78b9a482ff49712626055a1a49426d"
+dependencies = [
+ "fixedbitset",
+ "ndarray",
+ "num-traits",
+]
 
 [[package]]
 name = "hyper"
@@ -853,6 +877,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matrixmultiply"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916806ba0031cd542105d916a97c8572e1fa6dd79c9c51e7eb43a09ec2dd84c1"
+dependencies = [
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -880,10 +913,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndarray"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac06db03ec2f46ee0ecdca1a1c34a99c0d188a0d83439b84bf0cb4b386e4ab09"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "rawpointer",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "once_cell"
@@ -1062,6 +1136,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "regex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ similar = "2"
 regex = "1"
 unicode-width = "0.2"
 libc = "0.2"
+hungarian = "1.1.1"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -565,7 +565,7 @@ t3203-branch-output	t3	yes	41	15	26	false	ok	0
 t3204-branch-name-interpretation	t3	yes	16	9	7	false	ok	0
 t3205-branch-color	t3	yes	4	4	0	true	ok	0
 t3206-branch-advanced	t3	yes	29	29	0	true	ok	0
-t3206-range-diff	t3	yes	48	1	47	false	ok	0
+t3206-range-diff	t3	yes	48	20	28	false	ok	0
 t3207-branch-submodule	t3	yes	20	0	20	false	ok	0
 t3210-pack-refs	t3	yes	29	25	4	false	ok	0
 t3211-peel-ref	t3	yes	8	8	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T04:28:41+00:00" class="gen-time" title="2026-04-08 04:28 UTC">2026-04-08 04:28 UTC</time> · <a href="https://github.com/schacon/grit/commit/454a69c8fc171de2dd14bc6a655840211e4b3f3a" style="color:#58a6ff">454a69c</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T05:32:19+00:00" class="gen-time" title="2026-04-08 05:32 UTC">2026-04-08 05:32 UTC</time> · <a href="https://github.com/schacon/grit/commit/424189b46be6c4ca854443fbf3435557a2be2c9f" style="color:#58a6ff">424189b</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,476</div>
+      <div class="summary-big-val">29,495</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -212,11 +212,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">29/141 files · 2 skipped · 3,438/5,297 tests</span>
+        <span class="group-meta">29/141 files · 2 skipped · 3,457/5,297 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.9%"></div></div>
-        <span class="group-pct pct-blue">64.9%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:65.3%"></div></div>
+        <span class="group-pct pct-blue">65.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -84,12 +84,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T04:28:41+00:00" class="gen-time" title="2026-04-08 04:28 UTC">2026-04-08 04:28 UTC</time> · <a href="https://github.com/schacon/grit/commit/454a69c8fc171de2dd14bc6a655840211e4b3f3a" style="color:#58a6ff">454a69c</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T05:32:19+00:00" class="gen-time" title="2026-04-08 05:32 UTC">2026-04-08 05:32 UTC</time> · <a href="https://github.com/schacon/grit/commit/424189b46be6c4ca854443fbf3435557a2be2c9f" style="color:#58a6ff">424189b</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for visible in-scope rows" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">43,745</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,476</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,495</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">67.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -5787,14 +5787,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="48" data-passed="1">
+<tr class="" data-group="t3" data-tests="48" data-passed="20">
   <td class="mono">t3206-range-diff</td>
   <td>t3</td>
   <td></td>
   <td class="right">48</td>
-  <td class="right">1</td>
+  <td class="right">20</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:2.1%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:41.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="20" data-passed="0">

--- a/grit-lib/src/fast_import.rs
+++ b/grit-lib/src/fast_import.rs
@@ -1,0 +1,467 @@
+//! Minimal [`git fast-import`](https://git-scm.com/docs/git-fast-import) stream support.
+//!
+//! Handles the subset of commands used by upstream tests: `blob` (with optional
+//! `mark`), `commit` (with `author`/`committer`, `data`, optional `from`, and
+//! `M` / `D` file commands), `reset`, `done`, and comment lines.
+
+use std::collections::HashMap;
+use std::io::BufRead;
+
+use crate::error::{Error, Result};
+use crate::index::{Index, IndexEntry, MODE_GITLINK, MODE_REGULAR, MODE_TREE};
+use crate::objects::{parse_commit, serialize_commit, CommitData, ObjectId, ObjectKind};
+use crate::refs::write_ref;
+use crate::repo::Repository;
+use crate::rev_parse::resolve_revision;
+use crate::write_tree::write_tree_from_index;
+
+/// Import objects and refs from a fast-import stream read from `reader`.
+///
+/// # Errors
+///
+/// Returns [`Error`] variants for I/O, corrupt stream input, or missing marks/refs.
+pub fn import_stream(repo: &Repository, mut reader: impl BufRead) -> Result<()> {
+    let mut imp = Importer {
+        repo,
+        marks: HashMap::new(),
+        branch_tips: HashMap::new(),
+        stashed_line: None,
+        pending_byte: None,
+        reader: &mut reader,
+    };
+    imp.run()
+}
+
+struct Importer<'a, R: BufRead> {
+    repo: &'a Repository,
+    marks: HashMap<u32, ObjectId>,
+    branch_tips: HashMap<String, ObjectId>,
+    /// Line read too far while parsing a `commit` or `reset`; next top-level command.
+    stashed_line: Option<String>,
+    /// Byte read while handling optional `LF` after a `data` block; must precede next line.
+    pending_byte: Option<u8>,
+    reader: &'a mut R,
+}
+
+impl<'a, R: BufRead> Importer<'a, R> {
+    fn run(&mut self) -> Result<()> {
+        loop {
+            let line = match self.next_command_line()? {
+                Some(l) => l,
+                None => break,
+            };
+            let trimmed = line.trim_end();
+            if trimmed.is_empty() {
+                continue;
+            }
+            if trimmed == "done" {
+                break;
+            }
+            if trimmed.starts_with('#') {
+                continue;
+            }
+            if trimmed == "blob" {
+                self.read_blob()?;
+                continue;
+            }
+            if let Some(rest) = trimmed.strip_prefix("commit ") {
+                let refname = rest.trim().to_string();
+                self.read_commit(&refname)?;
+                continue;
+            }
+            if let Some(rest) = trimmed.strip_prefix("reset ") {
+                let refname = rest.trim().to_string();
+                self.read_reset(&refname)?;
+                continue;
+            }
+            return Err(Error::IndexError(format!(
+                "fast-import: unsupported command: {trimmed}"
+            )));
+        }
+        Ok(())
+    }
+
+    fn next_command_line(&mut self) -> Result<Option<String>> {
+        if let Some(l) = self.stashed_line.take() {
+            return Ok(Some(l));
+        }
+        self.read_line_nonempty()
+    }
+
+    fn read_line_nonempty(&mut self) -> Result<Option<String>> {
+        let mut buf = String::new();
+        loop {
+            buf.clear();
+            let n = self.read_line_into(&mut buf)?;
+            if n == 0 {
+                return Ok(None);
+            }
+            if !buf.trim().is_empty() {
+                return Ok(Some(buf));
+            }
+        }
+    }
+
+    fn read_line_any(&mut self) -> Result<Option<String>> {
+        let mut buf = String::new();
+        let n = self.read_line_into(&mut buf)?;
+        if n == 0 {
+            return Ok(None);
+        }
+        Ok(Some(buf))
+    }
+
+    fn read_line_into(&mut self, buf: &mut String) -> Result<usize> {
+        buf.clear();
+        if let Some(b) = self.pending_byte.take() {
+            if b == b'\n' {
+                buf.push('\n');
+                return Ok(1);
+            }
+            buf.push(char::from(b));
+        }
+        let prev = buf.len();
+        let n = self.reader.read_line(buf).map_err(Error::Io)?;
+        Ok(prev + n)
+    }
+
+    fn read_blob(&mut self) -> Result<()> {
+        let mut mark: Option<u32> = None;
+        loop {
+            let line = self.read_line_nonempty()?.ok_or_else(|| {
+                Error::IndexError("fast-import: unexpected EOF in blob".to_owned())
+            })?;
+            let t = line.trim_end();
+            if let Some(id) = t.strip_prefix("mark :") {
+                mark = Some(
+                    id.parse()
+                        .map_err(|_| Error::IndexError(format!("fast-import: bad mark: {t}")))?,
+                );
+                continue;
+            }
+            if t.starts_with("original-oid ") {
+                continue;
+            }
+            let rest = t.strip_prefix("data ").ok_or_else(|| {
+                Error::IndexError(format!("fast-import: expected data line in blob, got: {t}"))
+            })?;
+            let size: usize = rest.parse().map_err(|_| {
+                Error::IndexError(format!("fast-import: invalid data size: {rest}"))
+            })?;
+            let mut payload = vec![0u8; size];
+            self.reader
+                .read_exact(&mut payload)
+                .map_err(|_| Error::IndexError("fast-import: truncated blob data".to_owned()))?;
+            self.consume_optional_lf_after_data()?;
+            let oid = self.repo.odb.write(ObjectKind::Blob, &payload)?;
+            if let Some(m) = mark {
+                self.marks.insert(m, oid);
+            }
+            return Ok(());
+        }
+    }
+
+    /// After `data` payload, an extra LF is optional (see git-fast-import docs).
+    fn consume_optional_lf_after_data(&mut self) -> Result<()> {
+        let mut one = [0u8; 1];
+        match self.reader.read(&mut one) {
+            Ok(0) => Ok(()),
+            Ok(1) => {
+                if one[0] != b'\n' {
+                    self.pending_byte = Some(one[0]);
+                }
+                Ok(())
+            }
+            Ok(_) => unreachable!(),
+            Err(e) => Err(Error::Io(e)),
+        }
+    }
+
+    fn read_commit(&mut self, refname: &str) -> Result<()> {
+        let mut mark: Option<u32> = None;
+        let mut author: Option<String> = None;
+        let mut committer: Option<String> = None;
+
+        loop {
+            let line = self.read_line_nonempty()?.ok_or_else(|| {
+                Error::IndexError("fast-import: unexpected EOF in commit".to_owned())
+            })?;
+            let t = line.trim_end();
+            if let Some(id) = t.strip_prefix("mark :") {
+                mark = Some(
+                    id.parse()
+                        .map_err(|_| Error::IndexError(format!("fast-import: bad mark: {t}")))?,
+                );
+                continue;
+            }
+            if t.starts_with("original-oid ") {
+                continue;
+            }
+            if let Some(rest) = t.strip_prefix("author ") {
+                author = Some(rest.to_owned());
+                continue;
+            }
+            if let Some(rest) = t.strip_prefix("committer ") {
+                committer = Some(rest.to_owned());
+                continue;
+            }
+            if t.starts_with("gpgsig ") || t.starts_with("encoding ") {
+                return Err(Error::IndexError(format!(
+                    "fast-import: unsupported commit header: {t}"
+                )));
+            }
+            if t.starts_with("data ") {
+                // Re-parse: we already have full line with "data N".
+                let rest = t.strip_prefix("data ").unwrap();
+                let size: usize = rest.parse().map_err(|_| {
+                    Error::IndexError(format!("fast-import: invalid data size: {rest}"))
+                })?;
+                let mut message = vec![0u8; size];
+                self.reader.read_exact(&mut message).map_err(|_| {
+                    Error::IndexError("fast-import: truncated commit message".to_owned())
+                })?;
+                self.consume_optional_lf_after_data()?;
+                let committer = committer.ok_or_else(|| {
+                    Error::IndexError("fast-import: commit missing committer".to_owned())
+                })?;
+                let author = author.unwrap_or_else(|| committer.clone());
+                self.finish_commit(refname, mark, author, committer, message)?;
+                return Ok(());
+            }
+            return Err(Error::IndexError(format!(
+                "fast-import: unexpected in commit before message: {t}"
+            )));
+        }
+    }
+
+    fn finish_commit(
+        &mut self,
+        refname: &str,
+        mark: Option<u32>,
+        author: String,
+        committer: String,
+        message: Vec<u8>,
+    ) -> Result<()> {
+        let mut from_oid: Option<ObjectId> = None;
+        let mut modifications: Vec<(u32, ObjectId, Vec<u8>)> = Vec::new();
+        let mut deletions: Vec<Vec<u8>> = Vec::new();
+
+        loop {
+            let Some(line) = self.read_line_any()? else {
+                break;
+            };
+            let t = line.trim_end();
+            if t.is_empty() {
+                continue;
+            }
+            if t.starts_with("from ") {
+                let spec = t["from ".len()..].trim();
+                from_oid = Some(self.resolve_commit_ish(spec)?);
+                continue;
+            }
+            if t.starts_with("merge ") {
+                return Err(Error::IndexError(
+                    "fast-import: merge commits not supported".to_owned(),
+                ));
+            }
+            if let Some(rest) = t.strip_prefix("M ") {
+                let parts: Vec<&str> = rest.split_whitespace().collect();
+                if parts.len() != 3 {
+                    return Err(Error::IndexError(format!("fast-import: bad M line: {t}")));
+                }
+                let mode = u32::from_str_radix(parts[0], 8).map_err(|_| {
+                    Error::IndexError(format!("fast-import: bad file mode: {}", parts[0]))
+                })?;
+                let blob_ref = parts[1];
+                let path = parts[2].as_bytes().to_vec();
+                let blob_oid = self.resolve_blob_ref(blob_ref)?;
+                modifications.push((mode, blob_oid, path));
+                continue;
+            }
+            if let Some(rest) = t.strip_prefix("D ") {
+                deletions.push(rest.as_bytes().to_vec());
+                continue;
+            }
+            self.stashed_line = Some(line);
+            break;
+        }
+
+        let empty_tree: ObjectId = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+            .parse()
+            .map_err(|_| Error::IndexError("fast-import: empty tree oid".to_owned()))?;
+
+        let (parent_tree, parents) = match from_oid {
+            Some(oid) => {
+                let obj = self.repo.odb.read(&oid)?;
+                if obj.kind != ObjectKind::Commit {
+                    return Err(Error::IndexError(format!(
+                        "fast-import: from {oid} is not a commit"
+                    )));
+                }
+                let c = parse_commit(&obj.data)?;
+                (c.tree, vec![oid])
+            }
+            None => {
+                if let Some(tip) = self.branch_tips.get(refname).copied() {
+                    let obj = self.repo.odb.read(&tip)?;
+                    if obj.kind != ObjectKind::Commit {
+                        return Err(Error::IndexError(format!(
+                            "fast-import: branch tip {tip} is not a commit"
+                        )));
+                    }
+                    let c = parse_commit(&obj.data)?;
+                    (c.tree, vec![tip])
+                } else {
+                    (empty_tree, Vec::new())
+                }
+            }
+        };
+
+        let mut index = tree_to_index(&self.repo.odb, &parent_tree)?;
+        for path in deletions {
+            index.entries.retain(|e| e.path != path);
+        }
+        for (mode, blob_oid, path) in modifications {
+            let mode = normalize_mode(mode)?;
+            index.add_or_replace(index_entry(path, mode, blob_oid));
+        }
+        let tree_oid = write_tree_from_index(&self.repo.odb, &index, "")?;
+
+        let message_str = String::from_utf8_lossy(&message).into_owned();
+        let raw_message = (!message.is_empty() && std::str::from_utf8(&message).is_err())
+            .then_some(message.clone());
+
+        let commit = CommitData {
+            tree: tree_oid,
+            parents,
+            author,
+            committer,
+            encoding: None,
+            message: message_str,
+            raw_message,
+        };
+        let bytes = serialize_commit(&commit);
+        let commit_oid = self.repo.odb.write(ObjectKind::Commit, &bytes)?;
+
+        if let Some(m) = mark {
+            self.marks.insert(m, commit_oid);
+        }
+        self.branch_tips.insert(refname.to_string(), commit_oid);
+        write_ref(&self.repo.git_dir, refname, &commit_oid)?;
+        Ok(())
+    }
+
+    fn resolve_commit_ish(&self, spec: &str) -> Result<ObjectId> {
+        if let Some(rest) = spec.strip_prefix(':') {
+            let id: u32 = rest
+                .parse()
+                .map_err(|_| Error::IndexError(format!("fast-import: bad mark ref: {spec}")))?;
+            return self
+                .marks
+                .get(&id)
+                .copied()
+                .ok_or_else(|| Error::IndexError(format!("fast-import: unknown mark :{id}")));
+        }
+        if spec.len() == 40 && spec.chars().all(|c| c.is_ascii_hexdigit()) {
+            return spec.parse();
+        }
+        resolve_revision(self.repo, spec)
+    }
+
+    fn resolve_blob_ref(&self, spec: &str) -> Result<ObjectId> {
+        if let Some(rest) = spec.strip_prefix(':') {
+            let id: u32 = rest
+                .parse()
+                .map_err(|_| Error::IndexError(format!("fast-import: bad mark ref: {spec}")))?;
+            return self
+                .marks
+                .get(&id)
+                .copied()
+                .ok_or_else(|| Error::IndexError(format!("fast-import: unknown mark :{id}")));
+        }
+        if spec.len() == 40 && spec.chars().all(|c| c.is_ascii_hexdigit()) {
+            return spec.parse();
+        }
+        Err(Error::IndexError(format!(
+            "fast-import: unsupported blob ref: {spec}"
+        )))
+    }
+
+    fn read_reset(&mut self, refname: &str) -> Result<()> {
+        let Some(line) = self.read_line_any()? else {
+            return Ok(());
+        };
+        let t = line.trim_end();
+        if t.is_empty() {
+            return Ok(());
+        }
+        if let Some(spec) = t.strip_prefix("from ") {
+            let oid = self.resolve_commit_ish(spec.trim())?;
+            self.branch_tips.insert(refname.to_string(), oid);
+            write_ref(&self.repo.git_dir, refname, &oid)?;
+            return Ok(());
+        }
+        self.stashed_line = Some(line);
+        Ok(())
+    }
+}
+
+fn normalize_mode(mode: u32) -> Result<u32> {
+    match mode {
+        0o100644 | 0o644 => Ok(MODE_REGULAR),
+        0o100755 | 0o755 => Ok(crate::index::MODE_EXECUTABLE),
+        0o120000 => Ok(crate::index::MODE_SYMLINK),
+        0o160000 => Ok(MODE_GITLINK),
+        0o040000 => Ok(MODE_TREE),
+        _ => Err(Error::IndexError(format!(
+            "fast-import: unsupported mode {mode:o}"
+        ))),
+    }
+}
+
+fn index_entry(path: Vec<u8>, mode: u32, oid: ObjectId) -> IndexEntry {
+    let path_len = path.len().min(0xFFF) as u16;
+    IndexEntry {
+        ctime_sec: 0,
+        ctime_nsec: 0,
+        mtime_sec: 0,
+        mtime_nsec: 0,
+        dev: 0,
+        ino: 0,
+        mode,
+        uid: 0,
+        gid: 0,
+        size: 0,
+        oid,
+        flags: path_len,
+        flags_extended: Some(0),
+        path,
+    }
+}
+
+fn tree_to_index(odb: &crate::odb::Odb, tree_oid: &ObjectId) -> Result<Index> {
+    let obj = odb.read(tree_oid)?;
+    if obj.kind != ObjectKind::Tree {
+        return Err(Error::IndexError(format!("expected tree at {tree_oid}")));
+    }
+    let entries = crate::objects::parse_tree(&obj.data)?;
+    let mut index = Index::new();
+    for te in entries {
+        let path = te.name;
+        if te.mode == MODE_TREE {
+            let sub = tree_to_index(odb, &te.oid)?;
+            for mut e in sub.entries {
+                let mut full = path.clone();
+                full.push(b'/');
+                full.extend_from_slice(&e.path);
+                e.path = full;
+                let pl = e.path.len().min(0xFFF) as u16;
+                e.flags = pl;
+                index.add_or_replace(e);
+            }
+        } else {
+            index.add_or_replace(index_entry(path, te.mode, te.oid));
+        }
+    }
+    Ok(index)
+}

--- a/grit-lib/src/lib.rs
+++ b/grit-lib/src/lib.rs
@@ -22,6 +22,7 @@ pub mod crlf;
 pub mod delta_encode;
 pub mod diff;
 pub mod error;
+pub mod fast_import;
 pub mod fmt_merge_msg;
 pub mod fsck_standalone;
 pub mod git_date;

--- a/grit/Cargo.toml
+++ b/grit/Cargo.toml
@@ -33,3 +33,4 @@ hex.workspace = true
 flate2.workspace = true
 unicode-width.workspace = true
 encoding_rs = "0.8.35"
+hungarian.workspace = true

--- a/grit/src/commands/fast_import.rs
+++ b/grit/src/commands/fast_import.rs
@@ -1,12 +1,13 @@
 //! `grit fast-import` — import from a fast-export stream.
 //!
-//! Supports a minimal subset: `blob` objects with `data <n>` payloads, and `done`.
+//! Delegates to [`grit_lib::fast_import::import_stream`] for the supported
+//! command subset (blobs, commits, reset, done).
 
 use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
-use grit_lib::objects::ObjectKind;
+use grit_lib::fast_import;
 use grit_lib::repo::Repository;
-use std::io::{self, BufRead, Read};
+use std::io;
 
 /// Arguments for `grit fast-import`.
 #[derive(Debug, ClapArgs)]
@@ -21,46 +22,6 @@ pub struct Args {
 pub fn run(_args: Args) -> Result<()> {
     let repo = Repository::discover(None).context("not a git repository")?;
     let stdin = io::stdin();
-    let mut reader = stdin.lock();
-    let mut line = String::new();
-    loop {
-        line.clear();
-        if reader.read_line(&mut line)? == 0 {
-            break;
-        }
-        let trimmed = line.trim_end();
-        if trimmed.is_empty() {
-            continue;
-        }
-        if trimmed == "done" {
-            break;
-        }
-        if trimmed == "blob" {
-            line.clear();
-            reader
-                .read_line(&mut line)
-                .context("reading data line after blob")?;
-            let data_line = line.trim_end();
-            let rest = data_line
-                .strip_prefix("data ")
-                .ok_or_else(|| anyhow::anyhow!("expected 'data <n>' after blob"))?;
-            let size: usize = rest
-                .parse()
-                .map_err(|e| anyhow::anyhow!("invalid data size: {e}"))?;
-            let mut payload = vec![0u8; size];
-            reader
-                .read_exact(&mut payload)
-                .context("reading blob payload")?;
-            let oid = repo.odb.write(ObjectKind::Blob, &payload)?;
-            eprintln!("fast-import: wrote blob {oid}");
-            continue;
-        }
-        if trimmed.starts_with('#') {
-            continue;
-        }
-        return Err(anyhow::anyhow!(
-            "unsupported fast-import command: {trimmed}"
-        ));
-    }
-    Ok(())
+    let reader = stdin.lock();
+    fast_import::import_stream(&repo, reader).map_err(|e| anyhow::anyhow!("{e}"))
 }

--- a/grit/src/commands/log.rs
+++ b/grit/src/commands/log.rs
@@ -6,7 +6,7 @@
 use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::diff::{
-    count_changes, diff_trees, format_raw, format_stat_line, unified_diff, DiffEntry, DiffStatus,
+    count_changes, diff_trees, format_raw, format_stat_line, DiffEntry, DiffStatus,
 };
 use grit_lib::objects::{parse_commit, ObjectId};
 use grit_lib::odb::Odb;
@@ -252,6 +252,16 @@ pub struct Args {
     #[arg(long = "no-abbrev")]
     pub no_abbrev: bool,
 
+    /// Replace `+`/`-`/context prefixes in unified diff hunks (Git `range-diff` / `fast-import` tests).
+    #[arg(long = "output-indicator-new", value_name = "C", hide = true)]
+    pub output_indicator_new: Option<String>,
+
+    #[arg(long = "output-indicator-old", value_name = "C", hide = true)]
+    pub output_indicator_old: Option<String>,
+
+    #[arg(long = "output-indicator-context", value_name = "C", hide = true)]
+    pub output_indicator_context: Option<String>,
+
     /// Grep log messages.
     #[arg(long = "grep", value_name = "PATTERN")]
     pub grep_patterns: Vec<String>,
@@ -319,6 +329,24 @@ pub struct Args {
     /// Show full object hashes in diff output.
     #[arg(long = "full-index")]
     pub full_index: bool,
+
+    /// Omit `a/` and `b/` prefixes from diff paths (Git `--no-prefix`).
+    #[arg(long = "no-prefix")]
+    pub no_prefix: bool,
+
+    /// Do not show commit notes (Git `log --no-notes`).
+    #[arg(long = "no-notes")]
+    pub no_notes: bool,
+
+    /// Additional notes refs (`--notes` → default ref; `--notes=ref` → `refs/notes/<ref>`).
+    #[arg(
+        long = "notes",
+        value_name = "REF",
+        action = clap::ArgAction::Append,
+        num_args = 0..=1,
+        default_missing_value = ""
+    )]
+    pub notes_refs: Vec<String>,
 
     /// Show binary diffs in git-apply format.
     #[arg(long = "binary")]
@@ -2965,6 +2993,10 @@ impl<'a> NotesMapCache<'a> {
         Self { repo, map: None }
     }
 
+    fn repo(&self) -> &'a Repository {
+        self.repo
+    }
+
     fn map(&mut self) -> &std::collections::HashMap<ObjectId, Vec<u8>> {
         if self.map.is_none() {
             self.map = Some(load_notes_map(self.repo));
@@ -2977,12 +3009,7 @@ impl<'a> NotesMapCache<'a> {
 /// Returns a map from commit OID to the notes blob OID.
 fn load_notes_map(repo: &Repository) -> std::collections::HashMap<ObjectId, Vec<u8>> {
     use grit_lib::config::ConfigSet;
-    use grit_lib::objects::parse_tree;
-    use grit_lib::refs::resolve_ref;
 
-    let mut map = std::collections::HashMap::new();
-
-    // Determine notes ref: check core.notesRef, GIT_NOTES_REF env, or default
     let notes_ref = std::env::var("GIT_NOTES_REF")
         .ok()
         .filter(|s| !s.is_empty())
@@ -2992,9 +3019,20 @@ fn load_notes_map(repo: &Repository) -> std::collections::HashMap<ObjectId, Vec<
                 .get("core.notesRef")
                 .unwrap_or_else(|| "refs/notes/commits".to_string())
         });
+    load_notes_map_for_ref(repo, &notes_ref)
+}
+
+fn load_notes_map_for_ref(
+    repo: &Repository,
+    notes_ref: &str,
+) -> std::collections::HashMap<ObjectId, Vec<u8>> {
+    use grit_lib::objects::parse_tree;
+    use grit_lib::refs::resolve_ref;
+
+    let mut map = std::collections::HashMap::new();
 
     // Resolve notes ref to a commit, then get its tree
-    let notes_oid = match resolve_ref(&repo.git_dir, &notes_ref) {
+    let notes_oid = match resolve_ref(&repo.git_dir, notes_ref) {
         Ok(oid) => oid,
         Err(_) => return map,
     };
@@ -3041,15 +3079,45 @@ fn write_notes(
     out: &mut impl Write,
     oid: &ObjectId,
     notes_cache: &mut NotesMapCache<'_>,
+    args: &Args,
     _odb: &Odb,
 ) -> Result<()> {
-    let notes_map = notes_cache.map();
-    if let Some(note_data) = notes_map.get(oid) {
-        let note_text = String::from_utf8_lossy(note_data);
-        writeln!(out)?;
-        writeln!(out, "Notes:")?;
-        for line in note_text.lines() {
-            writeln!(out, "    {line}")?;
+    if args.no_notes {
+        return Ok(());
+    }
+    if args.notes_refs.is_empty() {
+        let notes_map = notes_cache.map();
+        if let Some(note_data) = notes_map.get(oid) {
+            let note_text = String::from_utf8_lossy(note_data);
+            writeln!(out)?;
+            writeln!(out, "Notes:")?;
+            for line in note_text.lines() {
+                writeln!(out, "    {line}")?;
+            }
+        }
+        return Ok(());
+    }
+    for spec in &args.notes_refs {
+        let (header, refname) = if spec.is_empty() {
+            ("Notes".to_owned(), "refs/notes/commits".to_owned())
+        } else {
+            let s = spec.as_str();
+            let refname = if s.starts_with("refs/") {
+                s.to_owned()
+            } else {
+                format!("refs/notes/{s}")
+            };
+            let short = s.strip_prefix("refs/notes/").unwrap_or(s);
+            (format!("Notes ({short})"), refname)
+        };
+        let map = load_notes_map_for_ref(notes_cache.repo(), &refname);
+        if let Some(note_data) = map.get(oid) {
+            let note_text = String::from_utf8_lossy(note_data);
+            writeln!(out)?;
+            writeln!(out, "{header}:")?;
+            for line in note_text.lines() {
+                writeln!(out, "    {line}")?;
+            }
         }
     }
     Ok(())
@@ -3122,7 +3190,11 @@ fn format_commit(
     odb: &Odb,
 ) -> Result<()> {
     let hex = oid.to_hex();
-    let abbrev_len = parse_abbrev(&args.abbrev);
+    let abbrev_len = if args.no_abbrev {
+        40
+    } else {
+        parse_abbrev(&args.abbrev)
+    };
 
     if args.oneline || args.format.as_deref() == Some("oneline") {
         let first_line = info.message.lines().next().unwrap_or("");
@@ -3217,7 +3289,7 @@ fn format_commit(
             for line in info.message.lines() {
                 writeln!(out, "    {line}")?;
             }
-            write_notes(out, oid, notes_cache, odb)?;
+            write_notes(out, oid, notes_cache, args, odb)?;
             writeln!(out)?;
         }
         Some("full") => {
@@ -3240,7 +3312,7 @@ fn format_commit(
             for line in info.message.lines() {
                 writeln!(out, "    {line}")?;
             }
-            write_notes(out, oid, notes_cache, odb)?;
+            write_notes(out, oid, notes_cache, args, odb)?;
             writeln!(out)?;
         }
         Some("fuller") => {
@@ -3273,7 +3345,7 @@ fn format_commit(
             for line in info.message.lines() {
                 writeln!(out, "    {line}")?;
             }
-            write_notes(out, oid, notes_cache, odb)?;
+            write_notes(out, oid, notes_cache, args, odb)?;
             writeln!(out)?;
         }
         Some(other) => {
@@ -4484,7 +4556,7 @@ fn write_commit_diff(
             &entries
         };
         for entry in show_entries {
-            log_write_patch_entry(out, odb, entry, args.unified.unwrap_or(3))?;
+            log_write_patch_entry(out, odb, entry, args)?;
         }
     }
 
@@ -4496,8 +4568,9 @@ fn log_write_patch_entry(
     out: &mut impl Write,
     odb: &Odb,
     entry: &DiffEntry,
-    context_lines: usize,
+    args: &Args,
 ) -> Result<()> {
+    let context_lines = args.unified.unwrap_or(3);
     let old_path = entry
         .old_path
         .as_deref()
@@ -4507,7 +4580,11 @@ fn log_write_patch_entry(
         .as_deref()
         .unwrap_or(entry.old_path.as_deref().unwrap_or(""));
 
-    writeln!(out, "diff --git a/{old_path} b/{new_path}")?;
+    if args.no_prefix {
+        writeln!(out, "diff --git {old_path} {new_path}")?;
+    } else {
+        writeln!(out, "diff --git a/{old_path} b/{new_path}")?;
+    }
 
     match entry.status {
         DiffStatus::Added => {
@@ -4578,16 +4655,69 @@ fn log_write_patch_entry(
     } else {
         new_path
     };
-    let patch = unified_diff(
+    let (src_pfx, dst_pfx) = if args.no_prefix {
+        ("", "")
+    } else {
+        ("a/", "b/")
+    };
+    let patch = grit_lib::diff::unified_diff_with_prefix(
         &old_content,
         &new_content,
         display_old,
         display_new,
         context_lines,
+        src_pfx,
+        dst_pfx,
     );
+    let patch = apply_diff_output_indicators(&patch, args);
     write!(out, "{patch}")?;
 
     Ok(())
+}
+
+fn apply_diff_output_indicators(patch: &str, args: &Args) -> String {
+    if args.output_indicator_new.is_none()
+        && args.output_indicator_old.is_none()
+        && args.output_indicator_context.is_none()
+    {
+        return patch.to_owned();
+    }
+    let new_c = args
+        .output_indicator_new
+        .as_deref()
+        .and_then(|s| s.chars().next())
+        .unwrap_or('>');
+    let old_c = args
+        .output_indicator_old
+        .as_deref()
+        .and_then(|s| s.chars().next())
+        .unwrap_or('<');
+    let ctx_c = args
+        .output_indicator_context
+        .as_deref()
+        .and_then(|s| s.chars().next())
+        .unwrap_or('#');
+    let mut out = String::with_capacity(patch.len());
+    for line in patch.split_inclusive('\n') {
+        let bytes = line.as_bytes();
+        if bytes.first() == Some(&b'+') && bytes.get(1) != Some(&b'+') && !line.starts_with("+++ ")
+        {
+            out.push(new_c);
+            out.push_str(&line[1..]);
+        } else if bytes.first() == Some(&b'-')
+            && bytes.get(1) != Some(&b'-')
+            && !line.starts_with("--- ")
+        {
+            out.push(old_c);
+            out.push_str(&line[1..]);
+        } else if bytes.first() == Some(&b' ') {
+            out.push(ctx_c);
+            out.push_str(&line[1..]);
+        } else {
+            out.push_str(line);
+        }
+    }
+    out
 }
 
 /// Write a `--stat` summary for log.

--- a/grit/src/commands/range_diff.rs
+++ b/grit/src/commands/range_diff.rs
@@ -1,203 +1,883 @@
-//! `grit range-diff` — compare two commit ranges.
+//! `grit range-diff` — compare two commit ranges (Git-compatible).
 //!
-//! Shows which commits differ between two ranges.  Each commit in range A is
-//! matched against commits in range B by patch-id.  Paired commits are shown
-//! side-by-side, and unpaired commits are flagged as only in one range.
-//!
-//! Supports two calling conventions:
-//! - `grit range-diff <base1>..<rev1> <base2>..<rev2>`
-//! - `grit range-diff <rev1>...<rev2>` (symmetric difference via merge-base)
+//! Mirrors Git's `range-diff.c`: `grit log -p` output is normalized into patches,
+//! matched with a Hungarian assignment, then printed in RHS order with optional
+//! inner diffs.
 
 use anyhow::{bail, Context, Result};
-use clap::Args as ClapArgs;
-use grit_lib::objects::{parse_commit, ObjectId, ObjectKind};
-use grit_lib::patch_ids::compute_patch_id;
+use clap::{CommandFactory, Parser};
+use grit_lib::objects::{parse_commit, ObjectId};
 use grit_lib::repo::Repository;
-use grit_lib::rev_list::{rev_list, RevListOptions, RevListResult};
+use grit_lib::rev_parse::{
+    abbreviate_object_id, resolve_revision, split_double_dot_range, split_triple_dot_range,
+};
+use hungarian::minimize;
 use std::collections::HashMap;
-use std::io::{self, Write};
+use std::io::{IsTerminal, Write};
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+const COST_MAX: u64 = 1 << 16;
+const DEFAULT_CREATION_FACTOR: i32 = 60;
 
 /// Arguments for `grit range-diff`.
-#[derive(Debug, ClapArgs)]
+#[derive(Debug, Parser)]
 #[command(
+    name = "grit range-diff",
     about = "Compare two commit ranges",
-    override_usage = "grit range-diff <base1>..<rev1> <base2>..<rev2>\n       grit range-diff <rev1>...<rev2>"
+    disable_help_subcommand = true
 )]
 pub struct Args {
-    /// Revision range arguments.
-    #[arg(required = true)]
-    pub ranges: Vec<String>,
+    #[arg(long = "creation-factor", value_name = "N")]
+    pub creation_factor: Option<i32>,
+
+    #[arg(long = "no-dual-color")]
+    pub no_dual_color: bool,
+
+    #[arg(long = "left-only")]
+    pub left_only: bool,
+
+    #[arg(long = "right-only")]
+    pub right_only: bool,
+
+    #[arg(short = 's', long = "no-patch")]
+    pub no_patch: bool,
+
+    #[arg(long = "stat")]
+    pub stat: bool,
+
+    #[arg(long = "color", default_missing_value = "always", num_args = 0..=1, require_equals = true)]
+    pub color: Option<String>,
+
+    #[arg(long = "no-color")]
+    pub no_color: bool,
+
+    #[arg(long = "abbrev", value_name = "N", default_missing_value = "7", num_args = 0..=1, require_equals = true)]
+    pub abbrev: Option<String>,
+
+    #[arg(long = "no-notes")]
+    pub no_notes: bool,
+
+    #[arg(
+        long = "notes",
+        value_name = "REF",
+        action = clap::ArgAction::Append,
+        num_args = 0..=1,
+        default_missing_value = ""
+    )]
+    pub notes: Vec<String>,
+
+    #[arg(long = "diff-merges", value_name = "STYLE", default_missing_value = "on", num_args = 0..=1, require_equals = true)]
+    pub diff_merges: Option<String>,
+
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+    pub rest: Vec<String>,
 }
 
-/// A commit in a range with its summary and optional patch-id.
-struct RangeCommit {
+struct Patch {
     oid: ObjectId,
-    summary: String,
-    patch_id: Option<ObjectId>,
+    full: String,
+    diff_offset: usize,
+    diffsize: i32,
+    matching: i32,
+    shown: bool,
 }
 
-/// Run the `range-diff` command.
-pub fn run(args: Args) -> Result<()> {
+/// Parse argv after `range-diff` and run (used from `main` so `--` / pathspecs work).
+pub fn run_with_rest(rest: &[String]) -> Result<()> {
+    if rest.len() == 1 && (rest[0] == "-h" || rest[0] == "--help") {
+        let mut cmd = Args::command();
+        cmd.print_help().ok();
+        return Ok(());
+    }
+    let mut argv = vec!["grit range-diff".to_string()];
+    argv.extend(rest.iter().cloned());
+    let args = Args::try_parse_from(&argv).map_err(|e| anyhow::anyhow!("{e}"))?;
+    run(args)
+}
+
+fn run(args: Args) -> Result<()> {
+    if args.left_only && args.right_only {
+        bail!("options '--left-only' and '--right-only' cannot be used together");
+    }
+
     let repo = Repository::discover(None).context("not a git repository")?;
+    let (rev1, rev2, log_extra) = parse_invocation(&repo, &args.rest)?;
 
-    let (range_a, range_b) = parse_ranges(&args.ranges)?;
+    let creation = args
+        .creation_factor
+        .unwrap_or(DEFAULT_CREATION_FACTOR)
+        .max(0) as u64;
 
-    let commits_a = walk_range(&repo, &range_a.0, &range_a.1)?;
-    let commits_b = walk_range(&repo, &range_b.0, &range_b.1)?;
+    let mut branch1 = read_patches_from_log(&repo, &rev1, &args, &log_extra)?;
+    let mut branch2 = read_patches_from_log(&repo, &rev2, &args, &log_extra)?;
 
-    let enriched_a = enrich_commits(&repo, commits_a)?;
-    let enriched_b = enrich_commits(&repo, commits_b)?;
+    find_exact_matches(&mut branch1, &mut branch2);
+    get_correspondences(&mut branch1, &mut branch2, creation);
 
-    // Build patch-id → index map for range B.
-    let mut b_by_patch_id: HashMap<ObjectId, usize> = HashMap::new();
-    for (i, c) in enriched_b.iter().enumerate() {
-        if let Some(pid) = &c.patch_id {
-            b_by_patch_id.entry(*pid).or_insert(i);
+    let use_color = !args.no_color
+        && args
+            .color
+            .as_deref()
+            .map(|c| c == "always" || c.is_empty())
+            .unwrap_or_else(|| {
+                std::io::stdout().is_terminal() || std::env::var_os("GIT_PAGER_IN_USE").is_some()
+            })
+        && !args.no_dual_color;
+
+    let abbrev_len = args
+        .abbrev
+        .as_deref()
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(7)
+        .clamp(4, 40);
+
+    output(
+        &repo,
+        &mut branch1,
+        &mut branch2,
+        args.left_only,
+        args.right_only,
+        args.no_patch,
+        args.stat,
+        use_color,
+        abbrev_len,
+    )?;
+
+    Ok(())
+}
+
+fn parse_invocation(
+    repo: &Repository,
+    rest: &[String],
+) -> Result<(Vec<String>, Vec<String>, Vec<String>)> {
+    let (rpart, pspecs) = if let Some(i) = rest.iter().position(|s| s == "--") {
+        (&rest[..i], &rest[i + 1..])
+    } else {
+        (rest, &[][..])
+    };
+
+    let mut log_extra: Vec<String> = Vec::new();
+    if !pspecs.is_empty() {
+        log_extra.push("--".to_string());
+        log_extra.extend(pspecs.iter().cloned());
+    }
+
+    let argc = rpart.len();
+
+    if argc >= 3 && all_committish(repo, &rpart[..3]) {
+        for s in &rpart[..3] {
+            resolve_revision(repo, s).map_err(|_| anyhow::anyhow!("not a revision: '{s}'"))?;
+        }
+        let s1 = log_range_vec(&format!("{}..{}", rpart[0], rpart[1]));
+        let s2 = log_range_vec(&format!("{}..{}", rpart[0], rpart[2]));
+        return Ok((s1, s2, log_extra));
+    }
+
+    if argc >= 2 && is_range(repo, &rpart[0]) && is_range(repo, &rpart[1]) {
+        return Ok((
+            log_range_vec(&rpart[0]),
+            log_range_vec(&rpart[1]),
+            log_extra,
+        ));
+    }
+
+    if argc == 2 {
+        let a = expand_parent_only_syntax(repo, &rpart[0])?;
+        let b = expand_parent_only_syntax(repo, &rpart[1])?;
+        if let (Some(va), Some(vb)) = (a, b) {
+            return Ok((va, vb, log_extra));
+        }
+        if rpart[0].contains("..") || rpart[1].contains("..") {
+            bail!("not a commit range");
         }
     }
 
-    // Match commits from A to B by patch-id.
-    let mut b_matched = vec![false; enriched_b.len()];
-    let mut matches: Vec<Option<usize>> = Vec::with_capacity(enriched_a.len());
+    if argc >= 1 {
+        let arg0 = rpart[0].as_str();
+        if let Some((a, b)) = split_triple_dot_range(arg0) {
+            if !a.is_empty() || !b.is_empty() {
+                let a_oid = resolve_revision(repo, if a.is_empty() { "HEAD" } else { a })?;
+                let b_oid = resolve_revision(repo, if b.is_empty() { "HEAD" } else { b })?;
+                // Match `git range-diff` / `builtin/range-diff.c`: `B..A` then `A..B`.
+                let range1 = format!("{}..{}", b_oid.to_hex(), a_oid.to_hex());
+                let range2 = format!("{}..{}", a_oid.to_hex(), b_oid.to_hex());
+                return Ok((log_range_vec(&range1), log_range_vec(&range2), log_extra));
+            }
+        }
+    }
 
-    for c in &enriched_a {
-        if let Some(pid) = &c.patch_id {
-            if let Some(&bi) = b_by_patch_id.get(pid) {
-                if !b_matched[bi] {
-                    b_matched[bi] = true;
-                    matches.push(Some(bi));
-                    continue;
+    bail!("need two commit ranges");
+}
+
+/// `topic^!` → `^p1 ^p2 … tip`; `topic^-N` → `^pN tip` (Git parent-only revision syntax).
+fn expand_parent_only_syntax(repo: &Repository, spec: &str) -> Result<Option<Vec<String>>> {
+    if let Some(base) = spec.strip_suffix("^!") {
+        if base.is_empty() {
+            return Ok(None);
+        }
+        let oid = resolve_revision(repo, base)?;
+        let obj = repo.odb.read(&oid)?;
+        let commit = parse_commit(&obj.data)?;
+        let mut out: Vec<String> = commit
+            .parents
+            .iter()
+            .map(|p| format!("^{}", p.to_hex()))
+            .collect();
+        out.push(oid.to_hex());
+        return Ok(Some(out));
+    }
+    if let Some(pos) = spec.rfind("^-") {
+        let base = &spec[..pos];
+        let rest = &spec[pos + 2..];
+        if base.is_empty() {
+            return Ok(None);
+        }
+        let n: usize = if rest.is_empty() {
+            1
+        } else {
+            rest.parse()
+                .map_err(|_| anyhow::anyhow!("invalid parent spec"))?
+        };
+        if n < 1 {
+            return Ok(None);
+        }
+        let oid = resolve_revision(repo, base)?;
+        let obj = repo.odb.read(&oid)?;
+        let commit = parse_commit(&obj.data)?;
+        let parent = commit
+            .parents
+            .get(n - 1)
+            .ok_or_else(|| anyhow::anyhow!("revision '{spec}' has no parent {n}"))?;
+        return Ok(Some(vec![format!("^{}", parent.to_hex()), oid.to_hex()]));
+    }
+    Ok(None)
+}
+
+fn log_range_vec(range: &str) -> Vec<String> {
+    log_range_args(range)
+}
+
+fn all_committish(repo: &Repository, specs: &[String]) -> bool {
+    specs.iter().all(|s| resolve_revision(repo, s).is_ok())
+}
+
+fn is_range(repo: &Repository, spec: &str) -> bool {
+    if split_triple_dot_range(spec).is_some() {
+        return true;
+    }
+    let Some((left, right)) = split_double_dot_range(spec) else {
+        return false;
+    };
+    if left.is_empty() || right.is_empty() {
+        return false;
+    }
+    resolve_revision(repo, left).is_ok() && resolve_revision(repo, right).is_ok()
+}
+
+fn read_patches_from_log(
+    repo: &Repository,
+    rev_args: &[String],
+    args: &Args,
+    log_extra: &[String],
+) -> Result<Vec<Patch>> {
+    let exe = std::env::current_exe().context("current_exe")?;
+    let mut cmd = Command::new(&exe);
+    cmd.arg("-C")
+        .arg(repo_work_dir(repo))
+        .arg("log")
+        .arg("--no-color")
+        .arg("--no-abbrev")
+        .arg("--reverse")
+        .arg("--date-order")
+        .arg("--decorate=no")
+        .arg("--no-prefix")
+        .arg("--output-indicator-new")
+        .arg(">")
+        .arg("--output-indicator-old")
+        .arg("<")
+        .arg("--output-indicator-context")
+        .arg("#")
+        .arg("--pretty=medium")
+        .arg("-p");
+    for arg in rev_args {
+        cmd.arg(arg);
+    }
+    if args.diff_merges.is_none() {
+        cmd.arg("--no-merges");
+    }
+    if args.no_notes {
+        cmd.arg("--no-notes");
+    }
+    for n in &args.notes {
+        if n.is_empty() {
+            cmd.arg("--notes");
+        } else {
+            cmd.arg(format!("--notes={n}"));
+        }
+    }
+    if let Some(dm) = &args.diff_merges {
+        cmd.arg(format!("--diff-merges={dm}"));
+    }
+    for e in log_extra {
+        cmd.arg(e);
+    }
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    let out = cmd.output().context("spawn grit log")?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        bail!("log failed: {stderr}");
+    }
+    parse_log_into_patches(&String::from_utf8_lossy(&out.stdout))
+}
+
+fn log_range_args(range: &str) -> Vec<String> {
+    if let Some((left, right)) = split_double_dot_range(range) {
+        if !left.is_empty() && !right.is_empty() && split_triple_dot_range(range).is_none() {
+            return vec![format!("^{left}"), right.to_string()];
+        }
+    }
+    vec![range.to_string()]
+}
+
+fn repo_work_dir(repo: &Repository) -> &Path {
+    repo.work_tree.as_deref().unwrap_or(repo.git_dir.as_path())
+}
+
+fn parse_log_into_patches(contents: &str) -> Result<Vec<Patch>> {
+    let mut list: Vec<Patch> = Vec::new();
+    let mut buf = String::new();
+    let mut current: Option<Patch> = None;
+    let mut in_header = true;
+    let mut current_filename: Option<String> = None;
+    let mut skip_diff_header = false;
+
+    for line in contents.lines() {
+        if let Some(rest) = line.strip_prefix("commit ") {
+            if let Some(p) = current.take() {
+                list.push(finish_patch(p, &buf)?);
+                buf.clear();
+            }
+            let oid_str = rest
+                .split(" (from ")
+                .next()
+                .unwrap_or(rest)
+                .split_whitespace()
+                .next()
+                .unwrap_or(rest)
+                .trim();
+            let oid: ObjectId = oid_str
+                .parse()
+                .map_err(|_| anyhow::anyhow!("could not parse commit '{oid_str}'"))?;
+            current = Some(Patch {
+                oid,
+                full: String::new(),
+                diff_offset: 0,
+                diffsize: 0,
+                matching: -1,
+                shown: false,
+            });
+            in_header = true;
+            current_filename = None;
+            continue;
+        }
+
+        let util = current.as_mut().ok_or_else(|| {
+            anyhow::anyhow!("could not parse log output (expected commit line first)")
+        })?;
+
+        if line.starts_with("diff --git ") {
+            in_header = false;
+            buf.push('\n');
+            if util.diff_offset == 0 {
+                util.diff_offset = buf.len();
+            }
+            let (summary, fname) = parse_diff_git_header(line);
+            util.diffsize += summary.lines().count() as i32;
+            buf.push_str(&summary);
+            current_filename = Some(fname);
+            skip_diff_header = true;
+            continue;
+        }
+
+        if skip_diff_header {
+            if line.starts_with("@@ ") {
+                skip_diff_header = false;
+            } else {
+                continue;
+            }
+        }
+
+        if in_header {
+            if line.starts_with("Author: ") {
+                buf.push_str(" ## Metadata ##\n");
+                buf.push_str(line);
+                buf.push_str("\n\n");
+                buf.push_str(" ## Commit message ##\n");
+            } else if line.starts_with("Notes") && line.ends_with(':') {
+                buf.push_str("\n\n");
+                let name = line.trim_end_matches(':');
+                buf.push_str(&format!(" ## {name} ##\n"));
+            } else if let Some(body) = line.strip_prefix("    ") {
+                let trimmed = body.trim_end();
+                buf.push_str(trimmed);
+                buf.push('\n');
+            }
+            continue;
+        }
+
+        if let Some(rest) = line.strip_prefix("@@ ") {
+            let mut h = String::from("@@");
+            if let Some(pos) = rest.find("@@") {
+                let after = &rest[pos + 2..];
+                if let Some(ref fname) = current_filename {
+                    if !after.is_empty() {
+                        h.push_str(&format!(" {fname}:"));
+                    }
+                }
+                h.push_str(after);
+            }
+            buf.push_str(&h);
+            buf.push('\n');
+            util.diffsize += 1;
+            continue;
+        }
+
+        if line.is_empty() {
+            continue;
+        }
+
+        let first = line.as_bytes().first().copied();
+        if first == Some(b'>') {
+            buf.push('+');
+            buf.push_str(&line[1..]);
+        } else if first == Some(b'<') {
+            buf.push('-');
+            buf.push_str(&line[1..]);
+        } else if first == Some(b'#') {
+            buf.push(' ');
+            buf.push_str(&line[1..]);
+        } else {
+            buf.push(' ');
+            buf.push_str(line);
+        }
+        buf.push('\n');
+        util.diffsize += 1;
+    }
+
+    if let Some(p) = current {
+        list.push(finish_patch(p, &buf)?);
+    }
+
+    Ok(list)
+}
+
+fn finish_patch(mut p: Patch, buf: &str) -> Result<Patch> {
+    p.full = buf.to_string();
+    if p.diff_offset > p.full.len() {
+        p.diff_offset = p.full.len();
+    }
+    Ok(p)
+}
+
+fn parse_diff_git_header(line: &str) -> (String, String) {
+    let rest = line.strip_prefix("diff --git ").unwrap_or("");
+    let mut parts = rest.split_whitespace();
+    let a_raw = parts.next().unwrap_or("");
+    let b_raw = parts.next().unwrap_or("");
+    let a = a_raw.strip_prefix("a/").unwrap_or(a_raw);
+    let b = b_raw.strip_prefix("b/").unwrap_or(b_raw);
+    let summary = format!(" ## {b} ##\n");
+    (
+        summary,
+        if b.is_empty() {
+            a.to_string()
+        } else {
+            b.to_string()
+        },
+    )
+}
+
+fn find_exact_matches(a: &mut [Patch], b: &mut [Patch]) {
+    let mut map: HashMap<String, Vec<usize>> = HashMap::new();
+    for (i, p) in a.iter().enumerate() {
+        let d = p.full[p.diff_offset..].to_string();
+        map.entry(d).or_default().push(i);
+    }
+    for (j, p) in b.iter_mut().enumerate() {
+        let d = &p.full[p.diff_offset..];
+        if let Some(indices) = map.get(d) {
+            for &i in indices {
+                if a[i].matching < 0 && p.matching < 0 {
+                    a[i].matching = j as i32;
+                    p.matching = i as i32;
+                    break;
                 }
             }
         }
-        matches.push(None);
     }
+}
 
-    // Output.
-    let stdout = io::stdout();
-    let mut out = stdout.lock();
+fn diffsize_lines(x: &str, y: &str) -> i32 {
+    if x == y {
+        return 0;
+    }
+    line_diff_inner(x, y).lines().count() as i32
+}
 
-    let a_width = enriched_a.len().to_string().len().max(1);
-    let b_width = enriched_b.len().to_string().len().max(1);
-
-    for (i, c) in enriched_a.iter().enumerate() {
-        let short_a = &c.oid.to_hex()[..12];
-        let num_a = i + 1;
-        match matches[i] {
-            Some(bi) => {
-                let bc = &enriched_b[bi];
-                let short_b = &bc.oid.to_hex()[..12];
-                let num_b = bi + 1;
-                let marker = if c.oid == bc.oid { "=" } else { "!" };
-                writeln!(
-                    out,
-                    "{num_a:>a_width$}: {short_a} {marker} {num_b:>b_width$}: {short_b} {}",
-                    c.summary
-                )?;
-            }
-            None => {
-                let pad = " ".repeat(b_width + 2 + 12);
-                writeln!(out, "{num_a:>a_width$}: {short_a} < {pad} {}", c.summary)?;
-            }
+fn get_correspondences(a: &mut [Patch], b: &mut [Patch], creation_factor: u64) {
+    let n = a.len() + b.len();
+    if n == 0 {
+        return;
+    }
+    let mut cost = vec![0u64; n * n];
+    for i in 0..a.len() {
+        for j in 0..b.len() {
+            let ai = &a[i];
+            let bj = &b[j];
+            let c = if ai.matching == j as i32 {
+                0
+            } else if ai.matching < 0 && bj.matching < 0 {
+                let da = &ai.full[ai.diff_offset..];
+                let db = &bj.full[bj.diff_offset..];
+                diffsize_lines(da, db) as u64
+            } else {
+                COST_MAX
+            };
+            cost[j + n * i] = c;
+        }
+        let ai = &a[i];
+        let c_pad = if ai.matching < 0 {
+            (ai.diffsize as u64).saturating_mul(creation_factor) / 100
+        } else {
+            COST_MAX
+        };
+        for j in b.len()..n {
+            cost[j + n * i] = c_pad;
+        }
+    }
+    for j in 0..b.len() {
+        let bj = &b[j];
+        let c_pad = if bj.matching < 0 {
+            (bj.diffsize as u64).saturating_mul(creation_factor) / 100
+        } else {
+            COST_MAX
+        };
+        for i in a.len()..n {
+            cost[j + n * i] = c_pad;
+        }
+    }
+    for i in a.len()..n {
+        for j in b.len()..n {
+            cost[j + n * i] = 0;
         }
     }
 
-    // Unmatched commits in B.
-    for (i, c) in enriched_b.iter().enumerate() {
-        if !b_matched[i] {
-            let short_b = &c.oid.to_hex()[..12];
-            let num_b = i + 1;
-            let pad_a = " ".repeat(a_width + 2 + 12);
-            writeln!(out, "{pad_a} > {num_b:>b_width$}: {short_b} {}", c.summary)?;
+    let assign = minimize(&cost, n, n);
+    for i in 0..a.len() {
+        if let Some(Some(j)) = assign.get(i) {
+            if *j < b.len() {
+                a[i].matching = *j as i32;
+                b[*j].matching = i as i32;
+            }
+        }
+    }
+}
+
+fn output(
+    repo: &Repository,
+    a: &mut [Patch],
+    b: &mut [Patch],
+    left_only: bool,
+    right_only: bool,
+    no_patch: bool,
+    stat_mode: bool,
+    use_color: bool,
+    abbrev_len: usize,
+) -> Result<()> {
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    let max_n = 1 + a.len().max(b.len());
+    let w = decimal_width(max_n);
+    let reset = if use_color { "\x1b[m" } else { "" };
+    let color_old = if use_color { "\x1b[31m" } else { "" };
+    let color_new = if use_color { "\x1b[32m" } else { "" };
+    let color_commit = if use_color { "\x1b[33m" } else { "" };
+
+    let dash_str: String = std::iter::repeat_n('-', abbrev_len).collect();
+
+    let mut i = 0usize;
+    let mut j = 0usize;
+    while i < a.len() || j < b.len() {
+        while i < a.len() && a[i].shown {
+            i += 1;
+        }
+        if i < a.len() && a[i].matching < 0 {
+            if !right_only {
+                write_pair_header(
+                    &mut out,
+                    repo,
+                    w,
+                    Some((i, &a[i])),
+                    None,
+                    abbrev_len,
+                    &dash_str,
+                    reset,
+                    color_old,
+                    color_new,
+                    color_commit,
+                )?;
+            }
+            i += 1;
+            continue;
+        }
+        while j < b.len() && b[j].matching < 0 {
+            if !left_only {
+                write_pair_header(
+                    &mut out,
+                    repo,
+                    w,
+                    None,
+                    Some((j, &b[j])),
+                    abbrev_len,
+                    &dash_str,
+                    reset,
+                    color_old,
+                    color_new,
+                    color_commit,
+                )?;
+            }
+            j += 1;
+        }
+        if j < b.len() {
+            let bj = &b[j];
+            let ai_idx = bj.matching as usize;
+            let ai = &a[ai_idx];
+            write_pair_header(
+                &mut out,
+                repo,
+                w,
+                Some((ai_idx, ai)),
+                Some((j, bj)),
+                abbrev_len,
+                &dash_str,
+                reset,
+                color_old,
+                color_new,
+                color_commit,
+            )?;
+            if !no_patch && ai.full != bj.full {
+                let inner = diff_patches(&ai.full, &bj.full);
+                if stat_mode {
+                    write_stat_summary(&mut out, &inner)?;
+                } else {
+                    for line in inner.lines() {
+                        writeln!(out, "    {line}")?;
+                    }
+                }
+            }
+            a[ai_idx].shown = true;
+            j += 1;
         }
     }
 
     Ok(())
 }
 
-/// Parse range arguments into two `(base, tip)` pairs.
-fn parse_ranges(args: &[String]) -> Result<((String, String), (String, String))> {
-    if args.len() == 1 {
-        // Symmetric: rev1...rev2
-        let arg = &args[0];
-        if let Some((left, right)) = arg.split_once("...") {
-            if left.is_empty() || right.is_empty() {
-                bail!("invalid symmetric range: {arg}");
+fn write_stat_summary(out: &mut impl Write, diff: &str) -> Result<()> {
+    let mut ins = 0usize;
+    let mut dels = 0usize;
+    let mut files = 0usize;
+    for line in diff.lines() {
+        if line.starts_with('+') && !line.starts_with("+++") {
+            ins += 1;
+        } else if line.starts_with('-') && !line.starts_with("---") {
+            dels += 1;
+        }
+    }
+    if diff.contains("diff --git") {
+        files = diff.matches("diff --git").count();
+    } else if ins + dels > 0 {
+        files = 1;
+    }
+    writeln!(out, "     a => b | {} +-", ins.saturating_add(dels))?;
+    writeln!(
+        out,
+        "     {} file{} changed, {} insertion{}(+), {} deletion{}(-)",
+        files,
+        if files == 1 { "" } else { "s" },
+        ins,
+        if ins == 1 { "" } else { "s" },
+        dels,
+        if dels == 1 { "" } else { "s" },
+    )?;
+    Ok(())
+}
+
+fn diff_patches(x: &str, y: &str) -> String {
+    line_diff_inner(x, y)
+}
+
+/// Git-style line diff (one prefix character per output line).
+fn line_diff_inner(a: &str, b: &str) -> String {
+    let la: Vec<&str> = a.lines().collect();
+    let lb: Vec<&str> = b.lines().collect();
+    let n = la.len();
+    let m = lb.len();
+    let mut dp = vec![vec![0usize; m + 1]; n + 1];
+    for i in (0..n).rev() {
+        for j in (0..m).rev() {
+            dp[i][j] = if la[i] == lb[j] {
+                1 + dp[i + 1][j + 1]
+            } else {
+                dp[i + 1][j].max(dp[i][j + 1])
+            };
+        }
+    }
+    let mut i = 0usize;
+    let mut j = 0usize;
+    let mut out = String::new();
+    while i < n || j < m {
+        if i < n && j < m && la[i] == lb[j] {
+            out.push(' ');
+            out.push_str(la[i]);
+            out.push('\n');
+            i += 1;
+            j += 1;
+        } else if i < n && (j == m || dp[i + 1][j] >= dp[i][j + 1]) {
+            out.push('-');
+            out.push_str(la[i]);
+            out.push('\n');
+            i += 1;
+        } else if j < m {
+            out.push('+');
+            out.push_str(lb[j]);
+            out.push('\n');
+            j += 1;
+        }
+    }
+    out
+}
+
+fn write_pair_header(
+    out: &mut impl Write,
+    repo: &Repository,
+    w: usize,
+    left: Option<(usize, &Patch)>,
+    right: Option<(usize, &Patch)>,
+    abbrev_len: usize,
+    dash_str: &str,
+    reset: &str,
+    color_old: &str,
+    color_new: &str,
+    color_commit: &str,
+) -> Result<()> {
+    let status = match (left, right) {
+        (Some(_), None) => '<',
+        (None, Some(_)) => '>',
+        (Some((_, l)), Some((_, r))) => {
+            if l.full == r.full {
+                '='
+            } else {
+                '!'
             }
-            // The base for both is the merge-base of left and right.
-            // We represent it as the range base..tip where base is
-            // derived via merge-base at walk time. For simplicity,
-            // use left as base for right's range and right as base for left's.
-            return Ok((
-                (right.to_string(), left.to_string()),
-                (left.to_string(), right.to_string()),
-            ));
         }
-        bail!("expected <rev1>...<rev2> or two <base>..<tip> arguments");
-    }
-    if args.len() == 2 {
-        let a = parse_dotdot(&args[0])?;
-        let b = parse_dotdot(&args[1])?;
-        return Ok((a, b));
-    }
-    if args.len() == 3 {
-        // Three-arg form: base rev1 rev2
-        return Ok((
-            (args[0].clone(), args[1].clone()),
-            (args[0].clone(), args[2].clone()),
-        ));
-    }
-    bail!("usage: range-diff <base1>..<rev1> <base2>..<rev2> or range-diff <rev1>...<rev2>");
-}
-
-/// Parse a `base..tip` range specification.
-fn parse_dotdot(s: &str) -> Result<(String, String)> {
-    if let Some((base, tip)) = s.split_once("..") {
-        if base.is_empty() || tip.is_empty() {
-            bail!("invalid range: {s}");
-        }
-        Ok((base.to_string(), tip.to_string()))
-    } else {
-        bail!("expected <base>..<tip>, got: {s}");
-    }
-}
-
-/// Walk a range of commits from base..tip (exclusive base).
-fn walk_range(repo: &Repository, base: &str, tip: &str) -> Result<Vec<ObjectId>> {
-    let options = RevListOptions {
-        max_count: None,
-        skip: 0,
-        reverse: true,
-        ..Default::default()
+        (None, None) => unreachable!(),
     };
 
-    let positive = vec![tip.to_string()];
-    let negative = vec![base.to_string()];
+    let oid_for_subject = left
+        .map(|(_, p)| p.oid)
+        .or_else(|| right.map(|(_, p)| p.oid))
+        .unwrap();
 
-    let result: RevListResult = rev_list(repo, &positive, &negative, &options)?;
-    Ok(result.commits)
+    match (left, right) {
+        (None, Some((rj, rp))) => {
+            write!(out, "{color_new}{:>w$}:  {} ", "-", dash_str, w = w)?;
+            write!(out, "{status} ")?;
+            write!(
+                out,
+                "{:>w$}:  {}",
+                rj + 1,
+                abbreviate_object_id(repo, rp.oid, abbrev_len)?,
+                w = w
+            )?;
+        }
+        (Some((li, lp)), None) => {
+            let c0 = if status == '!' {
+                color_old
+            } else {
+                color_commit
+            };
+            write!(
+                out,
+                "{c0}{:>w$}:  {} ",
+                li + 1,
+                abbreviate_object_id(repo, lp.oid, abbrev_len)?,
+                w = w
+            )?;
+            if status == '!' {
+                write!(out, "{reset}{color_commit}")?;
+            }
+            write!(out, "{status}")?;
+            if status == '!' {
+                write!(out, "{reset}{color_new}")?;
+            }
+            write!(out, " {:>w$}:  {}", "-", dash_str, w = w)?;
+        }
+        (Some((li, lp)), Some((rj, rp))) => {
+            let c0 = if status == '!' {
+                color_old
+            } else {
+                color_commit
+            };
+            write!(
+                out,
+                "{c0}{:>w$}:  {} ",
+                li + 1,
+                abbreviate_object_id(repo, lp.oid, abbrev_len)?,
+                w = w
+            )?;
+            if status == '!' {
+                write!(out, "{reset}{color_commit}")?;
+            }
+            write!(out, "{status}")?;
+            if status == '!' {
+                write!(out, "{reset}{color_new}")?;
+            }
+            write!(
+                out,
+                " {:>w$}:  {}",
+                rj + 1,
+                abbreviate_object_id(repo, rp.oid, abbrev_len)?,
+                w = w
+            )?;
+        }
+        _ => {}
+    }
+
+    let subj = lookup_commit_subject(repo, oid_for_subject)?;
+    if !subj.is_empty() {
+        if status == '!' {
+            write!(out, "{reset}")?;
+        }
+        write!(out, " {subj}")?;
+    }
+    writeln!(out, "{reset}")?;
+    Ok(())
 }
 
-/// Enrich commit OIDs with summary lines and patch-ids.
-fn enrich_commits(repo: &Repository, oids: Vec<ObjectId>) -> Result<Vec<RangeCommit>> {
-    let mut out = Vec::with_capacity(oids.len());
-    for oid in oids {
-        let obj = repo.odb.read(&oid)?;
-        let summary = if obj.kind == ObjectKind::Commit {
-            let commit = parse_commit(&obj.data)?;
-            let msg = &commit.message;
-            msg.lines().next().unwrap_or("").to_string()
-        } else {
-            String::new()
-        };
+fn lookup_commit_subject(repo: &Repository, oid: ObjectId) -> Result<String> {
+    let obj = repo.odb.read(&oid)?;
+    let c = parse_commit(&obj.data)?;
+    Ok(c.message.lines().next().unwrap_or("").to_string())
+}
 
-        let patch_id = compute_patch_id(&repo.odb, &oid).unwrap_or(None);
-
-        out.push(RangeCommit {
-            oid,
-            summary,
-            patch_id,
-        });
+fn decimal_width(mut n: usize) -> usize {
+    let mut w = 1;
+    while n >= 10 {
+        n /= 10;
+        w += 1;
     }
-    Ok(out)
+    w
 }

--- a/grit/src/commands/reflog.rs
+++ b/grit/src/commands/reflog.rs
@@ -283,6 +283,12 @@ fn run_show(args: ShowArgs) -> Result<()> {
         full_history: false,
         simplify_merges: false,
         sparse: false,
+        output_indicator_new: None,
+        output_indicator_old: None,
+        output_indicator_context: None,
+        no_prefix: false,
+        no_notes: false,
+        notes_refs: Vec::new(),
     })
 }
 

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -3024,7 +3024,7 @@ pub(crate) fn dispatch(subcmd: &str, rest: &[String], opts: &GlobalOpts) -> Resu
         "prune-packed" => commands::prune_packed::run(parse_cmd_args(subcmd, rest)),
         "pull" => commands::pull::run(parse_cmd_args(subcmd, rest)),
         "push" => commands::push::run(parse_cmd_args(subcmd, rest)),
-        "range-diff" => commands::range_diff::run(parse_cmd_args(subcmd, rest)),
+        "range-diff" => commands::range_diff::run_with_rest(rest),
         "read-tree" => commands::read_tree::run(parse_cmd_args(subcmd, rest)),
         "rebase" => commands::rebase::run(parse_cmd_args(subcmd, rest)),
         "receive-pack" => commands::receive_pack::run(parse_cmd_args(subcmd, rest)),

--- a/logs/2026-04-08_t3206-range-diff.md
+++ b/logs/2026-04-08_t3206-range-diff.md
@@ -1,0 +1,20 @@
+# t3206-range-diff (partial)
+
+## Done
+
+- **`grit fast-import`**: Implemented blob/commit/reset subset in `grit-lib` (`fast_import.rs`) so `tests/t3206/history.export` imports; fixes harness setup.
+- **`grit range-diff`**: Rewrote to approximate Git `range-diff.c`: subprocess `grit log` with `--no-prefix` and custom diff indicators, patch normalization (skip index/---/+++ after `diff --git`), Hungarian assignment (`hungarian` crate), symmetric range `B..A` / `A..B`, `^!` / `^-N` parent-only revs, dash padding for null side, inner line diff (LCS).
+- **`grit log`**: `--no-prefix` emits `diff --git file file` like Git; `--no-abbrev` + full hex in medium format; `--output-indicator-*`; `--no-notes` / multiple `--notes`; `write_notes` respects those flags.
+
+## Harness
+
+- `t3206-range-diff.sh`: **20/48** passing after `./scripts/run-tests.sh t3206-range-diff.sh`.
+
+## Remaining failures (high level)
+
+- Inner `range-diff` hunks still differ from Git where `grit log -p` hunk headers/context differ from upstream `git log -p`.
+- `format-patch --range-diff`, notes sections, submodule / `diff.submodule`, `merge-tree` for test 48, dual-coloring.
+
+## Compare
+
+- Compared `grit range-diff` vs `/usr/bin/git range-diff` on `topic...changed`: headers/metadata alignment improved after `diff --git` fix; remaining gap is hunk line numbering / context.


### PR DESCRIPTION
- Add grit-lib fast_import (blob/commit/reset) for history.export streams
- Rewrite range-diff: log-based patches, Hungarian matching, ^!/^-N, symmetric ranges
- Extend log: --no-prefix git headers, output indicators, notes flags, no-abbrev full hash
- Wire main to range-diff run_with_rest; add hungarian dependency

t3206-range-diff: 20/48 passing; remaining gaps vs git log hunks and format-patch.