### PR TITLE
fix: make t7601-merge-pull-config pass (pull/merge/add)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -92,7 +92,7 @@ t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
 t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
-t1006-cat-file	t1	yes	290	285	5	false	ok	1
+t1006-cat-file	t1	yes	290	285	5	false	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	32	8	false	ok	0
 t10070-cat-file-batch-format	t1	yes	33	33	0	true	ok	0
@@ -1250,7 +1250,7 @@ t7526-commit-pathspec-file	t7	yes	11	2	9	false	ok	0
 t7527-builtin-fsmonitor	t7	yes	0	0	0	false	ok	0
 t7528-signed-commit-ssh	t7	skip	29	0	0	false	ok	3
 t7600-merge	t7	skip	83	0	0	false	ok	0
-t7601-merge-pull-config	t7	yes	65	41	24	false	ok	0
+t7601-merge-pull-config	t7	yes	65	65	0	true	ok	0
 t7602-merge-octopus-many	t7	yes	5	2	3	false	ok	0
 t7603-merge-reduce-heads	t7	yes	13	10	3	false	ok	0
 t7604-merge-custom-message	t7	yes	8	8	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T19:27:35+00:00" class="gen-time" title="2026-04-08 19:27 UTC">2026-04-08 19:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,565</div>
+      <div class="summary-big-val">29,597</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>713 files fully passing</span>
+    <span>717 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,7 +212,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">41/141 files · 2 skipped · 3,333/4,611 tests</span>
+        <span class="group-meta">42/141 files · 2 skipped · 3,334/4,611 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.3%"></div></div>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,336/3,949 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,342/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.8%"></div></div>
-        <span class="group-pct pct-red">33.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.0%"></div></div>
+        <span class="group-pct pct-red">34.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -256,11 +256,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">42/126 files · 11 skipped · 1,793/2,944 tests</span>
+        <span class="group-meta">44/126 files · 11 skipped · 1,818/2,944 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>
-        <span class="group-pct pct-blue">60.9%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:61.8%"></div></div>
+        <span class="group-pct pct-blue">61.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T19:27:35+00:00" class="gen-time" title="2026-04-08 19:27 UTC">2026-04-08 19:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,864</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,565</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,597</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1085,7 +1085,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">285</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.3%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t10060-hash-object-determinism</td>
@@ -5110,8 +5110,7 @@ tr.row-skip td { opacity: 0.65; }
 <tr class="" data-group="t2" data-tests="15" data-passed="5">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td><span class="badge ok">full pass</span></td>
-  <td class="right">15</td>
+  <td></td>
   <td class="right">15</td>
   <td class="right">5</td>
   <td class="right">ok</td>
@@ -6218,14 +6217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="54" data-passed="38">
+<tr class="" data-group="t3" data-tests="52" data-passed="3">
   <td class="mono">t3420-rebase-autostash</td>
   <td>t3</td>
   <td></td>
-  <td class="right">54</td>
-  <td class="right">38</td>
+  <td class="right">52</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="63" data-passed="11">
@@ -12598,7 +12597,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="2" data-passed="2">
+<tr class="" data-group="t7" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t7524-commit-summary</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>
@@ -12658,14 +12657,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="65" data-passed="41">
+<tr class="" data-group="t7" data-tests="65" data-passed="65" data-full-pass="1">
   <td class="mono">t7601-merge-pull-config</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">65</td>
-  <td class="right">41</td>
+  <td class="right">65</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:63.1%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="5" data-passed="2">

--- a/grit/src/commands/add.rs
+++ b/grit/src/commands/add.rs
@@ -8,7 +8,6 @@ use clap::Args as ClapArgs;
 use grit_lib::attributes::{parse_gitattributes_file_content, validate_rules_for_add};
 use grit_lib::config::ConfigSet;
 use grit_lib::crlf::{self, ConversionConfig, GitAttributes};
-use grit_lib::diff::stat_matches;
 use grit_lib::ignore::IgnoreMatcher;
 use grit_lib::index::{entry_from_metadata, normalize_mode, Index, IndexEntry};
 #[allow(unused_imports)]
@@ -1136,14 +1135,8 @@ fn stage_file(
         mode
     };
 
