### PR TITLE
fix: make t1006-cat-file fully pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -92,7 +92,7 @@ t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
 t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
-t1006-cat-file	t1	yes	290	288	2	false	ok	1
+t1006-cat-file	t1	yes	291	291	0	true	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	32	8	false	ok	0
 t10070-cat-file-batch-format	t1	yes	33	33	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T16:29:04+00:00" class="gen-time" title="2026-04-08 16:29 UTC">2026-04-08 16:29 UTC</time> · <a href="https://github.com/schacon/grit/commit/4cfc4781fc6a433906a199b8c58352223f644407" style="color:#58a6ff">4cfc478</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T17:08:08+00:00" class="gen-time" title="2026-04-08 17:08 UTC">2026-04-08 17:08 UTC</time> · <a href="https://github.com/schacon/grit/commit/22c3797a9e58e2ad24c5b6ad966f74bb16e7cc02" style="color:#58a6ff">22c3797</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,11 +150,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,447</div>
+      <div class="summary-big-val">29,450</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">39,697</div>
+      <div class="summary-big-val">39,698</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>700 files fully passing</span>
+    <span>701 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -190,7 +190,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">265/368 files · 8 skipped · 10,678/11,349 tests</span>
+        <span class="group-meta">266/368 files · 8 skipped · 10,681/11,350 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-green" style="width:94.1%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T16:29:04+00:00" class="gen-time" title="2026-04-08 16:29 UTC">2026-04-08 16:29 UTC</time> · <a href="https://github.com/schacon/grit/commit/4cfc4781fc6a433906a199b8c58352223f644407" style="color:#58a6ff">4cfc478</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T17:08:08+00:00" class="gen-time" title="2026-04-08 17:08 UTC">2026-04-08 17:08 UTC</time> · <a href="https://github.com/schacon/grit/commit/22c3797a9e58e2ad24c5b6ad966f74bb16e7cc02" style="color:#58a6ff">22c3797</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">39,697</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,447</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n" id="sum-tests">39,698</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,450</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1077,15 +1077,15 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:42.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="290" data-passed="288">
+<tr class="" data-group="t1" data-tests="291" data-passed="291" data-full-pass="1">
   <td class="mono">t1006-cat-file</td>
   <td>t1</td>
-  <td></td>
-  <td class="right">290</td>
-  <td class="right">288</td>
+  <td><span class="badge ok">full pass</span></td>
+  <td class="right">291</td>
+  <td class="right">291</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:99.3%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t10060-hash-object-determinism</td>

