### PR TITLE
fix: make t7513-interpret-trailers fully pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -92,7 +92,7 @@ t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
 t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
-t1006-cat-file	t1	yes	290	285	5	false	ok	1
+t1006-cat-file	t1	yes	290	285	5	false	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	32	8	false	ok	0
 t10070-cat-file-batch-format	t1	yes	33	33	0	true	ok	0
@@ -1234,7 +1234,7 @@ t7509-commit-authorship	t7	yes	12	4	8	false	ok	0
 t7510-signed-commit	t7	skip	28	0	0	false	ok	0
 t7511-status-index	t7	yes	24	24	0	true	ok	0
 t7512-status-help	t7	yes	47	7	40	false	ok	0
-t7513-interpret-trailers	t7	yes	99	11	88	false	ok	0
+t7513-interpret-trailers	t7	yes	99	99	0	true	ok	0
 t7514-commit-patch	t7	yes	3	1	2	false	ok	0
 t7514-interpret-trailers-options	t7	yes	10	10	0	true	ok	0
 t7515-status-symlinks	t7	yes	3	1	2	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,16 +141,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T19:32:55+00:00" class="gen-time" title="2026-04-08 19:32 UTC">2026-04-08 19:32 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">74.2%</div>
+      <div class="summary-big-val pct-blue">74.4%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,565</div>
+      <div class="summary-big-val">29,661</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -159,12 +159,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:74.2%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:74.4%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>713 files fully passing</span>
+    <span>717 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,7 +212,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">41/141 files · 2 skipped · 3,333/4,611 tests</span>
+        <span class="group-meta">42/141 files · 2 skipped · 3,334/4,611 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.3%"></div></div>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,336/3,949 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,342/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.8%"></div></div>
-        <span class="group-pct pct-red">33.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.0%"></div></div>
+        <span class="group-pct pct-red">34.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -256,11 +256,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">42/126 files · 11 skipped · 1,793/2,944 tests</span>
+        <span class="group-meta">44/126 files · 11 skipped · 1,882/2,944 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>
-        <span class="group-pct pct-blue">60.9%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:63.9%"></div></div>
+        <span class="group-pct pct-blue">63.9%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T19:32:55+00:00" class="gen-time" title="2026-04-08 19:32 UTC">2026-04-08 19:32 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,864</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,565</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,661</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">74.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -1085,7 +1085,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">285</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.3%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t10060-hash-object-determinism</td>
@@ -5110,8 +5110,7 @@ tr.row-skip td { opacity: 0.65; }
 <tr class="" data-group="t2" data-tests="15" data-passed="5">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td><span class="badge ok">full pass</span></td>
-  <td class="right">15</td>
+  <td></td>
   <td class="right">15</td>
   <td class="right">5</td>
   <td class="right">ok</td>
@@ -6218,14 +6217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="54" data-passed="38">
+<tr class="" data-group="t3" data-tests="52" data-passed="3">
   <td class="mono">t3420-rebase-autostash</td>
   <td>t3</td>
   <td></td>
-  <td class="right">54</td>
-  <td class="right">38</td>
+  <td class="right">52</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="63" data-passed="11">
@@ -12498,14 +12497,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:14.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="99" data-passed="11">
+<tr class="" data-group="t7" data-tests="99" data-passed="99" data-full-pass="1">
   <td class="mono">t7513-interpret-trailers</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">99</td>
-  <td class="right">11</td>
+  <td class="right">99</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:11.1%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="3" data-passed="1">
@@ -12598,7 +12597,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="2" data-passed="2">
+<tr class="" data-group="t7" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t7524-commit-summary</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>

