### PR TITLE
fix: make t3425-rebase-topology-merges pass

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -311,7 +311,7 @@ commit → check it off → move on.
 - [ ] `t3402-rebase-merge` ███░░░░░░░░░░░░░░░░░ 2/13 (11 left) — git rebase --merge test
 - [ ] `t3602-rm-sparse-checkout` ███░░░░░░░░░░░░░░░░░ 2/13 (11 left) — git rm in sparse checked out working trees
 - [ ] `t3013-ls-files-format` ████████░░░░░░░░░░░░ 8/20 (12 left) — git ls-files --format test
-- [ ] `t3425-rebase-topology-merges` █░░░░░░░░░░░░░░░░░░░ 1/13 (12 left) — rebase topology tests with merges
+- [x] `t3425-rebase-topology-merges` — rebase topology tests with merges (13/13)
 - [ ] `t3412-rebase-root` █████████░░░░░░░░░░░ 12/25 (13 left) — git rebase --root
 
 - [ ] `t3300-funny-names` ███████░░░░░░░░░░░░░ 8/21 (13 left) — Pathnames with funny characters.

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -92,7 +92,7 @@ t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
 t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
-t1006-cat-file	t1	yes	290	285	5	false	ok	1
+t1006-cat-file	t1	yes	290	285	5	false	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	32	8	false	ok	0
 t10070-cat-file-batch-format	t1	yes	33	33	0	true	ok	0
@@ -611,7 +611,7 @@ t3421-rebase-topology-linear	t3	yes	63	11	52	false	ok	0
 t3422-rebase-incompatible-options	t3	yes	52	19	33	false	ok	0
 t3423-rebase-reword	t3	yes	3	1	2	false	ok	0
 t3424-rebase-empty	t3	yes	19	3	16	false	ok	1
-t3425-rebase-topology-merges	t3	yes	13	1	12	false	ok	0
+t3425-rebase-topology-merges	t3	yes	13	13	0	true	ok	0
 t3426-rebase-submodule	t3	yes	29	2	27	false	ok	0
 t3427-rebase-subtree	t3	yes	3	0	3	false	ok	0
 t3428-rebase-signoff	t3	yes	7	1	6	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T20:05:26+00:00" class="gen-time" title="2026-04-08 20:05 UTC">2026-04-08 20:05 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,565</div>
+      <div class="summary-big-val">29,585</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>713 files fully passing</span>
+    <span>717 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,11 +212,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">41/141 files · 2 skipped · 3,333/4,611 tests</span>
+        <span class="group-meta">43/141 files · 2 skipped · 3,346/4,611 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.3%"></div></div>
-        <span class="group-pct pct-blue">72.3%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.6%"></div></div>
+        <span class="group-pct pct-blue">72.6%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,336/3,949 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,342/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.8%"></div></div>
-        <span class="group-pct pct-red">33.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.0%"></div></div>
+        <span class="group-pct pct-red">34.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -256,7 +256,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">42/126 files · 11 skipped · 1,793/2,944 tests</span>
+        <span class="group-meta">43/126 files · 11 skipped · 1,794/2,944 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T20:05:26+00:00" class="gen-time" title="2026-04-08 20:05 UTC">2026-04-08 20:05 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,864</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,565</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,585</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1085,7 +1085,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">285</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.3%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t10060-hash-object-determinism</td>
@@ -5110,8 +5110,7 @@ tr.row-skip td { opacity: 0.65; }
 <tr class="" data-group="t2" data-tests="15" data-passed="5">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td><span class="badge ok">full pass</span></td>
-  <td class="right">15</td>
+  <td></td>
   <td class="right">15</td>
   <td class="right">5</td>
   <td class="right">ok</td>
@@ -6218,14 +6217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="54" data-passed="38">
+<tr class="" data-group="t3" data-tests="52" data-passed="3">
   <td class="mono">t3420-rebase-autostash</td>
   <td>t3</td>
   <td></td>
