### PR TITLE
fix(tests): t10620-update-ref-nul-stdin — reset trash cwd per test block

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -92,7 +92,7 @@ t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
 t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
-t1006-cat-file	t1	yes	290	285	5	false	ok	1
+t1006-cat-file	t1	yes	290	285	5	false	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	32	8	false	ok	0
 t10070-cat-file-batch-format	t1	yes	33	33	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T20:56:02+00:00" class="gen-time" title="2026-04-08 20:56 UTC">2026-04-08 20:56 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,565</div>
+      <div class="summary-big-val">29,573</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>713 files fully passing</span>
+    <span>716 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,7 +212,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">41/141 files · 2 skipped · 3,333/4,611 tests</span>
+        <span class="group-meta">42/141 files · 2 skipped · 3,334/4,611 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.3%"></div></div>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,336/3,949 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,342/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.8%"></div></div>
-        <span class="group-pct pct-red">33.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.0%"></div></div>
+        <span class="group-pct pct-red">34.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -256,7 +256,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">42/126 files · 11 skipped · 1,793/2,944 tests</span>
+        <span class="group-meta">43/126 files · 11 skipped · 1,794/2,944 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T20:56:02+00:00" class="gen-time" title="2026-04-08 20:56 UTC">2026-04-08 20:56 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,864</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,565</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,573</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1085,7 +1085,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">285</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.3%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t10060-hash-object-determinism</td>
@@ -5110,8 +5110,7 @@ tr.row-skip td { opacity: 0.65; }
 <tr class="" data-group="t2" data-tests="15" data-passed="5">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td><span class="badge ok">full pass</span></td>
-  <td class="right">15</td>
+  <td></td>
   <td class="right">15</td>
   <td class="right">5</td>
   <td class="right">ok</td>
@@ -6218,14 +6217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="54" data-passed="38">
+<tr class="" data-group="t3" data-tests="52" data-passed="3">
   <td class="mono">t3420-rebase-autostash</td>
   <td>t3</td>
   <td></td>
-  <td class="right">54</td>
-  <td class="right">38</td>
+  <td class="right">52</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="63" data-passed="11">
@@ -12598,7 +12597,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="2" data-passed="2">
+<tr class="" data-group="t7" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t7524-commit-summary</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>

--- a/logs/2026-04-08_t10620-update-ref-nul-stdin.md
+++ b/logs/2026-04-08_t10620-update-ref-nul-stdin.md
@@ -1,0 +1,14 @@
+# t10620-update-ref-nul-stdin
+
+## Symptom
+
+Harness reported 1/30 passing: only the setup test ran from the trash root; later tests used `cd repo` while the shell was still inside `repo/` from the previous block, so `cd repo` failed (no nested `repo/repo`).
+
+## Fix
+
+Prefix each `test_expect_success` body with `cd "$TRASH_DIRECTORY" &&` so every block starts at the trash root. This matches the intent of upstream-style tests that assume a fresh trash cwd per case; our TAP harness intentionally keeps cwd between blocks (see `progress.md` note on t6409-merge-subtree).
+
+## Verification
+
+- `./scripts/run-tests.sh t10620-update-ref-nul-stdin.sh` — 30/30
+- `t6409-merge-subtree.sh` — 12/12 (no harness-wide `cd` reset; avoids breaking cwd-carrying tests)

--- a/progress.md
+++ b/progress.md
@@ -15,6 +15,7 @@ Task lines in `PLAN.md`: 231 completed (`[x]`), 2 in progress (`[~]`), 535 remai
 
 ## Recently completed
 
