### PR TITLE
fix(tests): make t9760-hash-object-blob-tree fully pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -92,7 +92,7 @@ t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
 t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
-t1006-cat-file	t1	yes	290	285	5	false	ok	1
+t1006-cat-file	t1	yes	290	285	5	false	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	32	8	false	ok	0
 t10070-cat-file-batch-format	t1	yes	33	33	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T20:36:59+00:00" class="gen-time" title="2026-04-08 20:36 UTC">2026-04-08 20:36 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,565</div>
+      <div class="summary-big-val">29,573</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>713 files fully passing</span>
+    <span>716 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,7 +212,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">41/141 files · 2 skipped · 3,333/4,611 tests</span>
+        <span class="group-meta">42/141 files · 2 skipped · 3,334/4,611 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.3%"></div></div>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,336/3,949 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,342/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.8%"></div></div>
-        <span class="group-pct pct-red">33.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.0%"></div></div>
+        <span class="group-pct pct-red">34.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -256,7 +256,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">42/126 files · 11 skipped · 1,793/2,944 tests</span>
+        <span class="group-meta">43/126 files · 11 skipped · 1,794/2,944 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T20:36:59+00:00" class="gen-time" title="2026-04-08 20:36 UTC">2026-04-08 20:36 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,864</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,565</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,573</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1085,7 +1085,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">285</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.3%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t10060-hash-object-determinism</td>
@@ -5110,8 +5110,7 @@ tr.row-skip td { opacity: 0.65; }
 <tr class="" data-group="t2" data-tests="15" data-passed="5">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td><span class="badge ok">full pass</span></td>
-  <td class="right">15</td>
+  <td></td>
   <td class="right">15</td>
   <td class="right">5</td>
   <td class="right">ok</td>
@@ -6218,14 +6217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="54" data-passed="38">
+<tr class="" data-group="t3" data-tests="52" data-passed="3">
   <td class="mono">t3420-rebase-autostash</td>
   <td>t3</td>
   <td></td>
-  <td class="right">54</td>
-  <td class="right">38</td>
+  <td class="right">52</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="63" data-passed="11">
@@ -12598,7 +12597,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="2" data-passed="2">
+<tr class="" data-group="t7" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t7524-commit-summary</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>

--- a/logs/2026-04-08-t9760-hash-object-blob-tree.md
+++ b/logs/2026-04-08-t9760-hash-object-blob-tree.md
@@ -1,0 +1,14 @@
+# t9760-hash-object-blob-tree
+
+## Issue
+
+Harness reported 1/32 passing: first test left cwd inside `repo/`, so later `cd repo` tried `repo/repo` and failed.
+
+## Fix
+
+1. Setup: use `git -C repo config` instead of `cd repo` so trash cwd stays at trash root.
+2. All tests: `cd "$TRASH_DIRECTORY/repo"` so each block enters the nested repo from an absolute path regardless of prior test cwd.
+
+## Verification
+
+`./scripts/run-tests.sh t9760-hash-object-blob-tree.sh` → 32/32.

--- a/tests/t9760-hash-object-blob-tree.sh
+++ b/tests/t9760-hash-object-blob-tree.sh
@@ -14,13 +14,12 @@ REAL_GIT=$(command -v git)
 
 test_expect_success 'setup: create repository with real git' '
 	"$REAL_GIT" init repo &&
-	cd repo &&
-	"$REAL_GIT" config user.name "Test User" &&
-	"$REAL_GIT" config user.email "test@example.com"
+	"$REAL_GIT" -C repo config user.name "Test User" &&
+	"$REAL_GIT" -C repo config user.email "test@example.com"
 '
 
 test_expect_success 'hash-object blob matches real git for simple content' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY/repo" &&
 	echo "hello world" >hw.txt &&
 	grit hash-object hw.txt >actual &&
 	"$REAL_GIT" hash-object hw.txt >expect &&