-  <td class="right">54</td>
-  <td class="right">38</td>
+  <td class="right">52</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="63" data-passed="11">
@@ -6268,14 +6267,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:15.8%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t3" data-tests="13" data-passed="1">
+<tr class="" data-group="t3" data-tests="13" data-passed="13" data-full-pass="1">
   <td class="mono">t3425-rebase-topology-merges</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">13</td>
-  <td class="right">1</td>
+  <td class="right">13</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:7.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="29" data-passed="2">
@@ -12598,7 +12597,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="2" data-passed="2">
+<tr class="" data-group="t7" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t7524-commit-summary</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>

--- a/grit-lib/src/rev_list.rs
+++ b/grit-lib/src/rev_list.rs
@@ -5,7 +5,7 @@
 //! limits, ordering (`--topo-order`, `--date-order`, `--reverse`), and basic
 //! output shaping (`--count`, `--parents`, `--format`).
 
-use std::cmp::Ordering;
+use std::cmp::{Ordering, Reverse};
 use std::collections::{BTreeSet, BinaryHeap, HashMap, HashSet, VecDeque};
 use std::fs;
 use std::path::Path;
@@ -2156,18 +2156,21 @@ fn topo_sort(graph: &mut CommitGraph<'_>, selected: &HashSet<ObjectId>) -> Resul
         }
     }
 
-    let mut ready = BinaryHeap::new();
+    // Git's `--topo-order`: among commits whose children have all been emitted, take the one
+    // with the smallest committer date first (Kahn + min-heap). A max-heap on `CommitDateKey`
+    // inverts this and breaks `rev-list --reverse --topo-order` vs upstream (t3425).
+    let mut ready: BinaryHeap<Reverse<CommitDateKey>> = BinaryHeap::new();
     for (&oid, &count) in &child_count {
         if count == 0 {
-            ready.push(CommitDateKey {
+            ready.push(Reverse(CommitDateKey {
                 oid,
                 date: graph.committer_time(oid),
-            });
+            }));
         }
     }
 
     let mut out = Vec::with_capacity(selected.len());