+- `t10620-update-ref-nul-stdin` — 30/30 tests pass (each case `cd`s to `$TRASH_DIRECTORY` first: harness keeps cwd between blocks unlike upstream `git/t`, so `cd repo` must not run from inside `repo/`)
 - `t12820-diff-no-index-symlink` — 41/41 tests pass (symlink add/modify/delete, `diff`/`diff --cached`/`diff-tree`, stat/numstat/name output, multi-symlink and file↔symlink replacements; harness dashboards refreshed)
 - `t7817-grep-sparse-checkout` — 8/8 tests pass (non-cone sparse: `path_in_sparse_checkout` parent walk + last-match-wins; `sparse-checkout init` preserves cone mode and seeds `/*` + `!/*/` when recreating file; `disable` keeps pattern file so re-init reapplies `!b`; submodule `reset --hard` + sparse reapply; `grep` worktree: skip-worktree when absent, CE_VALID vs skip-worktree, unmerged paths grep worktree once; `grep_cached` per-stage for `--cached`)
 - `t7417-submodule-path-url` — 5/5 tests pass (`.gitmodules` dash paths: `mv` updates path + index blob; `escape_value` quotes leading `-`; receive-side `transfer.fsckObjects` via repo-local config only; clone `--recurse-submodules` resolves relative URLs from `origin` repo root + quoted path parsing + `GIT_QUIET` quiet mode)

--- a/t1-plan.md
+++ b/t1-plan.md
@@ -32,7 +32,7 @@
 - [x] t10560-switch-create-detach.sh
 - [ ] t10570-restore-worktree-only.sh
 - [ ] t1060-object-corruption.sh                                                                        - [ ] t10610-show-ref-dereference-extra.sh
-- [ ] t10620-update-ref-nul-stdin.sh
+- [x] t10620-update-ref-nul-stdin.sh
 - [ ] t10630-symbolic-ref-chain-extra.sh
 - [ ] t10640-check-ignore-negation.sh
 - [ ] t10650-merge-file-zdiff3.sh

--- a/tests/t10620-update-ref-nul-stdin.sh
+++ b/tests/t10620-update-ref-nul-stdin.sh
@@ -13,6 +13,7 @@ cd "$(dirname "$0")" || exit 1
 ###########################################################################
 
 test_expect_success 'setup: create repo with initial commit' '
+	cd "$TRASH_DIRECTORY" &&
 	"$REAL_GIT" init repo &&
 	cd repo &&
 	"$REAL_GIT" config user.name "Test User" &&
@@ -27,9 +28,13 @@ test_expect_success 'setup: create repo with initial commit' '
 
 ###########################################################################
 # Section 2: Basic update-ref (non-stdin)
+# Each block begins with `cd "$TRASH_DIRECTORY"` because this harness keeps
+# the shell cwd across tests (unlike upstream git/t), so `cd repo` must start
+# from the trash root every time.
 ###########################################################################
 
 test_expect_success 'update-ref creates a new ref' '
+	cd "$TRASH_DIRECTORY" &&
 	cd repo &&
 	HEAD_OID=$("$REAL_GIT" rev-parse HEAD) &&
 	grit update-ref refs/heads/new-branch "$HEAD_OID" &&
@@ -39,6 +44,7 @@ test_expect_success 'update-ref creates a new ref' '
 '
 
 test_expect_success 'update-ref can update existing ref' '
+	cd "$TRASH_DIRECTORY" &&
 	cd repo &&
 	OLD_OID=$("$REAL_GIT" rev-parse HEAD~1) &&
 	grit update-ref refs/heads/new-branch "$OLD_OID" &&
@@ -48,6 +54,7 @@ test_expect_success 'update-ref can update existing ref' '
 '
 
 test_expect_success 'update-ref with old value check succeeds when matching' '
+	cd "$TRASH_DIRECTORY" &&
 	cd repo &&
 	OLD_OID=$("$REAL_GIT" rev-parse HEAD~1) &&
 	NEW_OID=$("$REAL_GIT" rev-parse HEAD) &&
@@ -55,12 +62,14 @@ test_expect_success 'update-ref with old value check succeeds when matching' '
 '
 
 test_expect_success 'update-ref with wrong old value fails' '