-    // Skip if index already has this file with matching stat data and no chmod override
-    if args.chmod.is_none() {
-        if let Some(existing) = index.get(rel_path.as_bytes(), 0) {
-            if stat_matches(existing, &meta) && existing.mode == final_mode {
-                return Ok(());
-            }
-        }
-    }
+    // Do not skip based on stat cache alone: mtime/ctime can match across different contents
+    // (common in tests and on fast filesystems), which would leave the index stale (t7601).
 
     // Read file content and hash it
     let data = if is_symlink {

--- a/grit/src/commands/merge.rs
+++ b/grit/src/commands/merge.rs
@@ -30,6 +30,30 @@ use time::OffsetDateTime;
 use crate::commands::diff_index;
 use crate::explicit_exit::ExplicitExit;
 
+/// Count distinct paths that have any unmerged index stage (matches `git merge` conflict scoring).
+fn unmerged_path_count(index: &Index) -> usize {
+    let mut paths = BTreeSet::new();
+    for e in &index.entries {
+        if e.stage() != 0 {
+            paths.insert(e.path.clone());
+        }
+    }
+    paths.len()
+}
+
+/// Returned from [`do_real_merge`] when probing strategies: carries unmerged path count for
+/// `try_merge_strategies` (matches git's `evaluate_result` scoring).
+#[derive(Debug)]
+struct StrategyTrialConflict(usize);
+
+impl std::fmt::Display for StrategyTrialConflict {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "merge strategy trial left {} conflicted paths", self.0)
+    }
+}
+
+impl std::error::Error for StrategyTrialConflict {}
+
 /// Arguments for `grit merge`.
 #[derive(Debug, Clone, ClapArgs)]
 #[command(about = "Join two or more development histories together")]
@@ -468,6 +492,18 @@ pub fn run(mut args: Args) -> Result<()> {
                 }
             }
         }
+        if args.strategy.is_empty() {
+            let key = if args.commits.len() > 1 {
+                "pull.octopus"
+            } else {
+                "pull.twohead"
+            };
+            if let Some(s) = config.get(key) {
+                for part in s.split_whitespace() {
+                    args.strategy.push(part.to_owned());
+                }
+            }
+        }
         if let Some(value) = config.get_bool("merge.renormalize") {
             merge_renormalize = value.unwrap_or(false);
         }
@@ -511,7 +547,8 @@ pub fn run(mut args: Args) -> Result<()> {
         bail!("fatal: You cannot combine --squash with --commit.");
     }
 
-    // Validate --strategy: accept known names for every `-s` occurrence.
+    // Validate --strategy: each `-s` is one strategy name (space-separated lists come from
+    // `pull.twohead` / `pull.octopus`, expanded before `merge` runs).
     for strat in &args.strategy {
         match strat.as_str() {
             "recursive" | "ort" | "resolve" | "octopus" | "ours" | "theirs" | "subtree" => {}
@@ -637,6 +674,7 @@ pub fn run(mut args: Args) -> Result<()> {
                 diff_algorithm.as_deref(),
                 &eff_shift,
                 merge_renormalize,
+                false,
                 true,
             );
         }
@@ -705,6 +743,7 @@ pub fn run(mut args: Args) -> Result<()> {
         diff_algorithm.as_deref(),
         &eff_shift,
         merge_renormalize,
+        false,
         true,
     )
 }
