### PR TITLE
fix: make t2061-switch-orphan pass (git switch --orphan semantics)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -495,7 +495,7 @@ t2045-checkout-conflict	t2	yes	29	29	0	true	ok	0
 t2050-checkout	t2	yes	80	80	0	true	ok	0
 t2050-git-dir-relative	t2	yes	4	2	2	false	ok	0
 t2060-switch	t2	yes	16	8	8	false	ok	0
-t2061-switch-orphan	t2	yes	15	9	6	false	ok	0
+t2061-switch-orphan	t2	yes	15	15	0	true	ok	0
 t2070-restore	t2	yes	15	13	2	false	ok	0
 t2071-restore-patch	t2	yes	15	6	9	false	ok	0
 t2072-restore-pathspec-file	t2	yes	12	12	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T16:43:51+00:00" class="gen-time" title="2026-04-08 16:43 UTC">2026-04-08 16:43 UTC</time> · <a href="https://github.com/schacon/grit/commit/daca62bd6142ca049f641ffdc2834f863c43d63e" style="color:#58a6ff">daca62b</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T17:26:37+00:00" class="gen-time" title="2026-04-08 17:26 UTC">2026-04-08 17:26 UTC</time> · <a href="https://github.com/schacon/grit/commit/a87848343ddab1238f785fbb08c1214bcedf6f57" style="color:#58a6ff">a878483</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,477</div>
+      <div class="summary-big-val">29,483</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>704 files fully passing</span>
+    <span>705 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -201,11 +201,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t2</span>
         <span class="group-desc">Basic commands concerning the working tree</span>
-        <span class="group-meta">32/61 files · 9 skipped · 671/872 tests</span>
+        <span class="group-meta">33/61 files · 9 skipped · 677/872 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:76.9%"></div></div>
-        <span class="group-pct pct-blue">76.9%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:77.6%"></div></div>
+        <span class="group-pct pct-blue">77.6%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t3">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T16:43:51+00:00" class="gen-time" title="2026-04-08 16:43 UTC">2026-04-08 16:43 UTC</time> · <a href="https://github.com/schacon/grit/commit/daca62bd6142ca049f641ffdc2834f863c43d63e" style="color:#58a6ff">daca62b</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T17:26:37+00:00" class="gen-time" title="2026-04-08 17:26 UTC">2026-04-08 17:26 UTC</time> · <a href="https://github.com/schacon/grit/commit/a87848343ddab1238f785fbb08c1214bcedf6f57" style="color:#58a6ff">a878483</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,721</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,477</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,483</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -5107,14 +5107,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t2" data-tests="15" data-passed="9">
+<tr class="" data-group="t2" data-tests="15" data-passed="15" data-full-pass="1">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">15</td>
-  <td class="right">9</td>
+  <td class="right">15</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:60.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t2" data-tests="15" data-passed="13">

--- a/grit/src/commands/checkout.rs
+++ b/grit/src/commands/checkout.rs
@@ -326,7 +326,6 @@ pub fn run(mut args: Args) -> Result<()> {
         // Append to existing rest args
         args.rest.extend(pathspecs);
     }
-    let switch_force = args.force || args.merge;
 
     // Post-process rest: extract -b/-B/--new-branch/--force-new-branch that
     // appeared after a positional arg (e.g. `checkout <rev> -b <branch>`).
@@ -389,6 +388,9 @@ pub fn run(mut args: Args) -> Result<()> {
         }
         args.rest = new_rest;
     }
+
+    // After peeling `-f` / `--force` from `rest` (e.g. `switch --discard-changes` → `-f`).
+    let switch_force = args.force || args.merge;
 
     // `git checkout <branch> -q` places `-q` in trailing positionals; peel it so it is not
     // mistaken for a pathspec.
@@ -456,7 +458,15 @@ pub fn run(mut args: Args) -> Result<()> {
         } else {
             None
         };
-        return create_orphan_branch(&repo, orphan_name, start_point);
+        return create_orphan_branch(
+            &repo,
+            orphan_name,
+            start_point,
+            CreateOrphanOptions {
+                switch_style: args.switch_mode,
+                force: switch_force,
+            },
+        );
     }
 
     // Case: checkout -B <name> [<start_point>] (force create/reset)
@@ -1260,18 +1270,53 @@ fn force_create_and_switch_branch(
     Ok(())
 }
 
+/// Options for [`create_orphan_branch`].
+struct CreateOrphanOptions {
+    /// When true, this came from `git switch --orphan`: empty index/worktree, no start point.
+    switch_style: bool,
+    /// `-f` / `--discard-changes` / `-m` (same as branch switch force).
+    force: bool,
+}
+
 /// Create an orphan branch (`checkout --orphan <name> [<start_point>]`).
 ///
 /// Sets HEAD to the new branch but does NOT create the ref (no commit yet).
 /// If a start_point is given, populates the index/worktree from that commit.
