### PR TITLE
fix: diff-tree -R and bogus null blob patch errors (t4054)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -734,7 +734,7 @@ t4051-diff-function-context	t4	yes	42	12	30	false	ok	0
 t4051-diff-function-name	t4	yes	27	7	20	false	ok	0
 t4052-stat-output	t4	yes	89	17	72	false	ok	0
 t4053-diff-no-index	t4	skip	41	0	0	false	ok	0
-t4054-diff-bogus-tree	t4	yes	14	8	6	false	ok	0
+t4054-diff-bogus-tree	t4	yes	14	14	0	true	ok	0
 t4055-diff-context	t4	yes	10	7	3	false	ok	0
 t4056-diff-order	t4	yes	23	10	13	false	ok	0
 t4057-diff-combined-paths	t4	yes	4	0	4	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T16:29:04+00:00" class="gen-time" title="2026-04-08 16:29 UTC">2026-04-08 16:29 UTC</time> · <a href="https://github.com/schacon/grit/commit/4cfc4781fc6a433906a199b8c58352223f644407" style="color:#58a6ff">4cfc478</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T16:46:53+00:00" class="gen-time" title="2026-04-08 16:46 UTC">2026-04-08 16:46 UTC</time> · <a href="https://github.com/schacon/grit/commit/22c3797a9e58e2ad24c5b6ad966f74bb16e7cc02" style="color:#58a6ff">22c3797</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,447</div>
+      <div class="summary-big-val">29,453</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>700 files fully passing</span>
+    <span>701 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -223,11 +223,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">68/178 files · 2 skipped · 1,883/3,541 tests</span>
+        <span class="group-meta">69/178 files · 2 skipped · 1,889/3,541 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:53.2%"></div></div>
-        <span class="group-pct pct-orange">53.2%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:53.3%"></div></div>
+        <span class="group-pct pct-orange">53.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T16:29:04+00:00" class="gen-time" title="2026-04-08 16:29 UTC">2026-04-08 16:29 UTC</time> · <a href="https://github.com/schacon/grit/commit/4cfc4781fc6a433906a199b8c58352223f644407" style="color:#58a6ff">4cfc478</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T16:46:53+00:00" class="gen-time" title="2026-04-08 16:46 UTC">2026-04-08 16:46 UTC</time> · <a href="https://github.com/schacon/grit/commit/22c3797a9e58e2ad24c5b6ad966f74bb16e7cc02" style="color:#58a6ff">22c3797</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,697</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,447</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,453</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -7497,14 +7497,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="14" data-passed="8">
+<tr class="" data-group="t4" data-tests="14" data-passed="14" data-full-pass="1">
   <td class="mono">t4054-diff-bogus-tree</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">14</td>
-  <td class="right">8</td>
+  <td class="right">14</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:57.1%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="10" data-passed="7">

--- a/grit/src/commands/diff_tree.rs
+++ b/grit/src/commands/diff_tree.rs
@@ -115,6 +115,8 @@ struct Options {
     quiet: bool,
     /// Re-merge parents and diff against merge result tree.
     remerge_diff: bool,
+    /// Swap the two tree sides (`-R`), inverting raw/patch output like Git.
+    reverse: bool,
 }
 
 impl Default for Options {
@@ -150,6 +152,7 @@ impl Default for Options {
             exit_code: false,
             quiet: false,
             remerge_diff: false,
+            reverse: false,
         }
     }
 }
@@ -289,6 +292,17 @@ fn parse_options(argv: &[String]) -> Result<Options> {
                 }
                 // Silently accept common diff options that we do not implement.
                 "--no-rename-empty" | "--always" | "--diff-merges=off" | "--check" => {}
+                "-R" => opts.reverse = true,
+                _ if arg.len() > 2 && arg.starts_with("-R") => {
+                    opts.reverse = true;
+                    let rest = arg[2..].chars();
+                    for ch in rest {
+                        match ch {
+                            'p' | 'u' => opts.format = OutputFormat::Patch,
+                            _ => bail!("unknown option: -{ch}"),
+                        }
+                    }
+                }
                 _ if arg.starts_with("--diff-filter=")
                     || arg.starts_with("--diff-merges=")
                     || arg.starts_with("--format=")