@@ -28,7 +27,7 @@ test_expect_success 'hash-object blob matches real git for simple content' '
 '
 
 test_expect_success 'hash-object blob matches real git for empty file' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY/repo" &&
 	>empty.txt &&
 	grit hash-object empty.txt >actual &&
 	"$REAL_GIT" hash-object empty.txt >expect &&
@@ -36,7 +35,7 @@ test_expect_success 'hash-object blob matches real git for empty file' '
 '
 
 test_expect_success 'hash-object blob matches for binary-like content' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY/repo" &&
 	printf "\000\001\002\003" >binary.bin &&
 	grit hash-object binary.bin >actual &&
 	"$REAL_GIT" hash-object binary.bin >expect &&
@@ -44,7 +43,7 @@ test_expect_success 'hash-object blob matches for binary-like content' '
 '
 
 test_expect_success 'hash-object blob matches for file with only newlines' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY/repo" &&
 	printf "\n\n\n" >newlines.txt &&
 	grit hash-object newlines.txt >actual &&
 	"$REAL_GIT" hash-object newlines.txt >expect &&
@@ -52,7 +51,7 @@ test_expect_success 'hash-object blob matches for file with only newlines' '
 '
 
 test_expect_success 'hash-object blob matches for large content' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY/repo" &&
 	dd if=/dev/urandom bs=1024 count=64 2>/dev/null | base64 >large.txt &&
 	grit hash-object large.txt >actual &&
 	"$REAL_GIT" hash-object large.txt >expect &&
@@ -60,7 +59,7 @@ test_expect_success 'hash-object blob matches for large content' '
 '
 
 test_expect_success 'hash-object blob matches for file with trailing spaces' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY/repo" &&
 	printf "line with trailing spaces   \n" >spaces.txt &&
 	grit hash-object spaces.txt >actual &&
 	"$REAL_GIT" hash-object spaces.txt >expect &&
@@ -68,7 +67,7 @@ test_expect_success 'hash-object blob matches for file with trailing spaces' '
 '
 
 test_expect_success 'hash-object blob matches for unicode content' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY/repo" &&
 	printf "日本語テスト\nÜmlaut\n" >unicode.txt &&
 	grit hash-object unicode.txt >actual &&
 	"$REAL_GIT" hash-object unicode.txt >expect &&
@@ -80,7 +79,7 @@ test_expect_success 'hash-object blob matches for unicode content' '
 ###########################################################################
 
 test_expect_success 'hash-object -w writes blob retrievable by cat-file' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY/repo" &&
 	echo "write and read" >wr.txt &&
 	oid=$(grit hash-object -w wr.txt) &&
 	grit cat-file -p "$oid" >actual &&
@@ -88,7 +87,7 @@ test_expect_success 'hash-object -w writes blob retrievable by cat-file' '
 '
 
 test_expect_success 'hash-object -w for empty file produces retrievable blob' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY/repo" &&
 	>empty_write.txt &&
 	oid=$(grit hash-object -w empty_write.txt) &&
 	grit cat-file -t "$oid" >actual &&
@@ -97,7 +96,7 @@ test_expect_success 'hash-object -w for empty file produces retrievable blob' '
 '
 
 test_expect_success 'hash-object -w blob type confirmed by cat-file -t' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY/repo" &&
 	echo "type check" >tc.txt &&
 	oid=$(grit hash-object -w tc.txt) &&
 	grit cat-file -t "$oid" >actual &&
@@ -106,7 +105,7 @@ test_expect_success 'hash-object -w blob type confirmed by cat-file -t' '
 '
 
 test_expect_success 'hash-object -w blob size confirmed by cat-file -s' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY/repo" &&
 	echo "size check content" >sc.txt &&
 	oid=$(grit hash-object -w sc.txt) &&
 	grit cat-file -s "$oid" >actual &&
