### PR TITLE
fix: pass t5544 pack-objects-hook (protected config, clone --no-local fetch)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -584,7 +584,7 @@ commit → check it off → move on.
 - [ ] `t5564-http-proxy` ███████░░░░░░░░░░░░░ 3/8 (5 left) — test fetching through http proxy
 - [ ] `t5402-post-merge-hook` █████░░░░░░░░░░░░░░░ 2/7 (5 left) — Test the post-merge hook.
 - [ ] `t5502-quickfetch` █████░░░░░░░░░░░░░░░ 2/7 (5 left) — test quickfetch from local
-- [ ] `t5544-pack-objects-hook` █████░░░░░░░░░░░░░░░ 2/7 (5 left) — test custom script in place of pack-objects
+- [x] `t5544-pack-objects-hook` ████████████████████ 7/7 (0 left) — test custom script in place of pack-objects
 - [ ] `t5316-pack-delta-depth` ░░░░░░░░░░░░░░░░░░░░ 0/5 (5 left) — pack-objects breaks long cross-pack delta chains
 - [ ] `t5546-receive-limits` ████████████░░░░░░░░ 11/17 (6 left) — check receive input limits
 - [ ] `t5534-push-signed` ██████████░░░░░░░░░░ 7/13 (6 left) — signed push

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -964,7 +964,7 @@ t5541-remote-subcommands	t5	yes	5	5	0	true	ok	0
 t5542-push-advanced	t5	yes	4	4	0	true	ok	0
 t5542-push-http-shallow	t5	yes	3	1	2	false	ok	0
 t5543-atomic-push	t5	yes	13	7	6	false	ok	0
-t5544-pack-objects-hook	t5	yes	7	3	4	false	ok	0
+t5544-pack-objects-hook	t5	yes	7	7	0	true	ok	0
 t5545-push-options	t5	yes	13	5	8	false	ok	0
 t5546-receive-limits	t5	yes	17	14	3	false	ok	0
 t5547-push-quarantine	t5	yes	6	5	1	false	ok	0
@@ -1192,7 +1192,7 @@ t7111-reset-table	t7	yes	42	33	9	false	ok	0
 t7112-reset-submodule	t7	yes	76	10	66	false	ok	0
 t7113-post-index-change-hook	t7	yes	4	1	3	false	ok	0
 t7201-co	t7	yes	46	15	31	false	ok	0
-t7300-clean	t7	yes	55	53	0	true	ok	2
+t7300-clean	t7	yes	53	53	0	true	ok	2
 t7301-clean-interactive	t7	yes	23	5	18	false	ok	0
 t7400-submodule-basic	t7	yes	0	0	0	false	timeout	0
 t7401-submodule-summary	t7	yes	25	6	19	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T11:37:37+00:00" class="gen-time" title="2026-04-08 11:37 UTC">2026-04-08 11:37 UTC</time> · <a href="https://github.com/schacon/grit/commit/fae36b0ec56b5d8566a6509b6ae4ae9314fb597d" style="color:#58a6ff">fae36b0</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T12:20:33+00:00" class="gen-time" title="2026-04-08 12:20 UTC">2026-04-08 12:20 UTC</time> · <a href="https://github.com/schacon/grit/commit/8b84835510160720cef2a8ef51b13d07e2be92f6" style="color:#58a6ff">8b84835</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,11 +150,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">28,730</div>
+      <div class="summary-big-val">28,734</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">39,450</div>
+      <div class="summary-big-val">39,448</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>689 files fully passing</span>
+    <span>690 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">28/167 files · 17 skipped · 1,428/3,949 tests</span>
+        <span class="group-meta">29/167 files · 17 skipped · 1,432/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:36.2%"></div></div>
-        <span class="group-pct pct-red">36.2%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:36.3%"></div></div>
+        <span class="group-pct pct-red">36.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -256,7 +256,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">41/126 files · 11 skipped · 1,776/2,946 tests</span>
+        <span class="group-meta">41/126 files · 11 skipped · 1,776/2,944 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.3%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T11:37:37+00:00" class="gen-time" title="2026-04-08 11:37 UTC">2026-04-08 11:37 UTC</time> · <a href="https://github.com/schacon/grit/commit/fae36b0ec56b5d8566a6509b6ae4ae9314fb597d" style="color:#58a6ff">fae36b0</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T12:20:33+00:00" class="gen-time" title="2026-04-08 12:20 UTC">2026-04-08 12:20 UTC</time> · <a href="https://github.com/schacon/grit/commit/8b84835510160720cef2a8ef51b13d07e2be92f6" style="color:#58a6ff">8b84835</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">39,450</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">28,730</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n" id="sum-tests">39,448</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">28,734</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">72.8%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -9797,14 +9797,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:53.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="7" data-passed="3">
+<tr class="" data-group="t5" data-tests="7" data-passed="7" data-full-pass="1">
   <td class="mono">t5544-pack-objects-hook</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">7</td>
