### PR TITLE
fix: t12620 rev-parse resolve ref (setup cwd)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -92,7 +92,7 @@ t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
 t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
-t1006-cat-file	t1	yes	290	285	5	false	ok	1
+t1006-cat-file	t1	yes	290	285	5	false	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	32	8	false	ok	0
 t10070-cat-file-batch-format	t1	yes	33	33	0	true	ok	0
@@ -316,7 +316,7 @@ t12580-log-oneline-all	t1	yes	31	28	3	false	ok	0
 t12590-log-format-tformat	t1	yes	33	32	1	false	ok	0
 t12600-rev-list-not-exclude	t1	yes	32	31	1	false	ok	0
 t12610-rev-list-all-branches	t1	yes	32	30	2	false	ok	0
-t12620-rev-parse-resolve-ref	t1	yes	32	31	1	false	ok	0
+t12620-rev-parse-resolve-ref	t1	yes	32	32	0	true	ok	0
 t12630-rev-parse-is-bare	t1	yes	33	33	0	true	ok	0
 t12640-config-list-show-origin	t1	yes	33	33	0	true	ok	0
 t12650-config-null-value	t1	yes	34	33	1	false	ok	0
@@ -1106,7 +1106,7 @@ t6405-merge-symlinks	t6	yes	7	7	0	true	ok	0
 t6406-merge-attr	t6	yes	13	13	0	true	ok	0
 t6407-merge-binary	t6	yes	3	3	0	true	ok	0
 t6408-merge-up-to-date	t6	yes	7	6	1	false	ok	0
-t6409-merge-subtree	t6	yes	12	7	5	false	ok	0
+t6409-merge-subtree	t6	yes	12	12	0	true	ok	0
 t6411-merge-filemode	t6	yes	19	14	5	false	ok	0
 t6412-merge-large-rename	t6	yes	10	10	0	true	ok	0
 t6413-merge-crlf	t6	yes	3	1	2	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T20:32:34+00:00" class="gen-time" title="2026-04-08 20:32 UTC">2026-04-08 20:32 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,565</div>
+      <div class="summary-big-val">29,579</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>713 files fully passing</span>
+    <span>718 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -190,7 +190,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">273/368 files · 8 skipped · 10,802/11,373 tests</span>
+        <span class="group-meta">274/368 files · 8 skipped · 10,803/11,373 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-green" style="width:95.0%"></div></div>
@@ -212,7 +212,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">41/141 files · 2 skipped · 3,333/4,611 tests</span>
+        <span class="group-meta">42/141 files · 2 skipped · 3,334/4,611 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.3%"></div></div>
@@ -234,29 +234,29 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,336/3,949 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,342/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.8%"></div></div>
-        <span class="group-pct pct-red">33.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.0%"></div></div>
+        <span class="group-pct pct-red">34.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
       <div class="group-line1">
         <span class="group-id">t6</span>
         <span class="group-desc">Revision tree commands (e.g. merge-base)</span>
-        <span class="group-meta">45/105 files · 3 skipped · 1,197/2,135 tests</span>
+        <span class="group-meta">46/105 files · 3 skipped · 1,202/2,135 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:56.1%"></div></div>
-        <span class="group-pct pct-orange">56.1%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:56.3%"></div></div>
+        <span class="group-pct pct-orange">56.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t7">
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">42/126 files · 11 skipped · 1,793/2,944 tests</span>
+        <span class="group-meta">43/126 files · 11 skipped · 1,794/2,944 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T20:32:34+00:00" class="gen-time" title="2026-04-08 20:32 UTC">2026-04-08 20:32 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,864</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,565</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,579</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1085,7 +1085,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">285</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.3%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t10060-hash-object-determinism</td>
@@ -3317,14 +3317,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:93.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="32" data-passed="31">
+<tr class="" data-group="t1" data-tests="32" data-passed="32" data-full-pass="1">
   <td class="mono">t12620-rev-parse-resolve-ref</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">32</td>
-  <td class="right">31</td>
+  <td class="right">32</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:96.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="33" data-passed="33" data-full-pass="1">
@@ -5110,8 +5110,7 @@ tr.row-skip td { opacity: 0.65; }
 <tr class="" data-group="t2" data-tests="15" data-passed="5">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td><span class="badge ok">full pass</span></td>
-  <td class="right">15</td>
+  <td></td>
   <td class="right">15</td>
   <td class="right">5</td>
   <td class="right">ok</td>
@@ -6218,14 +6217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="54" data-passed="38">
+<tr class="" data-group="t3" data-tests="52" data-passed="3">
   <td class="mono">t3420-rebase-autostash</td>
   <td>t3</td>
   <td></td>
-  <td class="right">54</td>
-  <td class="right">38</td>
+  <td class="right">52</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="63" data-passed="11">
@@ -11218,14 +11217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:85.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t6" data-tests="12" data-passed="7">
+<tr class="" data-group="t6" data-tests="12" data-passed="12" data-full-pass="1">
   <td class="mono">t6409-merge-subtree</td>
   <td>t6</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">12</td>