@@ -115,7 +114,7 @@ test_expect_success 'hash-object -w blob size confirmed by cat-file -s' '
 '
 
 test_expect_success 'hash-object without -w does not store object' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY/repo" &&
 	echo "no write" >nw.txt &&
 	oid=$(grit hash-object nw.txt) &&
 	test_must_fail grit cat-file -t "$oid"
@@ -126,7 +125,7 @@ test_expect_success 'hash-object without -w does not store object' '
 ###########################################################################
 
 test_expect_success 'hash-object --stdin matches file hash' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY/repo" &&
 	echo "stdin test" >st.txt &&
 	grit hash-object st.txt >expect &&
 	echo "stdin test" | grit hash-object --stdin >actual &&
@@ -134,7 +133,7 @@ test_expect_success 'hash-object --stdin matches file hash' '
 '
 
 test_expect_success 'hash-object --stdin -w writes retrievable blob' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY/repo" &&
 	echo "stdin write" | grit hash-object --stdin -w >oid_file &&
 	oid=$(cat oid_file) &&
 	grit cat-file -p "$oid" >actual &&
@@ -143,14 +142,14 @@ test_expect_success 'hash-object --stdin -w writes retrievable blob' '
 '
 
 test_expect_success 'hash-object --stdin with empty input' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY/repo" &&
 	grit hash-object --stdin </dev/null >actual &&
 	"$REAL_GIT" hash-object --stdin </dev/null >expect &&
 	test_cmp expect actual
 '
 
 test_expect_success 'hash-object --stdin matches real git for multi-line' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY/repo" &&
 	printf "line1\nline2\nline3\n" | grit hash-object --stdin >actual &&
 	printf "line1\nline2\nline3\n" | "$REAL_GIT" hash-object --stdin >expect &&
 	test_cmp expect actual
@@ -161,7 +160,7 @@ test_expect_success 'hash-object --stdin matches real git for multi-line' '
 ###########################################################################
 
 test_expect_success 'blob written by hash-object appears in tree after add' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY/repo" &&
 	echo "for tree" >tree_file.txt &&
 	"$REAL_GIT" add tree_file.txt &&
 	"$REAL_GIT" commit -m "add tree_file" &&
@@ -171,7 +170,7 @@ test_expect_success 'blob written by hash-object appears in tree after add' '
 '
 
 test_expect_success 'hash-object of file matches blob in committed tree' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY/repo" &&
 	echo "committed blob" >cb.txt &&
 	"$REAL_GIT" add cb.txt &&
 	"$REAL_GIT" commit -m "add cb" &&
@@ -181,7 +180,7 @@ test_expect_success 'hash-object of file matches blob in committed tree' '
 '
 
 test_expect_success 'hash-object of modified file differs from tree blob' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY/repo" &&
 	echo "original" >mod.txt &&
 	"$REAL_GIT" add mod.txt &&
 	"$REAL_GIT" commit -m "add mod" &&
@@ -192,7 +191,7 @@ test_expect_success 'hash-object of modified file differs from tree blob' '
 '
 
 test_expect_success 'hash-object of unmodified file matches tree blob' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY/repo" &&
 	echo "unchanged" >unch.txt &&
 	"$REAL_GIT" add unch.txt &&
 	"$REAL_GIT" commit -m "add unch" &&
@@ -206,7 +205,7 @@ test_expect_success 'hash-object of unmodified file matches tree blob' '
 ###########################################################################
 
 test_expect_success 'identical files produce same OID (content addressable)' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY/repo" &&
 	echo "duplicate content" >dup1.txt &&
 	echo "duplicate content" >dup2.txt &&
 	oid1=$(grit hash-object dup1.txt) &&
