### PR TITLE
fix: make t5506-remote-groups fully pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -92,7 +92,7 @@ t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
 t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
-t1006-cat-file	t1	yes	290	285	5	false	ok	1
+t1006-cat-file	t1	yes	290	285	5	false	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	32	8	false	ok	0
 t10070-cat-file-batch-format	t1	yes	33	33	0	true	ok	0
@@ -922,7 +922,7 @@ t5502-quickfetch	t5	yes	7	2	5	false	ok	0
 t5503-tagfollow	t5	yes	12	6	6	false	ok	0
 t5504-fetch-receive-strict	t5	skip	29	0	0	false	ok	0
 t5505-remote	t5	yes	0	0	0	false	timeout	1
-t5506-remote-groups	t5	yes	9	1	8	false	ok	0
+t5506-remote-groups	t5	yes	9	9	0	true	ok	0
 t5507-remote-environment	t5	yes	5	3	2	false	ok	0
 t5509-fetch-push-namespaces	t5	yes	15	4	11	false	ok	0
 t5510-fetch	t5	yes	215	81	134	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T21:03:47+00:00" class="gen-time" title="2026-04-08 21:03 UTC">2026-04-08 21:03 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,565</div>
+      <div class="summary-big-val">29,581</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>713 files fully passing</span>
+    <span>717 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,7 +212,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">41/141 files · 2 skipped · 3,333/4,611 tests</span>
+        <span class="group-meta">42/141 files · 2 skipped · 3,334/4,611 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.3%"></div></div>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,336/3,949 tests</span>
+        <span class="group-meta">32/167 files · 17 skipped · 1,350/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.8%"></div></div>
-        <span class="group-pct pct-red">33.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.2%"></div></div>
+        <span class="group-pct pct-red">34.2%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -256,7 +256,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">42/126 files · 11 skipped · 1,793/2,944 tests</span>
+        <span class="group-meta">43/126 files · 11 skipped · 1,794/2,944 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T21:03:47+00:00" class="gen-time" title="2026-04-08 21:03 UTC">2026-04-08 21:03 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,864</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,565</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,581</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1085,7 +1085,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">285</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.3%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t10060-hash-object-determinism</td>
@@ -5110,8 +5110,7 @@ tr.row-skip td { opacity: 0.65; }
 <tr class="" data-group="t2" data-tests="15" data-passed="5">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td><span class="badge ok">full pass</span></td>
-  <td class="right">15</td>
+  <td></td>
   <td class="right">15</td>
   <td class="right">5</td>
   <td class="right">ok</td>
@@ -6218,14 +6217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="54" data-passed="38">
+<tr class="" data-group="t3" data-tests="52" data-passed="3">
   <td class="mono">t3420-rebase-autostash</td>
   <td>t3</td>
   <td></td>
-  <td class="right">54</td>
-  <td class="right">38</td>
+  <td class="right">52</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="63" data-passed="11">
@@ -9378,14 +9377,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t5" data-tests="9" data-passed="1">
+<tr class="" data-group="t5" data-tests="9" data-passed="9" data-full-pass="1">
   <td class="mono">t5506-remote-groups</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">9</td>
-  <td class="right">1</td>
+  <td class="right">9</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:11.1%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="5" data-passed="3">
@@ -12598,7 +12597,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="2" data-passed="2">
+<tr class="" data-group="t7" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t7524-commit-summary</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>

--- a/grit-lib/src/rev_parse.rs
+++ b/grit-lib/src/rev_parse.rs
@@ -151,7 +151,29 @@ pub fn symbolic_full_name(repo: &Repository, spec: &str) -> Option<String> {
             return Some(candidate);
         }
     }
+    // Remote name alone: `one` → `refs/remotes/one/HEAD` when `remote.one.url` exists (matches Git).
+    if let Some(full) = remote_tracking_head_symbolic_target(repo, spec) {
+        return Some(full);
+    }
     None
+}
+
+/// When `name` is a configured remote, return the full ref `refs/remotes/<name>/HEAD` resolves to.
+fn remote_tracking_head_symbolic_target(repo: &Repository, name: &str) -> Option<String> {
+    if name.contains('/')
+        || matches!(
+            name,
+            "HEAD" | "FETCH_HEAD" | "MERGE_HEAD" | "CHERRY_PICK_HEAD" | "REVERT_HEAD"
+        )
+    {
+        return None;
+    }
+    let config = ConfigSet::load(Some(&repo.git_dir), true).ok()?;
+    let url_key = format!("remote.{name}.url");
+    config.get(&url_key)?;
+    let head_ref = format!("refs/remotes/{name}/HEAD");
+    let target = refs::read_symbolic_ref(&repo.git_dir, &head_ref).ok()??;
+    Some(target)
 }
 
 /// Expand an `@{-N}` token to the corresponding previous branch name.
