### PR TITLE
fix: make t8003-blame-corner-cases fully pass

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -922,7 +922,7 @@ commit → check it off → move on.
 - [ ] `t8006-blame-textconv` ███████░░░░░░░░░░░░░ 6/16 (10 left) — git blame textconv support
 - [ ] `t8014-blame-ignore-fuzzy` █████░░░░░░░░░░░░░░░ 4/16 (12 left) — git blame ignore fuzzy heuristic
 - [ ] `t8013-blame-ignore-revs` ███░░░░░░░░░░░░░░░░░ 3/19 (16 left) — ignore revisions when blaming
-- [ ] `t8003-blame-corner-cases` ████████░░░░░░░░░░░░ 12/30 (18 left) — git blame corner cases
+- [x] `t8003-blame-corner-cases` ████████████████████ 30/30 (0 left) — git blame corner cases
 - [ ] `t8020-last-modified` ░░░░░░░░░░░░░░░░░░░░ 1/28 (27 left) — last-modified tests
 
 ## 10. Contrib/Other (15 files)

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -92,7 +92,7 @@ t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
 t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
-t1006-cat-file	t1	yes	290	285	5	false	ok	1
+t1006-cat-file	t1	yes	290	285	5	false	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	32	8	false	ok	0
 t10070-cat-file-batch-format	t1	yes	33	33	0	true	ok	0
@@ -1283,7 +1283,7 @@ t7900-maintenance	t7	yes	0	0	0	false	timeout	0
 t7901-stash-resolve-merge	t7	yes	7	7	0	true	ok	0
 t8001-annotate	t8	yes	117	97	20	false	ok	0
 t8002-blame	t8	yes	135	53	82	false	ok	0
-t8003-blame-corner-cases	t8	yes	30	24	6	false	ok	0
+t8003-blame-corner-cases	t8	yes	30	30	0	true	ok	0
 t8004-blame-with-conflicts	t8	yes	3	3	0	true	ok	0
 t8005-blame-i18n	t8	yes	5	0	5	false	ok	0
 t8006-blame-textconv	t8	yes	16	7	9	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T19:45:43+00:00" class="gen-time" title="2026-04-08 19:45 UTC">2026-04-08 19:45 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,565</div>
+      <div class="summary-big-val">29,579</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>713 files fully passing</span>
+    <span>717 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,7 +212,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">41/141 files · 2 skipped · 3,333/4,611 tests</span>
+        <span class="group-meta">42/141 files · 2 skipped · 3,334/4,611 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.3%"></div></div>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,336/3,949 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,342/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.8%"></div></div>
-        <span class="group-pct pct-red">33.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.0%"></div></div>
+        <span class="group-pct pct-red">34.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -256,7 +256,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">42/126 files · 11 skipped · 1,793/2,944 tests</span>
+        <span class="group-meta">43/126 files · 11 skipped · 1,794/2,944 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>
@@ -267,11 +267,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t8</span>
         <span class="group-desc">Porcelainish commands concerning forensics</span>
-        <span class="group-meta">79/105 files · 0 skipped · 2,855/3,116 tests</span>
+        <span class="group-meta">80/105 files · 0 skipped · 2,861/3,116 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:91.6%"></div></div>
-        <span class="group-pct pct-green">91.6%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:91.8%"></div></div>
+        <span class="group-pct pct-green">91.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t9">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T19:45:43+00:00" class="gen-time" title="2026-04-08 19:45 UTC">2026-04-08 19:45 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,864</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,565</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,579</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1085,7 +1085,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">285</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.3%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t10060-hash-object-determinism</td>
@@ -5110,8 +5110,7 @@ tr.row-skip td { opacity: 0.65; }
 <tr class="" data-group="t2" data-tests="15" data-passed="5">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td><span class="badge ok">full pass</span></td>
-  <td class="right">15</td>
+  <td></td>
   <td class="right">15</td>
   <td class="right">5</td>
   <td class="right">ok</td>
@@ -6218,14 +6217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="54" data-passed="38">
+<tr class="" data-group="t3" data-tests="52" data-passed="3">
   <td class="mono">t3420-rebase-autostash</td>
   <td>t3</td>
   <td></td>
-  <td class="right">54</td>
-  <td class="right">38</td>
+  <td class="right">52</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="63" data-passed="11">
@@ -12598,7 +12597,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="2" data-passed="2">
+<tr class="" data-group="t7" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t7524-commit-summary</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>
@@ -12988,14 +12987,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:39.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t8" data-tests="30" data-passed="24">
+<tr class="" data-group="t8" data-tests="30" data-passed="30" data-full-pass="1">
   <td class="mono">t8003-blame-corner-cases</td>
   <td>t8</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">30</td>
