### PR TITLE
chore: verify t13180-log-patch-stat passes (35/35)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1192,7 +1192,7 @@ t7111-reset-table	t7	yes	42	33	9	false	ok	0
 t7112-reset-submodule	t7	yes	76	10	66	false	ok	0
 t7113-post-index-change-hook	t7	yes	4	1	3	false	ok	0
 t7201-co	t7	yes	46	15	31	false	ok	0
-t7300-clean	t7	yes	55	53	0	true	ok	2
+t7300-clean	t7	yes	53	53	0	true	ok	2
 t7301-clean-interactive	t7	yes	23	5	18	false	ok	0
 t7400-submodule-basic	t7	yes	0	0	0	false	timeout	0
 t7401-submodule-summary	t7	yes	25	6	19	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T10:21:49+00:00" class="gen-time" title="2026-04-08 10:21 UTC">2026-04-08 10:21 UTC</time> · <a href="https://github.com/schacon/grit/commit/86e789923780b3b68e7a9fee6c23a0c710c88579" style="color:#58a6ff">86e7899</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T11:40:30+00:00" class="gen-time" title="2026-04-08 11:40 UTC">2026-04-08 11:40 UTC</time> · <a href="https://github.com/schacon/grit/commit/fae36b0ec56b5d8566a6509b6ae4ae9314fb597d" style="color:#58a6ff">fae36b0</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -154,7 +154,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">39,450</div>
+      <div class="summary-big-val">39,448</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -256,7 +256,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">41/126 files · 11 skipped · 1,776/2,946 tests</span>
+        <span class="group-meta">41/126 files · 11 skipped · 1,776/2,944 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.3%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,11 +100,11 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T10:21:49+00:00" class="gen-time" title="2026-04-08 10:21 UTC">2026-04-08 10:21 UTC</time> · <a href="https://github.com/schacon/grit/commit/86e789923780b3b68e7a9fee6c23a0c710c88579" style="color:#58a6ff">86e7899</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T11:40:30+00:00" class="gen-time" title="2026-04-08 11:40 UTC">2026-04-08 11:40 UTC</time> · <a href="https://github.com/schacon/grit/commit/fae36b0ec56b5d8566a6509b6ae4ae9314fb597d" style="color:#58a6ff">fae36b0</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">39,450</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card"><div class="n" id="sum-tests">39,448</div><div class="lbl">Unskipped tests</div></div>
   <div class="card accent"><div class="n" id="sum-passed">28,719</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">72.8%</div><div class="lbl">Pass rate</div></div>
 </div>
@@ -12077,14 +12077,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:32.6%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="55" data-passed="53" data-full-pass="1">
+<tr class="" data-group="t7" data-tests="53" data-passed="53" data-full-pass="1">
   <td class="mono">t7300-clean</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>
-  <td class="right">55</td>
+  <td class="right">53</td>
   <td class="right">53</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:96.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">2</td>
 </tr>
 <tr class="" data-group="t7" data-tests="23" data-passed="5">

--- a/grit-lib/src/rev_list.rs
+++ b/grit-lib/src/rev_list.rs
@@ -3067,9 +3067,8 @@ fn collect_tree_objects_filtered(
         }
     };
     let tree_included = tree_included