@@ -215,14 +214,14 @@ test_expect_success 'identical files produce same OID (content addressable)' '
 '
 
 test_expect_success 'hash-object -w of same content twice does not error' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY/repo" &&
 	echo "write twice" >wt.txt &&
 	grit hash-object -w wt.txt &&
 	grit hash-object -w wt.txt
 '
 
 test_expect_success 'hash-object multiple files on command line' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY/repo" &&
 	echo "file a" >ma.txt &&
 	echo "file b" >mb.txt &&
 	grit hash-object ma.txt mb.txt >actual &&
@@ -230,7 +229,7 @@ test_expect_success 'hash-object multiple files on command line' '
 '
 
 test_expect_success 'hash-object multiple files match individual hashes' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY/repo" &&
 	echo "multi a" >mua.txt &&
 	echo "multi b" >mub.txt &&
 	grit hash-object mua.txt >expect_a &&
@@ -247,7 +246,7 @@ test_expect_success 'hash-object multiple files match individual hashes' '
 ###########################################################################
 
 test_expect_success 'hash-object file with no trailing newline' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY/repo" &&
 	printf "no newline" >nonl.txt &&
 	grit hash-object nonl.txt >actual &&
 	"$REAL_GIT" hash-object nonl.txt >expect &&
@@ -255,7 +254,7 @@ test_expect_success 'hash-object file with no trailing newline' '
 '
 
 test_expect_success 'hash-object file with only null bytes' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY/repo" &&
 	printf "\000\000\000\000" >nulls.bin &&
 	grit hash-object nulls.bin >actual &&
 	"$REAL_GIT" hash-object nulls.bin >expect &&
@@ -263,7 +262,7 @@ test_expect_success 'hash-object file with only null bytes' '
 '
 
 test_expect_success 'hash-object file with CR LF line endings' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY/repo" &&
 	printf "line1\r\nline2\r\n" >crlf.txt &&
 	grit hash-object crlf.txt >actual &&
 	"$REAL_GIT" hash-object crlf.txt >expect &&
@@ -271,7 +270,7 @@ test_expect_success 'hash-object file with CR LF line endings' '
 '
 
 test_expect_success 'hash-object file with mixed line endings' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY/repo" &&
 	printf "unix\nwindows\r\nold-mac\r" >mixed.txt &&
 	grit hash-object mixed.txt >actual &&
 	"$REAL_GIT" hash-object mixed.txt >expect &&
@@ -279,7 +278,7 @@ test_expect_success 'hash-object file with mixed line endings' '
 '
 
 test_expect_success 'hash-object very long single line' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY/repo" &&
 	python3 -c "print(\"x\" * 100000)" >longline.txt &&
 	grit hash-object longline.txt >actual &&
 	"$REAL_GIT" hash-object longline.txt >expect &&
@@ -287,12 +286,12 @@ test_expect_success 'hash-object very long single line' '
 '
 
 test_expect_success 'hash-object nonexistent file fails' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY/repo" &&
 	test_must_fail grit hash-object does-not-exist.txt
 '
 
 test_expect_success 'hash-object -w --stdin blob is findable in ODB' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY/repo" &&
 	echo "find me in odb" | grit hash-object -w --stdin >oid_file &&
 	oid=$(cat oid_file) &&
 	grit cat-file -e "$oid"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t9760-hash-object-blob-tree.sh` failed because the harness keeps a single shell cwd across tests. The first test that ran `cd repo` left cwd inside the nested repository, so later `cd repo` tried `repo/repo` and failed.

## Changes

- **Setup:** Configure the nested repo with `git -C repo config` instead of `cd repo`, so the trash-directory cwd stays at the trash root after setup.
- **All body tests:** Use `cd "$TRASH_DIRECTORY/repo"` so each block enters the nested repo from an absolute path regardless of the previous test’s cwd.

## Verification

`./scripts/run-tests.sh t9760-hash-object-blob-tree.sh` → **32/32** passing.

Also refreshed `data/test-files.csv` and dashboard HTML from the harness run.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f756494-a21d-45a9-8603-11126843467e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f756494-a21d-45a9-8603-11126843467e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