@@ -1373,6 +1395,13 @@ fn resolve_base(
         format!("refs/notes/{spec}"),
     ] {
         if let Ok(oid) = refs::resolve_ref(&repo.git_dir, candidate) {
+            return Ok(oid);
+        }
+    }
+
+    // `git log one` / `git rev-parse one`: remote name → `refs/remotes/<name>/HEAD` (Git DWIM).
+    if let Some(head_ref) = remote_tracking_head_symbolic_target(repo, spec) {
+        if let Ok(oid) = refs::resolve_ref(&repo.git_dir, &head_ref) {
             return Ok(oid);
         }
     }

--- a/grit/src/commands/fetch.rs
+++ b/grit/src/commands/fetch.rs
@@ -154,14 +154,32 @@ pub fn run(args: Args) -> Result<()> {
         let url_key = format!("remote.{remote_name}.url");
         if config.get(&url_key).is_some() {
             fetch_remote(&git_dir, &config, remote_name, None, &args)
-        } else if remote_name.starts_with('.')
-            || remote_name.contains('/')
-            || std::path::Path::new(remote_name).is_dir()
-        {
-            // Treat as a local directory path.
-            fetch_remote(&git_dir, &config, remote_name, Some(remote_name), &args)
         } else {
-            fetch_remote(&git_dir, &config, remote_name, None, &args)
+            let group_key = format!("remotes.{remote_name}");
+            let group_lines = config.get_all(&group_key);
+            if !group_lines.is_empty() {
+                let mut seen = HashSet::<String>::new();
+                let mut members = Vec::new();
+                for line in &group_lines {
+                    for m in line.split_whitespace() {
+                        if seen.insert(m.to_string()) {
+                            members.push(m.to_string());
+                        }
+                    }
+                }
+                for m in members {
+                    fetch_remote(&git_dir, &config, &m, None, &args)?;
+                }
+                Ok(())
+            } else if remote_name.starts_with('.')
+                || remote_name.contains('/')
+                || std::path::Path::new(remote_name).is_dir()
+            {
+                // Treat as a local directory path.
+                fetch_remote(&git_dir, &config, remote_name, Some(remote_name), &args)
+            } else {
+                fetch_remote(&git_dir, &config, remote_name, None, &args)
+            }
         }
     };
 

--- a/grit/src/commands/remote.rs
+++ b/grit/src/commands/remote.rs
@@ -6,6 +6,7 @@
 use anyhow::{bail, Context, Result};
 use clap::{Args as ClapArgs, Subcommand};
 use grit_lib::config::{ConfigFile, ConfigScope, ConfigSet};