+	cd "$TRASH_DIRECTORY" &&
 	cd repo &&
 	WRONG_OID=$("$REAL_GIT" rev-parse HEAD~1) &&
 	test_must_fail grit update-ref refs/heads/new-branch "$WRONG_OID" "$WRONG_OID"
 '
 
 test_expect_success 'update-ref -d deletes a ref' '
+	cd "$TRASH_DIRECTORY" &&
 	cd repo &&
 	HEAD_OID=$("$REAL_GIT" rev-parse HEAD) &&
 	grit update-ref refs/heads/to-delete "$HEAD_OID" &&
@@ -74,6 +83,7 @@ test_expect_success 'update-ref -d deletes a ref' '
 ###########################################################################
 
 test_expect_success 'update-ref --stdin create command' '
+	cd "$TRASH_DIRECTORY" &&
 	cd repo &&
 	HEAD_OID=$("$REAL_GIT" rev-parse HEAD) &&
 	printf "create refs/heads/stdin-branch %s\n" "$HEAD_OID" |
@@ -84,6 +94,7 @@ test_expect_success 'update-ref --stdin create command' '
 '
 
 test_expect_success 'update-ref --stdin update command' '
+	cd "$TRASH_DIRECTORY" &&
 	cd repo &&
 	OLD_OID=$("$REAL_GIT" rev-parse HEAD) &&
 	NEW_OID=$("$REAL_GIT" rev-parse HEAD~1) &&
@@ -95,6 +106,7 @@ test_expect_success 'update-ref --stdin update command' '
 '
 
 test_expect_success 'update-ref --stdin delete command' '
+	cd "$TRASH_DIRECTORY" &&
 	cd repo &&
 	CURRENT=$("$REAL_GIT" rev-parse HEAD~1) &&
 	printf "delete refs/heads/stdin-branch %s\n" "$CURRENT" |
@@ -103,6 +115,7 @@ test_expect_success 'update-ref --stdin delete command' '
 '
 
 test_expect_success 'update-ref --stdin multiple commands in one batch' '
+	cd "$TRASH_DIRECTORY" &&
 	cd repo &&
 	HEAD_OID=$("$REAL_GIT" rev-parse HEAD) &&
 	OLD_OID=$("$REAL_GIT" rev-parse HEAD~1) &&
@@ -117,6 +130,7 @@ test_expect_success 'update-ref --stdin multiple commands in one batch' '
 ###########################################################################
 
 test_expect_success 'update-ref --stdin -z create command' '
+	cd "$TRASH_DIRECTORY" &&
 	cd repo &&
 	HEAD_OID=$("$REAL_GIT" rev-parse HEAD) &&
 	printf "create refs/heads/nul-branch %s\0" "$HEAD_OID" |
@@ -127,6 +141,7 @@ test_expect_success 'update-ref --stdin -z create command' '
 '
 
 test_expect_success 'update-ref --stdin -z update command' '
+	cd "$TRASH_DIRECTORY" &&
 	cd repo &&
 	OLD_OID=$("$REAL_GIT" rev-parse HEAD) &&
 	NEW_OID=$("$REAL_GIT" rev-parse HEAD~1) &&
@@ -138,6 +153,7 @@ test_expect_success 'update-ref --stdin -z update command' '
 '
 
 test_expect_success 'update-ref --stdin -z delete command' '
+	cd "$TRASH_DIRECTORY" &&
 	cd repo &&
 	CURRENT=$("$REAL_GIT" rev-parse HEAD~1) &&
 	printf "delete refs/heads/nul-branch %s\0" "$CURRENT" |
@@ -146,6 +162,7 @@ test_expect_success 'update-ref --stdin -z delete command' '
 '
 
 test_expect_success 'update-ref --stdin -z multiple creates' '
+	cd "$TRASH_DIRECTORY" &&
 	cd repo &&
 	HEAD_OID=$("$REAL_GIT" rev-parse HEAD) &&
 	OLD_OID=$("$REAL_GIT" rev-parse HEAD~1) &&
