### PR TITLE
fix: make t5404-tracking-branches pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -908,7 +908,7 @@ t5400-send-pack	t5	yes	17	10	7	false	ok	0
 t5401-update-hooks	t5	yes	13	4	9	false	ok	0
 t5402-post-merge-hook	t5	yes	7	3	4	false	ok	0
 t5403-post-checkout-hook	t5	yes	14	13	1	false	ok	0
-t5404-tracking-branches	t5	yes	7	3	4	false	ok	0
+t5404-tracking-branches	t5	yes	7	7	0	true	ok	0
 t5405-send-pack-rewind	t5	yes	3	3	0	true	ok	0
 t5406-remote-rejects	t5	yes	3	2	1	false	ok	0
 t5407-post-rewrite-hook	t5	yes	17	3	14	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T16:37:47+00:00" class="gen-time" title="2026-04-08 16:37 UTC">2026-04-08 16:37 UTC</time> · <a href="https://github.com/schacon/grit/commit/4dbe51122b58f7086a20b8f91bc11e3324f0ead0" style="color:#58a6ff">4dbe511</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T17:01:40+00:00" class="gen-time" title="2026-04-08 17:01 UTC">2026-04-08 17:01 UTC</time> · <a href="https://github.com/schacon/grit/commit/ab3bc7996b9c7b030b06ff331035366be87de616" style="color:#58a6ff">ab3bc79</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,476</div>
+      <div class="summary-big-val">29,480</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>703 files fully passing</span>
+    <span>704 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,585/3,941 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,589/3,941 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:40.2%"></div></div>
-        <span class="group-pct pct-orange">40.2%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:40.3%"></div></div>
+        <span class="group-pct pct-orange">40.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T16:37:47+00:00" class="gen-time" title="2026-04-08 16:37 UTC">2026-04-08 16:37 UTC</time> · <a href="https://github.com/schacon/grit/commit/4dbe51122b58f7086a20b8f91bc11e3324f0ead0" style="color:#58a6ff">4dbe511</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T17:01:40+00:00" class="gen-time" title="2026-04-08 17:01 UTC">2026-04-08 17:01 UTC</time> · <a href="https://github.com/schacon/grit/commit/ab3bc7996b9c7b030b06ff331035366be87de616" style="color:#58a6ff">ab3bc79</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,721</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,476</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,480</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -9237,14 +9237,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:92.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="7" data-passed="3">
+<tr class="" data-group="t5" data-tests="7" data-passed="7" data-full-pass="1">
   <td class="mono">t5404-tracking-branches</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">7</td>
-  <td class="right">3</td>
+  <td class="right">7</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:42.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="3" data-passed="3" data-full-pass="1">

--- a/grit/src/commands/branch.rs
+++ b/grit/src/commands/branch.rs
@@ -1130,6 +1130,25 @@ fn delete_branch(repo: &Repository, head: &HeadState, args: &Args) -> Result<()>
         .name
         .as_deref()
         .ok_or_else(|| anyhow::anyhow!("branch name required"))?;
+
+    if args.remotes {
+        let refname = if name_input.starts_with("refs/remotes/") {
+            name_input.to_owned()
+        } else {
+            format!("refs/remotes/{name_input}")
+        };
+        let branch_oid = grit_lib::refs::resolve_ref(&repo.git_dir, &refname).map_err(|_| {
+            anyhow::anyhow!("error: remote-tracking branch '{name_input}' not found.")
+        })?;
+        grit_lib::refs::delete_ref(&repo.git_dir, &refname).map_err(|e| anyhow::anyhow!("{e}"))?;
+        if !args.quiet {
+            let hex = branch_oid.to_hex();
+            let short = &hex[..7.min(hex.len())];
+            eprintln!("Deleted remote-tracking branch {name_input} (was {short}).");
+        }
+        return Ok(());
+    }
+
     let resolved_ref =
         symbolic_full_name(repo, name_input).filter(|full| full.starts_with("refs/heads/"));
     let (name, refname) = if let Some(full) = resolved_ref {

--- a/grit/src/commands/push.rs
+++ b/grit/src/commands/push.rs
@@ -264,6 +264,8 @@ fn push_to_url(
         )
     })?;
 
+    let remote_config = ConfigSet::load(Some(&remote_repo.git_dir), false)?;
+
     // Build list of ref updates
     let mut updates = Vec::new();
 