--- a/grit-lib/src/interpret_trailers.rs
+++ b/grit-lib/src/interpret_trailers.rs
@@ -1,0 +1,1126 @@
+//! Commit message trailer parsing and rewriting (Git-compatible).
+//!
+//! Behaviour matches upstream `git/trailer.c` / `git interpret-trailers`.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use crate::config::{ConfigEntry, ConfigSet};
+
+const CUT_LINE: &str = "------------------------ >8 ------------------------";
+
+const GIT_GENERATED_PREFIXES: &[&str] = &["Signed-off-by: ", "(cherry picked from commit "];
+
+const TRAILER_ARG_PLACEHOLDER: &str = "$ARG";
+
+/// Placement of a new trailer relative to an anchor trailer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TrailerWhere {
+    #[default]
+    Default,
+    End,
+    After,
+    Before,
+    Start,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TrailerIfExists {
+    #[default]
+    Default,
+    AddIfDifferentNeighbor,
+    AddIfDifferent,
+    Add,
+    Replace,
+    DoNothing,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TrailerIfMissing {
+    #[default]
+    Default,
+    Add,
+    DoNothing,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ProcessTrailerOptions {
+    pub trim_empty: bool,
+    pub only_trailers: bool,
+    pub only_input: bool,
+    pub unfold: bool,
+    pub no_divider: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewTrailerArg {
+    pub text: String,
+    pub where_: TrailerWhere,
+    pub if_exists: TrailerIfExists,
+    pub if_missing: TrailerIfMissing,
+}
+
+#[derive(Debug, Clone)]
+struct ConfInfo {
+    name: String,
+    key: Option<String>,
+    command: Option<String>,
+    cmd: Option<String>,
+    where_: TrailerWhere,
+    if_exists: TrailerIfExists,
+    if_missing: TrailerIfMissing,
+}
+
+#[derive(Debug, Clone)]
+struct TrailerItem {
+    token: Option<String>,
+    value: String,
+}
+
+#[derive(Debug, Clone)]
+struct ArgItem {
+    token: String,
+    value: String,
+    conf: ConfInfo,
+}
+
+#[derive(Debug)]
+struct TrailerBlock {
+    blank_line_before: bool,
+    start: usize,
+    end: usize,
+    lines: Vec<String>,
+}
+
+/// Parse `trailer.where` / `--where` values (Git spelling).
+pub fn trailer_where_from_str(s: &str) -> Option<TrailerWhere> {
+    set_where(s)
+}
+
+/// Parse `trailer.ifexists` / `--if-exists` values.
+pub fn trailer_if_exists_from_str(s: &str) -> Option<TrailerIfExists> {
+    set_if_exists(s)
+}
+
+/// Parse `trailer.ifmissing` / `--if-missing` values.
+pub fn trailer_if_missing_from_str(s: &str) -> Option<TrailerIfMissing> {
+    set_if_missing(s)
+}
+
+fn set_where(s: &str) -> Option<TrailerWhere> {
+    match s.to_ascii_lowercase().as_str() {
+        "after" => Some(TrailerWhere::After),
+        "before" => Some(TrailerWhere::Before),
+        "end" => Some(TrailerWhere::End),
+        "start" => Some(TrailerWhere::Start),
+        _ => None,
+    }
+}
+
+fn set_if_exists(s: &str) -> Option<TrailerIfExists> {
+    match s.to_ascii_lowercase().as_str() {
+        "addifdifferent" => Some(TrailerIfExists::AddIfDifferent),
+        "addifdifferentneighbor" => Some(TrailerIfExists::AddIfDifferentNeighbor),
+        "add" => Some(TrailerIfExists::Add),
+        "replace" => Some(TrailerIfExists::Replace),
+        "donothing" => Some(TrailerIfExists::DoNothing),
+        _ => None,
+    }
+}
+
+fn set_if_missing(s: &str) -> Option<TrailerIfMissing> {
+    match s.to_ascii_lowercase().as_str() {
+        "add" => Some(TrailerIfMissing::Add),
+        "donothing" => Some(TrailerIfMissing::DoNothing),
+        _ => None,
+    }
+}
+
+fn after_or_end(where_: TrailerWhere) -> bool {
+    matches!(where_, TrailerWhere::After | TrailerWhere::End)
+}
+
+fn token_len_without_separator(token: &str) -> usize {
+    let b = token.as_bytes();
+    let mut len = token.len();
+    while len > 0 && !b[len - 1].is_ascii_alphanumeric() {
+        len -= 1;
+    }
+    len
+}
+
+fn same_token(a_token: Option<&str>, b_token: &str) -> bool {
+    let Some(a) = a_token else {
+        return false;
+    };
+    let a_len = token_len_without_separator(a);
+    let b_len = token_len_without_separator(b_token);
+    let min_len = a_len.min(b_len);
+    a[..min_len].eq_ignore_ascii_case(&b_token[..min_len])
+}
+
+fn same_value(a: &TrailerItem, b_val: &str) -> bool {
+    a.value.eq_ignore_ascii_case(b_val)
+}
+
+fn same_trailer(a: &TrailerItem, b: &ArgItem) -> bool {
+    same_token(a.token.as_deref(), &b.token) && same_value(a, &b.value)
+}
+
+fn is_blank_line(s: &str) -> bool {
+    s.chars().all(|c| c.is_whitespace())
+}
+
+fn last_non_space_char(s: &str) -> Option<char> {
+    s.chars().rev().find(|c| !c.is_whitespace())
+}
+
+fn line_end(buf: &str, bol: usize, limit: usize) -> usize {
+    bol + buf[bol..limit].find('\n').unwrap_or(limit - bol)
+}
+
+fn after_line(buf: &str, bol: usize, limit: usize) -> usize {
+    let le = line_end(buf, bol, limit);
+    if le < limit {
+        le + 1
+    } else {
+        limit
+    }
+}
+
+fn last_line_start(buf: &str, len: usize) -> Option<usize> {
+    if len == 0 {
+        return None;
+    }
+    if len == 1 {
+        return Some(0);
+    }
+    let slice = &buf.as_bytes()[..len];
+    let mut i = len - 2;
+    loop {
+        if slice[i] == b'\n' {
+            return Some(i + 1);
+        }
+        if i == 0 {
+            return Some(0);
+        }
+        i -= 1;
+    }
+}
+
+fn starts_with_comment_line(line: &str, prefix: &str) -> bool {
+    line.starts_with(prefix)
+}
+
+fn wt_status_locate_end(s: &str, len: usize, comment_prefix: &str) -> usize {
+    let pattern = format!("\n{comment_prefix} {CUT_LINE}\n");
+    let head = format!("{comment_prefix} {CUT_LINE}\n");
+    if s.len() >= head.len() && s[..head.len()] == head {
+        return 0;
+    }
+    if let Some(p) = s[..len].find(&pattern) {
+        let newlen = p + 1;
+        if newlen < len {
+            return newlen;
+        }
+    }
+    len
+}
+
+fn ignored_log_message_bytes(buf: &str, len: usize, comment_prefix: &str) -> usize {
+    let cutoff = wt_status_locate_end(buf, len, comment_prefix);
+    let mut bol = 0usize;
+    let mut boc = 0usize;
+    let mut in_old_conflicts = false;
+
+    while bol < cutoff {
+        let le = line_end(buf, bol, cutoff);
+        let line = &buf[bol..le];
+
+        let is_comment = starts_with_comment_line(line, comment_prefix) || line.is_empty();
+        if is_comment {
+            if boc == 0 {
+                boc = bol;
+            }
+        } else if line.starts_with("Conflicts:") {
+            in_old_conflicts = true;
+            if boc == 0 {
+                boc = bol;
+            }
+        } else if in_old_conflicts && line.starts_with('\t') {
+            // path in conflicts block
+        } else if boc != 0 {
+            boc = 0;
+            in_old_conflicts = false;
+        }
+
+        bol = if le < cutoff { le + 1 } else { cutoff };
+    }
+
+    if boc != 0 {
+        len - boc
+    } else {
+        len - cutoff
+    }
+}
+
+fn find_end_of_log_message(input: &str, no_divider: bool, comment_prefix: &str) -> usize {
+    let mut end = input.len();
+    if !no_divider {
+        let mut pos = 0usize;
+        while pos < input.len() {
+            let rest = &input[pos..];
+            if rest.len() >= 3 && rest.as_bytes().get(0..3) == Some(b"---") {
+                let after = rest.as_bytes().get(3).copied();
+                if after.is_none() || after.is_some_and(|c| c.is_ascii_whitespace()) {
+                    end = pos;
+                    break;
+                }
+            }
+            pos = after_line(input, pos, input.len());
+            if pos >= input.len() {
+                break;
+            }
+        }
+    }
+    end - ignored_log_message_bytes(input, end, comment_prefix)
+}
+
+fn find_separator(line: &str, separators: &str) -> Option<usize> {
+    let mut whitespace_found = false;
+    for (i, c) in line.char_indices() {
+        if separators.contains(c) {
+            return Some(i);
+        }
+        if !whitespace_found && (c.is_ascii_alphanumeric() || c == '-') {
+            continue;
+        }
+        if i > 0 && (c == ' ' || c == '\t') {
+            whitespace_found = true;
+            continue;
+        }
+        break;
+    }
+    None
+}
+
+fn token_matches_item(line: &str, item: &ConfInfo, sep_pos: usize) -> bool {
+    let tok = line[..sep_pos].trim_end();
+    let name = &item.name;
+    let name_len = name.len();
+    let tok_len = token_len_without_separator(tok);
+    if tok_len >= name_len && tok[..name_len].eq_ignore_ascii_case(name) {
+        return true;
+    }
+    if let Some(ref key) = item.key {
+        let key_len = token_len_without_separator(key);
+        if tok_len >= key_len && tok[..key_len].eq_ignore_ascii_case(&key[..key_len]) {
+            return true;
+        }
+    }
+    false
+}
+
+fn find_trailer_block_start(
+    buf: &str,
+    len: usize,
+    conf: &[ConfInfo],
+    separators: &str,
+    comment_prefix: &str,
+) -> usize {
+    let mut end_of_title = len;
+    let mut pos = 0usize;
+    while pos < len {
+        let le = line_end(buf, pos, len);
+        let line = &buf[pos..le];
+        if starts_with_comment_line(line, comment_prefix) {
+            pos = if le < len { le + 1 } else { len };
+            continue;
+        }
+        if is_blank_line(line) {
+            end_of_title = pos;
+            break;
+        }
+        pos = if le < len { le + 1 } else { len };
+    }
+
+    let mut l = last_line_start(buf, len);
+    let mut only_spaces = true;
+    let mut recognized_prefix = false;
+    let mut trailer_lines = 0i32;
+    let mut non_trailer_lines = 0i32;
+    let mut possible_continuation = 0i32;
+
+    while let Some(bol) = l {
+        if bol < end_of_title {
+            break;
+        }
+        let le = line_end(buf, bol, len);
+        let line = &buf[bol..le];
+
+        if starts_with_comment_line(line, comment_prefix) {
+            non_trailer_lines += possible_continuation;
+            possible_continuation = 0;
+            l = if bol == 0 {
+                None
+            } else {
+                last_line_start(buf, bol)
+            };
+            continue;
+        }
+
+        if is_blank_line(line) {
+            if only_spaces {
+                l = if bol == 0 {
+                    None
+                } else {
+                    last_line_start(buf, bol)
+                };
+                continue;
+            }
+            non_trailer_lines += possible_continuation;
+            if recognized_prefix && trailer_lines * 3 >= non_trailer_lines {
+                return after_line(buf, bol, len);
+            }
+            if trailer_lines > 0 && non_trailer_lines == 0 {
+                return after_line(buf, bol, len);
+            }
+            return len;
+        }
+        only_spaces = false;
+
+        let mut matched_gen = false;
+        for p in GIT_GENERATED_PREFIXES {
+            if line.starts_with(p) {
+                trailer_lines += 1;
+                possible_continuation = 0;
+                recognized_prefix = true;
+                matched_gen = true;
+                break;
+            }
+        }
+        if matched_gen {
+            l = if bol == 0 {
+                None
+            } else {
+                last_line_start(buf, bol)
+            };
+            continue;
+        }
+
+        if let Some(sep_pos) = find_separator(line, separators) {
+            if sep_pos >= 1 && !line.starts_with(|c: char| c.is_whitespace()) {
+                trailer_lines += 1;
+                possible_continuation = 0;
+                if !recognized_prefix {
+                    for item in conf {
+                        if token_matches_item(line, item, sep_pos) {
+                            recognized_prefix = true;
+                            break;
+                        }
+                    }
+                }
+            } else if line.starts_with(|c: char| c.is_whitespace()) {
+                possible_continuation += 1;
+            } else {
+                non_trailer_lines += 1;
+                non_trailer_lines += possible_continuation;
+                possible_continuation = 0;
+            }
+        } else if line.starts_with(|c: char| c.is_whitespace()) {
+            possible_continuation += 1;
+        } else {
+            non_trailer_lines += 1;
+            non_trailer_lines += possible_continuation;
+            possible_continuation = 0;
+        }
+
+        l = if bol == 0 {
+            None
+        } else {
+            last_line_start(buf, bol)
+        };
+    }
+
+    len
+}
+
+fn ends_with_blank_line(buf: &str, trailer_block_start: usize) -> bool {
+    if trailer_block_start == 0 {
+        return false;
+    }
+    let slice = &buf[..trailer_block_start];
+    last_line_start(slice, slice.len()).is_some_and(|i| is_blank_line(&slice[i..]))
+}
+
+fn unfold_value(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\n' {
+            while chars.peek().is_some_and(|x| x.is_whitespace()) {
+                chars.next();
+            }
+            if !out.is_empty() && !out.ends_with(' ') {
+                out.push(' ');
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out.trim().to_string()
+}
+
+impl Default for ConfInfo {
+    fn default() -> Self {
+        Self {
+            name: String::new(),
+            key: None,
+            command: None,
+            cmd: None,
+            where_: TrailerWhere::End,
+            if_exists: TrailerIfExists::AddIfDifferentNeighbor,
+            if_missing: TrailerIfMissing::Add,
+        }
+    }
+}
+
+fn duplicate_conf(src: &ConfInfo) -> ConfInfo {
+    ConfInfo {
+        name: src.name.clone(),
+        key: src.key.clone(),
+        command: src.command.clone(),
+        cmd: src.cmd.clone(),
+        where_: src.where_,
+        if_exists: src.if_exists,
+        if_missing: src.if_missing,
+    }
+}
+
+fn token_from_item(item: &ConfInfo, tok_from_arg: Option<&str>) -> String {
+    if let Some(k) = &item.key {
+        return k.clone();
+    }
+    tok_from_arg.map_or_else(|| item.name.clone(), str::to_string)
+}
+
+fn parse_trailer_into(
+    trailer: &str,
+    separators: &str,
+    conf: &[ConfInfo],
+    apply_conf: bool,
+) -> (String, String, ConfInfo) {
+    let sep_pos = find_separator(trailer, separators);
+    let (mut tok, val, mut picked) = if let Some(pos) = sep_pos {
+        (
+            trailer[..pos].trim().to_string(),
+            trailer[pos + 1..].trim().to_string(),
+            ConfInfo {
+                name: String::new(),
+                ..Default::default()
+            },
+        )
+    } else {
+        (
+            trailer.trim().to_string(),
+            String::new(),
+            ConfInfo {
+                name: String::new(),
+                ..Default::default()
+            },
+        )
+    };
+
+    if apply_conf {
+        let tok_len = token_len_without_separator(&tok);
+        for item in conf {
+            if tok_len >= item.name.len() && tok[..item.name.len()].eq_ignore_ascii_case(&item.name)
+            {
+                let tbuf = std::mem::take(&mut tok);
+                tok = token_from_item(item, Some(&tbuf));
+                picked = duplicate_conf(item);
+                break;
+            }
+            if let Some(ref key) = item.key {
+                let kl = token_len_without_separator(key);
+                if tok_len >= kl && tok[..kl].eq_ignore_ascii_case(&key[..kl]) {
+                    let tbuf = std::mem::take(&mut tok);
+                    tok = token_from_item(item, Some(&tbuf));
+                    picked = duplicate_conf(item);
+                    break;
+                }
+            }
+        }
+    }
+
+    (tok, val, picked)
+}
+
+fn var_ci_eq(s: &str, lit: &str) -> bool {
+    s.eq_ignore_ascii_case(lit)
+}
+
+fn comment_line_prefix(cfg: &ConfigSet) -> String {
+    match cfg.get("core.commentChar") {
+        Some(s) => {
+            let t = s.trim();
+            if t.is_empty() || t.eq_ignore_ascii_case("auto") {
+                "#".to_string()
+            } else {
+                t.chars().next().unwrap_or('#').to_string()
+            }
+        }
+        None => "#".to_string(),
+    }
+}
+
+fn load_trailer_config(cfg: &ConfigSet) -> (ConfInfo, Vec<ConfInfo>, String) {
+    // Git reads `trailer.*` globals first (`git_trailer_default_config`), then per-alias keys.
+    // Each `trailer.<alias>.*` entry inherits the current global defaults at creation time.
+    let hardcoded = ConfInfo::default();
+    let mut default_conf = duplicate_conf(&hardcoded);
+    let mut map: HashMap<String, ConfInfo> = HashMap::new();
+    let mut separators = ":".to_string();
+
+    for e in cfg.entries() {
+        let ConfigEntry { key, value, .. } = e;
+        let Some(rest) = key.strip_prefix("trailer.") else {
+            continue;
+        };
+        if rest.rsplit_once('.').is_none() {
+            if var_ci_eq(rest, "where") {
+                if let Some(v) = value.as_deref().and_then(set_where) {
+                    default_conf.where_ = v;
+                }
+            } else if var_ci_eq(rest, "ifexists") {
+                if let Some(v) = value.as_deref().and_then(set_if_exists) {
+                    default_conf.if_exists = v;
+                }
+            } else if var_ci_eq(rest, "ifmissing") {
+                if let Some(v) = value.as_deref().and_then(set_if_missing) {
+                    default_conf.if_missing = v;
+                }
+            } else if var_ci_eq(rest, "separators") {
+                if let Some(v) = value {
+                    separators = v.clone();
+                }
+            }
+        }
+    }
+
+    for e in cfg.entries() {
+        let ConfigEntry { key, value, .. } = e;
+        let Some(rest) = key.strip_prefix("trailer.") else {
+            continue;
+        };
+        let Some((name_part, var)) = rest.rsplit_once('.') else {
+            continue;
+        };
+
+        let entry = map
+            .entry(name_part.to_string())
+            .or_insert_with(|| ConfInfo {
+                name: name_part.to_string(),
+                ..duplicate_conf(&default_conf)
+            });
+
+        if var_ci_eq(var, "key") {
+            if let Some(v) = value {
+                entry.key = Some(v.clone());
+            }
+        } else if var_ci_eq(var, "command") {
+            if let Some(v) = value {
+                entry.command = Some(v.clone());
+            }
+        } else if var_ci_eq(var, "cmd") {
+            if let Some(v) = value {
+                entry.cmd = Some(v.clone());
+            }
+        } else if var_ci_eq(var, "where") {
+            if let Some(v) = value.as_deref().and_then(set_where) {
+                entry.where_ = v;
+            }
+        } else if var_ci_eq(var, "ifexists") {
+            if let Some(v) = value.as_deref().and_then(set_if_exists) {
+                entry.if_exists = v;
+            }
+        } else if var_ci_eq(var, "ifmissing") {
+            if let Some(v) = value.as_deref().and_then(set_if_missing) {
+                entry.if_missing = v;
+            }
+        }
+    }
+
+    (default_conf, map.into_values().collect(), separators)
+}
+
+fn trailer_block_get(
+    input: &str,
+    opts: &ProcessTrailerOptions,
+    conf: &[ConfInfo],
+    separators: &str,
+    comment_prefix: &str,
+) -> TrailerBlock {
+    let end_of_log = find_end_of_log_message(input, opts.no_divider, comment_prefix);
+    let trailer_start =
+        find_trailer_block_start(input, end_of_log, conf, separators, comment_prefix);
+    let slice = &input[trailer_start..end_of_log];
+    let mut lines: Vec<String> = Vec::new();
+    let mut pos = 0usize;
+    let mut last_trailer_idx: Option<usize> = None;
+
+    while pos < slice.len() {
+        let le = line_end(slice, pos, slice.len());
+        let line = slice[pos..le].to_string();
+        pos = if le < slice.len() {
+            le + 1
+        } else {
+            slice.len()
+        };
+
+        if let Some(idx) = last_trailer_idx {
+            if !line.is_empty() && line.chars().next().is_some_and(|c| c == ' ' || c == '\t') {
+                lines[idx].push('\n');
+                lines[idx].push_str(&line);
+                continue;
+            }
+        }
+
+        let is_trailer_line = find_separator(&line, separators)
+            .is_some_and(|p| p >= 1 && !line.starts_with(|c: char| c.is_whitespace()));
+        last_trailer_idx = if is_trailer_line {
+            lines.push(line);
+            Some(lines.len() - 1)
+        } else {
+            lines.push(line);
+            None
+        };
+    }
+
+    TrailerBlock {
+        blank_line_before: ends_with_blank_line(input, trailer_start),
+        start: trailer_start,
+        end: end_of_log,
+        lines,
+    }
+}
+
+fn parse_trailers_from_input(
+    block: &TrailerBlock,
+    opts: &ProcessTrailerOptions,
+    conf: &[ConfInfo],
+    separators: &str,
+    comment_prefix: &str,
+) -> Vec<TrailerItem> {
+    let mut out = Vec::new();
+    for line in &block.lines {
+        if starts_with_comment_line(line, comment_prefix) {
+            continue;
+        }
+        if let Some(sep) = find_separator(line, separators) {
+            if sep >= 1 {
+                let (tok, mut val, _) = parse_trailer_into(line, separators, conf, true);
+                if opts.unfold {
+                    val = unfold_value(&val);
+                }
+                out.push(TrailerItem {
+                    token: Some(tok),
+                    value: val,
+                });
+            }
+        } else if !opts.only_trailers {
+            out.push(TrailerItem {
+                token: None,
+                value: line.clone(),
+            });
+        }
+    }
+    out
+}
+
+fn apply_command(conf: &ConfInfo, arg: Option<&str>, cwd: Option<&Path>) -> String {
+    let arg = arg.unwrap_or("");
+    let dir = cwd.unwrap_or_else(|| Path::new("."));
+    let output = if let Some(cmd) = &conf.cmd {
+        // Match Git `prepare_shell_cmd`: `sh -c '$cmd \"$@\"' $cmd <trailer-arg>` (always).
+        let script = format!("{cmd} \"$@\"");
+        Command::new("sh")
+            .arg("-c")
+            .arg(&script)
+            .arg(cmd)
+            .arg(arg)
+            .stdin(Stdio::null())
+            .current_dir(dir)
+            .output()
+    } else if let Some(command) = &conf.command {
+        let cmd_line = command.replace(TRAILER_ARG_PLACEHOLDER, arg);
+        Command::new("sh")
+            .arg("-c")
+            .arg(&cmd_line)
+            .stdin(Stdio::null())
+            .current_dir(dir)
+            .output()
+    } else {
+        return String::new();
+    };
+
+    match output {
+        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).trim().to_string(),
+        _ => String::new(),
+    }
+}
+
+/// Git `check_if_different`: walk the trailer list in placement direction; return false if any
+/// visited line is the same trailer (token + value) as `arg`.
+fn check_if_different(
+    head: &[TrailerItem],
+    start_idx: usize,
+    arg: &ArgItem,
+    check_all: bool,
+) -> bool {
+    let where_ = arg.conf.where_;
+    let mut idx = start_idx;
+    loop {
+        if same_trailer(&head[idx], arg) {
+            return false;
+        }
+        let next = if after_or_end(where_) {
+            idx.checked_sub(1)
+        } else if idx + 1 < head.len() {
+            Some(idx + 1)
+        } else {
+            None
+        };
+        let Some(ni) = next else {
+            return true;
+        };
+        idx = ni;
+        if !check_all {
+            return true;
+        }
+    }
+}
+
+fn insert_relative_to(
+    head: &mut Vec<TrailerItem>,
+    anchor_idx: usize,
+    item: TrailerItem,
+    where_: TrailerWhere,
+) {
+    if head.is_empty() {
+        head.push(item);
+        return;
+    }
+    let anchor_idx = anchor_idx.min(head.len().saturating_sub(1));
+    let at = if after_or_end(where_) {
+        (anchor_idx + 1).min(head.len())
+    } else {
+        anchor_idx.min(head.len())
+    };
+    head.insert(at, item);
+}
+
+fn apply_item_command(
+    head: &[TrailerItem],
+    in_idx: Option<usize>,
+    arg: &mut ArgItem,
+    cwd: Option<&Path>,
+) {
+    if arg.conf.command.is_none() && arg.conf.cmd.is_none() {
+        return;
+    }
+    let in_val = in_idx.and_then(|i| head.get(i)).and_then(|t| {
+        if t.token.is_some() {
+            Some(t.value.as_str())
+        } else {
+            None
+        }
+    });
+    let arg_for_cmd = if !arg.value.is_empty() {
+        Some(arg.value.as_str())
+    } else {
+        in_val
+    };
+    arg.value = apply_command(&arg.conf, arg_for_cmd, cwd);
+}
+
+fn apply_arg_if_exists(
+    head: &mut Vec<TrailerItem>,
+    in_idx: usize,
+    mut arg: ArgItem,
+    on_idx: usize,
+    cwd: Option<&Path>,
+) {
+    let if_exists = arg.conf.if_exists;
+    match if_exists {
+        TrailerIfExists::DoNothing => {}
+        TrailerIfExists::Replace => {
+            apply_item_command(head, Some(in_idx), &mut arg, cwd);
+            let where_for_insert = arg.conf.where_;
+            let new_item = TrailerItem {
+                token: Some(arg.token),
+                value: arg.value,
+            };
+            // Git adds the new trailer next to `on_tok`, then deletes `in_tok`.
+            let on_idx = on_idx.min(head.len().saturating_sub(1));
+            let insert_pos = if after_or_end(where_for_insert) {
+                (on_idx + 1).min(head.len())
+            } else {
+                on_idx.min(head.len())
+            };
+            head.insert(insert_pos, new_item);
+            let del = if insert_pos <= in_idx {
+                in_idx + 1
+            } else {
+                in_idx
+            };
+            head.remove(del);
+        }
+        TrailerIfExists::Add => {
+            apply_item_command(head, Some(in_idx), &mut arg, cwd);
+            let new_item = TrailerItem {
+                token: Some(arg.token),
+                value: arg.value,
+            };
+            insert_relative_to(head, on_idx, new_item, arg.conf.where_);
+        }
+        TrailerIfExists::AddIfDifferent => {
+            apply_item_command(head, Some(in_idx), &mut arg, cwd);
+            if check_if_different(head, in_idx, &arg, true) {
+                let new_item = TrailerItem {
+                    token: Some(arg.token.clone()),
+                    value: arg.value.clone(),
+                };
+                insert_relative_to(head, on_idx, new_item, arg.conf.where_);
+            }
+        }
+        TrailerIfExists::AddIfDifferentNeighbor => {
+            apply_item_command(head, Some(in_idx), &mut arg, cwd);
+            if check_if_different(head, on_idx, &arg, false) {
+                let new_item = TrailerItem {
+                    token: Some(arg.token.clone()),
+                    value: arg.value.clone(),
+                };
+                insert_relative_to(head, on_idx, new_item, arg.conf.where_);
+            }
+        }
+        TrailerIfExists::Default => {}
+    }
+}
+
+fn apply_arg_if_missing(head: &mut Vec<TrailerItem>, mut arg: ArgItem, cwd: Option<&Path>) {
+    match arg.conf.if_missing {
+        TrailerIfMissing::DoNothing => {}
+        TrailerIfMissing::Add | TrailerIfMissing::Default => {
+            apply_item_command(head, None, &mut arg, cwd);
+            let where_ = arg.conf.where_;
+            let item = TrailerItem {
+                token: Some(arg.token),
+                value: arg.value,
+            };
+            if after_or_end(where_) {
+                head.push(item);
+            } else {
+                head.insert(0, item);
+            }
+        }
+    }
+}
+
+/// Returns `None` if `arg` was applied to an existing trailer, `Some(arg)` if no match.
+fn find_same_and_apply_arg(
+    head: &mut Vec<TrailerItem>,
+    arg: ArgItem,
+    cwd: Option<&Path>,
+) -> Option<ArgItem> {
+    let where_ = arg.conf.where_;
+    let middle = matches!(where_, TrailerWhere::After | TrailerWhere::Before);
+    let backwards = after_or_end(where_);
+
+    if head.is_empty() {
+        return Some(arg);
+    }
+
+    let start_idx = if backwards { head.len() - 1 } else { 0 };
+
+    let mut i: isize = if backwards {
+        head.len() as isize - 1
+    } else {
+        0
+    };
+
+    loop {
+        if i < 0 || (i as usize) >= head.len() {
+            break;
+        }
+        let idx = i as usize;
+        if same_token(head[idx].token.as_deref(), &arg.token) {
+            let on_idx = if middle { idx } else { start_idx };
+            apply_arg_if_exists(head, idx, arg, on_idx, cwd);
+            return None;
+        }
+        i = if backwards { i - 1 } else { i + 1 };
+    }
+    Some(arg)
+}
+
+fn merge_arg_conf(base: &ConfInfo, new_arg: &NewTrailerArg) -> ConfInfo {
+    let mut c = duplicate_conf(base);
+    if new_arg.where_ != TrailerWhere::Default {
+        c.where_ = new_arg.where_;
+    }
+    if new_arg.if_exists != TrailerIfExists::Default {
+        c.if_exists = new_arg.if_exists;
+    }
+    if new_arg.if_missing != TrailerIfMissing::Default {
+        c.if_missing = new_arg.if_missing;
+    }
+    c
+}
+
+fn parse_trailers_from_config(conf_list: &[ConfInfo]) -> Vec<ArgItem> {
+    let mut v = Vec::new();
+    for item in conf_list {
+        if item.command.is_some() {
+            v.push(ArgItem {
+                token: token_from_item(item, None),
+                value: String::new(),
+                conf: duplicate_conf(item),
+            });
+        }
+    }
+    v
+}
+
+fn parse_command_line_trailers(
+    new_args: &[NewTrailerArg],
+    default_conf: &ConfInfo,
+    conf_list: &[ConfInfo],
+    separators: &str,
+) -> Vec<ArgItem> {
+    let cl_separators: String = format!("={separators}");
+    let mut out = Vec::new();
+    for nt in new_args {
+        let sep = find_separator(&nt.text, &cl_separators);
+        if sep == Some(0) {
+            continue;
+        }
+        let (tok, val, picked) = parse_trailer_into(&nt.text, &cl_separators, conf_list, true);
+        let base = if !picked.name.is_empty() {
+            picked
+        } else {
+            duplicate_conf(default_conf)
+        };
+        let conf = merge_arg_conf(&base, nt);
+        out.push(ArgItem {
+            token: tok,
+            value: val,
+            conf,
+        });
+    }
+    out
+}
+
+fn process_trailers_lists(head: &mut Vec<TrailerItem>, args: Vec<ArgItem>, cwd: Option<&Path>) {
+    for arg_tok in args {
+        if let Some(a) = find_same_and_apply_arg(head, arg_tok, cwd) {
+            apply_arg_if_missing(head, a, cwd);
+        }
+    }
+}
+
+fn format_one_trailer(
+    item: &TrailerItem,
+    trim_empty: bool,
+    only_trailers: bool,
+    separators: &str,
+    out: &mut String,
+) {
+    let Some(ref tok) = item.token else {
+        if only_trailers {
+            return;
+        }
+        out.push_str(&item.value);
+        out.push('\n');
+        return;
+    };
+    if trim_empty && item.value.is_empty() {
+        return;
+    }
+    out.push_str(tok);
+    let c = last_non_space_char(tok);
+    let need_sep = c.is_none_or(|ch| !separators.contains(ch));
+    if need_sep {
+        out.push(separators.chars().next().unwrap_or(':'));
+        out.push(' ');
+    }
+    out.push_str(&item.value);
+    out.push('\n');
+}
+
+fn format_trailers_list(
+    items: &[TrailerItem],
+    opts: &ProcessTrailerOptions,
+    separators: &str,
+    out: &mut String,
+) {
+    for item in items {
+        format_one_trailer(item, opts.trim_empty, opts.only_trailers, separators, out);
+    }
+}
+
+/// Process a commit message: parse trailer block, apply config and `--trailer` args, emit result.
+///
+/// `git_dir` selects which repository config to load (with standard cascade). When `None`, only
+/// non-repo config layers are used (matches `git interpret-trailers` outside a repo).
+pub fn process_trailers(
+    input: &str,
+    opts: &ProcessTrailerOptions,
+    new_trailer_args: &[NewTrailerArg],
+    git_dir: Option<&Path>,
+) -> String {
+    let cfg = ConfigSet::load(git_dir, true).unwrap_or_default();
+    let comment_prefix = comment_line_prefix(&cfg);
+    let (default_conf, conf_list, separators) = load_trailer_config(&cfg);
+
+    let block = trailer_block_get(input, opts, &conf_list, &separators, &comment_prefix);
+    let mut head =
+        parse_trailers_from_input(&block, opts, &conf_list, &separators, &comment_prefix);
+
+    if !opts.only_input {
+        let mut arg_queue = parse_trailers_from_config(&conf_list);
+        arg_queue.extend(parse_command_line_trailers(
+            new_trailer_args,
+            &default_conf,
+            &conf_list,
+            &separators,
+        ));
+        let cwd = std::env::current_dir().ok();
+        process_trailers_lists(&mut head, arg_queue, cwd.as_deref());
+    }
+
+    let mut out = String::new();
+    if !opts.only_trailers {
+        out.push_str(&input[..block.start]);
+        if !block.blank_line_before {
+            out.push('\n');
+        }
+    }
+    format_trailers_list(&head, opts, &separators, &mut out);
+    if !opts.only_trailers {
+        out.push_str(&input[block.end..]);
+    }
+    out
+}
+
+/// Complete stdin/file input with a trailing newline when missing (Git `strbuf_complete_line`).
+pub fn complete_line(s: &str) -> String {
+    if s.is_empty() || !s.ends_with('\n') {
+        let mut o = s.to_string();
+        o.push('\n');
+        o
+    } else {
+        s.to_string()
+    }
+}

--- a/grit-lib/src/lib.rs
+++ b/grit-lib/src/lib.rs
@@ -32,6 +32,7 @@ pub mod gitmodules;
 pub mod hooks;
 pub mod ignore;
 pub mod index;
+pub mod interpret_trailers;
 pub mod line_log;
 pub mod ls_remote;
 pub mod merge_base;

--- a/grit/src/commands/interpret_trailers.rs
+++ b/grit/src/commands/interpret_trailers.rs
@@ -1,375 +1,193 @@
 //! `grit interpret-trailers` — add or parse structured trailers in commit messages.
-//!
-//! Trailers are key-value pairs at the end of a commit message, separated from
-//! the body by a blank line.  Format: `Key: Value` or `Key #Value`.
-//!
-//! Examples:
-//!   Signed-off-by: Name <email>
-//!   Reviewed-by: Name <email>
 
-use anyhow::{Context, Result};
-use clap::Args as ClapArgs;
+use anyhow::{bail, Context, Result};
+use grit_lib::interpret_trailers::{
+    complete_line, process_trailers, NewTrailerArg, ProcessTrailerOptions, TrailerIfExists,
+    TrailerIfMissing, TrailerWhere,
+};
+use grit_lib::repo::Repository;
 use std::fs;
 use std::io::{self, Read, Write};
-
-/// Arguments for `grit interpret-trailers`.
-#[derive(Debug, ClapArgs)]
-#[command(
-    about = "Add or parse trailers in commit messages",
-    override_usage = "grit interpret-trailers [OPTIONS] [<file>...]"
-)]
-pub struct Args {
-    /// Add a trailer (can be specified multiple times).
-    #[arg(long = "trailer", value_name = "token")]
-    pub trailer: Vec<String>,
-
-    /// Only output the trailers (parse mode).
-    #[arg(long = "parse")]
-    pub parse: bool,
-
-    /// Edit files in-place instead of writing to stdout.
-    #[arg(long = "in-place")]
+/// Arguments for `grit interpret-trailers` (manual parse to match Git's per-`--trailer` state).
+#[derive(Debug, Default)]
+pub struct ParsedCli {
+    pub opts: ProcessTrailerOptions,
     pub in_place: bool,
-
-    /// Only output trailers that consist of a key-value pair.
-    #[arg(long = "only-trailers")]
-    pub only_trailers: bool,
-
-    /// Do not apply the standard cleanup rules to the trailer value.
-    #[arg(long = "no-divider")]
-    pub no_divider: bool,
-
-    /// Trim trailing whitespace from trailers.
-    #[arg(long = "trim-empty")]
-    pub trim_empty: bool,
-
-    /// Remove duplicate trailers with the same key and value.
-    #[arg(long = "if-exists", value_name = "action")]
-    pub if_exists: Option<String>,
-
-    /// What to do if a trailer with the same key doesn't exist.
-    #[arg(long = "if-missing", value_name = "action")]
-    pub if_missing: Option<String>,
-
-    /// Where to place new trailers: end (default), start, after, before.
-    #[arg(long = "where", value_name = "placement")]
-    pub placement: Option<String>,
-
-    /// Input files (reads from stdin if none given).
+    pub trailer_specs: Vec<NewTrailerArg>,
     pub files: Vec<String>,
 }
 
-/// Run the `interpret-trailers` command.
-pub fn run(args: Args) -> Result<()> {
-    if args.files.is_empty() {
-        // Read from stdin.
+pub fn parse_interpret_trailers_argv(args: &[String]) -> Result<ParsedCli> {
+    let mut out = ParsedCli::default();
+    let mut i = 0usize;
+    let mut cli_where = TrailerWhere::Default;
+    let mut cli_if_exists = TrailerIfExists::Default;
+    let mut cli_if_missing = TrailerIfMissing::Default;
+
+    while i < args.len() {
+        let a = &args[i];
+        match a.as_str() {
+            "--in-place" | "-i" => {
+                out.in_place = true;
+                i += 1;
+            }
+            "--trim-empty" => {
+                out.opts.trim_empty = true;
+                i += 1;
+            }
+            "--parse" => {
+                out.opts.only_trailers = true;
+                out.opts.only_input = true;
+                out.opts.unfold = true;
+                i += 1;
+            }
+            "--only-trailers" => {
+                out.opts.only_trailers = true;
+                i += 1;
+            }
+            "--only-input" => {
+                out.opts.only_input = true;
+                i += 1;
+            }
+            "--unfold" => {
+                out.opts.unfold = true;
+                i += 1;
+            }
+            "--no-divider" => {
+                out.opts.no_divider = true;
+                i += 1;
+            }
+            "--where" => {
+                let v = args
+                    .get(i + 1)
+                    .ok_or_else(|| anyhow::anyhow!("option '--where' requires a value"))?;
+                cli_where = parse_where_value(v)?;
+                i += 2;
+            }
+            "--no-where" => {
+                cli_where = TrailerWhere::Default;
+                i += 1;
+            }
+            "--if-exists" => {
+                let v = args
+                    .get(i + 1)
+                    .ok_or_else(|| anyhow::anyhow!("option '--if-exists' requires a value"))?;
+                cli_if_exists = parse_if_exists_value(v)?;
+                i += 2;
+            }
+            "--no-if-exists" => {
+                cli_if_exists = TrailerIfExists::Default;
+                i += 1;
+            }
+            "--if-missing" => {
+                let v = args
+                    .get(i + 1)
+                    .ok_or_else(|| anyhow::anyhow!("option '--if-missing' requires a value"))?;
+                cli_if_missing = parse_if_missing_value(v)?;
+                i += 2;
+            }
+            "--no-if-missing" => {
+                cli_if_missing = TrailerIfMissing::Default;
+                i += 1;
+            }
+            "--trailer" => {
+                let v = args
+                    .get(i + 1)
+                    .ok_or_else(|| anyhow::anyhow!("option '--trailer' requires a value"))?;
+                out.trailer_specs.push(NewTrailerArg {
+                    text: v.clone(),
+                    where_: cli_where,
+                    if_exists: cli_if_exists,
+                    if_missing: cli_if_missing,
+                });
+                i += 2;
+            }
+            "--" => {
+                out.files.extend(args[i + 1..].iter().cloned());
+                break;
+            }
+            x if x.starts_with('-') && x != "-" => {
+                bail!("unknown option '{x}'");
+            }
+            _ => {
+                out.files.push(a.clone());
+                i += 1;
+            }
+        }
+    }
+
+    if out.opts.only_input
+        && out.opts.only_trailers
+        && out.opts.unfold
+        && !out.trailer_specs.is_empty()
+    {
+        bail!("--trailer with --only-input does not make sense");
+    }
+
+    Ok(out)
+}
+
+fn parse_where_value(v: &str) -> Result<TrailerWhere> {
+    grit_lib::interpret_trailers::trailer_where_from_str(v)
+        .ok_or_else(|| anyhow::anyhow!("unknown --where value '{v}'"))
+}
+
+fn parse_if_exists_value(v: &str) -> Result<TrailerIfExists> {
+    grit_lib::interpret_trailers::trailer_if_exists_from_str(v)
+        .ok_or_else(|| anyhow::anyhow!("unknown --if-exists value '{v}'"))
+}
+
+fn parse_if_missing_value(v: &str) -> Result<TrailerIfMissing> {
+    grit_lib::interpret_trailers::trailer_if_missing_from_str(v)
+        .ok_or_else(|| anyhow::anyhow!("unknown --if-missing value '{v}'"))
+}
+
+/// Run `interpret-trailers` from already-split argv (subcommand name stripped).
+pub fn run_from_argv(args: &[String]) -> Result<()> {
+    let parsed = parse_interpret_trailers_argv(args)?;
+    run_parsed(parsed)
+}
+
+fn discover_git_dir() -> Option<std::path::PathBuf> {
+    Repository::discover(None).ok().map(|r| r.git_dir)
+}
+
+fn run_parsed(parsed: ParsedCli) -> Result<()> {
+    let git_dir = discover_git_dir();
+
+    if parsed.files.is_empty() {
+        if parsed.in_place {
+            bail!("no input file given for in-place editing");
+        }
         let mut input = String::new();
         io::stdin()
             .read_to_string(&mut input)
             .context("reading stdin")?;
-
-        let output = process_message(&input, &args);
+        let input = complete_line(&input);
+        let output = process_trailers(
+            &input,
+            &parsed.opts,
+            &parsed.trailer_specs,
+            git_dir.as_deref(),
+        );
         io::stdout().write_all(output.as_bytes())?;
-    } else {
-        for file in &args.files {
-            let input = fs::read_to_string(file).with_context(|| format!("reading '{file}'"))?;
-            let output = process_message(&input, &args);
-
-            if args.in_place {
-                fs::write(file, &output).with_context(|| format!("writing '{file}'"))?;
-            } else {
-                io::stdout().write_all(output.as_bytes())?;
-            }
-        }
+        return Ok(());
     }
 
+    for file in &parsed.files {
+        let raw = fs::read_to_string(file).with_context(|| format!("reading '{file}'"))?;
+        let input = complete_line(&raw);
+        let output = process_trailers(
+            &input,
+            &parsed.opts,
+            &parsed.trailer_specs,
+            git_dir.as_deref(),
+        );
+        if parsed.in_place {
+            fs::write(file, &output).with_context(|| format!("writing '{file}'"))?;
+        } else {
+            io::stdout().write_all(output.as_bytes())?;
+        }
+    }
     Ok(())
-}
-
-/// A parsed trailer: key-separator-value.
-#[derive(Debug, Clone)]
-struct Trailer {
-    key: String,
-    separator: String,
-    value: String,
-}
-
-impl Trailer {
-    fn parse(line: &str) -> Option<Self> {
-        // Try "Key: Value" first, then "Key #Value".
-        if let Some(colon_pos) = line.find(": ") {
-            let key = line[..colon_pos].trim().to_string();
-            let value = line[colon_pos + 2..].trim().to_string();
-            if is_valid_trailer_key(&key) {
-                return Some(Trailer {
-                    key,
-                    separator: ": ".to_string(),
-                    value,
-                });
-            }
-        }
-        if let Some(hash_pos) = line.find(" #") {
-            let key = line[..hash_pos].trim().to_string();
-            let value = line[hash_pos + 2..].trim().to_string();
-            if is_valid_trailer_key(&key) {
-                return Some(Trailer {
-                    key,
-                    separator: " #".to_string(),
-                    value,
-                });
-            }
-        }
-        None
-    }
-
-    fn format(&self) -> String {
-        format!("{}{}{}", self.key, self.separator, self.value)
-    }
-}
-
-/// Check if a string is a valid trailer key (alphanumeric + hyphens, no spaces).
-fn is_valid_trailer_key(key: &str) -> bool {
-    !key.is_empty()
-        && key
-            .chars()
-            .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
-}
-
-/// Parse a trailer token from --trailer argument.
-/// Accepts "Key: Value", "Key=Value", "Key:Value".
-fn parse_trailer_token(token: &str) -> Trailer {
-    // Try "Key: Value" first.
-    if let Some(pos) = token.find(": ") {
-        return Trailer {
-            key: token[..pos].trim().to_string(),
-            separator: ": ".to_string(),
-            value: token[pos + 2..].trim().to_string(),
-        };
-    }
-    // Try "Key:Value".
-    if let Some(pos) = token.find(':') {
-        return Trailer {
-            key: token[..pos].trim().to_string(),
-            separator: ": ".to_string(),
-            value: token[pos + 1..].trim().to_string(),
-        };
-    }
-    // Try "Key=Value".
-    if let Some(pos) = token.find('=') {
-        return Trailer {
-            key: token[..pos].trim().to_string(),
-            separator: ": ".to_string(),
-            value: token[pos + 1..].trim().to_string(),
-        };
-    }
-    // Fallback: treat whole thing as key with empty value.
-    Trailer {
-        key: token.trim().to_string(),
-        separator: ": ".to_string(),
-        value: String::new(),
-    }
-}
-
-/// Find where the trailer block starts in the message.
-/// Returns (body_end, trailer_start) indices into lines.
-fn find_trailer_block(lines: &[&str]) -> (usize, usize) {
-    // Walk backwards from the end, skipping trailing blank lines.
-    let mut end = lines.len();
-    while end > 0 && lines[end - 1].trim().is_empty() {
-        end -= 1;
-    }
-
-    if end == 0 {
-        return (0, 0);
-    }
-
-    // Check if the last non-blank lines form a trailer block.
-    let mut trailer_start = end;
-    let mut i = end;
-    while i > 0 {
-        i -= 1;
-        let line = lines[i].trim();
-        if line.is_empty() {
-            // Blank line before trailers = separator.
-            break;
-        }
-        if Trailer::parse(line).is_some() {
-            trailer_start = i;
-        } else {
-            // Non-trailer, non-blank line — stop.
-            trailer_start = end; // no trailer block found at this level
-            break;
-        }
-    }
-
-    // Body ends at the blank line before trailers (or at trailer_start if no blank line).
-    let body_end = if trailer_start > 0 && trailer_start < end {
-        // Check if line before trailer_start is blank.
-        if trailer_start > 0
-            && lines
-                .get(trailer_start - 1)
-                .is_some_and(|l| l.trim().is_empty())
-        {
-            trailer_start - 1
-        } else {
-            trailer_start
-        }
-    } else {
-        end
-    };
-
-    (body_end, trailer_start)
-}
-
-/// Process a commit message: parse existing trailers, add new ones.
-fn process_message(input: &str, args: &Args) -> String {
-    let lines: Vec<&str> = input.lines().collect();
-    let (body_end, trailer_start) = find_trailer_block(&lines);
-
-    // Parse existing trailers.
-    let mut existing_trailers: Vec<Trailer> = Vec::new();
-    if trailer_start < lines.len() {
-        for line in &lines[trailer_start..] {
-            if let Some(t) = Trailer::parse(line.trim()) {
-                existing_trailers.push(t);
-            }
-        }
-    }
-
-    // Parse new trailers from --trailer args.
-    let new_trailers: Vec<Trailer> = args
-        .trailer
-        .iter()
-        .map(|t| parse_trailer_token(t))
-        .collect();
-
-    if args.parse {
-        // --parse: only output trailers.
-        let mut out = String::new();
-        for t in &existing_trailers {
-            if !args.only_trailers || (!t.key.is_empty() && !t.value.is_empty()) {
-                out.push_str(&t.format());
-                out.push('\n');
-            }
-        }
-        for t in &new_trailers {
-            if !args.only_trailers || (!t.key.is_empty() && !t.value.is_empty()) {
-                out.push_str(&t.format());
-                out.push('\n');
-            }
-        }
-        return out;
-    }
-
-    // Determine placement, if-exists, if-missing from args.
-    let placement = args.placement.as_deref().unwrap_or("end");
-    let if_exists_action = args.if_exists.as_deref().unwrap_or("addIfDifferent");
-    let if_missing_action = args.if_missing.as_deref().unwrap_or("add");
-
-    // Filter new trailers based on --if-exists and --if-missing.
-    let mut trailers_to_add: Vec<Trailer> = Vec::new();
-    for new_t in &new_trailers {
-        if args.trim_empty && new_t.value.is_empty() {
-            continue;
-        }
-
-        let key_lower = new_t.key.to_lowercase();
-        let existing_with_same_key: Vec<&Trailer> = existing_trailers
-            .iter()
-            .filter(|t| t.key.to_lowercase() == key_lower)
-            .collect();
-
-        if !existing_with_same_key.is_empty() {
-            // Trailer with this key already exists — apply --if-exists.
-            match if_exists_action {
-                "addIfDifferentNeighbor" | "addIfDifferent" => {
-                    let dominated = existing_with_same_key
-                        .iter()
-                        .any(|t| t.value == new_t.value);
-                    if !dominated {
-                        trailers_to_add.push(new_t.clone());
-                    }
-                }
-                "add" => {
-                    trailers_to_add.push(new_t.clone());
-                }
-                "replace" => {
-                    // Remove existing trailers with matching key, add replacement.
-                    existing_trailers.retain(|t| t.key.to_lowercase() != key_lower);
-                    trailers_to_add.push(new_t.clone());
-                }
-                "donothing" => {
-                    // Do nothing — skip this trailer.
-                }
-                _ => {
-                    trailers_to_add.push(new_t.clone());
-                }
-            }
-        } else {
-            // Trailer with this key doesn't exist — apply --if-missing.
-            match if_missing_action {
-                "add" => {
-                    trailers_to_add.push(new_t.clone());
-                }
-                "donothing" => {
-                    // Don't add.
-                }
-                _ => {
-                    trailers_to_add.push(new_t.clone());
-                }
-            }
-        }
-    }
-
-    // Reconstruct message with trailers added.
-    let mut out = String::new();
-
-    // Body (up to body_end).
-    for line in &lines[..body_end] {
-        out.push_str(line);
-        out.push('\n');
-    }
-
-    // Ensure blank line before trailers.
-    if !out.is_empty() && !out.ends_with("\n\n") {
-        out.push('\n');
-    }
-
-    // Combine existing + new trailers respecting --where placement.
-    match placement {
-        "start" => {
-            for t in &trailers_to_add {
-                out.push_str(&t.format());
-                out.push('\n');
-            }
-            for t in &existing_trailers {
-                out.push_str(&t.format());
-                out.push('\n');
-            }
-        }
-        "before" => {
-            // Insert new trailers before existing ones.
-            for t in &trailers_to_add {
-                out.push_str(&t.format());
-                out.push('\n');
-            }
-            for t in &existing_trailers {
-                out.push_str(&t.format());
-                out.push('\n');
-            }
-        }
-        "after" | "end" | _ => {
-            // Append new trailers after existing ones (default).
-            for t in &existing_trailers {
-                out.push_str(&t.format());
-                out.push('\n');
-            }
-            for t in &trailers_to_add {
-                out.push_str(&t.format());
-                out.push('\n');
-            }
-        }
-    }
-
-    out
 }

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -3222,7 +3222,7 @@ pub(crate) fn dispatch(subcmd: &str, rest: &[String], opts: &GlobalOpts) -> Resu
             commands::index_pack::run(parse_cmd_args(subcmd, &argv))
         }
         "init" => commands::init::run(parse_cmd_args(subcmd, rest), opts.bare),
-        "interpret-trailers" => commands::interpret_trailers::run(parse_cmd_args(subcmd, rest)),
+        "interpret-trailers" => commands::interpret_trailers::run_from_argv(rest),
         "last-modified" => commands::last_modified::run(parse_cmd_args(subcmd, rest)),
         "log" => {
             let rest = preprocess_log_args(rest);

--- a/logs/2026-04-08_t7513-interpret-trailers.md
+++ b/logs/2026-04-08_t7513-interpret-trailers.md
@@ -1,0 +1,5 @@
+# t7513-interpret-trailers
+
+- Added `grit_lib::interpret_trailers` porting Git `trailer.c` behaviour: trailer block detection (--- divider, cut line, ignored tail), `trailer.*` config (two-pass global defaults + per-alias), `process_trailers_lists`, command/`cmd` execution via `sh` with stdin closed, `core.commentChar` for comment lines.
+- Replaced clap-based `interpret-trailers` with manual argv parsing so `--where` / `--if-exists` / `--if-missing` apply per following `--trailer` like Git.
+- Harness: `./scripts/run-tests.sh t7513-interpret-trailers.sh` → 99/99 pass.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible `interpret-trailers` in `grit-lib` (ported from upstream `trailer.c` behaviour): trailer block detection (`---` patch divider, cut line, trailing ignored region), `trailer.*` configuration with correct two-pass global defaults, `trailer.command` / `trailer.cmd` execution, and `core.commentChar` for comment-line handling.

The CLI no longer uses clap for this subcommand; arguments are parsed manually so `--where`, `--if-exists`, and `--if-missing` apply to the following `--trailer` options exactly like Git.

## Testing

- `./scripts/run-tests.sh t7513-interpret-trailers.sh` — **99/99** pass
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-039f3b7f-ef42-4bdc-9177-097896607fe8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-039f3b7f-ef42-4bdc-9177-097896607fe8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