@@ -156,6 +173,7 @@ test_expect_success 'update-ref --stdin -z multiple creates' '
 '
 
 test_expect_success 'update-ref --stdin -z create and delete in one batch' '
+	cd "$TRASH_DIRECTORY" &&
 	cd repo &&
 	HEAD_OID=$("$REAL_GIT" rev-parse HEAD) &&
 	NUL_A_OID=$("$REAL_GIT" rev-parse refs/heads/nul-a) &&
@@ -166,6 +184,7 @@ test_expect_success 'update-ref --stdin -z create and delete in one batch' '
 '
 
 test_expect_success 'update-ref --stdin -z verify command succeeds on match' '
+	cd "$TRASH_DIRECTORY" &&
 	cd repo &&
 	NUL_C_OID=$("$REAL_GIT" rev-parse refs/heads/nul-c) &&
 	printf "verify refs/heads/nul-c %s\0" "$NUL_C_OID" |
@@ -173,6 +192,7 @@ test_expect_success 'update-ref --stdin -z verify command succeeds on match' '
 '
 
 test_expect_success 'update-ref --stdin -z verify command fails on mismatch' '
+	cd "$TRASH_DIRECTORY" &&
 	cd repo &&
 	WRONG=$("$REAL_GIT" rev-parse HEAD~1) &&
 	printf "verify refs/heads/nul-c %s\0" "$WRONG" |
@@ -184,6 +204,7 @@ test_expect_success 'update-ref --stdin -z verify command fails on mismatch' '
 ###########################################################################
 
 test_expect_success 'update-ref --no-deref on symbolic ref updates symref itself' '
+	cd "$TRASH_DIRECTORY" &&
 	cd repo &&
 	HEAD_OID=$("$REAL_GIT" rev-parse HEAD) &&
 	"$REAL_GIT" symbolic-ref refs/heads/symlink refs/heads/master &&
@@ -198,6 +219,7 @@ test_expect_success 'update-ref --no-deref on symbolic ref updates symref itself
 ###########################################################################
 
 test_expect_success 'update-ref creates deeply nested ref' '
+	cd "$TRASH_DIRECTORY" &&
 	cd repo &&
 	HEAD_OID=$("$REAL_GIT" rev-parse HEAD) &&
 	grit update-ref refs/custom/deep/nested/ref "$HEAD_OID" &&
@@ -207,6 +229,7 @@ test_expect_success 'update-ref creates deeply nested ref' '
 '
 
 test_expect_success 'update-ref creates refs/notes/ namespace' '
+	cd "$TRASH_DIRECTORY" &&
 	cd repo &&
 	HEAD_OID=$("$REAL_GIT" rev-parse HEAD) &&
 	grit update-ref refs/notes/commits "$HEAD_OID" &&
@@ -214,6 +237,7 @@ test_expect_success 'update-ref creates refs/notes/ namespace' '
 '
 
 test_expect_success 'update-ref creates refs/stash ref' '
+	cd "$TRASH_DIRECTORY" &&
 	cd repo &&
 	HEAD_OID=$("$REAL_GIT" rev-parse HEAD) &&
 	grit update-ref refs/stash "$HEAD_OID" &&
@@ -225,6 +249,7 @@ test_expect_success 'update-ref creates refs/stash ref' '
 ###########################################################################
 
 test_expect_success 'update-ref -m sets reflog message' '
+	cd "$TRASH_DIRECTORY" &&
 	cd repo &&
 	HEAD_OID=$("$REAL_GIT" rev-parse HEAD) &&
 	grit update-ref -m "test message" refs/heads/reflog-test "$HEAD_OID" &&
@@ -236,27 +261,32 @@ test_expect_success 'update-ref -m sets reflog message' '
 ###########################################################################
 
 test_expect_success 'update-ref -d on nonexistent ref is silent' '