@@ -307,6 +309,8 @@ fn push_to_url(
                 });
             }
         }
+    } else if args.refspecs.len() == 1 && args.refspecs[0] == ":" {
+        collect_matching_push_updates(repo, &remote_repo, remote_name, args, &mut updates)?;
     } else if push_all {
         // Push all branches (refs/heads/*)
         let local_branches = refs::list_refs(&repo.git_dir, "refs/heads/")?;
@@ -333,7 +337,9 @@ fn push_to_url(
             let remote_ref = normalize_ref(spec);
             let old_oid = refs::resolve_ref(&remote_repo.git_dir, &remote_ref).ok();
             if old_oid.is_none() {
-                bail!("remote ref '{}' not found", spec);
+                // Git skips delete refspecs when the remote ref is already absent
+                // (e.g. tracking ref removed locally first).
+                continue;
             }
             let expected_oid = resolve_force_with_lease_expect(
                 &args.force_with_lease,
@@ -366,7 +372,7 @@ fn push_to_url(
                 let remote_ref = normalize_ref(&dst);
                 let old_oid = refs::resolve_ref(&remote_repo.git_dir, &remote_ref).ok();
                 if old_oid.is_none() {
-                    bail!("remote ref '{}' not found", dst);
+                    continue;
                 }
                 let expected_oid = resolve_force_with_lease_expect(
                     &args.force_with_lease,
@@ -612,10 +618,11 @@ fn push_to_url(
         return Ok(());
     }
 
-    // Validate updates (fast-forward check unless --force or --force-with-lease)
-    for update in &updates {
-        // force-with-lease: verify remote ref matches what we think it is
-        // (i.e., what our remote-tracking ref says)
+    // Per-ref validation. Force-with-lease still fails the whole push when stale.
+    // Non-fast-forward updates are rejected per ref so other refs can still be pushed
+    // (matching `git push` with multiple refspecs).
+    let mut pre_reject: Vec<Option<String>> = vec![None; updates.len()];
+    for (i, update) in updates.iter().enumerate() {
         if let Some(expected) = &update.expected_oid {
             let actual_remote = refs::resolve_ref(&remote_repo.git_dir, &update.remote_ref).ok();
             if actual_remote.as_ref() != Some(expected) {
@@ -636,12 +643,12 @@ fn push_to_url(
                 && args.force_with_lease.is_none()
                 && !is_ancestor(repo, *old, *new)?
             {
-                bail!(
+                pre_reject[i] = Some(format!(
                     "Updates were rejected because the tip of your current branch is behind\n\
                      its remote counterpart. If you want to force the update, use --force.\n\
                      remote ref: {}",
                     update.remote_ref
-                );
+                ));
             }
         }
     }
@@ -786,11 +793,14 @@ fn push_to_url(
         println!("To {url}");
     }
 
-    // Build stdin for pre-receive / post-receive hooks
+    // Build stdin for pre-receive / post-receive hooks (omit client-side rejected refs).
     let zero_oid_str = "0".repeat(40);
     let hook_stdin = {
         let mut lines = String::new();
-        for update in &updates {
+        for (i, update) in updates.iter().enumerate() {
+            if pre_reject[i].is_some() {
+                continue;
+            }
             let old_hex = update
                 .old_oid
                 .map(|o| o.to_hex())
@@ -845,7 +855,13 @@ fn push_to_url(
     let mut applied_updates: Vec<(&RefUpdate, Option<ObjectId>)> = Vec::new();
     let mut rejected: Vec<(&RefUpdate, String)> = Vec::new();
 
-    for update in &updates {
+    for (i, update) in updates.iter().enumerate() {
+        if let Some(msg) = &pre_reject[i] {
+            eprintln!("{msg}");
+            rejected.push((update, "non-fast-forward".to_string()));
+            continue;
+        }
+
         // Run the remote's `update` hook: update <refname> <old-oid> <new-oid>
         if !args.dry_run {
             let old_hex = update
@@ -901,15 +917,40 @@ fn push_to_url(
             }
         }
 
-        let result = apply_ref_update(repo, &remote_repo, remote_name, update, args, url);
+        let result = apply_ref_update(
+            repo,
+            &remote_repo,
+            remote_name,
+            update,
+            args,
+            url,
+            config,
+            &remote_config,
+        );
 
         match result {
-            Ok(()) => {
+            Ok(ApplyRefResult::Applied) => {
                 applied_updates.push((update, update.old_oid));
+            }
+            Ok(ApplyRefResult::RemoteRejected(reason)) => {
+                if args.atomic {
+                    for (prev_update, prev_old) in &applied_updates {
+                        if let Some(old_oid) = prev_old {
+                            let _ = refs::write_ref(
+                                &remote_repo.git_dir,
+                                &prev_update.remote_ref,
+                                old_oid,
+                            );
+                        } else {
+                            let _ = refs::delete_ref(&remote_repo.git_dir, &prev_update.remote_ref);
+                        }
+                    }
+                    bail!("failed to push some refs to '{url}'");
+                }
+                rejected.push((update, reason));
             }
             Err(e) => {
                 if args.atomic {
-                    // Rollback all applied updates
                     for (prev_update, prev_old) in &applied_updates {
                         if let Some(old_oid) = prev_old {
                             let _ = refs::write_ref(
@@ -1056,6 +1097,191 @@ fn push_to_url(
     Ok(())
 }
 
+/// Git `receive.denyCurrentBranch` / `receive.denyDeleteCurrent` policy (subset).
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ReceiveDenyAction {
+    Unconfigured,
+    Ignore,
+    Warn,
+    Refuse,
+    UpdateInstead,
+}
+
+fn parse_receive_deny_action(value: Option<&str>) -> ReceiveDenyAction {
+    match value.map(str::trim) {
+        None => ReceiveDenyAction::Ignore,
+        Some(s) if s.eq_ignore_ascii_case("ignore") => ReceiveDenyAction::Ignore,
+        Some(s) if s.eq_ignore_ascii_case("warn") => ReceiveDenyAction::Warn,
+        Some(s) if s.eq_ignore_ascii_case("refuse") => ReceiveDenyAction::Refuse,
+        Some(s) if s.eq_ignore_ascii_case("updateinstead") => ReceiveDenyAction::UpdateInstead,
+        Some(s) => match parse_bool(s) {
+            Ok(true) => ReceiveDenyAction::Refuse,
+            Ok(false) => ReceiveDenyAction::Ignore,
+            Err(_) => ReceiveDenyAction::Ignore,
+        },
+    }
+}
+
+fn read_receive_deny_current(cfg: &ConfigSet) -> ReceiveDenyAction {
+    let v = cfg
+        .get("receive.denyCurrentBranch")
+        .or_else(|| cfg.get("receive.denycurrentbranch"));
+    parse_receive_deny_action(v.as_deref())
+}
+
+fn read_receive_deny_delete_current(cfg: &ConfigSet) -> ReceiveDenyAction {
+    let v = cfg
+        .get("receive.denyDeleteCurrent")
+        .or_else(|| cfg.get("receive.denydeletecurrent"));
+    parse_receive_deny_action(v.as_deref())
+}
+
+/// Enforce receive-pack rules for the non-bare remote (checked-out branch updates/deletes).
+///
+/// Returns `Err(short_reason)` when the ref must be rejected (matches Git's parenthetical in
+/// `! [remote rejected] ... (reason)`).
+fn check_receive_pack_policy(
+    remote_repo: &Repository,
+    remote_config: &ConfigSet,
+    pushing_config: &ConfigSet,
+    update: &RefUpdate,
+) -> std::result::Result<(), String> {
+    if remote_repo.is_bare() {
+        return Ok(());
+    }
+
+    let head = resolve_head(&remote_repo.git_dir).map_err(|e| e.to_string())?;
+    let head_ref = match head {
+        grit_lib::state::HeadState::Branch { refname, .. } => refname,
+        _ => return Ok(()),
+    };
+
+    let style = RemoteMessageColorStyle::from_config(pushing_config);
+
+    if update.remote_ref != head_ref {
+        return Ok(());
+    }
+
+    if update.new_oid.is_some() {
+        let deny = read_receive_deny_current(remote_config);
+        match deny {
+            ReceiveDenyAction::Ignore => {}
+            ReceiveDenyAction::Warn => {
+                colorize_remote_output("warning: updating the current branch", &style);
+            }
+            ReceiveDenyAction::Unconfigured => {
+                colorize_remote_output(
+                    &format!("error: refusing to update checked out branch: {head_ref}"),
+                    &style,
+                );
+                colorize_remote_output(
+                    "error: By default, updating the current branch in a non-bare repository\n\
+                     is denied, because it will make the index and work tree inconsistent\n\
+                     with what you pushed, and will require 'git reset --hard' to match\n\
+                     the work tree to HEAD.\n\
+                     \n\
+                     You can set the 'receive.denyCurrentBranch' configuration variable\n\
+                     to 'ignore' or 'warn' in the remote repository to allow pushing into\n\
+                     its current branch; however, this is not recommended unless you\n\
+                     arranged to update its work tree to match what you pushed in some\n\
+                     other way.\n\
+                     \n\
+                     To squelch this message and still keep the default behaviour, set\n\
+                     'receive.denyCurrentBranch' configuration variable to 'refuse'.",
+                    &style,
+                );
+                return Err("branch is currently checked out".to_owned());
+            }
+            ReceiveDenyAction::Refuse => {
+                colorize_remote_output(
+                    &format!("error: refusing to update checked out branch: {head_ref}"),
+                    &style,
+                );
+                return Err("branch is currently checked out".to_owned());
+            }
+            ReceiveDenyAction::UpdateInstead => {
+                return Err("denyCurrentBranch = updateInstead is not supported".to_owned());
+            }
+        }
+    } else {
+        let deny = read_receive_deny_delete_current(remote_config);
+        match deny {
+            ReceiveDenyAction::Ignore => {}
+            ReceiveDenyAction::Warn => {
+                colorize_remote_output("warning: deleting the current branch", &style);
+            }
+            ReceiveDenyAction::Unconfigured => {
+                colorize_remote_output(
+                    "error: By default, deleting the current branch is denied, because the next\n\
+                     'git clone' won't result in any file checked out, causing confusion.\n\
+                     \n\
+                     You can set 'receive.denyDeleteCurrent' configuration variable to\n\
+                     'warn' or 'ignore' in the remote repository to allow deleting the\n\
+                     current branch, with or without a warning message.\n\
+                     \n\
+                     To squelch this message, you can set it to 'refuse'.",
+                    &style,
+                );
+                colorize_remote_output(
+                    &format!("error: refusing to delete the current branch: {head_ref}"),
+                    &style,
+                );
+                return Err("deletion of the current branch prohibited".to_owned());
+            }
+            ReceiveDenyAction::Refuse | ReceiveDenyAction::UpdateInstead => {
+                colorize_remote_output(
+                    &format!("error: refusing to delete the current branch: {head_ref}"),
+                    &style,
+                );
+                return Err("deletion of the current branch prohibited".to_owned());
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Outcome of applying one ref update on the remote.
+enum ApplyRefResult {
+    Applied,
+    RemoteRejected(String),
+}
+
+/// Matching refspec `:` — push every `refs/heads/*` whose tip differs from the remote.
+fn collect_matching_push_updates(
+    repo: &Repository,
+    remote_repo: &Repository,
+    remote_name: &str,
+    args: &Args,
+    updates: &mut Vec<RefUpdate>,
+) -> Result<()> {
+    let local_branches = refs::list_refs(&repo.git_dir, "refs/heads/")?;
+    for (refname, local_oid) in &local_branches {
+        let old_oid = refs::resolve_ref(&remote_repo.git_dir, refname).ok();
+        if old_oid.as_ref() == Some(local_oid) {
+            continue;
+        }
+        let dst = refname
+            .strip_prefix("refs/heads/")
+            .unwrap_or(refname.as_str());
+        let expected_oid = resolve_force_with_lease_expect(
+            &args.force_with_lease,
+            &repo.git_dir,
+            remote_name,
+            dst,
+        );
+        updates.push(RefUpdate {
+            local_ref: Some(refname.clone()),
+            remote_ref: refname.clone(),
+            old_oid,
+            new_oid: Some(*local_oid),
+            expected_oid,
+            refspec_force: false,
+        });
+    }
+    Ok(())
+}
+
 /// Apply a single ref update on the remote, printing output as appropriate.
 fn apply_ref_update(
     repo: &Repository,
@@ -1064,7 +1290,15 @@ fn apply_ref_update(
     update: &RefUpdate,
     args: &Args,
     _url: &str,
-) -> Result<()> {
+    pushing_config: &ConfigSet,
+    remote_config: &ConfigSet,
+) -> Result<ApplyRefResult> {
+    if let Err(reason) =
+        check_receive_pack_policy(remote_repo, remote_config, pushing_config, update)
+    {
+        return Ok(ApplyRefResult::RemoteRejected(reason));
+    }
+
     let zero_oid = "0".repeat(40);
 
     match (&update.new_oid, &update.old_oid) {
@@ -1164,7 +1398,7 @@ fn apply_ref_update(
         _ => {}
     }
 
-    Ok(())
+    Ok(ApplyRefResult::Applied)
 }
 
 /// Update local remote-tracking refs after a successful push.

--- a/logs/2026-04-08_t5404-tracking-branches.md
+++ b/logs/2026-04-08_t5404-tracking-branches.md
@@ -1,0 +1,16 @@
+# t5404-tracking-branches
+
+## Issue
+
+Harness reset cwd to `TRASH_DIRECTORY` before every subtest; upstream Git preserves cwd so `cd aa` in one block affects later blocks. Test 3+ must run from clone `aa/`.
+
+## Fixes
+
+- `tests/test-lib-tap.sh`: stop `cd "$TRASH_DIRECTORY"` in `test_expect_success` / `test_expect_failure`.
+- `grit push`: implement matching refspec `:`; skip delete refspecs when remote ref already missing; enforce `receive.denyCurrentBranch` / `receive.denyDeleteCurrent` for non-bare remotes; reject non-fast-forward per ref (continue pushing others); treat receive-pack denial as per-ref rejection.
+- `grit branch`: `branch -d -r origin/foo` deletes `refs/remotes/origin/foo`.
+
+## Verification
+
+- `./scripts/run-tests.sh t5404-tracking-branches.sh` → 7/7
+- `cargo test -p grit-lib --lib`

--- a/tests/test-lib-tap.sh
+++ b/tests/test-lib-tap.sh
@@ -114,7 +114,6 @@ test_expect_success() {
 	fi
 	test_cleanup=:
 	test -z "$verbose" || say "expecting success of $TEST_NUMBER.$test_count '$description': $commands"
-	cd "$TRASH_DIRECTORY" || exit 1
 	test -f "$TRASH_DIRECTORY/.test-exports" && . "$TRASH_DIRECTORY/.test-exports"
 	test_run_ "$commands"
 	result=$?
@@ -197,7 +196,6 @@ test_expect_failure() {
 	test_cleanup=:
 	test -z "$verbose" || say "checking known breakage of $TEST_NUMBER.$test_count '$description': $commands"
 	_exports_file="$TRASH_DIRECTORY/.test-exports"
-	cd "$TRASH_DIRECTORY" || exit 1
 	test -f "$_exports_file" && . "$_exports_file"
 	test_run_ "$commands" expecting_failure
 	result=$?


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t5404-tracking-branches` exercises `git push origin :` (matching refspec), partial push success when some refs fail, remote-tracking updates, delete refspecs, and `branch -d -r`.

## Changes

1. **Test harness** (`tests/test-lib-tap.sh`): Stop resetting cwd to `TRASH_DIRECTORY` before every subtest so behavior matches upstream Git’s test-lib (later blocks keep the cwd from earlier `cd` commands).

2. **`grit push`** (`grit/src/commands/push.rs`):
   - Implement the matching refspec `:` (push every `refs/heads/*` that differs from the remote).
   - Treat non-fast-forward and receive-pack denials as **per-ref** rejections so other refs still push (with exit failure if any ref failed).
   - Enforce `receive.denyCurrentBranch` / `receive.denyDeleteCurrent` for non-bare file remotes (subset aligned with receive-pack defaults).
   - Skip delete refspecs when the remote ref is already absent (matches Git for `push origin :b3` after the tracking ref was removed).

3. **`grit branch`** (`grit/src/commands/branch.rs`): Support `git branch -d -r origin/...` by deleting `refs/remotes/...`.

Harness: `./scripts/run-tests.sh t5404-tracking-branches.sh` → 7/7. Unit tests: `cargo test -p grit-lib --lib`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9dc806c5-03d0-4802-a1da-af6666aafe29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9dc806c5-03d0-4802-a1da-af6666aafe29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