--- a/grit-lib/src/error.rs
+++ b/grit-lib/src/error.rs
@@ -58,6 +58,15 @@ pub enum Error {
     #[error("zlib error: {0}")]
     Zlib(String),
 
+    /// Loose object bytes hash to a different OID than the file path implies (`git fsck` / `read_loose_object`).
+    #[error("{real_oid}: hash-path mismatch, found at: {path}")]
+    LooseHashMismatch {
+        /// Repository-relative or filesystem path to the loose object file.
+        path: String,
+        /// Hex object id of the unpacked contents.
+        real_oid: String,
+    },
+
     /// The index file is missing, truncated, or has a bad header.
     #[error("index error: {0}")]
     IndexError(String),

--- a/grit-lib/src/odb.rs
+++ b/grit-lib/src/odb.rs
@@ -30,6 +30,31 @@ use crate::error::{Error, Result};
 use crate::objects::{Object, ObjectId, ObjectKind};
 use crate::pack;
 
+/// Decompress a zlib-wrapped loose object payload from an open file.
+///
+/// When the zlib wrapper advertises a preset dictionary (FDICT), `flate2` typically fails with a
+/// generic corrupt-stream error; map that to `"needs dictionary"` so callers match Git's messages
+/// (`t1006-cat-file` zlib-dictionary test).
+fn read_zlib_loose_payload(mut file: fs::File) -> Result<Vec<u8>> {
+    let mut hdr = [0u8; 2];
+    file.read_exact(&mut hdr).map_err(|e| Error::Io(e.into()))?;
+    let cmf_flg = u16::from(hdr[0]) << 8 | u16::from(hdr[1]);
+    let looks_like_zlib_header = cmf_flg != 0 && cmf_flg % 31 == 0;
+    let preset_dictionary = looks_like_zlib_header && (hdr[1] & 0x20) != 0;
+    let mut decoder = ZlibDecoder::new(hdr.as_slice().chain(file));
+    let mut raw = Vec::new();
+    match decoder.read_to_end(&mut raw) {
+        Ok(_) => Ok(raw),
+        Err(e) => {
+            if preset_dictionary {
+                Err(Error::Zlib("needs dictionary".to_owned()))
+            } else {
+                Err(Error::Zlib(e.to_string()))
+            }
+        }
+    }
+}
+
 /// A loose-object database rooted at a given `objects/` directory.
 #[derive(Debug, Clone)]
 pub struct Odb {
@@ -134,6 +159,30 @@ impl Odb {
         false
     }
 
+    /// Read a loose object file at `path`, verifying the uncompressed payload hashes to `expected_oid`.
+    ///
+    /// Git stores loose objects under paths derived from the OID; if the file contents hash to a
+    /// different id (for example after a mistaken `mv`), this returns [`Error::LooseHashMismatch`].
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::Zlib`] — decompression failed.
+    /// - [`Error::CorruptObject`] — header is malformed.
+    /// - [`Error::LooseHashMismatch`] — payload OID does not match `expected_oid`.
+    pub fn read_loose_verify_oid(path: &Path, expected_oid: &ObjectId) -> Result<Object> {
+        let file = fs::File::open(path).map_err(|e| Error::Io(e))?;
+        let raw = read_zlib_loose_payload(file)?;
+        let obj = parse_object_bytes(&raw)?;
+        let computed = hash_object_from_parsed(&obj);
+        if computed != *expected_oid {
+            return Err(Error::LooseHashMismatch {
+                path: path.display().to_string(),
+                real_oid: computed.to_hex(),
+            });
+        }
+        Ok(obj)
+    }
+
     /// Read and decompress an object from the loose store.
     ///
     /// # Errors
@@ -156,11 +205,7 @@ impl Odb {
         let path = self.object_path(oid);
         match fs::File::open(&path) {
             Ok(file) => {
-                let mut decoder = ZlibDecoder::new(file);
-                let mut raw = Vec::new();
-                decoder
-                    .read_to_end(&mut raw)
-                    .map_err(|e| Error::Zlib(e.to_string()))?;
+                let raw = read_zlib_loose_payload(file)?;
                 return parse_object_bytes_with_oid(&raw, oid);
             }
             Err(_) => {
@@ -198,11 +243,7 @@ impl Odb {
             .join(oid.loose_prefix())
             .join(oid.loose_suffix());
         if let Ok(file) = fs::File::open(&loose) {
-            let mut decoder = ZlibDecoder::new(file);
-            let mut raw = Vec::new();
-            decoder
-                .read_to_end(&mut raw)
-                .map_err(|e| Error::Zlib(e.to_string()))?;
+            let raw = read_zlib_loose_payload(file)?;
             return parse_object_bytes_with_oid(&raw, oid);
         }
         pack::read_object_from_packs(objects_dir, oid)
@@ -297,6 +338,10 @@ impl Odb {
 
         Ok(oid)
     }
+}
+
+fn hash_object_from_parsed(obj: &Object) -> ObjectId {
+    Odb::hash_object_data(obj.kind, &obj.data)
 }
 
 /// Compute the SHA-1 of a byte slice and return it as an [`ObjectId`].
@@ -490,6 +535,8 @@ mod tests {
     #![allow(clippy::expect_used, clippy::unwrap_used)]
 
     use super::*;
+    use flate2::read::ZlibDecoder;
+    use std::io::Read;
     use tempfile::TempDir;
 
     #[test]

--- a/grit-lib/src/rev_list.rs
+++ b/grit-lib/src/rev_list.rs
@@ -230,8 +230,10 @@ pub fn reachable_object_ids_for_cat_file(
     };
     let result = rev_list(repo, &[], &[], &opts)?;
     let mut set = BTreeSet::new();
-    for oid in &result.commits {
-        set.insert(*oid);
+    for (i, oid) in result.commits.iter().enumerate() {
+        if result.objects_print_commit.get(i).copied().unwrap_or(true) {
+            set.insert(*oid);
+        }
     }
     for (oid, _) in &result.objects {
         set.insert(*oid);

--- a/grit/src/commands/cat_file.rs
+++ b/grit/src/commands/cat_file.rs
@@ -226,7 +226,7 @@ pub fn run(args: Args) -> Result<()> {
 
     let obj = match read_object_with_promisor_lazy_fetch(&repo, &oid, false) {
         Ok(o) => o,
-        Err(e) => exit_cat_file_read_error(&e, &args, obj_str),
+        Err(e) => exit_cat_file_read_error(&e, &args, obj_str, &repo, &oid),
     };
 
     if args.show_type {
@@ -266,7 +266,13 @@ pub fn run(args: Args) -> Result<()> {
                             match read_object_with_promisor_lazy_fetch(&repo, &_current_oid, false)
                             {
                                 Ok(o) => o,
-                                Err(e) => exit_cat_file_read_error(&e, &args, obj_str),
+                                Err(e) => exit_cat_file_read_error(
+                                    &e,
+                                    &args,
+                                    obj_str,
+                                    &repo,
+                                    &_current_oid,
+                                ),
                             };
                     } else {
                         bail!("object {} is of type tag, not {}", oid, kind);
@@ -278,7 +284,9 @@ pub fn run(args: Args) -> Result<()> {
                     current_obj =
                         match read_object_with_promisor_lazy_fetch(&repo, &_current_oid, false) {
                             Ok(o) => o,
-                            Err(e) => exit_cat_file_read_error(&e, &args, obj_str),
+                            Err(e) => {
+                                exit_cat_file_read_error(&e, &args, obj_str, &repo, &_current_oid)
+                            }
                         };
                 }
                 _ => {
@@ -347,8 +355,31 @@ fn read_object_with_promisor_lazy_fetch(
     }
 }
 
+fn cat_file_zlib_stderr(msg: &str, loose_path: &str) -> ! {
+    let lower = msg.to_ascii_lowercase();
+    if lower.contains("dictionary") {
+        eprintln!("error: inflate: needs dictionary");
+    } else if lower.contains("incorrect header")
+        || lower.contains("invalid stored block")
+        || lower.contains("invalid code")
+        || lower.contains("corrupt deflate")
+    {
+        eprintln!("error: inflate: data stream error (incorrect header check)");
+    } else {
+        eprintln!("error: inflate: {msg}");
+    }
+    eprintln!("error: unable to unpack header of {loose_path}");
+    std::process::exit(128);
+}
+
 /// Map ODB read failures to `git cat-file` stderr (exit 128).
-fn exit_cat_file_read_error(err: &LibError, args: &Args, obj_spec: &str) -> ! {
+fn exit_cat_file_read_error(
+    err: &LibError,
+    args: &Args,
+    obj_spec: &str,
+    repo: &Repository,
+    oid: &ObjectId,
+) -> ! {
     match err {
         LibError::UnknownObjectType(_) => {
             eprintln!("fatal: invalid object type");
@@ -374,6 +405,10 @@ fn exit_cat_file_read_error(err: &LibError, args: &Args, obj_spec: &str) -> ! {
                 eprintln!("fatal: git cat-file: could not get object info");
             }
             std::process::exit(128);
+        }
+        LibError::Zlib(msg) => {
+            let loose_path = repo.odb.object_path(oid).display().to_string();
+            cat_file_zlib_stderr(msg, &loose_path);
         }
         _ => {
             eprintln!("fatal: git cat-file: could not get object info");
@@ -559,26 +594,6 @@ fn check_cat_file_filter_prefixes(spec: &str) {
         eprintln!("usage: objects filter not supported: '{name}'");
         std::process::exit(129);
     }
-}
-
-const DEFAULT_MAX_TREE_DEPTH: usize = 2048;
-
-fn max_tree_depth_object_filter(repo: &Repository) -> Result<ObjectFilter> {
-    let config = ConfigSet::load(Some(&repo.git_dir), true)?;
-    let depth = if let Some(raw) = config.get("core.maxtreedepth") {
-        raw.parse::<usize>()
-            .map_err(|_| anyhow::anyhow!("invalid core.maxtreedepth: '{raw}'"))?
-    } else {
-        DEFAULT_MAX_TREE_DEPTH
-    };
-    Ok(ObjectFilter::TreeDepth(depth as u64))
-}
-
-fn merged_cat_file_object_filter(repo: &Repository, user: ObjectFilter) -> Result<ObjectFilter> {
-    Ok(ObjectFilter::Combine(vec![
-        max_tree_depth_object_filter(repo)?,
-        user,
-    ]))
 }
 
 fn collect_all_loose_object_ids(objects_dir: &Path, oids: &mut BTreeSet<ObjectId>) -> Result<()> {
@@ -966,8 +981,7 @@ fn run_batch(repo: &Repository, args: &Args) -> Result<()> {
                 rev_list::reachable_object_ids_for_cat_file(repo, None, false)
                     .context("reachable objects for cat-file --batch-all-objects --no-filter")?
             } else if let Some(ref f) = objects_filter {
-                let merged = merged_cat_file_object_filter(repo, f.clone())?;
-                rev_list::object_ids_for_cat_file_filtered(repo, &merged)?
+                rev_list::object_ids_for_cat_file_filtered(repo, f)?
             } else {
                 collect_all_object_ids(repo)?
             };

--- a/grit/src/commands/fsck.rs
+++ b/grit/src/commands/fsck.rs
@@ -9,6 +9,7 @@ use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::config::ConfigSet;
 use grit_lib::diff::zero_oid;
+use grit_lib::error::Error as LibError;
 use grit_lib::objects::{parse_commit, parse_tag, parse_tree, ObjectId, ObjectKind};
 use grit_lib::odb::Odb;
 use grit_lib::pack::read_local_pack_indexes;
@@ -83,6 +84,10 @@ enum Issue {
     Unreachable { oid: ObjectId, kind: ObjectKind },
     /// Reflog references an object that is not present and not a promisor object.
     InvalidReflog { refname: String, oid: ObjectId },
+    /// Loose file path does not match the OID of the stored bytes.
+    HashPathMismatch { real_oid_hex: String, path: String },
+    /// Raw `error:` lines matching Git's `fsck` / `read_loose_object` diagnostics.
+    FsckMessage(String),
 }
 
 /// Run `grit fsck`.
@@ -141,6 +146,8 @@ pub fn run(args: Args) -> Result<()> {
 
     // 2. Enumerate all known objects (loose + packed).
     let all_objects = enumerate_all_objects(&odb, &objects_dir)?;
+    let loose_pairs = scan_loose_objects(&objects_dir)?;
+    let loose_oids: HashSet<ObjectId> = loose_pairs.iter().map(|(o, _)| *o).collect();
 
     // 3. Find unreachable/dangling objects.
     if show_dangling || show_unreachable {
@@ -177,8 +184,14 @@ pub fn run(args: Args) -> Result<()> {
 
     // 4. If not connectivity-only, validate ALL objects (including unreachable).
     if !connectivity_only {
+        let git_dir = repo.git_dir.as_path();
+        for (oid, path) in &loose_pairs {
+            validate_loose_object_file(git_dir, path, oid, &mut issues);
+        }
         for oid in &all_objects {
-            // Skip objects we already validated during the walk.
+            if loose_oids.contains(oid) {
+                continue;
+            }
             if walked_kinds.contains(oid) {
                 continue;
             }
@@ -290,6 +303,14 @@ pub fn run(args: Args) -> Result<()> {
             }
             Issue::InvalidReflog { refname, oid } => {
                 eprintln!("error: {}: invalid reflog entry {}", refname, oid.to_hex());
+                has_errors = true;
+            }
+            Issue::HashPathMismatch { real_oid_hex, path } => {
+                eprintln!("error: {real_oid_hex}: hash-path mismatch, found at: {path}");
+                has_errors = true;
+            }
+            Issue::FsckMessage(msg) => {
+                eprintln!("error: {msg}");
                 has_errors = true;
             }
         }
@@ -494,6 +515,59 @@ fn parse_reflog_line_oids(line: &str) -> Option<(ObjectId, ObjectId)> {
     let old_hex = &before_tab[..40];
     let new_hex = &before_tab[41..81];
     Some((old_hex.parse().ok()?, new_hex.parse().ok()?))
+}
+
+fn loose_path_display_for_fsck(git_dir: &Path, path: &Path) -> String {
+    let rel = path.strip_prefix(git_dir).unwrap_or(path);
+    format!("./{}", rel.display().to_string().replace('\\', "/"))
+}
+
+fn git_style_inflate_message(zlib_detail: &str) -> String {
+    let lower = zlib_detail.to_ascii_lowercase();
+    if lower.contains("dictionary") {
+        "inflate: needs dictionary".to_owned()
+    } else if lower.contains("incorrect header")
+        || lower.contains("invalid stored block")
+        || lower.contains("invalid code")
+        || lower.contains("corrupt deflate")
+    {
+        "inflate: data stream error (incorrect header check)".to_owned()
+    } else {
+        format!("inflate: {zlib_detail}")
+    }
+}
+
+/// Validate a loose object file, including Git's hash-vs-path check.
+fn validate_loose_object_file(
+    git_dir: &Path,
+    path: &Path,
+    oid: &ObjectId,
+    issues: &mut Vec<Issue>,
+) {
+    let display_path = loose_path_display_for_fsck(git_dir, path);
+    match Odb::read_loose_verify_oid(path, oid) {
+        Ok(obj) => validate_object_data(oid, &obj.kind, &obj.data, issues),
+        Err(LibError::LooseHashMismatch { path: _, real_oid }) => {
+            issues.push(Issue::HashPathMismatch {
+                real_oid_hex: real_oid,
+                path: display_path,
+            });
+        }
+        Err(LibError::Zlib(msg)) => {
+            let inflate = git_style_inflate_message(&msg);
+            issues.push(Issue::FsckMessage(inflate));
+            issues.push(Issue::FsckMessage(format!(
+                "unable to unpack header of {display_path}"
+            )));
+            issues.push(Issue::FsckMessage(format!(
+                "{}: object corrupt or missing: {display_path}",
+                oid.to_hex()
+            )));
+        }
+        Err(e) => {
+            issues.push(Issue::FsckMessage(e.to_string()));
+        }
+    }
 }
 
 /// Validate an object's content can be parsed correctly.

--- a/logs/2026-04-08-t1006-cat-file.md
+++ b/logs/2026-04-08-t1006-cat-file.md
@@ -1,0 +1,7 @@
+# t1006-cat-file
+
+- **Loose zlib:** Read CMF/FLG, validate zlib header checksum; map valid FDICT + failure to `needs dictionary` for dictionary-compressed test bytes; avoid false FDICT on plaintext like `other\n`.
+- **fsck:** Verify loose payload OID vs path (`hash-path mismatch`); emit Git-style `error:` lines for zlib unpack failures.
+- **cat-file:** Git-style zlib stderr for corrupt loose reads; pass resolved OID for correct object path.
+- **object:type filters:** Stop merging implicit `TreeDepth` into cat-file filters; fix `reachable_object_ids_for_cat_file` to only include commits when `objects_print_commit` is true (matches `rev-list` object lines).
+- **Harness:** `--batch-check` with `%(rest)` and paths containing spaces now `test_expect_success`.

--- a/tests/t1006-cat-file.sh
+++ b/tests/t1006-cat-file.sh
@@ -194,14 +194,7 @@ $content"
 	test_cmp expect actual
     '
 
-    # FIXME: %(rest) is incompatible with object names that include whitespace,
-    # e.g. HEAD:path/to/a/file with spaces. Use the resolved OID as input to
-    # test this instead of the raw object name.
-    if echo "$object_name" | grep -q " "; then
-	test_rest=test_expect_failure
-    else
-	test_rest=test_expect_success
-    fi
+    test_rest=test_expect_success
 
     $test_rest '--batch-check with %(rest)' '
 	echo "$type this is some extra content" >expect &&


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This completes `t1006-cat-file` (291/291) by aligning loose-object handling, `fsck`, `cat-file` error output, object-filter enumeration with `rev-list`, and one harness expectation.

## Changes

- **Loose zlib:** Read and validate the zlib CMF/FLG header (RFC 1950 checksum). When FDICT is set on a valid header and decompression fails, report `needs dictionary` (matches Git for the dictionary-compressed blob case) while still reporting `incorrect header check` for invalid headers / plaintext swapped into object paths.
- **`grit fsck`:** Verify loose file contents hash against the path-derived OID (`hash-path mismatch`). Emit Git-style `error:` lines for zlib unpack failures on loose objects.
- **`grit cat-file`:** On zlib failure, print `error: inflate: …` and `error: unable to unpack header of <path>` using the resolved object path (works for short OIDs).
- **`reachable_object_ids_for_cat_file`:** Only add commit OIDs when `objects_print_commit` is true, so `object:type=blob|tag|tree` sets match `git rev-list --objects --all --filter=… --filter-provided-objects`.
- **`cat-file --filter`:** Stop implicitly AND-ing `core.maxtreedepth` into user filters (Git does not combine that for these tests).
- **Test file:** `--batch-check` with `%(rest)` and object names containing spaces is now `test_expect_success` (known breakage removed).

## Validation

- `./scripts/run-tests.sh t1006-cat-file.sh` — 291/291 pass
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0e79607-7054-4250-bb9b-39f771b3daf1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0e79607-7054-4250-bb9b-39f771b3daf1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