-  <td class="right">24</td>
+  <td class="right">30</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:80.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t8" data-tests="3" data-passed="3" data-full-pass="1">

--- a/grit/src/commands/blame.rs
+++ b/grit/src/commands/blame.rs
@@ -10,7 +10,7 @@ use grit_lib::crlf::{
 use grit_lib::objects::{parse_commit, parse_tree, CommitData, ObjectId, ObjectKind};
 use grit_lib::odb::Odb;
 use grit_lib::repo::Repository;
-use grit_lib::rev_parse::resolve_revision;
+use grit_lib::rev_parse::{resolve_revision, resolve_revision_without_index_dwim};
 use grit_lib::state::resolve_head;
 use grit_lib::userdiff;
 use grit_lib::wildmatch::wildmatch;
@@ -1866,7 +1866,7 @@ pub fn run(args: Args) -> Result<()> {
     normalize_detection_args(&args.move_detection, &mut normalized_positional);
     normalized_positional.extend(args.args.iter().cloned());
 
-    let (rev, file_path) = parse_blame_args(&repo, &normalized_positional)?;
+    let (rev, file_path) = parse_blame_args(&odb, &repo, &normalized_positional)?;
     let use_textconv = !args.no_textconv;
     let copy_depth = args.copy_detection.len();
     let textconv_ctx = Some(BlameTextconvContext::new(&repo));
@@ -2245,7 +2245,19 @@ fn looks_like_object_id(s: &str) -> bool {
     b.iter().all(|c| matches!(c, b'0'..=b'9' | b'a'..=b'f'))
 }
 
-fn parse_blame_args(repo: &Repository, args: &[String]) -> Result<(Option<String>, String)> {
+/// True when `spec` resolves to an object that peels to a commit (not a lone blob/tree).
+fn spec_resolves_to_commit(odb: &Odb, repo: &Repository, spec: &str) -> bool {
+    let Ok(oid) = resolve_revision_without_index_dwim(repo, spec) else {
+        return false;
+    };
+    peel_to_commit_oid(odb, oid).ok().flatten().is_some()
+}
+
+fn parse_blame_args(
+    odb: &Odb,
+    repo: &Repository,
+    args: &[String],
+) -> Result<(Option<String>, String)> {
     match args.len() {
         0 => bail!("usage: grit blame [<rev>] [--] <file>"),
         1 => Ok((None, args[0].clone())),
@@ -2253,10 +2265,23 @@ fn parse_blame_args(repo: &Repository, args: &[String]) -> Result<(Option<String
         2 => {
             let a0 = &args[0];
             let a1 = &args[1];
-            if resolve_revision(repo, a1).is_ok() || a1 == "HEAD" || looks_like_object_id(a1) {
-                Ok((Some(a1.clone()), a0.clone()))
-            } else {
-                Ok((Some(a0.clone()), a1.clone()))
+            let c0 = spec_resolves_to_commit(odb, repo, a0);
+            let c1 = spec_resolves_to_commit(odb, repo, a1);
+            match (c0, c1) {
+                (true, false) => Ok((Some(a0.clone()), a1.clone())),
+                (false, true) => Ok((Some(a1.clone()), a0.clone())),
+                (true, true) => Ok((Some(a0.clone()), a1.clone())),
+                (false, false) => {
+                    // Neither peels to a commit; keep legacy heuristic for odd cases.
+                    if resolve_revision_without_index_dwim(repo, a1).is_ok()
+                        || a1 == "HEAD"
+                        || looks_like_object_id(a1)
+                    {
+                        Ok((Some(a1.clone()), a0.clone()))
+                    } else {
+                        Ok((Some(a0.clone()), a1.clone()))
+                    }
+                }
             }
         }
         3 if args[1] == "--" => Ok((Some(args[0].clone()), args[2].clone())),
@@ -2277,10 +2302,6 @@ fn resolve_blame_start_oid(repo: &Repository, rev_spec: &str) -> Result<ObjectId
         // Accept two-dot ranges by resolving the right side (or merge base
         // from the rev parser in cases where that is appropriate).
         return resolve_revision(repo, rhs).map_err(Into::into);
-    }
-    if let Some((_, rhs)) = rev_spec.split_once("..") {
-        let target = if rhs.is_empty() { "HEAD" } else { rhs };
-        return resolve_revision(repo, target).map_err(Into::into);
     }
     resolve_revision(repo, rev_spec).map_err(Into::into)
 }

--- a/logs/2026-04-08_t8003-blame-corner-cases.md
+++ b/logs/2026-04-08_t8003-blame-corner-cases.md
@@ -1,0 +1,17 @@
+# t8003-blame-corner-cases
+
+## Summary
+
+Made `tests/t8003-blame-corner-cases.sh` pass 30/30.
+
+## Root causes
+
+1. **`resolve_blame_start_oid`**: A second `split_once("..")` block treated `HEAD^` as `HEAD` + `^`, resolving to the tree OID instead of the parent commit. Removed the dead/wrong branch (first `if` already handled `..` ranges).
+
+2. **`parse_blame_args` (two positional args)**: `resolve_revision` index DWIM and short-hex disambiguation could resolve a filename like `f` to a blob OID, so the parser swapped rev/path (`HEAD^` became the path). Fixed by resolving without index DWIM and treating a token as the revision only when it peels to a commit via `peel_to_commit_oid`; if both peel to commits, Git order (`rev` then `path`) is used.
+
+## Validation
+
+- `./scripts/run-tests.sh t8003-blame-corner-cases.sh` → 30/30
+- `cargo fmt`, `cargo check -p grit-rs`, `cargo clippy -p grit-rs --fix --allow-dirty`
+- `cargo test -p grit-lib --lib`

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   231 |
+| Completed   |   232 |
 | In progress |     2 |
-| Remaining   |   535 |
+| Remaining   |   534 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 231 completed (`[x]`), 2 in progress (`[~]`), 535 remaining (`[ ]`).
+Task lines in `PLAN.md`: 232 completed (`[x]`), 2 in progress (`[~]`), 534 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t8003-blame-corner-cases` — 30/30 tests pass (`blame` rev/file disambiguation: commit-ish peel vs index DWIM/abbrev blob; `HEAD^` range parsing; harness CSV refreshed)
 - `t12820-diff-no-index-symlink` — 41/41 tests pass (symlink add/modify/delete, `diff`/`diff --cached`/`diff-tree`, stat/numstat/name output, multi-symlink and file↔symlink replacements; harness dashboards refreshed)
 - `t7817-grep-sparse-checkout` — 8/8 tests pass (non-cone sparse: `path_in_sparse_checkout` parent walk + last-match-wins; `sparse-checkout init` preserves cone mode and seeds `/*` + `!/*/` when recreating file; `disable` keeps pattern file so re-init reapplies `!b`; submodule `reset --hard` + sparse reapply; `grep` worktree: skip-worktree when absent, CE_VALID vs skip-worktree, unmerged paths grep worktree once; `grep_cached` per-stage for `--cached`)
 - `t7417-submodule-path-url` — 5/5 tests pass (`.gitmodules` dash paths: `mv` updates path + index blob; `escape_value` quotes leading `-`; receive-side `transfer.fsckObjects` via repo-local config only; clone `--recurse-submodules` resolves relative URLs from `origin` repo root + quoted path parsing + `GIT_QUIET` quiet mode)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`tests/t8003-blame-corner-cases.sh` now passes **30/30**.

## Changes

1. **`resolve_blame_start_oid`** — Removed a redundant second `split_once("..")` branch that incorrectly parsed `HEAD^` as `HEAD` + `^`, yielding a **tree** OID instead of the parent **commit** (breaking wholesale-copy blame and anything using `rev^` without `--`).

2. **`parse_blame_args` (two positional arguments)** — Replaced naive `resolve_revision` checks with commit-oriented disambiguation:
   - Use `resolve_revision_without_index_dwim` so short paths are not resolved via index DWIM.
   - Treat a token as the revision only when `peel_to_commit_oid` succeeds (so abbreviated hex that resolves to a **blob** does not steal the revision slot from `HEAD^`, etc.).
   - If both arguments peel to commits, use Git order: first is rev, second is path.

## Validation

- `./scripts/run-tests.sh t8003-blame-corner-cases.sh`
- `cargo fmt`, `cargo check -p grit-rs`, `cargo test -p grit-lib --lib`

Also refreshed harness CSV/dashboards and marked `t8003-blame-corner-cases` complete in `PLAN.md` / `progress.md`; added `logs/2026-04-08_t8003-blame-corner-cases.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba0e2abe-8290-4fa2-b73d-65a2388191bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba0e2abe-8290-4fa2-b73d-65a2388191bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