@@ -297,7 +311,6 @@ fn parse_options(argv: &[String]) -> Result<Options> {
                     || arg.starts_with("--pickaxe-all")
                     || arg.starts_with("--pickaxe-regex")
                     || arg.starts_with("-O")
-                    || arg.starts_with("-R")
                     || arg.starts_with("--relative") =>
                 {
                     // ignored
@@ -365,8 +378,13 @@ pub fn run(args: Args) -> Result<()> {
 // ── Two-tree mode ────────────────────────────────────────────────────
 
 fn run_two_trees(repo: &Repository, opts: &Options, out: &mut impl Write) -> Result<bool> {
-    let oid1 = resolve_to_tree(repo, &opts.objects[0])?;
-    let oid2 = resolve_to_tree(repo, &opts.objects[1])?;
+    let (spec_a, spec_b) = if opts.reverse {
+        (&opts.objects[1], &opts.objects[0])
+    } else {
+        (&opts.objects[0], &opts.objects[1])
+    };
+    let oid1 = resolve_to_tree(repo, spec_a)?;
+    let oid2 = resolve_to_tree(repo, spec_b)?;
     let max_tree_depth = resolve_max_tree_depth(repo)?;
     let old_tree = if is_magic_empty_tree_oid(&oid1) {
         None
@@ -658,7 +676,12 @@ fn process_stdin_two_trees(
     // Print both tree OIDs.
     writeln!(out, "{} {}", oid1.to_hex(), oid2.to_hex())?;
 
-    let entries = diff_with_opts(&repo.odb, Some(oid1), Some(&oid2), opts)?;
+    let (old_side, new_side) = if opts.reverse {
+        (Some(&oid2), Some(oid1))
+    } else {
+        (Some(oid1), Some(&oid2))
+    };
+    let entries = diff_with_opts(&repo.odb, old_side, new_side, opts)?;
     let filtered = filter_entries(entries, opts);
     print_diff(out, &repo.odb, &filtered, opts, None, &repo.git_dir)
 }
@@ -1178,6 +1201,8 @@ fn write_patch_entry(
     full_index: bool,
     git_dir: &Path,
 ) -> Result<bool> {
+    let (old_content, new_content) = read_blob_pair(odb, entry)?;
+
     let old_path = entry
         .old_path
         .as_deref()
@@ -1239,7 +1264,6 @@ fn write_patch_entry(
         DiffStatus::Unmerged => {}
     }
 
-    let (old_content, new_content) = read_blob_pair(odb, entry)?;
     let display_old = if entry.status == DiffStatus::Added {
         "/dev/null"
     } else {
@@ -1551,25 +1575,35 @@ fn commit_tree(odb: &Odb, commit_oid: &ObjectId) -> Result<ObjectId> {
 }
 
 /// Read both blob sides of a diff entry as UTF-8 strings.
+///
+/// Fails with `unable to read <oid>` when a side stores the null OID but a real
+/// blob mode (bogus tree entry), or when a non-null OID is missing from the ODB,
+/// matching `git diff-tree` / `git diff-index` patch behavior.
 fn read_blob_pair(odb: &Odb, entry: &DiffEntry) -> Result<(String, String)> {
     let zero = grit_lib::diff::zero_oid();
 
     let old_content = if entry.old_oid == zero {
+        if entry.old_mode != "000000" {
+            bail!("unable to read {}", zero.to_hex());
+        }
         String::new()
     } else {
-        match odb.read(&entry.old_oid) {
-            Ok(obj) => String::from_utf8_lossy(&obj.data).into_owned(),
-            Err(_) => String::new(),
-        }
+        let obj = odb
+            .read(&entry.old_oid)
+            .map_err(|_| anyhow::anyhow!("unable to read {}", entry.old_oid.to_hex()))?;
+        String::from_utf8_lossy(&obj.data).into_owned()
     };
 
     let new_content = if entry.new_oid == zero {
+        if entry.new_mode != "000000" {
+            bail!("unable to read {}", zero.to_hex());
+        }
         String::new()
     } else {
-        match odb.read(&entry.new_oid) {
-            Ok(obj) => String::from_utf8_lossy(&obj.data).into_owned(),
-            Err(_) => String::new(),
-        }
+        let obj = odb
+            .read(&entry.new_oid)
+            .map_err(|_| anyhow::anyhow!("unable to read {}", entry.new_oid.to_hex()))?;
+        String::from_utf8_lossy(&obj.data).into_owned()
     };
 
     Ok((old_content, new_content))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Implement `diff-tree -R` by swapping the two tree sides when computing the diff so raw output matches Git (including test 7 in `t4054-diff-bogus-tree`).
- Parse bundled `-Rp` the same way Git does (reverse + patch).
- For patch (and stat) output, load blob content before writing patch headers. If a tree entry uses the null OID with a non-`000000` mode (bogus blob), fail with `fatal: unable to read 0000000000000000000000000000000000000000` (exit 128), matching upstream `git diff-tree -p`.
- `--stdin` two-tree mode: when `-R` is set, swap sides for the diff while still printing the original tree OIDs on the header line (Git behavior).

## Testing

- `./scripts/run-tests.sh t4054-diff-bogus-tree.sh` — 14/14 pass
- `cargo test -p grit-lib --lib`
- `cargo check -p grit-rs`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9f116d9-33cb-4a08-b9f4-fc9be526123f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9f116d9-33cb-4a08-b9f4-fc9be526123f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