+	cd "$TRASH_DIRECTORY" &&
 	cd repo &&
 	grit update-ref -d refs/heads/no-such-ref &&
 	test_must_fail grit show-ref --exists refs/heads/no-such-ref
 '
 
 test_expect_success 'update-ref --stdin -z with empty input succeeds' '
+	cd "$TRASH_DIRECTORY" &&
 	cd repo &&
 	printf "" | grit update-ref --stdin -z
 '
 
 test_expect_success 'update-ref --stdin with empty input succeeds' '
+	cd "$TRASH_DIRECTORY" &&
 	cd repo &&
 	printf "" | grit update-ref --stdin
 '
 
 test_expect_success 'update-ref with invalid OID fails' '
+	cd "$TRASH_DIRECTORY" &&
 	cd repo &&
 	test_must_fail grit update-ref refs/heads/bad-oid "not-a-valid-oid"
 '
 
 test_expect_success 'update-ref --stdin -z create then verify in single batch' '
+	cd "$TRASH_DIRECTORY" &&
 	cd repo &&
 	HEAD_OID=$("$REAL_GIT" rev-parse HEAD) &&
 	printf "create refs/heads/batch-verify %s\0verify refs/heads/batch-verify %s\0" "$HEAD_OID" "$HEAD_OID" |
@@ -265,6 +295,7 @@ test_expect_success 'update-ref --stdin -z create then verify in single batch' '
 '
 
 test_expect_success 'update-ref --stdin -z atomic: all-or-nothing on conflict' '
+	cd "$TRASH_DIRECTORY" &&
 	cd repo &&
 	HEAD_OID=$("$REAL_GIT" rev-parse HEAD) &&
 	OLD_OID=$("$REAL_GIT" rev-parse HEAD~1) &&
@@ -276,6 +307,7 @@ test_expect_success 'update-ref --stdin -z atomic: all-or-nothing on conflict' '
 '
 
 test_expect_success 'update-ref --stdin -z handles update without old value' '
+	cd "$TRASH_DIRECTORY" &&
 	cd repo &&
 	HEAD_OID=$("$REAL_GIT" rev-parse HEAD) &&
 	printf "update refs/heads/no-old-val %s\0" "$HEAD_OID" |
@@ -284,6 +316,7 @@ test_expect_success 'update-ref --stdin -z handles update without old value' '
 '
 
 test_expect_success 'update-ref --stdin newline: create + update + delete batch' '
+	cd "$TRASH_DIRECTORY" &&
 	cd repo &&
 	HEAD_OID=$("$REAL_GIT" rev-parse HEAD) &&
 	OLD_OID=$("$REAL_GIT" rev-parse HEAD~1) &&


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t10620-update-ref-nul-stdin` was failing because our TAP harness (`tests/test-lib-tap.sh`) keeps the shell working directory between `test_expect_success` blocks, while each case assumed it could run `cd repo` from the trash root. After the setup test ended inside `repo/`, subsequent `cd repo` commands failed.

## Changes

- Prefix each test body in `tests/t10620-update-ref-nul-stdin.sh` with `cd "$TRASH_DIRECTORY" &&` (with a short comment in section 2).
- Refresh harness artifacts from a clean run: `data/test-files.csv`, `docs/index.html`, `docs/testfiles.html`.
- Mark `t10620-update-ref-nul-stdin.sh` done in `t1-plan.md`, note in `progress.md`, add `logs/2026-04-08_t10620-update-ref-nul-stdin.md`.

## Verification

- `./scripts/run-tests.sh t10620-update-ref-nul-stdin.sh` — 30/30

We intentionally did **not** add a global `cd "$TRASH_DIRECTORY"` in the harness: tests like `t6409-merge-subtree` rely on cwd persisting across blocks.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-456bd666-cc1b-430e-af57-8624a3c7d5c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-456bd666-cc1b-430e-af57-8624a3c7d5c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