-        && sparse_lines.is_none_or(|lines| {
-            path_matches_sparse_pattern_list(prefix, lines) != Some(false)
-        });
+        && sparse_lines
+            .is_none_or(|lines| path_matches_sparse_pattern_list(prefix, lines) != Some(false));
     if tree_included {
         if !packed_set.is_some_and(|p| p.contains(&tree_oid)) && emitted.insert(tree_oid) {
             let out_path = if omit_object_paths {

--- a/logs/2026-04-08_t13180-log-patch-stat.md
+++ b/logs/2026-04-08_t13180-log-patch-stat.md
@@ -1,0 +1,4 @@
+# t13180-log-patch-stat
+
+- Verified `./scripts/run-tests.sh t13180-log-patch-stat.sh`: **35/35** pass on current `main`-based tree (`grit log`: oneline, graph, decorate, skip, max-count, reverse, first-parent, format placeholders).
+- No Rust changes required; harness run refreshed `data/test-files.csv` and dashboards.

--- a/progress.md
+++ b/progress.md
@@ -15,6 +15,7 @@ Task lines in `PLAN.md`: 230 completed (`[x]`), 2 in progress (`[~]`), 536 remai
 
 ## Recently completed
 
+- `t13180-log-patch-stat` — 35/35 tests pass (`grit log` display: oneline, graph, decorate, skip/max-count/reverse, `%H`/`%h`, `--first-parent`, `--no-decorate`; harness CSV refreshed)
 - `t7426-submodule-get-default-remote` — 15/15 tests pass (`submodule--helper get-default-remote`; nested submodule URL resolution uses outer superproject `remote.*.url` + Git `relative_url`; `pull` resolves local path remotes from `remote.<name>.url` for detached HEAD; `submodule update` treats path `.` as all submodules; submodule clone clears `GIT_DIR` and rewrites `remote.origin.url` to canonical path)
 - `t10560-switch-create-detach` — 28/28 tests pass (`switch`: `-- <branch>` treats a single token as the branch even when it matches a tracked path; `-c`/`-C`/`--orphan` reject invalid ref names via `check_refname_format` with Git-style `is not a valid branch name`)
 - `t3310-notes-merge-manual-resolve` — 22/22 tests pass (`notes merge`: manual 3-way merge with `NOTES_MERGE_*` state, `--commit`/`--abort`, conflict worktree paths and messages; `notes` honors `core.notesRef` and `--ref` short names; `append` matches Git blob layout; `log` `%N` + fanout notes trees; `update-ref` resolves `refs/notes/*`; root merge refs stored in main git dir)

--- a/t1-plan.md
+++ b/t1-plan.md
@@ -161,7 +161,7 @@
 - [ ] t1309-early-config.sh
 - [ ] t13120-diff-no-index-dir-file.sh
 - [ ] t13150-diff-stat-insertions-deletions.sh
-- [ ] t13180-log-patch-stat.sh
+- [x] t13180-log-patch-stat.sh
 - [ ] t13210-rev-list-count-all.sh
 - [ ] t13220-rev-parse-worktree.sh
 - [ ] t13240-config-get-all-values.sh

--- a/test-results.md
+++ b/test-results.md
@@ -2,6 +2,7 @@
 
 **Updated:** 2026-04-08
 
+- `./scripts/run-tests.sh t13180-log-patch-stat.sh`: 35/35 passing (`grit log` oneline/graph/decorate/skip/max-count/reverse/format; harness CSV/dashboards refreshed).
 - `./scripts/run-tests.sh t10560-switch-create-detach.sh`: 28/28 passing (`switch -- <branch>` disambiguation; invalid `-c`/`-C`/`--orphan` branch names rejected like Git; harness CSV/dashboards refreshed).
 - `cargo test -p grit-lib --lib`: 110/110 passing.
 - `./scripts/run-tests.sh t5403-post-checkout-hook.sh`: 14/14 passing (`post-checkout` hook on checkout/rebase/clone; clone default branch resolution with detached `HEAD` and `GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME`; harness CSV/dashboards refreshed).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`tests/t13180-log-patch-stat.sh` already passes end-to-end against current Grit (`grit log` oneline, graph, decorate, skip/max-count/reverse, format placeholders, etc.). This change records that verification and refreshes harness artifacts.

## Changes

- Ran `./scripts/run-tests.sh t13180-log-patch-stat.sh` → **35/35** passing; updated `data/test-files.csv` and dashboards.
- Marked `t13180-log-patch-stat.sh` complete in `t1-plan.md`.
- Added `logs/2026-04-08_t13180-log-patch-stat.md` and noted the run in `test-results.md` / `progress.md`.
- Follow-up: `cargo fmt` on `grit-lib/src/rev_list.rs` (formatting-only).

## Testing

- `./scripts/run-tests.sh t13180-log-patch-stat.sh`
- `cargo test -p grit-lib --lib` (110/110)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ba1fcf4-7d2a-4fda-b810-3278754bb270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ba1fcf4-7d2a-4fda-b810-3278754bb270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

