### PR TITLE
t9420-update-ref-delete: refresh harness after full pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1510,7 +1510,7 @@ t9400-git-cvsserver-server	t9	skip	45	0	0	false	ok	1
 t9401-git-cvsserver-crlf	t9	skip	18	0	0	false	ok	0
 t9402-git-cvsserver-refs	t9	skip	37	0	0	false	ok	0
 t9410-show-ref-verify	t9	yes	31	20	11	false	ok	0
-t9420-update-ref-delete	t9	yes	24	23	1	false	ok	0
+t9420-update-ref-delete	t9	yes	24	24	0	true	ok	0
 t9430-symbolic-ref-delete	t9	yes	28	24	4	false	ok	0
 t9440-check-ref-format-branch	t9	yes	34	33	1	false	ok	0
 t9450-merge-base-ancestor	t9	yes	32	27	5	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T16:37:47+00:00" class="gen-time" title="2026-04-08 16:37 UTC">2026-04-08 16:37 UTC</time> · <a href="https://github.com/schacon/grit/commit/4dbe51122b58f7086a20b8f91bc11e3324f0ead0" style="color:#58a6ff">4dbe511</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T16:40:49+00:00" class="gen-time" title="2026-04-08 16:40 UTC">2026-04-08 16:40 UTC</time> · <a href="https://github.com/schacon/grit/commit/ab3bc7996b9c7b030b06ff331035366be87de616" style="color:#58a6ff">ab3bc79</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,476</div>
+      <div class="summary-big-val">29,477</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>703 files fully passing</span>
+    <span>704 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -278,7 +278,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t9</span>
         <span class="group-desc">Git tools</span>
-        <span class="group-meta">64/90 files · 127 skipped · 2,682/2,850 tests</span>
+        <span class="group-meta">65/90 files · 127 skipped · 2,683/2,850 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-green" style="width:94.1%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T16:37:47+00:00" class="gen-time" title="2026-04-08 16:37 UTC">2026-04-08 16:37 UTC</time> · <a href="https://github.com/schacon/grit/commit/4dbe51122b58f7086a20b8f91bc11e3324f0ead0" style="color:#58a6ff">4dbe511</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T16:40:49+00:00" class="gen-time" title="2026-04-08 16:40 UTC">2026-04-08 16:40 UTC</time> · <a href="https://github.com/schacon/grit/commit/ab3bc7996b9c7b030b06ff331035366be87de616" style="color:#58a6ff">ab3bc79</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,721</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,476</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,477</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -15257,14 +15257,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:64.5%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t9" data-tests="24" data-passed="23">
+<tr class="" data-group="t9" data-tests="24" data-passed="24" data-full-pass="1">
   <td class="mono">t9420-update-ref-delete</td>
   <td>t9</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">24</td>
-  <td class="right">23</td>
+  <td class="right">24</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:95.8%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t9" data-tests="28" data-passed="24">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t9420-update-ref-delete.sh` already passes **24/24** tests on this branch; `grit update-ref -d` behavior matches the suite (basic delete, old-value checks, idempotent delete of missing refs, `--no-deref`, `--stdin` / `-z`, reflog `-m`, custom refs).

This PR commits the harness refresh from `./scripts/run-tests.sh t9420-update-ref-delete.sh` (`data/test-files.csv`, dashboard HTML).

## Verification

```bash
./scripts/run-tests.sh t9420-update-ref-delete.sh
# ✓ t9420-update-ref-delete (24/24)
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8541e0f-ba4a-4624-a60e-26b78b266988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8541e0f-ba4a-4624-a60e-26b78b266988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