+use grit_lib::refs;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
@@ -59,6 +60,9 @@ pub struct AddArgs {
     /// Track only this branch (may be given more than once).
     #[arg(short = 't', long = "track")]
     pub track: Vec<String>,
+    /// Set `refs/remotes/<name>/HEAD` to track this branch on the remote.
+    #[arg(short = 'm', long = "master", value_name = "BRANCH")]
+    pub master: Option<String>,
     /// Fetch immediately after adding.
     #[arg(short = 'f')]
     pub fetch: bool,
@@ -129,8 +133,6 @@ pub struct UpdateArgs {
     pub groups: Vec<String>,
 }
 
-// ── Entrypoint ──────────────────────────────────────────────────────
-
 pub fn run(args: Args) -> Result<()> {
     match args.subcommand {
         Some(RemoteSubcommand::Add(add_args)) => cmd_add(add_args),
@@ -147,8 +149,6 @@ pub fn run(args: Args) -> Result<()> {
         None => cmd_list(args.verbose),
     }
 }
-
-// ── List remotes ────────────────────────────────────────────────────
 
 fn cmd_list(verbose: bool) -> Result<()> {
     let git_dir = resolve_git_dir()?;
@@ -170,8 +170,6 @@ fn cmd_list(verbose: bool) -> Result<()> {
 
     Ok(())
 }
-
-// ── Add ─────────────────────────────────────────────────────────────
 
 fn cmd_add(args: AddArgs) -> Result<()> {
     let git_dir = resolve_git_dir()?;
@@ -200,6 +198,13 @@ fn cmd_add(args: AddArgs) -> Result<()> {
     config_file.set(&format!("remote.{}.fetch", args.name), &fetch_refspec)?;
     config_file.write().context("writing config")?;
 
+    if let Some(ref master) = args.master {
+        let head_ref = format!("refs/remotes/{}/HEAD", args.name);
+        let target = format!("refs/remotes/{}/{}", args.name, master);
+        refs::write_symbolic_ref(&git_dir, &head_ref, &target)
+            .with_context(|| format!("Could not setup master '{master}'"))?;
+    }
+
     // If -f was given, fetch immediately.
     if args.fetch {
         let self_exe = std::env::current_exe().context("cannot determine own executable")?;
@@ -215,8 +220,6 @@ fn cmd_add(args: AddArgs) -> Result<()> {
 
     Ok(())
 }
-
-// ── Remove ──────────────────────────────────────────────────────────
 
 fn cmd_remove(args: RemoveArgs) -> Result<()> {
     let git_dir = resolve_git_dir()?;
@@ -276,8 +279,6 @@ fn cmd_remove(args: RemoveArgs) -> Result<()> {
 
     Ok(())
 }
-
-// ── Rename ──────────────────────────────────────────────────────────
 
 fn cmd_rename(args: RenameArgs) -> Result<()> {
     let git_dir = resolve_git_dir()?;
@@ -342,8 +343,6 @@ fn cmd_rename(args: RenameArgs) -> Result<()> {
     Ok(())
 }
 
-// ── Get URL ─────────────────────────────────────────────────────────
-
 fn cmd_get_url(args: GetUrlArgs) -> Result<()> {
     let git_dir = resolve_git_dir()?;
     let config = load_local_config(&git_dir)?;
@@ -357,8 +356,6 @@ fn cmd_get_url(args: GetUrlArgs) -> Result<()> {
         None => bail!("No such remote '{}'", args.name),
     }
 }
-
-// ── Set URL ─────────────────────────────────────────────────────────
 
 fn cmd_set_url(args: SetUrlArgs) -> Result<()> {
     let git_dir = resolve_git_dir()?;
@@ -379,8 +376,6 @@ fn cmd_set_url(args: SetUrlArgs) -> Result<()> {
 
     Ok(())
 }
-
-// ── Show ────────────────────────────────────────────────────────────
 
 fn cmd_show(args: ShowArgs) -> Result<()> {
     let git_dir = resolve_git_dir()?;
@@ -405,8 +400,6 @@ fn cmd_show(args: ShowArgs) -> Result<()> {
         None => bail!("No such remote '{}'", args.name),
     }
 }
-
-// ── Set Branches ────────────────────────────────────────────────────
 
 fn cmd_set_branches(args: SetBranchesArgs) -> Result<()> {
     let git_dir = resolve_git_dir()?;
@@ -438,8 +431,6 @@ fn cmd_set_branches(args: SetBranchesArgs) -> Result<()> {
     config_file.write().context("writing config")?;
     Ok(())
 }
-
-// ── Prune ───────────────────────────────────────────────────────────
 
 fn cmd_prune(args: PruneArgs) -> Result<()> {
     let git_dir = resolve_git_dir()?;
@@ -487,8 +478,6 @@ fn cmd_prune(args: PruneArgs) -> Result<()> {
     Ok(())
 }
 
-// ── Update ──────────────────────────────────────────────────────────
-
 fn cmd_update(args: UpdateArgs) -> Result<()> {
     let git_dir = resolve_git_dir()?;
     let config = load_local_config(&git_dir)?;
@@ -505,16 +494,18 @@ fn cmd_update(args: UpdateArgs) -> Result<()> {
             if all_remotes.contains_key(group) {
                 names.push(group.clone());
             } else {
-                // Check remotes.<group> config for group members
                 let group_key = format!("remotes.{group}");
-                if let Some(members) = config.get(&group_key) {
-                    for member in members.split_whitespace() {
-                        if !names.contains(&member.to_string()) {
-                            names.push(member.to_string());
+                let member_lines = config.get_all(&group_key);
+                if member_lines.is_empty() {
+                    bail!("No such remote or remote group: '{}'", group);
+                }
+                for line in &member_lines {
+                    for member in line.split_whitespace() {
+                        let m = member.to_string();
+                        if !names.contains(&m) {
+                            names.push(m);
                         }
                     }
-                } else {
-                    bail!("No such remote or remote group: '{}'", group);
                 }
             }
         }
@@ -556,8 +547,6 @@ fn cmd_update(args: UpdateArgs) -> Result<()> {
 
     Ok(())
 }
-
-// ── Helpers ─────────────────────────────────────────────────────────
 
 struct RemoteInfo {
     url: String,

--- a/logs/2026-04-08-t5506-remote-groups.md
+++ b/logs/2026-04-08-t5506-remote-groups.md
@@ -1,0 +1,12 @@
+# t5506-remote-groups
+
+## Changes
+
+- `git remote add -m <branch>`: write `refs/remotes/<name>/HEAD` symbolic ref (Git-compatible).
+- `remote update` / group expansion: read all `remotes.<group>` values via `ConfigSet::get_all` (supports `git config --add`).
+- `git fetch <group>`: same multi-value group resolution.
+- Revision DWIM: resolve a bare remote name to the OID of `refs/remotes/<name>/HEAD` when `remote.<name>.url` exists (fixes `git log -1 one` in the test).
+
+## Verification
+
+- `./scripts/run-tests.sh t5506-remote-groups.sh` → 9/9 pass.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible remote group behavior and related revision resolution so `tests/t5506-remote-groups.sh` passes (9/9).

## Changes

- **`git remote add -m <branch>`** — Sets `refs/remotes/<name>/HEAD` as a symbolic ref to `refs/remotes/<name>/<branch>` (same as upstream Git).
- **`remotes.<group>` multi-values** — `remote update` and `git fetch <group>` now merge every `git config --add remotes.<group> ...` line, not only the last value.
- **Revision DWIM** — A bare name that matches a configured remote resolves through `refs/remotes/<name>/HEAD`, so `git log -1 one` works like Git after fetch.

## Testing

- `cargo build --release -p grit-rs`
- `./scripts/run-tests.sh t5506-remote-groups.sh`
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-123ce15d-cca7-4f8e-a02c-949673526489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-123ce15d-cca7-4f8e-a02c-949673526489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