-fn create_orphan_branch(repo: &Repository, name: &str, start_point: Option<&str>) -> Result<()> {
+///
+/// `git switch --orphan` uses [`CreateOrphanOptions::switch_style`]: it clears the index and
+/// worktree to the empty tree (like switching to an empty branch) and rejects a start point.
+fn create_orphan_branch(
+    repo: &Repository,
+    name: &str,
+    start_point: Option<&str>,
+    opts: CreateOrphanOptions,
+) -> Result<()> {
     validate_new_branch_name(name)?;
     let branch_ref = format!("refs/heads/{name}");
 
-    // Re-creating an orphan branch name removes the old ref (matches `git switch --orphan`
-    // when re-running the same branch name in a test script).
     if refs::resolve_ref(&repo.git_dir, &branch_ref).is_ok() {
-        refs::delete_ref(&repo.git_dir, &branch_ref)?;
+        eprintln!("fatal: a branch named '{name}' already exists");
+        std::process::exit(128);
+    }
+
+    if opts.switch_style {
+        if start_point.is_some() {
+            bail!("fatal: '--orphan' cannot take <start-point>");
+        }
+        let head = resolve_head(&repo.git_dir)?;
+        let empty_tree: ObjectId = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+            .parse()
+            .map_err(|_| anyhow::anyhow!("internal error: empty tree OID"))?;
+        switch_to_tree(
+            repo,
+            &head,
+            &empty_tree,
+            opts.force,
+            RECURSE_SUBMODULES.with(|r| r.get()),
+        )?;
+        std::fs::write(repo.git_dir.join("HEAD"), format!("ref: {branch_ref}\n"))?;
+        checkout_eprintln!("Switched to a new branch '{}'", name);
+        return Ok(());
     }
 
     // If a start point is given, populate the index/worktree from it

--- a/grit/src/commands/switch.rs
+++ b/grit/src/commands/switch.rs
@@ -67,6 +67,11 @@ pub struct Args {
 
 /// Run `grit switch`.
 pub fn run(args: Args) -> Result<()> {
+    if args.orphan.is_some() && (args.create.is_some() || args.force_create.is_some()) {
+        eprintln!("fatal: options '-c', '-C', and '--orphan' cannot be used together");
+        std::process::exit(128);
+    }
+
     let mut checkout_tail: Vec<String> = Vec::new();
 
     if let Some(b) = &args.create {

--- a/logs/2026-04-08-t2061-switch-orphan.md
+++ b/logs/2026-04-08-t2061-switch-orphan.md
@@ -1,0 +1,18 @@
+# t2061-switch-orphan
+
+## Problem
+
+`git switch --orphan` delegated to checkout but behaved like `checkout --orphan`: index/worktree kept prior branch content, extra start-point was accepted, existing branch ref was deleted, and `--discard-changes` did not force because `-f` was peeled from `rest` after `switch_force` was computed.
+
+## Fix
+
+- `switch.rs`: reject combining `--orphan` with `-c`/`-C` (fatal 128, matches Git).
+- `checkout.rs`: `create_orphan_branch` takes `CreateOrphanOptions { switch_style, force }`.
+  - **switch_style** (`switch_mode`): empty tree checkout via `switch_to_tree`, unborn HEAD, reject `<start-point>`, reject existing branch name (no ref delete).
+  - **checkout** path unchanged for index preservation / start-point behavior.
+- Compute `switch_force` after peeling `-f` from `rest` so `switch --discard-changes --orphan` passes force through.
+
+## Validation
+
+- `./scripts/run-tests.sh t2061-switch-orphan.sh` — all pass.
+- `t2017-checkout-orphan.sh` — unchanged vs baseline (test 8 reflog still fails pre-existing).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible behavior for `git switch --orphan` while keeping `git checkout --orphan` on the existing checkout path.

## Changes

- **`switch`**: reject `--orphan` combined with `-c`/`-C` (exit 128), matching Git.
- **`checkout` / orphan creation**:
  - When invoked from `switch` (`switch_mode`), clear index and worktree to the empty tree via `switch_to_tree`, set unborn HEAD to `refs/heads/<name>`, reject an extra start-point, and error if the branch name already exists (no longer deleting an existing ref).
  - **`checkout --orphan`** path unchanged (preserve index/worktree when no start point; start point still populates from commit).
- **Force flag ordering**: compute `switch_force` after peeling `-f` from trailing args so `switch --discard-changes --orphan` actually forces.

## Testing

- `./scripts/run-tests.sh t2061-switch-orphan.sh` → **15/15**
- `cargo test -p grit-lib --lib` → pass

Harness CSV and dashboards updated for `t2061-switch-orphan`.

## Log

See `logs/2026-04-08-t2061-switch-orphan.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6fff7c4f-eb18-4790-bbc9-607980efc0ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6fff7c4f-eb18-4790-bbc9-607980efc0ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