@@ -723,6 +762,8 @@ fn try_merge_strategies(
 ) -> Result<()> {
     let pre_index = repo.load_index()?;
     let mut last_err: Option<anyhow::Error> = None;
+    let mut best_strategy: Option<&str> = None;
+    let mut best_cnt: isize = -1;
 
     for strat_name in &args.strategy {
         if strat_name == "resolve" {
@@ -777,6 +818,7 @@ fn try_merge_strategies(
                 diff_algorithm,
                 &eff_shift,
                 merge_renormalize,
+                true,
                 false,
             ),
             other => bail!("Could not find merge strategy '{other}'"),
@@ -785,12 +827,48 @@ fn try_merge_strategies(
         match attempt {
             Ok(()) => return Ok(()),
             Err(e) => {
-                if !args.quiet {
-                    eprintln!("{e}");
+                if let Some(tc) = e.downcast_ref::<StrategyTrialConflict>() {
+                    let cnt = tc.0 as isize;
+                    if best_cnt < 0 || cnt <= best_cnt {
+                        best_cnt = cnt;
+                        best_strategy = Some(strat_name.as_str());
+                    }
+                    if !args.quiet {
+                        eprintln!(
+                            "Automatic merge failed; fix conflicts and then commit the result."
+                        );
+                    }
+                } else {
+                    if !args.quiet {
+                        eprintln!("{e}");
+                    }
                 }
                 last_err = Some(e);
             }
         }
+    }
+
+    if let Some(best) = best_strategy {
+        restore_index_and_worktree(repo, &pre_index)?;
+        if !args.quiet {
+            println!("Using the {best} strategy to prepare resolving by hand.");
+        }
+        let mut sub = args.clone();
+        sub.strategy = vec![best.to_owned()];
+        let eff_shift = effective_subtree_shift(Some(best), subtree_shift_config);
+        return do_real_merge(
+            repo,
+            head,
+            head_oid,
+            merge_oid,
+            &sub,
+            favor,
+            diff_algorithm,
+            &eff_shift,
+            merge_renormalize,
+            false,
+            true,
+        );
     }
 
     restore_index_and_worktree(repo, &pre_index)?;
@@ -1211,6 +1289,7 @@ fn do_real_merge(
     diff_algorithm: Option<&str>,
     subtree_shift: &SubtreeShift,
     merge_renormalize: bool,
+    trial_for_multi_strategy: bool,
     exit_on_merge_conflict: bool,
 ) -> Result<()> {
     if primary_merge_strategy(args) == Some("resolve") {
@@ -1297,6 +1376,17 @@ Aborting"
 
     maybe_simulate_partial_clone_fetch(repo, &args.commits[0])?;
 
+    // Git's `resolve` strategy does not use rename detection; `recursive`/`ort` do. Without this,
+    // resolve can incorrectly auto-merge renames that recursive reports as conflicts (t7601).
+    let rename_opts = if primary_merge_strategy(args) == Some("resolve") {
+        MergeRenameOptions {
+            detect: false,
+            threshold: 50,
+        }
+    } else {
+        MergeRenameOptions::from_config(repo)
+    };
+
     // Merge trees
     let mut merge_result = merge_trees(
         repo,
@@ -1316,7 +1406,7 @@ Aborting"
         false,
         false,
         MergeDirectoryRenamesMode::FromConfig,
-        MergeRenameOptions::from_config(repo),
+        rename_opts,
         None,
     )?;
 
@@ -1325,9 +1415,16 @@ Aborting"
         .as_deref()
         .is_some_and(|v| v.trim() == "0");
 
-    if merge_result.has_conflicts && !exit_on_merge_conflict {
-        restore_index_and_worktree(repo, &pre_merge_index_snapshot)?;
-        bail!("Automatic merge failed; fix conflicts and then commit the result.");
+    if merge_result.has_conflicts {
+        if trial_for_multi_strategy {
+            let n = unmerged_path_count(&merge_result.index);
+            restore_index_and_worktree(repo, &pre_merge_index_snapshot)?;
+            return Err(anyhow::Error::new(StrategyTrialConflict(n)));
+        }
+        if !exit_on_merge_conflict {
+            restore_index_and_worktree(repo, &pre_merge_index_snapshot)?;
+            bail!("Automatic merge failed; fix conflicts and then commit the result.");
+        }
     }
 
     if !args.autostash {
@@ -1406,6 +1503,10 @@ Aborting"
             grit_lib::rerere::RerereAutoupdate::FromConfig
         };
         let _ = grit_lib::rerere::repo_rerere(repo, rr);
+        if trial_for_multi_strategy {
+            let n = unmerged_path_count(&merge_result.index);
+            return Err(anyhow::Error::new(StrategyTrialConflict(n)));
+        }
         std::process::exit(1);
     }
 
@@ -2057,6 +2158,15 @@ fn do_octopus_merge(
         return Ok(());
     }
 
+    // `recursive` / `ort` only handle two-way merges; Git rejects true octopus with these alone
+    // (see `try_merge_strategy` in git's merge.c: "Not handling anything other than two heads").
+    if merge_oids.len() > 1
+        && args.strategy.len() == 1
+        && matches!(args.strategy[0].as_str(), "recursive" | "ort")
+    {
+        bail!("Not handling anything other than two heads merge.");
+    }
+
     let head_is_ancestor_of_all = merge_oids
         .iter()
         .all(|oid| is_ancestor(repo, head_oid, *oid).unwrap_or(false));
@@ -2075,6 +2185,7 @@ fn do_octopus_merge(
                 diff_algorithm,
                 subtree_shift,
                 merge_renormalize,
+                false,
                 true,
             );
         }
@@ -2091,6 +2202,7 @@ fn do_octopus_merge(
             diff_algorithm,
             subtree_shift,
             merge_renormalize,
+            false,
             true,
         );
     }
@@ -5642,7 +5754,7 @@ fn resolve_merge_target(repo: &Repository, spec: &str) -> Result<ObjectId> {
     }
 }
 
-fn read_fetch_head_merge_oids(repo: &Repository) -> Result<Vec<String>> {
+pub(crate) fn read_fetch_head_merge_oids(repo: &Repository) -> Result<Vec<String>> {
     let fetch_head_path = repo.git_dir.join("FETCH_HEAD");
     let content = fs::read_to_string(&fetch_head_path)
         .with_context(|| "FETCH_HEAD: object not found: FETCH_HEAD".to_string())?;

--- a/grit/src/commands/pull.rs
+++ b/grit/src/commands/pull.rs
@@ -6,22 +6,25 @@
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::config::ConfigSet;
+use grit_lib::merge_base::is_ancestor;
 use grit_lib::refs;
 use grit_lib::repo::Repository;
+use grit_lib::rev_parse::resolve_revision;
 use grit_lib::state::resolve_head;
+use std::fs;
 use std::path::{Path, PathBuf};
 
 /// Arguments for `grit pull`.
 #[derive(Debug, ClapArgs)]
 #[command(about = "Fetch from and integrate with another repository")]
 pub struct Args {
-    /// Remote name (defaults to "origin").
-    #[arg(value_name = "REMOTE")]
+    /// Repository (remote name or path) to pull from; defaults from branch config.
+    #[arg(value_name = "REPOSITORY")]
     pub remote: Option<String>,
 
-    /// Remote branch to pull (defaults to tracking branch or current branch name).
-    #[arg(value_name = "BRANCH")]
-    pub branch: Option<String>,
+    /// Refs to fetch and merge (multiple refs merge via octopus / multi-head rules).
+    #[arg(value_name = "REFSPEC")]
+    pub refspecs: Vec<String>,
 
     /// Rebase instead of merge. Optionally accepts a strategy like "merges".
     #[arg(long = "rebase", short = 'r', num_args = 0..=1, default_missing_value = "true")]
@@ -39,9 +42,9 @@ pub struct Args {
     #[arg(short = 'q', long = "quiet")]
     pub quiet: bool,
 
-    /// Merge strategy to use.
-    #[arg(short = 's', long = "strategy")]
-    pub strategy: Option<String>,
+    /// Merge strategy to use (may be given multiple times).
+    #[arg(short = 's', long = "strategy", action = clap::ArgAction::Append)]
+    pub strategy: Vec<String>,
 
     /// Strategy option.
     #[arg(short = 'X', long = "strategy-option")]
@@ -73,14 +76,37 @@ pub struct Args {
     pub no_recurse_submodules: bool,
 }
 
+fn rebase_cli_value_is_valid(s: &str) -> bool {
+    matches!(
+        s.to_ascii_lowercase().as_str(),
+        "false" | "no" | "off" | "0" | "true" | "yes" | "on" | "1" | "merges" | "interactive"
+    )
+}
+
+/// If clap consumed the repository token as `--rebase`'s optional value (`pull --rebase . c1` →
+/// rebase=".", remote=c1), restore Git's argv layout: remote=`.`, refspecs start with `c1`.
+fn normalize_pull_positionals(mut args: Args) -> Args {
+    if let Some(ref r) = args.rebase {
+        if !rebase_cli_value_is_valid(r) {
+            let bad = r.clone();
+            args.rebase = Some("true".to_owned());
+            if let Some(old_remote) = args.remote.take() {
+                args.refspecs.insert(0, old_remote);
+            }
+            args.remote = Some(bad);
+        }
+    }
+    args
+}
+
 pub fn run(args: Args) -> Result<()> {
+    let args = normalize_pull_positionals(args);
     let repo = Repository::discover(None).context("not a git repository")?;
     let config = ConfigSet::load(Some(&repo.git_dir), true)?;
 
     let head = resolve_head(&repo.git_dir)?;
     let current_branch = head.branch_name().map(|s| s.to_owned());
 
-    // Determine remote name: explicit arg > branch.<name>.remote > "origin"
     let remote_name_owned: String = if let Some(ref r) = args.remote {
         r.clone()
     } else if let Some(ref branch) = current_branch {
@@ -100,11 +126,9 @@ pub fn run(args: Args) -> Result<()> {
         resolve_local_remote_path(work_tree, remote_name, &config)?
     };
 
-    // Determine merge branch
-    let merge_branch = if let Some(ref b) = args.branch {
-        b.clone()
+    let merge_branch = if let Some(first) = args.refspecs.first() {
+        first.clone()
     } else if let Some(ref branch) = current_branch {
-        // Check branch.<name>.merge (e.g. "refs/heads/main")
         if let Some(merge_ref) = config.get(&format!("branch.{branch}.merge")) {
             merge_ref
                 .strip_prefix("refs/heads/")
@@ -127,56 +151,6 @@ pub fn run(args: Args) -> Result<()> {
         bail!("no tracking branch configured and no branch specified");
     };
 
-    if let Some(remote_path) = local_remote_path {
-        // Open remote repo (bare or non-bare)
-        let remote_repo = open_repository_at_path(&remote_path)?;
-
-        // Copy objects from remote to local
-        super::fetch::copy_objects_for_pull(&remote_repo.git_dir, &repo.git_dir)?;
-
-        // Determine which branch to merge: try the specified merge_branch on the remote,
-        // falling back to the remote's HEAD
-        let remote_oid = if let Ok(oid) =
-            refs::resolve_ref(&remote_repo.git_dir, &format!("refs/heads/{merge_branch}"))
-        {
-            oid
-        } else if let Ok(oid) = refs::resolve_ref(&remote_repo.git_dir, "HEAD") {
-            oid
-        } else {
-            bail!("bad revision '{merge_branch}': could not resolve in remote");
-        };
-
-        // Write FETCH_HEAD for compatibility
-        let fetch_head = format!("{}\t\t{}\n", remote_oid.to_hex(), merge_branch);
-        std::fs::write(repo.git_dir.join("FETCH_HEAD"), &fetch_head)?;
-
-        let res = do_merge_or_rebase(&args, &config, remote_oid.to_hex(), &merge_branch);
-        if res.is_ok() {
-            maybe_update_submodules_after_pull(&args, &config)?;
-        }
-        return res;
-    } else if is_local_dot {
-        // "." remote — merge the configured upstream ref (e.g. `refs/heads/main`), not a
-        // synthetic `refs/remotes/./main` remote-tracking ref (matches git pull).
-        let remote_oid = grit_lib::rev_parse::resolve_revision(&repo, &merge_branch)
-            .with_context(|| format!("bad revision '{merge_branch}'"))?;
-
-        let merge_ref = current_branch
-            .as_ref()
-            .and_then(|b| config.get(&format!("branch.{b}.merge")))
-            .unwrap_or_else(|| format!("refs/heads/{merge_branch}"));
-
-        let fetch_head = format!("{}\t\t{}\n", remote_oid.to_hex(), merge_branch);
-        std::fs::write(repo.git_dir.join("FETCH_HEAD"), &fetch_head)?;
-
-        let res = do_merge_or_rebase(&args, &config, remote_oid.to_hex(), &merge_ref);
-        if res.is_ok() {
-            maybe_update_submodules_after_pull(&args, &config)?;
-        }
-        return res;
-    }
-
-    // Step 1: Fetch
     let fetch_recurse = if args.no_recurse_submodules {
         None
     } else if config
@@ -193,9 +167,77 @@ pub fn run(args: Args) -> Result<()> {
         None
     };
 
+    if let Some(remote_path) = local_remote_path {
+        let remote_repo = open_repository_at_path(&remote_path)?;
+        super::fetch::copy_objects_for_pull(&remote_repo.git_dir, &repo.git_dir)?;
+
+        let lines = if args.refspecs.is_empty() {
+            let remote_oid = if let Ok(oid) =
+                refs::resolve_ref(&remote_repo.git_dir, &format!("refs/heads/{merge_branch}"))
+            {
+                oid
+            } else if let Ok(oid) = refs::resolve_ref(&remote_repo.git_dir, "HEAD") {
+                oid
+            } else {
+                bail!("bad revision '{merge_branch}': could not resolve in remote");
+            };
+            vec![format!(
+                "{}\t\tbranch 'refs/heads/{merge_branch}' of .\n",
+                remote_oid.to_hex()
+            )]
+        } else {
+            let mut out = Vec::new();
+            for spec in &args.refspecs {
+                let oid = grit_lib::rev_parse::resolve_revision(&remote_repo, spec)
+                    .with_context(|| format!("bad revision '{spec}'"))?;
+                out.push(format!(
+                    "{}\t\tbranch 'refs/heads/{spec}' of .\n",
+                    oid.to_hex()
+                ));
+            }
+            out
+        };
+        fs::write(repo.git_dir.join("FETCH_HEAD"), lines.concat())?;
+
+        let res = do_merge_or_rebase_after_fetch(&args, &config, &repo, &head);
+        if res.is_ok() {
+            maybe_update_submodules_after_pull(&args, &config)?;
+        }
+        return res;
+    }
+
+    if is_local_dot {
+        let lines = if args.refspecs.is_empty() {
+            let remote_oid = resolve_revision(&repo, &merge_branch)
+                .with_context(|| format!("bad revision '{merge_branch}'"))?;
+            vec![format!(
+                "{}\t\tbranch 'refs/heads/{merge_branch}' of .\n",
+                remote_oid.to_hex()
+            )]
+        } else {
+            let mut out = Vec::new();
+            for spec in &args.refspecs {
+                let oid = resolve_revision(&repo, spec)
+                    .with_context(|| format!("bad revision '{spec}'"))?;
+                out.push(format!(
+                    "{}\t\tbranch 'refs/heads/{spec}' of .\n",
+                    oid.to_hex()
+                ));
+            }
+            out
+        };
+        fs::write(repo.git_dir.join("FETCH_HEAD"), lines.concat())?;
+
+        let res = do_merge_or_rebase_after_fetch(&args, &config, &repo, &head);
+        if res.is_ok() {
+            maybe_update_submodules_after_pull(&args, &config)?;
+        }
+        return res;
+    }
+
     let fetch_args = super::fetch::Args {
         remote: Some(remote_name.to_owned()),
-        refspecs: Vec::new(),
+        refspecs: args.refspecs.clone(),
         filter: None,
         all: false,
         tags: false,
@@ -222,12 +264,7 @@ pub fn run(args: Args) -> Result<()> {
     };
     super::fetch::run(fetch_args)?;
 
-    // Step 2: Determine the remote-tracking ref to merge/rebase from
-    let tracking_ref = format!("refs/remotes/{remote_name}/{merge_branch}");
-    let remote_oid = refs::resolve_ref(&repo.git_dir, &tracking_ref)
-        .with_context(|| format!("no tracking ref '{tracking_ref}' after fetch"))?;
-
-    let res = do_merge_or_rebase(&args, &config, remote_oid.to_hex(), &tracking_ref);
+    let res = do_merge_or_rebase_after_fetch(&args, &config, &repo, &head);
     if res.is_ok() {
         maybe_update_submodules_after_pull(&args, &config)?;
     }
@@ -274,15 +311,235 @@ fn maybe_update_submodules_after_pull(args: &Args, config: &ConfigSet) -> Result
     Ok(())
 }
 
-fn do_merge_or_rebase(
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum RebaseTri {
+    False,
+    True,
+    Unset,
+}
+
+fn parse_rebase_value(key: &str, value: &str) -> Result<RebaseTri> {
+    let v = value.trim();
+    let lower = v.to_ascii_lowercase();
+    match lower.as_str() {
+        "false" | "no" | "off" | "0" => Ok(RebaseTri::False),
+        "true" | "yes" | "on" | "1" | "merges" | "interactive" => Ok(RebaseTri::True),
+        _ => bail!("invalid value for '{key}': '{value}'"),
+    }
+}
+
+fn config_pull_rebase(
+    config: &ConfigSet,
+    current_branch: Option<&str>,
+) -> Result<(RebaseTri, bool)> {
+    if let Some(b) = current_branch {
+        let key = format!("branch.{b}.rebase");
+        if let Some(v) = config.get(&key) {
+            return Ok((parse_rebase_value(&key, &v)?, false));
+        }
+    }
+    if let Some(v) = config.get("pull.rebase") {
+        return Ok((parse_rebase_value("pull.rebase", &v)?, false));
+    }
+    Ok((RebaseTri::False, true))
+}
+
+fn pull_ff_from_config(config: &ConfigSet) -> Result<Option<(bool, bool, bool)>> {
+    let Some(val) = config.get("pull.ff") else {
+        return Ok(None);
+    };
+    let lower = val.to_ascii_lowercase();
+    match lower.as_str() {
+        "true" | "yes" | "on" | "1" => Ok(Some((true, false, false))),
+        "false" | "no" | "off" | "0" => Ok(Some((false, true, false))),
+        "only" => Ok(Some((false, false, true))),
+        _ => bail!("invalid value for 'pull.ff': '{val}'"),
+    }
+}
+
+fn merge_heads_from_fetch_head(repo: &Repository) -> Result<Vec<grit_lib::objects::ObjectId>> {
+    use grit_lib::objects::ObjectId;
+    let path = repo.git_dir.join("FETCH_HEAD");
+    let content = fs::read_to_string(&path).with_context(|| "could not read FETCH_HEAD")?;
+    let mut out = Vec::new();
+    for line in content.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let mut parts = line.split('\t');
+        let Some(hex) = parts.next() else {
+            continue;
+        };
+        let not_for_merge = parts.next().is_some_and(|v| v == "not-for-merge");
+        if not_for_merge {
+            continue;
+        }
+        if hex.len() == 40 && hex.bytes().all(|b| b.is_ascii_hexdigit()) {
+            out.push(ObjectId::from_hex(hex)?);
+        }
+    }
+    if out.is_empty() {
+        bail!("FETCH_HEAD: no merge candidates");
+    }
+    Ok(out)
+}
+
+fn pull_can_fast_forward(
+    repo: &Repository,
+    head_oid: grit_lib::objects::ObjectId,
+    merge_heads: &[grit_lib::objects::ObjectId],
+) -> Result<bool> {
+    if merge_heads.len() != 1 {
+        return Ok(false);
+    }
+    Ok(is_ancestor(repo, head_oid, merge_heads[0])?)
+}
+
+fn pull_already_up_to_date(
+    repo: &Repository,
+    head_oid: grit_lib::objects::ObjectId,
+    merge_heads: &[grit_lib::objects::ObjectId],
+) -> Result<bool> {
+    for h in merge_heads {
+        if !is_ancestor(repo, *h, head_oid)? {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+fn advice_color_prefix(config: &ConfigSet) -> &'static str {
+    let use_color = config
+        .get("color.advice")
+        .or_else(|| config.get("color.ui"))
+        .map(|v| {
+            let l = v.to_ascii_lowercase();
+            l == "true" || l == "always" || l == "auto"
+        })
+        .unwrap_or(false);
+    if use_color {
+        "\x1b[33m"
+    } else {
+        ""
+    }
+}
+
+fn show_advice_pull_non_ff(config: &ConfigSet) {
+    let p = advice_color_prefix(config);
+    eprintln!("{p}hint: You have divergent branches and need to specify how to reconcile them.");
+    eprintln!("{p}hint: You can do so by running one of the following commands sometime before");
+    eprintln!("{p}hint: your next pull:");
+    eprintln!("{p}hint:");
+    eprintln!("{p}hint:   git config pull.rebase false  # merge");
+    eprintln!("{p}hint:   git config pull.rebase true   # rebase");
+    eprintln!("{p}hint:   git config pull.ff only       # fast-forward only");
+    eprintln!("{p}hint:");
+    eprintln!(
+        "{p}hint: You can replace \"git config\" with \"git config --global\" to set a default"
+    );
+    eprintln!("{p}hint: preference for all repositories. You can also pass --rebase, --no-rebase,");
+    eprintln!("{p}hint: or --ff-only on the command line to override the configured default per");
+    eprintln!("{p}hint: invocation.");
+}
+
+fn do_merge_or_rebase_after_fetch(
     args: &Args,
     config: &ConfigSet,
-    oid_hex: String,
-    ref_name: &str,
+    repo: &Repository,
+    head: &grit_lib::state::HeadState,
 ) -> Result<()> {
-    if args.rebase.is_some() {
+    let head_oid = match head.oid() {
+        Some(oid) => *oid,
+        None => {
+            if merge_heads_from_fetch_head(repo)?.len() > 1 {
+                bail!("Cannot merge multiple branches into empty head.");
+            }
+            let merge_args =
+                build_pull_merge_args(args, true, false, false, vec!["FETCH_HEAD".to_owned()])?;
+            return super::merge::run(merge_args);
+        }
+    };
+
+    let merge_heads = merge_heads_from_fetch_head(repo)?;
+    if merge_heads.is_empty() {
+        bail!("no merge candidates in FETCH_HEAD");
+    }
+
+    let (mut opt_rebase, rebase_unspecified) = if args.no_rebase {
+        (RebaseTri::False, false)
+    } else if let Some(ref s) = args.rebase {
+        (parse_rebase_value("--rebase", s)?, false)
+    } else {
+        config_pull_rebase(config, head.branch_name())?
+    };
+
+    let mut ff = args.ff;
+    let mut no_ff = args.no_ff;
+    let mut ff_only = args.ff_only;
+    let cli_touched_ff = ff || no_ff || ff_only;
+    let pull_ff_in_config = config.get("pull.ff").is_some();
+
+    if !cli_touched_ff {
+        if let Some((f, n, o)) = pull_ff_from_config(config)? {
+            ff = f;
+            no_ff = n;
+            ff_only = o;
+        }
+    }
+    // git pull.c: explicit `--rebase` on the CLI overrides `pull.ff=only` from config (not when
+    // both rebase and ff=only come from config).
+    if args.rebase.is_some() && !cli_touched_ff && pull_ff_in_config {
+        if let Some((_, _, only)) = pull_ff_from_config(config)? {
+            if only {
+                ff_only = false;
+                ff = true;
+                no_ff = false;
+            }
+        }
+    }
+    // `--no-rebase` overrides `pull.ff=only` from config (t7601: merge when branches diverge).
+    if args.no_rebase && ff_only && !args.ff_only {
+        ff_only = false;
+    }
+
+    if merge_heads.len() > 1 {
+        if opt_rebase == RebaseTri::True {
+            bail!("Cannot rebase onto multiple branches.");
+        }
+        if ff_only {
+            bail!("Cannot fast-forward to multiple branches.");
+        }
+    }
+
+    let can_ff = pull_can_fast_forward(repo, head_oid, &merge_heads)?;
+    let divergent = !can_ff && !pull_already_up_to_date(repo, head_oid, &merge_heads)?;
+
+    if ff_only {
+        if divergent {
+            bail!("Not possible to fast-forward, aborting.");
+        }
+        opt_rebase = RebaseTri::False;
+    }
+
+    // Match git pull.c: advise only when pull.rebase was left unspecified by config, branches
+    // diverge, and pull.ff was not configured (Git's `!opt_ff` after reading pull.ff).
+    if rebase_unspecified && divergent && !pull_ff_in_config && !cli_touched_ff && !ff_only {
+        show_advice_pull_non_ff(config);
+        bail!("Need to specify how to reconcile divergent branches.");
+    }
+
+    if opt_rebase == RebaseTri::True {
+        if can_ff {
+            let merge_args =
+                build_pull_merge_args(args, false, false, true, vec!["FETCH_HEAD".to_owned()])?;
+            return super::merge::run(merge_args);
+        }
+        let upstream = super::merge::read_fetch_head_merge_oids(repo)?
+            .into_iter()
+            .next()
+            .context("FETCH_HEAD merge oid")?;
         let rebase_args = super::rebase::Args {
-            upstream: Some(ref_name.to_owned()),
+            upstream: Some(upstream),
             branch: None,
             onto: None,
             root: false,
@@ -310,65 +567,63 @@ fn do_merge_or_rebase(
             autostash: false,
             no_autostash: false,
         };
-        super::rebase::run(rebase_args)
-    } else {
-        // Determine ff flags from pull.ff config, CLI overrides
-        let (mut ff, mut no_ff, mut ff_only) = (args.ff, args.no_ff, args.ff_only);
-        if !ff && !no_ff && !ff_only {
-            if let Some(val) = config.get("pull.ff") {
-                match val.to_lowercase().as_str() {
-                    "true" | "yes" => ff = true,
-                    "false" | "no" => no_ff = true,
-                    "only" => ff_only = true,
-                    _ => {}
-                }
-            }
-        }
-
-        let merge_args = super::merge::Args {
-            commits: vec![oid_hex],
-            message: None,
-            ff_only,
-            no_ff,
-            no_commit: false,
-            squash: false,
-            abort: false,
-            continue_merge: false,
-            strategy: args.strategy.clone().into_iter().collect::<Vec<_>>(),
-            strategy_option: args.strategy_option.clone(),
-            quiet: args.quiet,
-            progress: false,
-            no_progress: false,
-            no_edit: true,
-            edit: false,
-            signoff: false,
-            no_signoff: false,
-            stat: false,
-            no_stat: false,
-            log: args.log.as_ref().map(|v| {
-                let n = v.parse::<usize>().unwrap_or(0);
-                if n == 0 {
-                    20
-                } else {
-                    n
-                }
-            }),
-            no_log: args.no_log,
-            compact_summary: false,
-            summary: false,
-            ff,
-            commit: false,
-            no_squash: false,
-            quit: false,
-            autostash: false,
-            allow_unrelated_histories: false,
-            cleanup: None,
-            file: None,
-            rerere_autoupdate: false,
-            no_rerere_autoupdate: false,
-        };
-        super::merge::run(merge_args)
+        return super::rebase::run(rebase_args);
     }
+
+    let merge_args =
+        build_pull_merge_args(args, ff, no_ff, ff_only, vec!["FETCH_HEAD".to_owned()])?;
+    super::merge::run(merge_args)
+}
+
+fn build_pull_merge_args(
+    args: &Args,
+    ff: bool,
+    no_ff: bool,
+    ff_only: bool,
+    commits: Vec<String>,
+) -> Result<super::merge::Args> {
+    Ok(super::merge::Args {
+        commits,
+        message: None,
+        ff_only,
+        no_ff,
+        no_commit: false,
+        squash: false,
+        abort: false,
+        continue_merge: false,
+        strategy: args.strategy.clone(),
+        strategy_option: args.strategy_option.clone(),
+        quiet: args.quiet,
+        progress: false,
+        no_progress: false,
+        no_edit: true,
+        edit: false,
+        signoff: false,
+        no_signoff: false,
+        stat: false,
+        no_stat: false,
+        log: args.log.as_ref().map(|v| {
+            let n = v.parse::<usize>().unwrap_or(0);
+            if n == 0 {
+                20
+            } else {
+                n
+            }
+        }),
+        no_log: args.no_log,
+        compact_summary: false,
+        summary: false,
+        ff,
+        commit: false,
+        no_squash: false,
+        quit: false,
+        autostash: false,
+        allow_unrelated_histories: false,
+        cleanup: None,
+        file: None,
+        rerere_autoupdate: false,
+        no_rerere_autoupdate: false,
+    })
 }
 
 fn remote_token_looks_like_path(token: &str) -> bool {

--- a/logs/2026-04-08-t7601-merge-pull-config.md
+++ b/logs/2026-04-08-t7601-merge-pull-config.md
@@ -1,0 +1,16 @@
+# t7601-merge-pull-config
+
+## Summary
+
+Made `tests/t7601-merge-pull-config.sh` pass (65/65).
+
+## Changes
+
+- **pull**: Multiple refspecs (`git pull . c1 c2`), `FETCH_HEAD` layout, `pull.rebase` / `pull.ff` precedence matching `git/builtin/pull.c` (divergent-branch advice, ff-only vs rebase, multi-head errors). Normalized `--rebase . c1` argv when clap consumes `.` as the optional `--rebase` value.
+- **merge**: `pull.twohead` / `pull.octopus` from config; reject octopus with only `recursive`/`ort`; disable rename detection for `resolve` strategy; multi-strategy `-s` tries with conflict-path scoring and final re-run of best strategy (t7601 auto merge).
+- **add**: Removed stat-cache-only skip in `stage_file` so rapid `echo` + `add` updates the index (fixes test setup where `c6` omitted `conflict.c`).
+
+## Validation
+
+- `./scripts/run-tests.sh t7601-merge-pull-config.sh` — 65/65
+- `cargo test -p grit-lib --lib`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible `pull` configuration and merge behavior so `tests/t7601-merge-pull-config.sh` passes **65/65**.

## Key changes

- **`grit pull`**: Multiple refspecs, correct `FETCH_HEAD` lines, `pull.rebase` / `pull.ff` interaction (including divergent-branch advice and multi-head errors), and argv normalization when `--rebase` accidentally consumes the repository token (e.g. `pull --rebase . c1`).
- **`grit merge`**: Reads `pull.twohead` / `pull.octopus` when no `-s`; rejects true octopus with only `recursive`/`ort`; disables rename detection for `resolve` (so resolve vs recursive conflict counts differ as in Git); multi-strategy `-s` now scores trials by unmerged path count and re-runs the best strategy to leave the tree in conflict state (matches Git’s merge.c behavior).
- **`grit add`**: Removed stat-cache-only early return in `stage_file` so content changes are always re-hashed (fixes test setup where `echo C>conflict.c` + `add` could leave the index stale).

## Validation

- `./scripts/run-tests.sh t7601-merge-pull-config.sh` — 65/65
- `cargo test -p grit-lib --lib`

## Notes

Harness CSV/dashboards updated via `run-tests.sh`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a155800d-600a-43dd-a636-adc6e3f5e04e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a155800d-600a-43dd-a636-adc6e3f5e04e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