-  <td class="right">7</td>
+  <td class="right">12</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:58.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t6" data-tests="19" data-passed="14">
@@ -12598,7 +12597,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="2" data-passed="2">
+<tr class="" data-group="t7" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t7524-commit-summary</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>

--- a/logs/2026-04-08_t12620-rev-parse-resolve-ref.md
+++ b/logs/2026-04-08_t12620-rev-parse-resolve-ref.md
@@ -1,0 +1,14 @@
+# t12620-rev-parse-resolve-ref
+
+## Issue
+
+All cases after `setup` failed with `cd: repo: No such file or directory` because the setup block ended with `cd repo` in the main shell, so the trash cwd was left inside `repo/`. Later tests use `(cd repo && …)` relative to the trash root, so `repo` was not found.
+
+## Fix
+
+Wrapped the body of the setup `test_expect_success` in a subshell `( cd repo && … )` so the outer shell stays at the trash directory after setup completes.
+
+## Verification
+
+- `./scripts/run-tests.sh t12620-rev-parse-resolve-ref.sh` — 32/32 pass
+- `./scripts/run-tests.sh t6409-merge-subtree.sh` — 12/12 pass (confirmed no regression from avoiding a global `cd "$TRASH_DIRECTORY"` between tests)

--- a/progress.md
+++ b/progress.md
@@ -15,6 +15,7 @@ Task lines in `PLAN.md`: 231 completed (`[x]`), 2 in progress (`[~]`), 535 remai
 
 ## Recently completed
 
+- `t12620-rev-parse-resolve-ref` — 32/32 tests pass (setup `cd repo` confined to subshell so trash cwd stays at trash root for `(cd repo && …)` cases; harness CSV refreshed)
 - `t12820-diff-no-index-symlink` — 41/41 tests pass (symlink add/modify/delete, `diff`/`diff --cached`/`diff-tree`, stat/numstat/name output, multi-symlink and file↔symlink replacements; harness dashboards refreshed)
 - `t7817-grep-sparse-checkout` — 8/8 tests pass (non-cone sparse: `path_in_sparse_checkout` parent walk + last-match-wins; `sparse-checkout init` preserves cone mode and seeds `/*` + `!/*/` when recreating file; `disable` keeps pattern file so re-init reapplies `!b`; submodule `reset --hard` + sparse reapply; `grep` worktree: skip-worktree when absent, CE_VALID vs skip-worktree, unmerged paths grep worktree once; `grep_cached` per-stage for `--cached`)
 - `t7417-submodule-path-url` — 5/5 tests pass (`.gitmodules` dash paths: `mv` updates path + index blob; `escape_value` quotes leading `-`; receive-side `transfer.fsckObjects` via repo-local config only; clone `--recurse-submodules` resolves relative URLs from `origin` repo root + quoted path parsing + `GIT_QUIET` quiet mode)

--- a/t1-plan.md
+++ b/t1-plan.md
@@ -123,7 +123,7 @@
 - [x] t12590-log-format-tformat.sh
 - [ ] t12600-rev-list-not-exclude.sh
 - [ ] t12610-rev-list-all-branches.sh
-- [ ] t12620-rev-parse-resolve-ref.sh
+- [x] t12620-rev-parse-resolve-ref.sh
 - [ ] t12630-rev-parse-is-bare.sh
 - [ ] t12650-config-null-value.sh
 - [ ] t12660-init-shared-perm.sh

--- a/tests/t12620-rev-parse-resolve-ref.sh
+++ b/tests/t12620-rev-parse-resolve-ref.sh
@@ -6,7 +6,8 @@ cd "$(dirname "$0")" || exit 1
 . ./test-lib.sh
 
 test_expect_success 'setup' '
-    grit init repo && cd repo &&
+    grit init repo && (
+    cd repo &&
     git config user.email "t@t.com" && git config user.name "T" &&
     echo one >file.txt && grit add file.txt && grit commit -m "first" &&
     echo two >file2.txt && grit add file2.txt && grit commit -m "second" &&
@@ -15,6 +16,7 @@ test_expect_success 'setup' '
     git tag v2.0 HEAD~1 &&
     git tag v3.0 &&
     git branch feature
+    )
 '
 
 test_expect_success 'rev-parse HEAD resolves to commit hash' '


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t12620-rev-parse-resolve-ref` failed because the setup block left the harness shell’s cwd inside `repo/`, so subsequent `(cd repo && …)` blocks could not find `repo` relative to the trash root.

## Change

Wrap the repository setup in a subshell so only the subshell `cd`s into `repo`; the outer shell remains at the trash directory.

## Verification

- `./scripts/run-tests.sh t12620-rev-parse-resolve-ref.sh` — 32/32
- `./scripts/run-tests.sh t6409-merge-subtree.sh` — 12/12 (sanity: no harness-wide cwd regression)

Also refreshed harness CSV/dashboards, checked off `t12620` in `t1-plan.md`, and added `logs/2026-04-08_t12620-rev-parse-resolve-ref.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40d76fba-4d2e-47cf-a933-4a83a34bd914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40d76fba-4d2e-47cf-a933-4a83a34bd914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