-  <td class="right">3</td>
+  <td class="right">7</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:42.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="13" data-passed="5">
@@ -12077,14 +12077,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:32.6%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="55" data-passed="53" data-full-pass="1">
+<tr class="" data-group="t7" data-tests="53" data-passed="53" data-full-pass="1">
   <td class="mono">t7300-clean</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>
-  <td class="right">55</td>
+  <td class="right">53</td>
   <td class="right">53</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:96.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">2</td>
 </tr>
 <tr class="" data-group="t7" data-tests="23" data-passed="5">

--- a/grit-lib/src/config.rs
+++ b/grit-lib/src/config.rs
@@ -1418,6 +1418,75 @@ impl ConfigSet {
         Ok(set)
     }
 
+    /// Load configuration the way Git loads **protected** config (e.g. `uploadpack.packObjectsHook`).
+    ///
+    /// This matches Git's `read_protected_config`: system (optional), global files only (no
+    /// repository or worktree `config`), then command-line overrides from `GIT_CONFIG_COUNT` /
+    /// `GIT_CONFIG_PARAMETERS`. It does **not** read `$GIT_CONFIG` (Git omits that for protected
+    /// config).
+    ///
+    /// Global file order matches Git: XDG `git/config` first (when present), then `~/.gitconfig`,
+    /// unless `GIT_CONFIG_GLOBAL` is set (single file). When both global files exist, both are
+    /// merged so later entries win for duplicate keys.
+    pub fn load_protected(include_system: bool) -> Result<Self> {
+        let mut set = Self::new();
+
+        if include_system && std::env::var("GIT_CONFIG_NOSYSTEM").is_err() {
+            let system_path = std::env::var("GIT_CONFIG_SYSTEM")
+                .map(std::path::PathBuf::from)
+                .unwrap_or_else(|_| std::path::PathBuf::from("/etc/gitconfig"));
+            if let Ok(Some(f)) = ConfigFile::from_path(&system_path, ConfigScope::System) {
+                Self::merge_with_includes(&mut set, &f, true, 0)?;
+            }
+        }
+
+        if let Ok(p) = std::env::var("GIT_CONFIG_GLOBAL") {
+            let path = PathBuf::from(p);
+            if let Ok(Some(f)) = ConfigFile::from_path(&path, ConfigScope::Global) {
+                Self::merge_with_includes(&mut set, &f, true, 0)?;
+            }
+        } else {
+            let mut global_paths = Vec::new();
+            if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
+                global_paths.push(PathBuf::from(xdg).join("git/config"));
+            } else if let Some(home) = home_dir() {
+                global_paths.push(home.join(".config/git/config"));
+            }
+            if let Some(home) = home_dir() {
+                global_paths.push(home.join(".gitconfig"));
+            }
+            for path in global_paths {
+                if let Ok(Some(f)) = ConfigFile::from_path(&path, ConfigScope::Global) {
+                    Self::merge_with_includes(&mut set, &f, true, 0)?;
+                }
+            }
+        }
+
+        if let Ok(count_str) = std::env::var("GIT_CONFIG_COUNT") {
+            if let Ok(count) = count_str.parse::<usize>() {
+                for i in 0..count {
+                    let key_var = format!("GIT_CONFIG_KEY_{i}");
+                    let val_var = format!("GIT_CONFIG_VALUE_{i}");
+                    if let (Ok(key), Ok(val)) = (std::env::var(&key_var), std::env::var(&val_var)) {
+                        let _ = set.add_command_override(&key, &val);
+                    }
+                }
+            }
+        }
+
+        if let Ok(params) = std::env::var("GIT_CONFIG_PARAMETERS") {
+            for entry in parse_config_parameters(&params) {
+                if let Some((key, val)) = entry.split_once('=') {
+                    let _ = set.add_command_override(key.trim(), val);
+                } else {
+                    let _ = set.add_command_override(entry.trim(), "true");
+                }
+            }
+        }
+
+        Ok(set)
+    }
+
     /// Merge a file, processing `[include]` and `[includeIf]` directives.
     fn merge_with_includes(
         set: &mut Self,

--- a/grit/src/commands/clone.rs
+++ b/grit/src/commands/clone.rs
@@ -377,50 +377,6 @@ pub fn run(args: Args) -> Result<()> {
         return run_bundle_clone(args);
     }
 
-    // --no-local with custom upload-pack: use transport instead of direct copy
-    if args.no_local {
-        if let Some(ref upload_pack) = args.upload_pack {
-            let source_path = PathBuf::from(&args.repository);
-            let target_name = args.directory.clone().unwrap_or_else(|| {
-                let base = source_path
-                    .file_name()
-                    .unwrap_or_default()
-                    .to_string_lossy()
-                    .to_string();
-                base.strip_suffix(".git")
-                    .unwrap_or(&base)
-                    .trim_end_matches('/')
-                    .to_string()
-            });
-            let target_path = PathBuf::from(&target_name);
-            if target_path.exists() {
-                bail!(
-                    "destination path '{}' already exists and is not an empty directory",
-                    target_path.display()
-                );
-            }
-            if !args.quiet {
-                eprintln!("Cloning into '{}'...", target_name);
-            }
-            fs::create_dir_all(&target_path)?;
-            let repo_path_arg = source_path.to_string_lossy().to_string();
-            let status = std::process::Command::new("sh")
-                .arg("-c")
-                .arg(format!("{} '{}'", upload_pack, repo_path_arg))
-                .status();
-            match status {
-                Ok(s) if s.success() => {
-                    eprintln!("done.");
-                    return Ok(());
-                }
-                _ => {
-                    let _ = fs::remove_dir_all(&target_path);
-                    bail!("clone failed: upload-pack command failed");
-                }
-            }
-        }
-    }
-
     // Check protocol.file.allow before local clone
     crate::protocol::check_protocol_allowed("file", None)?;
 
@@ -545,7 +501,18 @@ pub fn run(args: Args) -> Result<()> {
     };
 
     // Copy or share objects from source to destination
-    if args.shared {
+    if args.no_local && !args.shared {
+        let upload_cmd = args.upload_pack.as_deref().filter(|s| !s.trim().is_empty());
+        if let Err(e) = crate::fetch_transport::fetch_via_upload_pack_skipping(
+            &dest.git_dir,
+            &source.git_dir,
+            upload_cmd,
+            &[],
+        ) {
+            let _ = fs::remove_dir_all(&target_path);
+            return Err(e).context("clone via upload-pack (--no-local) failed");
+        }
+    } else if args.shared {
         // Write alternates file instead of copying objects
         write_alternates(&source.git_dir, &dest.git_dir, &args.reference)
             .context("setting up alternates")?;

--- a/grit/src/commands/pack_objects.rs
+++ b/grit/src/commands/pack_objects.rs
@@ -34,6 +34,22 @@ pub struct Args {
     #[arg(long)]
     pub revs: bool,
 
+    /// Omit objects the client already has (after `--not` in rev-list input).
+    #[arg(long)]
+    pub thin: bool,
+
+    /// Shallow boundary file (accepted for `upload-pack` compatibility; no-op in grit).
+    #[arg(long = "shallow-file", allow_hyphen_values = true)]
+    pub shallow_file: Option<String>,
+
+    /// Shallow pack (accepted for compatibility; no-op in grit).
+    #[arg(long)]
+    pub shallow: bool,
+
+    /// Include annotated tags (accepted for compatibility; no-op in grit).
+    #[arg(long = "include-tag")]
+    pub include_tag: bool,
+
     /// Pack all objects in the repository.
     #[arg(long)]
     pub all: bool,
@@ -274,19 +290,33 @@ fn collect_oids(repo: &Repository, args: &Args) -> Result<Vec<ObjectId>> {
     }
 
     if args.revs {
-        // Read revision specs from stdin — for simplicity, treat each line as a
-        // ref/rev that we resolve, then walk its reachable objects.
-        // Lines starting with '^' exclude objects reachable from that ref.
+        // Git `pack-objects --revs` stdin: positive revs, then `--not`, then negative
+        // revs (client haves). Lines may be 40-char hex or ref names. With `--thin`,
+        // objects reachable from the haves are omitted from the pack.
         let stdin = io::stdin();
         let mut exclude = BTreeSet::new();
+        let mut post_not = false;
+        let mut have_roots: BTreeSet<ObjectId> = BTreeSet::new();
         for line in stdin.lock().lines() {
             let line = line?;
             let trimmed = line.trim();
             if trimmed.is_empty() {
                 continue;
             }
+            if trimmed == "--not" {
+                post_not = true;
+                continue;
+            }
+            if post_not {
+                let oid = if let Ok(oid) = ObjectId::from_hex(trimmed) {
+                    oid
+                } else {
+                    resolve_ref(repo, trimmed)?
+                };
+                have_roots.insert(oid);
+                continue;
+            }
             if let Some(neg_ref) = trimmed.strip_prefix('^') {
-                // Exclusion: walk reachable from this ref and exclude them.
                 let oid = if let Ok(oid) = ObjectId::from_hex(neg_ref) {
                     oid
                 } else {
@@ -294,7 +324,6 @@ fn collect_oids(repo: &Repository, args: &Args) -> Result<Vec<ObjectId>> {
                 };
                 walk_reachable(repo, &oid, &mut exclude)?;
             } else {
-                // Inclusion: walk reachable from this ref.
                 let oid = if let Ok(oid) = ObjectId::from_hex(trimmed) {
                     oid
                 } else {
@@ -303,9 +332,15 @@ fn collect_oids(repo: &Repository, args: &Args) -> Result<Vec<ObjectId>> {
                 walk_reachable(repo, &oid, &mut oids)?;
             }
         }
-        // Remove excluded objects.
         for oid in &exclude {
             oids.remove(oid);
+        }
+        if args.thin && !have_roots.is_empty() {
+            let mut have_closure = BTreeSet::new();
+            for root in &have_roots {
+                walk_reachable(repo, root, &mut have_closure)?;
+            }
+            oids.retain(|o| !have_closure.contains(o));
         }
     } else if args.stdin_packs {
         // Read pack filenames from stdin and include all objects in those packs.

--- a/grit/src/commands/serve_v2.rs
+++ b/grit/src/commands/serve_v2.rs
@@ -6,9 +6,11 @@
 
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
-use grit_lib::objects::{self, ObjectKind};
+use grit_lib::merge_base;
+use grit_lib::objects::{self, ObjectId, ObjectKind};
 use grit_lib::refs;
 use grit_lib::repo::Repository;
+use std::collections::HashSet;
 use std::io::{self, Read, Write};
 use std::path::Path;
 
@@ -307,27 +309,116 @@ fn peel_to_commit(
     }
 }
 
-/// Handle the `fetch` command — validate arguments.
-fn cmd_fetch(_git_dir: &Path, args: &[String], out: &mut impl Write) -> Result<()> {
-    // Validate arguments
+/// Handle the `fetch` command (protocol v2): negotiation + `packfile` section with raw pack bytes.
+fn cmd_fetch(git_dir: &Path, args: &[String], out: &mut impl Write) -> Result<()> {
+    let repo = Repository::open(git_dir, None)
+        .with_context(|| format!("could not open repository at '{}'", git_dir.display()))?;
+
+    let mut wants: Vec<ObjectId> = Vec::new();
+    let mut have_oids: Vec<ObjectId> = Vec::new();
+    let mut wait_for_done = false;
+    let mut seen_done = false;
+
     for arg in args {
         match arg.as_str() {
-            "thin-pack" | "no-progress" | "include-tag" | "ofs-delta" | "wait-for-done" => {}
-            s if s.starts_with("want ") => {}
-            s if s.starts_with("have ") => {}
-            s if s.starts_with("shallow ") => {}
-            s if s.starts_with("deepen ") => {}
-            s if s.starts_with("deepen-since ") => {}
-            s if s.starts_with("deepen-not ") => {}
+            "thin-pack" | "no-progress" | "include-tag" | "ofs-delta" => {}
+            "wait-for-done" => wait_for_done = true,
+            "done" => seen_done = true,
             "deepen-relative" => {}
-            "done" => {}
+            s if s.starts_with("want ") => {
+                let rest = s.strip_prefix("want ").unwrap_or("").trim();
+                let hex = rest.split_whitespace().next().unwrap_or(rest);
+                wants.push(
+                    ObjectId::from_hex(hex).with_context(|| format!("invalid want oid: {hex}"))?,
+                );
+            }
+            s if s.starts_with("have ") => {
+                let hex = s.strip_prefix("have ").unwrap_or("").trim();
+                if let Ok(oid) = ObjectId::from_hex(hex) {
+                    have_oids.push(oid);
+                }
+            }
+            s if s.starts_with("shallow ")
+                || s.starts_with("deepen ")
+                || s.starts_with("deepen-since ")
+                || s.starts_with("deepen-not ") => {}
             s if s.starts_with("want-ref ") => {}
             s if s.starts_with("filter ") => {}
+            s if s.starts_with("packfile-uris ") => {}
+            s if s.starts_with("sideband-all") => {}
             other => bail!("unexpected line: '{other}'"),
         }
     }
-    // For now, just send an empty response
+
+    if wants.is_empty() && !wait_for_done {
+        pkt_line::write_flush(out)?;
+        return Ok(());
+    }
+
+    let want_set: HashSet<ObjectId> = wants.iter().copied().collect();
+    let mut have_commits: Vec<ObjectId> = Vec::new();
+    for h in &have_oids {
+        if let Ok(obj) = repo.odb.read(h) {
+            if obj.kind == ObjectKind::Commit {
+                have_commits.push(*h);
+            }
+        }
+    }
+
+    if !have_oids.is_empty() && !seen_done {
+        pkt_line::write_line(out, "acknowledgments")?;
+        pkt_line::write_line(out, "NAK")?;
+        if ok_to_give_up_v2(&repo, &want_set, &have_commits) {
+            pkt_line::write_line(out, "ready")?;
+            pkt_line::write_delim(out)?;
+        } else {
+            pkt_line::write_flush(out)?;
+        }
+        return Ok(());
+    }
+
+    pkt_line::write_line(out, "packfile")?;
+    let mut child = crate::pack_objects_upload::spawn_pack_objects_upload(git_dir)?;
+    {
+        let mut pin = child
+            .stdin
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("pack-objects stdin"))?;
+        crate::pack_objects_upload::write_pack_objects_revs_stdin(&mut pin, &wants, &have_commits)?;
+    }
+    crate::pack_objects_upload::drain_pack_objects_child(child, out, false)?;
     pkt_line::write_flush(out)?;
+    Ok(())
+}
+
+fn ok_to_give_up_v2(
+    repo: &Repository,
+    wants: &HashSet<ObjectId>,
+    have_commits: &[ObjectId],
+) -> bool {
+    if have_commits.is_empty() {
+        return false;
+    }
+    let mut client_known: HashSet<ObjectId> = HashSet::new();
+    for h in have_commits {
+        if merge_ancestors_into_v2(repo, *h, &mut client_known).is_err() {
+            return false;
+        }
+    }
+    wants.iter().all(|w| {
+        client_known
+            .iter()
+            .any(|h| merge_base::is_ancestor(repo, *h, *w).unwrap_or(false))
+    })
+}
+
+fn merge_ancestors_into_v2(
+    repo: &Repository,
+    tip: ObjectId,
+    into: &mut HashSet<ObjectId>,
+) -> anyhow::Result<()> {
+    let anc = merge_base::ancestor_closure(repo, tip)?;
+    into.extend(anc);
     Ok(())
 }
 

--- a/grit/src/commands/upload_pack.rs
+++ b/grit/src/commands/upload_pack.rs
@@ -4,19 +4,17 @@
 //! negotiates want/have (protocol v0, `multi_ack_detailed`), then streams a
 //! packfile (side-band-64k) to the client.
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::merge_base;
 use grit_lib::objects::ObjectId;
 use grit_lib::refs;
 use grit_lib::repo::Repository;
 use std::collections::HashSet;
-use std::io::{self, Read, Write};
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
 
 use crate::commands::serve_v2::{serve_loop, ServerCaps};
-use crate::grit_exe::grit_executable;
 use crate::pkt_line;
 
 /// Arguments for `grit upload-pack`.
@@ -101,6 +99,7 @@ pub fn run(args: Args) -> Result<()> {
     let mut got_other = false;
     let mut last_hex = String::new();
     let mut client_known: HashSet<ObjectId> = HashSet::new();
+    let mut client_have_commits: Vec<ObjectId> = Vec::new();
 
     loop {
         match pkt_line::read_packet(&mut stdin)? {
@@ -146,6 +145,7 @@ pub fn run(args: Args) -> Result<()> {
                         } else {
                             got_common = true;
                             last_hex = oid.to_hex();
+                            client_have_commits.push(oid);
                             merge_ancestors_into(&repo, oid, &mut client_known)?;
                             if multi_ack_detailed {
                                 pkt_line::write_line(&mut out, &format!("ACK {last_hex} common"))?;
@@ -161,58 +161,16 @@ pub fn run(args: Args) -> Result<()> {
         }
     }
 
-    let grit = grit_executable();
-    let mut child = Command::new(&grit)
-        .arg("pack-objects")
-        .arg("--stdout")
-        .current_dir(&repo.git_dir)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .with_context(|| format!("failed to spawn '{} pack-objects'", grit.display()))?;
-
+    let mut child = crate::pack_objects_upload::spawn_pack_objects_upload(&repo.git_dir)?;
     {
         let mut pin = child.stdin.take().context("pack-objects stdin")?;
-        for w in &wants {
-            writeln!(pin, "{}", w.to_hex())?;
-        }
-        pin.flush()?;
+        crate::pack_objects_upload::write_pack_objects_revs_stdin(
+            &mut pin,
+            &wants,
+            &client_have_commits,
+        )?;
     }
-
-    let mut pack_out = child.stdout.take().context("pack-objects stdout")?;
-    let stderr_child = child.stderr.take();
-    let stderr_handle = std::thread::spawn(move || {
-        if let Some(mut e) = stderr_child {
-            let mut buf = Vec::new();
-            let _ = e.read_to_end(&mut buf);
-            buf
-        } else {
-            Vec::new()
-        }
-    });
-
-    const CHUNK: usize = 32000;
-    let mut buf = vec![0u8; CHUNK];
-    loop {
-        let n = pack_out.read(&mut buf)?;
-        if n == 0 {
-            break;
-        }
-        write_sideband_64k(&mut out, &buf[..n])?;
-    }
-
-    let status = child.wait()?;
-    let err_bytes = stderr_handle.join().unwrap_or_default();
-    if !err_bytes.is_empty() {
-        let _ = io::stderr().write_all(&err_bytes);
-    }
-    if !status.success() {
-        bail!(
-            "pack-objects failed with exit code {}",
-            status.code().unwrap_or(-1)
-        );
-    }
+    crate::pack_objects_upload::drain_pack_objects_child(child, &mut out, true)?;
 
     pkt_line::write_flush(&mut out)?;
     out.flush()?;
@@ -242,17 +200,6 @@ fn ok_to_give_up(
             .iter()
             .any(|h| merge_base::is_ancestor(repo, *h, *w).unwrap_or(false))
     })
-}
-
-fn write_sideband_64k(w: &mut impl Write, payload: &[u8]) -> io::Result<()> {
-    const MAX_PAYLOAD: usize = 65515;
-    for chunk in payload.chunks(MAX_PAYLOAD) {
-        let len = 4 + 1 + chunk.len();
-        write!(w, "{len:04x}")?;
-        w.write_all(&[1u8])?;
-        w.write_all(chunk)?;
-    }
-    Ok(())
 }
 
 fn write_ref_advertisement(w: &mut impl Write, git_dir: &Path) -> Result<()> {

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -20,6 +20,7 @@ mod git_commit_encoding;
 mod git_path;
 mod grit_exe;
 mod ident;
+mod pack_objects_upload;
 pub mod pathspec;
 pub mod pkt_line;
 pub mod protocol;

--- a/grit/src/pack_objects_upload.rs
+++ b/grit/src/pack_objects_upload.rs
@@ -1,0 +1,139 @@
+//! Spawn `pack-objects` for upload-pack (hook or direct `grit`), write rev-list stdin, stream stdout.
+
+use anyhow::{bail, Context, Result};
+use grit_lib::config::ConfigSet;
+use grit_lib::objects::ObjectId;
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+
+use crate::grit_exe::grit_executable;
+
+fn resolve_hook_path(git_dir: &Path, hook: &str) -> PathBuf {
+    let p = Path::new(hook);
+    if p.is_absolute() {
+        p.to_path_buf()
+    } else {
+        git_dir.join(p)
+    }
+}
+
+/// Build and spawn `git pack-objects` (via hook or `grit pack-objects`).
+pub fn spawn_pack_objects_upload(git_dir: &Path) -> Result<Child> {
+    let protected = ConfigSet::load_protected(true).unwrap_or_default();
+    let hook_raw = protected.get("uploadpack.packobjectshook");
+    let grit = grit_executable();
+
+    let mut cmd = if let Some(ref hook_path) = hook_raw {
+        let hook_resolved = resolve_hook_path(git_dir, hook_path);
+        let mut c = Command::new("sh");
+        c.arg("-c")
+            .arg("exec \"$0\" \"$@\"")
+            .arg(&hook_resolved)
+            .arg("git")
+            .arg("pack-objects")
+            .arg("--revs")
+            .arg("--thin")
+            .arg("--stdout")
+            .arg("--progress")
+            .arg("--delta-base-offset");
+        c
+    } else {
+        let mut c = Command::new(&grit);
+        c.arg("pack-objects")
+            .arg("--revs")
+            .arg("--thin")
+            .arg("--stdout")
+            .arg("--progress")
+            .arg("--delta-base-offset");
+        c
+    };
+
+    cmd.current_dir(git_dir)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_context(|| {
+            if hook_raw.is_some() {
+                anyhow::anyhow!("failed to spawn pack-objects hook")
+            } else {
+                anyhow::anyhow!("failed to spawn '{} pack-objects'", grit.display())
+            }
+        })
+}
+
+/// Write the stdin Git's `pack-objects --revs` expects (`--not` + have commit OIDs).
+pub fn write_pack_objects_revs_stdin(
+    pin: &mut impl Write,
+    wants: &[ObjectId],
+    have_commits: &[ObjectId],
+) -> Result<()> {
+    for w in wants {
+        writeln!(pin, "{}", w.to_hex())?;
+    }
+    writeln!(pin, "--not")?;
+    for h in have_commits {
+        writeln!(pin, "{}", h.to_hex())?;
+    }
+    writeln!(pin)?;
+    pin.flush()?;
+    Ok(())
+}
+
+fn write_sideband_64k(w: &mut impl Write, payload: &[u8]) -> io::Result<()> {
+    const MAX_PAYLOAD: usize = 65515;
+    for chunk in payload.chunks(MAX_PAYLOAD) {
+        let len = 4 + 1 + chunk.len();
+        write!(w, "{len:04x}")?;
+        w.write_all(&[1u8])?;
+        w.write_all(chunk)?;
+    }
+    Ok(())
+}
+
+/// Read pack bytes from `child` and write to `out`, optionally wrapping in side-band-64k (v0).
+pub fn drain_pack_objects_child(
+    mut child: Child,
+    out: &mut impl Write,
+    sideband: bool,
+) -> Result<()> {
+    let mut pack_out = child.stdout.take().context("pack-objects stdout")?;
+    let stderr_child = child.stderr.take();
+    let stderr_handle = std::thread::spawn(move || {
+        if let Some(mut e) = stderr_child {
+            let mut buf = Vec::new();
+            let _ = e.read_to_end(&mut buf);
+            buf
+        } else {
+            Vec::new()
+        }
+    });
+
+    const CHUNK: usize = 32000;
+    let mut buf = vec![0u8; CHUNK];
+    loop {
+        let n = pack_out.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        if sideband {
+            write_sideband_64k(out, &buf[..n])?;
+        } else {
+            out.write_all(&buf[..n])?;
+        }
+    }
+
+    let status = child.wait()?;
+    let err_bytes = stderr_handle.join().unwrap_or_default();
+    if !err_bytes.is_empty() {
+        let _ = io::stderr().write_all(&err_bytes);
+    }
+    if !status.success() {
+        bail!(
+            "pack-objects failed with exit code {}",
+            status.code().unwrap_or(-1)
+        );
+    }
+    Ok(())
+}

--- a/logs/2026-04-08_t5544-pack-objects-hook.md
+++ b/logs/2026-04-08_t5544-pack-objects-hook.md
@@ -1,0 +1,26 @@
+# t5544-pack-objects-hook
+
+## Goal
+
+Make `tests/t5544-pack-objects-hook.sh` pass (7/7).
+
+## Root causes
+
+1. `git clone --no-local` did not run `upload-pack`; it used direct object copy, so `pack-objects` (and any hook) never ran.
+2. Protocol v2 `serve-v2` `fetch` returned an empty response while clients negotiated v2 by default, which could break clones once v0 packing worked.
+3. `upload-pack` always spawned `grit pack-objects` with a bare want list; Git passes `--revs`, `--thin`, `--not`, and haves on stdin.
+4. `uploadpack.packObjectsHook` must come from **protected** config (system + global + command-line), not repo `config`.
+
+## Changes
+
+- `grit-lib::config::ConfigSet::load_protected()` — mirrors Git `read_protected_config` (no repo/worktree, no `$GIT_CONFIG`).
+- `grit upload-pack` — read hook from protected set; spawn `sh -c 'exec "$0" "$@"' <hook> git pack-objects --revs --thin --stdout --progress --delta-base-offset`; stdin: wants, `--not`, have OIDs, blank line; track `have` commits for stdin.
+- `grit pack-objects` — `--revs` parses `--not` / post-not haves; `--thin` drops reachable objects from haves; accept no-op flags matching Git’s argv (`--shallow-file`, `--include-tag`, …).
+- `grit clone` — when `--no-local` and not `--shared`, populate objects via `fetch_via_upload_pack_skipping` instead of copying; removed broken early path that ran custom `-u` as a one-shot shell without building a repo.
+- `serve_v2::cmd_fetch` — protocol v2 `fetch` sends `acknowledgments` / `ready` when appropriate, then `packfile` + raw pack bytes (shared `pack_objects_upload` helper with v0).
+- `pack_objects_upload` — shared spawn + stdin + drain (v0 uses side-band-64k wrapper).
+
+## Verification
+
+- `GUST_BIN=target/release/grit bash tests/t5544-pack-objects-hook.sh` — 7/7
+- `./scripts/run-tests.sh t5544-pack-objects-hook.sh` — 7/7

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   230 |
+| Completed   |   231 |
 | In progress |     2 |
-| Remaining   |   536 |
+| Remaining   |   535 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 230 completed (`[x]`), 2 in progress (`[~]`), 536 remaining (`[ ]`).
+Task lines in `PLAN.md`: 231 completed (`[x]`), 2 in progress (`[~]`), 535 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t5544-pack-objects-hook` — 7/7 tests pass (`uploadpack.packObjectsHook` from protected config only; `clone --no-local` fetches via `upload-pack`; hook invocation matches Git; `pack-objects --revs` handles `--not` and thin haves)
 - `t7426-submodule-get-default-remote` — 15/15 tests pass (`submodule--helper get-default-remote`; nested submodule URL resolution uses outer superproject `remote.*.url` + Git `relative_url`; `pull` resolves local path remotes from `remote.<name>.url` for detached HEAD; `submodule update` treats path `.` as all submodules; submodule clone clears `GIT_DIR` and rewrites `remote.origin.url` to canonical path)
 - `t10560-switch-create-detach` — 28/28 tests pass (`switch`: `-- <branch>` treats a single token as the branch even when it matches a tracked path; `-c`/`-C`/`--orphan` reject invalid ref names via `check_refname_format` with Git-style `is not a valid branch name`)
 - `t3310-notes-merge-manual-resolve` — 22/22 tests pass (`notes merge`: manual 3-way merge with `NOTES_MERGE_*` state, `--commit`/`--abort`, conflict worktree paths and messages; `notes` honors `core.notesRef` and `--ref` short names; `append` matches Git blob layout; `log` `%N` + fanout notes trees; `update-ref` resolves `refs/notes/*`; root merge refs stored in main git dir)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-style `uploadpack.packObjectsHook` for `grit upload-pack`, routes `grit clone --no-local` through the upload-pack transport so the hook actually runs, and extends `pack-objects --revs` to match Git's stdin (`--not`, thin haves). Adds protocol v2 `fetch` handling that emits a real `packfile` section (shared helper with v0).

## Test plan

- `./scripts/run-tests.sh t5544-pack-objects-hook.sh` (7/7)
- `./scripts/run-tests.sh t5704-protocol-violations.sh` (3/3)
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c353911a-8d46-4fec-a475-53fa7707127d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c353911a-8d46-4fec-a475-53fa7707127d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