-    while let Some(item) = ready.pop() {
+    while let Some(Reverse(item)) = ready.pop() {
         let oid = item.oid;
         out.push(oid);
         for parent in graph.parents_of(oid)? {
@@ -2177,10 +2180,10 @@ fn topo_sort(graph: &mut CommitGraph<'_>, selected: &HashSet<ObjectId>) -> Resul
             if let Some(count) = child_count.get_mut(&parent) {
                 *count = count.saturating_sub(1);
                 if *count == 0 {
-                    ready.push(CommitDateKey {
+                    ready.push(Reverse(CommitDateKey {
                         oid: parent,
                         date: graph.committer_time(parent),
-                    });
+                    }));
                 }
             }
         }

--- a/grit-lib/src/rev_parse.rs
+++ b/grit-lib/src/rev_parse.rs
@@ -491,6 +491,37 @@ pub fn resolve_revision_for_patch_old_blob(repo: &Repository, spec: &str) -> Res
     resolve_revision_impl(repo, spec, true, false, true, false, false, true)
 }
 
+/// When `spec` uses two-dot range syntax (`A..B`, `..B`, `A..`), returns the commits to
+/// **exclude** (left tip) and **include** (right tip) for `git log`-style walks.
+///
+/// Returns `Ok(None)` when `spec` is not a two-dot range. Symmetric `A...B` is handled by
+/// [`resolve_revision_as_commit`] instead.
+///
+/// # Errors
+///
+/// Propagates resolution errors from either range endpoint.
+pub fn try_parse_double_dot_log_range(
+    repo: &Repository,
+    spec: &str,
+) -> Result<Option<(ObjectId, ObjectId)>> {
+    let Some((left, right)) = split_double_dot_range(spec) else {
+        return Ok(None);
+    };
+    let left_tip = if left.is_empty() {
+        resolve_revision_for_range_end(repo, "HEAD")?
+    } else {
+        resolve_revision_for_range_end(repo, left)?
+    };
+    let right_tip = if right.is_empty() {
+        resolve_revision_for_range_end(repo, "HEAD")?
+    } else {
+        resolve_revision_for_range_end(repo, right)?
+    };
+    let left_c = peel_to_commit_for_merge_base(repo, left_tip)?;
+    let right_c = peel_to_commit_for_merge_base(repo, right_tip)?;
+    Ok(Some((left_c, right_c)))
+}
+
 /// Resolve `spec` to a commit OID for porcelain history commands (`log`, `reset`, etc.).
 ///
 /// Handles `A..B` / `..B` / `A..` (tip is the right side, defaulting to `HEAD`) and
@@ -516,18 +547,8 @@ pub fn resolve_revision_as_commit(repo: &Repository, spec: &str) -> Result<Objec
             .next()
             .ok_or_else(|| Error::ObjectNotFound(format!("no merge base for '{spec}'")));
     }
-    if let Some((left, right)) = split_double_dot_range(spec) {
-        if left.is_empty() {
-            peel_to_commit_for_merge_base(repo, resolve_revision_for_range_end(repo, "HEAD")?)?;
-        } else {
-            peel_to_commit_for_merge_base(repo, resolve_revision_for_range_end(repo, left)?)?;
-        }
-        let tip = if right.is_empty() {
-            resolve_revision_for_range_end(repo, "HEAD")?
-        } else {
-            resolve_revision_for_range_end(repo, right)?
-        };
-        return peel_to_commit_for_merge_base(repo, tip);
+    if let Some((_excl, tip)) = try_parse_double_dot_log_range(repo, spec)? {
+        return Ok(tip);
     }
     let oid = resolve_revision_for_range_end(repo, spec)?;
     peel_to_commit_for_merge_base(repo, oid)

--- a/grit/src/commands/format_patch.rs
+++ b/grit/src/commands/format_patch.rs
@@ -8,10 +8,12 @@ use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::config::ConfigSet;
 use grit_lib::diff::{diff_trees, unified_diff, zero_oid};
+use grit_lib::merge_base::merge_bases_first_vs_rest;
 use grit_lib::objects::{parse_commit, CommitData, ObjectId};
 use grit_lib::odb::Odb;
 use grit_lib::repo::Repository;
-use grit_lib::rev_parse::resolve_revision;
+use grit_lib::rev_list::{rev_list, split_symmetric_diff, OrderingMode, RevListOptions};
+use grit_lib::rev_parse::{resolve_revision, resolve_revision_for_range_end};
 use std::io::{self, Write};
 use std::path::PathBuf;
 
@@ -19,15 +21,46 @@ use std::path::PathBuf;
 #[derive(Debug, ClapArgs)]
 #[command(about = "Prepare patches for e-mail submission")]
 pub struct Args {
-    /// Revision or count. Use a commit ref (e.g. `HEAD~3`) to generate patches
-    /// for all commits since that ref, or a negative number (`-3`) for last N commits.
-    /// Supports `A..B` range syntax.
-    #[arg(allow_hyphen_values = true)]
-    pub revision: Option<String>,
+    /// Revision(s), range, or count. Empty means last commit (`-1`).
+    /// With `--cherry-pick --right-only`, supports symmetric `A...B` like `git rebase --apply`.
+    #[arg(value_name = "REV", num_args = 0.., allow_hyphen_values = true)]
+    pub revisions: Vec<String>,
 
     /// Write output to stdout instead of individual files.
     #[arg(long)]
     pub stdout: bool,
+
+    /// Omit patch-id equivalents on the left side of a symmetric range (used by `rebase --apply`).
+    #[arg(long = "cherry-pick")]
+    pub cherry_pick: bool,
+
+    /// With `--cherry-pick`, list only commits on the right side of `A...B`.
+    #[arg(long = "right-only")]
+    pub right_only: bool,
+
+    /// Use default a/b path prefixes (accepted for `rebase --apply` compatibility).
+    #[arg(long = "default-prefix", hide = true)]
+    pub default_prefix: bool,
+
+    /// Do not detect renames in diffs (accepted for `rebase --apply` compatibility).
+    #[arg(long = "no-renames", hide = true)]
+    pub no_renames: bool,
+
+    /// Do not emit a cover letter (accepted for `rebase --apply` compatibility).
+    #[arg(long = "no-cover-letter", hide = true)]
+    pub no_cover_letter: bool,
+
+    /// Pretty-print / mbox encoding (accepted; `mboxrd` is the default output shape).
+    #[arg(long = "pretty", value_name = "FORMAT", hide = true)]
+    pub pretty: Option<String>,
+
+    /// Order commits topologically (used by `rebase --apply`).
+    #[arg(long = "topo-order")]
+    pub topo_order: bool,
+
+    /// Omit base-commit trailer (accepted for `rebase --apply` compatibility).
+    #[arg(long = "no-base", hide = true)]
+    pub no_base: bool,
 
     /// Add `[PATCH n/m]` numbering to subjects.
     #[arg(short = 'n', long = "numbered")]
@@ -217,20 +250,47 @@ pub fn run(args: Args) -> Result<()> {
     // Load git configuration for format.* keys
     let config = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
 
+    let (positive_specs, exclude_specs): (Vec<&String>, Vec<&String>) =
+        args.revisions.iter().partition(|s| !s.starts_with('^'));
+    let exclude_rest: Vec<String> = exclude_specs
+        .iter()
+        .map(|s| s.strip_prefix('^').unwrap_or(s.as_str()).to_string())
+        .collect();
+
     // Determine the list of commits to format.
     // `-1 <rev>` should format exactly `<rev>`.
     let commits = if args.last_one {
-        if let Some(revision) = args.revision.as_deref() {
+        if let Some(revision) = positive_specs.first() {
             collect_single_commit(&repo, revision)?
         } else {
             collect_last_n_commits(&repo, 1)?
         }
+    } else if args.cherry_pick && args.right_only {
+        let range_spec = positive_specs
+            .first()
+            .map(|s| s.as_str())
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "--cherry-pick --right-only requires a symmetric revision range A...B"
+                )
+            })?;
+        collect_cherry_pick_right_only_commits(&repo, range_spec, &exclude_rest, args.topo_order)?
     } else {
-        let revision = args.revision.as_deref().unwrap_or("-1");
-        if args.root {
-            collect_root_commits(&repo, revision)?
+        if !exclude_rest.is_empty() {
+            anyhow::bail!(
+                "revision exclusions (^rev) are only supported with --cherry-pick --right-only"
+            );
+        }
+        let revision = if let Some(s) = positive_specs.first() {
+            (*s).clone()
         } else {
-            collect_commits(&repo, revision)?
+            "-1".to_owned()
+        };
+        if args.root {
+            collect_root_commits(&repo, &revision)?
+        } else {
+            collect_commits(&repo, &revision)?
         }
     };
 
@@ -259,8 +319,10 @@ pub fn run(args: Args) -> Result<()> {
     let start = args.start_number;
     let display_total = if start != 1 { start + total - 1 } else { total };
 
-    // Resolve --base commit
-    let base_commit = if let Some(ref base_rev) = args.base {
+    // Resolve --base commit (`rebase --apply` passes `--no-base`).
+    let base_commit = if args.no_base {
+        None
+    } else if let Some(ref base_rev) = args.base {
         let base_oid = resolve_revision(&repo, base_rev)
             .with_context(|| format!("unknown base revision '{base_rev}'"))?;
         Some(base_oid.to_hex())
@@ -392,6 +454,66 @@ pub fn run(args: Args) -> Result<()> {
     Ok(())
 }
 
+/// Commits for `git format-patch --cherry-pick --right-only A...B` (`rebase --apply` path).
+fn collect_cherry_pick_right_only_commits(
+    repo: &Repository,
+    range_spec: &str,
+    extra_excludes: &[String],
+    topo_order: bool,
+) -> Result<Vec<(ObjectId, CommitData)>> {
+    let Some((lhs, rhs)) = split_symmetric_diff(range_spec) else {
+        anyhow::bail!("expected symmetric revision range A...B, got '{range_spec}'");
+    };
+    let left_tip = if lhs.is_empty() {
+        resolve_revision_for_range_end(repo, "HEAD")?
+    } else {
+        resolve_revision_for_range_end(repo, &lhs)?
+    };
+    let right_tip = if rhs.is_empty() {
+        resolve_revision_for_range_end(repo, "HEAD")?
+    } else {
+        resolve_revision_for_range_end(repo, &rhs)?
+    };
+    let bases = merge_bases_first_vs_rest(repo, left_tip, &[right_tip])?;
+    let mut negative: Vec<String> = bases.iter().map(|b| b.to_hex()).collect();
+    for e in extra_excludes {
+        let oid = resolve_revision_for_range_end(repo, e)?;
+        negative.push(oid.to_hex());
+    }
+    let ordering = if topo_order {
+        OrderingMode::Topo
+    } else {
+        OrderingMode::Default
+    };
+    let result = rev_list(
+        repo,
+        &[left_tip.to_hex(), right_tip.to_hex()],
+        &negative,
+        &RevListOptions {
+            cherry_pick: true,
+            right_only: true,
+            left_right: true,
+            symmetric_left: Some(left_tip),
+            symmetric_right: Some(right_tip),
+            ordering,
+            ..Default::default()
+        },
+    )
+    .map_err(|e| anyhow::anyhow!("{e}"))?;
+    let mut oids = result.commits;
+    oids.reverse();
+    let mut commits = Vec::new();
+    for oid in oids {
+        let obj = repo.odb.read(&oid)?;
+        let c = parse_commit(&obj.data)?;
+        if c.parents.len() > 1 {
+            continue;
+        }
+        commits.push((oid, c));
+    }
+    Ok(commits)
+}
+
 /// Collect commits to format, in patch order (oldest first).
 fn collect_commits(repo: &Repository, revision: &str) -> Result<Vec<(ObjectId, CommitData)>> {
     // Check if it's a `-<n>` count form
@@ -401,10 +523,8 @@ fn collect_commits(repo: &Repository, revision: &str) -> Result<Vec<(ObjectId, C
         }
     }
 
-    // Check for A..B range syntax
-    if let Some(dotdot) = revision.find("..") {
-        let left = &revision[..dotdot];
-        let right = &revision[dotdot + 2..];
+    // Two-dot range only (avoid matching `...` in symmetric diff).
+    if let Some((left, right)) = grit_lib::rev_parse::split_double_dot_range(revision) {
         return collect_range_commits(repo, left, right);
     }
 

--- a/grit/src/commands/log.rs
+++ b/grit/src/commands/log.rs
@@ -18,7 +18,7 @@ use grit_lib::repo::Repository;
 use grit_lib::rev_list::{
     collect_revision_specs_with_stdin, rev_list, OrderingMode, RevListOptions,
 };
-use grit_lib::rev_parse::resolve_revision_as_commit;
+use grit_lib::rev_parse::{resolve_revision_as_commit, try_parse_double_dot_log_range};
 use grit_lib::state::{resolve_head, HeadState};
 use regex::{Regex, RegexBuilder};
 use std::collections::{HashMap, HashSet};
@@ -467,6 +467,9 @@ fn run_line_log(repo: &Repository, args: Args) -> Result<()> {
         for rev in &args.revisions {
             if let Some(stripped) = rev.strip_prefix('^') {
                 excludes.push(resolve_revision_as_commit(repo, stripped)?);
+            } else if let Some((excl, tip)) = try_parse_double_dot_log_range(repo, rev)? {
+                excludes.push(excl);
+                oids.push(tip);
             } else {
                 oids.push(resolve_revision_as_commit(repo, rev)?);
             }
@@ -2080,6 +2083,9 @@ pub fn run(mut args: Args) -> Result<()> {
             if let Some(stripped) = rev.strip_prefix('^') {
                 let oid = resolve_revision_as_commit(&repo, stripped)?;
                 excludes.push(oid);
+            } else if let Some((excl, tip)) = try_parse_double_dot_log_range(&repo, rev)? {
+                excludes.push(excl);
+                oids.push(tip);
             } else {
                 match resolve_revision_as_commit(&repo, rev) {
                     Ok(oid) => oids.push(oid),

--- a/grit/src/commands/rebase.rs
+++ b/grit/src/commands/rebase.rs
@@ -773,7 +773,13 @@ fn do_rebase(args: Args, pre_rebase_hook_second: Option<String>) -> Result<()> {
     let mut commits = if args.root {
         collect_commits_for_root_rebase(&repo, head_oid, onto_oid)?
     } else {
-        collect_rebase_todo_commits(&repo, head_oid, upstream_oid, !reapply_cherry_picks)?
+        collect_rebase_todo_commits(
+            &repo,
+            head_oid,
+            upstream_oid,
+            !reapply_cherry_picks,
+            !args.rebase_merges,
+        )?
     };
 
     let hook_arg1: &str = if args.root {
@@ -1067,6 +1073,7 @@ fn collect_rebase_todo_commits(
     head: ObjectId,
     upstream: ObjectId,
     filter_cherry_equivalents: bool,
+    omit_merge_commits: bool,
 ) -> Result<Vec<ObjectId>> {
     if !filter_cherry_equivalents {
         return collect_commits_to_replay(repo, head, upstream);
@@ -1091,6 +1098,17 @@ fn collect_rebase_todo_commits(
 
     let mut commits = result.commits;
     commits.reverse();
+    // Merge commits are omitted from `git format-patch` output used by `rebase --apply`, and
+    // the default merge backend todo matches that set (t3425: `c...w` is d,n,o,e — not tip w).
+    if omit_merge_commits {
+        commits.retain(|oid| {
+            repo.odb
+                .read(oid)
+                .ok()
+                .and_then(|obj| parse_commit(&obj.data).ok())
+                .is_some_and(|c| c.parents.len() <= 1)
+        });
+    }
     Ok(commits)
 }
 
@@ -1534,6 +1552,90 @@ fn cherry_pick_for_rebase(
     let head_commit = parse_commit(&head_obj.data)?;
     let head_tree_oid = head_commit.tree;
 
+    let rb_dir = rebase_dir(git_dir);
+    let root_rebase = rb_dir.join("root").exists();
+
+    // Two-parent merge during a non-root rebase: Git flattens the merge onto the replayed first
+    // parent. If replaying `n` then `o` already produced the merge result tree, the merge commit
+    // is redundant (t3425-rebase-topology-merges). Otherwise replay the merge with a three-way
+    // using the merge-base of the original parents as the base tree.
+    if !root_rebase && commit.parents.len() == 2 {
+        if head_tree_oid == commit_tree_oid {
+            return Ok(());
+        }
+        let p1 = commit.parents[0];
+        let p2 = commit.parents[1];
+        let bases = merge_bases_first_vs_rest(repo, p1, &[p2])?;
+        let Some(base_oid) = bases.first().copied() else {
+            bail!(
+                "cannot replay merge {}: no merge base for parents",
+                commit_oid.to_hex()
+            );
+        };
+        let base_obj = repo.odb.read(&base_oid)?;
+        let base_commit = parse_commit(&base_obj.data)?;
+        let base_tree_oid = base_commit.tree;
+
+        let ws_fix_rule = load_ws_fix_rule_from_rebase_state(git_dir);
+        let base_tree_oid = if ws_fix_rule.is_some() {
+            head_tree_oid
+        } else {
+            base_tree_oid
+        };
+
+        let base_entries = tree_to_map(tree_to_index_entries(repo, &base_tree_oid, "")?);
+        let ours_entries = tree_to_map(tree_to_index_entries(repo, &head_tree_oid, "")?);
+        let theirs_entries = tree_to_map(tree_to_index_entries(repo, &commit_tree_oid, "")?);
+        let conflict_ctx = RebaseConflictContext {
+            backend,
+            picked_subject: commit.message.lines().next().unwrap_or("replayed commit"),
+        };
+        let merge_result = three_way_merge_with_content(
+            repo,
+            &base_entries,
+            &ours_entries,
+            &theirs_entries,
+            &conflict_ctx,
+        )?;
+        let mut merged_index = merge_result.index;
+        let has_conflicts = merged_index.entries.iter().any(|e| e.stage() != 0)
+            || !merge_result.conflict_files.is_empty();
+
+        let old_index = load_index(repo)?;
+        repo.write_index(&mut merged_index)?;
+        if let Some(wt) = &repo.work_tree {
+            checkout_merged_index(repo, wt, &old_index, &merged_index)?;
+            if has_conflicts {
+                write_rebase_conflict_files(wt, &merge_result.conflict_files)?;
+            }
+        }
+
+        if has_conflicts {
+            let _ =
+                grit_lib::rerere::repo_rerere(repo, grit_lib::rerere::RerereAutoupdate::FromConfig);
+            fs::write(git_dir.join("MERGE_MSG"), &commit.message)?;
+            bail!("conflicts during cherry-pick of {}", commit_oid.to_hex());
+        }
+
+        let tree_oid = write_tree_from_index(&repo.odb, &merged_index, "")?;
+        let now = time::OffsetDateTime::now_utc();
+        let committer = resolve_identity(&config, "COMMITTER")?;
+        let (message, encoding, raw_message) = transcoded_replayed_message(&commit, &config);
+        let commit_data = CommitData {
+            tree: tree_oid,
+            parents: vec![head_oid],
+            author: commit.author.clone(),
+            committer: format_ident(&committer, now),
+            encoding,
+            message,
+            raw_message,
+        };
+        let commit_bytes = serialize_commit(&commit_data);
+        let new_oid = repo.odb.write(ObjectKind::Commit, &commit_bytes)?;
+        fs::write(git_dir.join("HEAD"), format!("{}\n", new_oid.to_hex()))?;
+        return Ok(());
+    }
+
     // Already at the picked commit's parent tip — nothing to replay (matches Git's noop pick).
     if let Some(p) = commit.parents.first() {
         if head_oid == *p {
@@ -1590,9 +1692,6 @@ fn cherry_pick_for_rebase(
             write_rebase_conflict_files(wt, &merge_result.conflict_files)?;
         }
     }
-
-    let rb_dir = rebase_dir(git_dir);
-    let root_rebase = rb_dir.join("root").exists();
 
     if has_conflicts {
         let _ = grit_lib::rerere::repo_rerere(repo, grit_lib::rerere::RerereAutoupdate::FromConfig);

--- a/logs/2026-04-08_t3425-rebase-topology-merges.md
+++ b/logs/2026-04-08_t3425-rebase-topology-merges.md
@@ -1,0 +1,27 @@
+# t3425-rebase-topology-merges
+
+## Summary
+
+Made `tests/t3425-rebase-topology-merges.sh` pass 13/13.
+
+## Root causes
+
+1. **`rebase --apply`** shells to `git format-patch` with `--cherry-pick --right-only --topo-order` on a symmetric range. Grit’s `format-patch` rejected unknown flags and did not implement that rev-list mode.
+2. **Topological order** in `rev_list::topo_sort` used a max-heap on committer date, so `--reverse --topo-order` differed from Git (e.g. `e` before `n` instead of `n o e w` for `d...w`).
+3. **Cherry-pick todo** for default rebase included merge commits; upstream’s patch series omits merges, so rebasing onto `c` must replay `d n o e` only and end at replayed `e`, not `w`.
+4. **Merge replay**: flattening a merge whose second parent is the rebase onto must skip when `HEAD^{tree}` already matches the merge tree, or use a three-way with merge-base of the two parents (t3425 `e w` case).
+5. **`git log A..B`**: log parsing treated `A..B` as tip-only; excluded side `A` was not applied, so `test_linear_range` saw too many commits.
+
+## Files touched
+
+- `grit-lib/src/rev_list.rs` — min-heap (`Reverse<CommitDateKey>`) for topo walk ready queue.
+- `grit-lib/src/rev_parse.rs` — `try_parse_double_dot_log_range` for log-style two-dot ranges.
+- `grit/src/commands/log.rs` — apply exclusions from `A..B`.
+- `grit/src/commands/format_patch.rs` — compat flags + symmetric cherry path + skip merges in mbox output.
+- `grit/src/commands/rebase.rs` — merge commit handling in cherry-pick; omit merges from todo unless `--rebase-merges`.
+
+## Validation
+
+- `cargo build --release -p grit-rs`
+- `cargo test -p grit-lib --lib`
+- `./scripts/run-tests.sh t3425-rebase-topology-merges.sh` → 13/13

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   231 |
-| In progress |     2 |
-| Remaining   |   535 |
+| Completed   |   247 |
+| In progress |     4 |
+| Remaining   |   517 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 231 completed (`[x]`), 2 in progress (`[~]`), 535 remaining (`[ ]`).
+Task lines in `PLAN.md`: 247 completed (`[x]`), 4 in progress (`[~]`), 517 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t3425-rebase-topology-merges` — 13/13 tests pass (`rev_list` topo-order uses min-heap tie-break like Git; `log` honors `A..B` exclusions; `format-patch` accepts `rebase --apply` flags and cherry symmetric ranges; rebase todo drops merge commits unless `--rebase-merges`; two-parent merge replay uses merge-base three-way or skips when tree already matches)
 - `t12820-diff-no-index-symlink` — 41/41 tests pass (symlink add/modify/delete, `diff`/`diff --cached`/`diff-tree`, stat/numstat/name output, multi-symlink and file↔symlink replacements; harness dashboards refreshed)
 - `t7817-grep-sparse-checkout` — 8/8 tests pass (non-cone sparse: `path_in_sparse_checkout` parent walk + last-match-wins; `sparse-checkout init` preserves cone mode and seeds `/*` + `!/*/` when recreating file; `disable` keeps pattern file so re-init reapplies `!b`; submodule `reset --hard` + sparse reapply; `grep` worktree: skip-worktree when absent, CE_VALID vs skip-worktree, unmerged paths grep worktree once; `grep_cached` per-stage for `--cached`)
 - `t7417-submodule-path-url` — 5/5 tests pass (`.gitmodules` dash paths: `mv` updates path + index blob; `escape_value` quotes leading `-`; receive-side `transfer.fsckObjects` via repo-local config only; clone `--recurse-submodules` resolves relative URLs from `origin` repo root + quoted path parsing + `GIT_QUIET` quiet mode)

--- a/test-results.md
+++ b/test-results.md
@@ -2,6 +2,8 @@
 
 **Updated:** 2026-04-08
 
+- `./scripts/run-tests.sh t3425-rebase-topology-merges.sh`: 13/13 passing (topo-order tie-break, `log A..B` exclusions, `format-patch` for `rebase --apply`, merge todo omission, merge replay; harness CSV/dashboards refreshed).
+- `cargo test -p grit-lib --lib`: 121/121 passing.
 - `./scripts/run-tests.sh t13180-log-patch-stat.sh`: 35/35 passing (`grit log` oneline/graph/decorate/skip/max-count/reverse/format; harness CSV/dashboards refreshed).
 - `./scripts/run-tests.sh t10560-switch-create-detach.sh`: 28/28 passing (`switch -- <branch>` disambiguation; invalid `-c`/`-C`/`--orphan` branch names rejected like Git; harness CSV/dashboards refreshed).
 - `cargo test -p grit-lib --lib`: 110/110 passing.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes `t3425-rebase-topology-merges` pass (13/13) by aligning rebase, rev-list, log, and format-patch with Git for merge-heavy topology.

## Changes

- **Topo-order**: min-heap tie-break among ready commits (`rev_list`).
- **Log**: honor `A..B` exclusions for range walks.
- **format-patch**: accept `rebase --apply` flags; symmetric `--cherry-pick --right-only`; omit merges from mbox output.
- **rebase**: omit merge commits from default todo (keep with `--rebase-merges`); replay two-parent merges via merge-base three-way or skip when redundant.

## Validation

- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t3425-rebase-topology-merges.sh` → 13/13

## Environment note

Push required `GIT_EXEC_PATH=/usr/lib/git-core` in this sandbox so `git-remote-https` resolves.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80610d37-6ee9-48d4-9328-bdf45518f078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80610d37-6ee9-48d4-9328-bdf45518f078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

