### PR TITLE
fix: make t7520-ignored-hook-warning fully pass

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -786,7 +786,7 @@ commit → check it off → move on.
 
 - [ ] `t7510-signed-commit` ███████████████████░ 27/28 (1 left) — signed commit tests
 - [ ] `t7008-filter-branch-null-sha1` ████████████████░░░░ 5/6 (1 left) — filter-branch removal of trees with null sha1
-- [ ] `t7520-ignored-hook-warning` ████████████████░░░░ 4/5 (1 left) — ignored hook warning
+- [x] `t7520-ignored-hook-warning` — ignored hook warning (5/5 harness; `test_hook --disable`/`--remove` + hooks hint)
 - [x] `t7524-commit-summary` — git commit summary (2/2; `diff --stat --break-rewrites` vs plain `--stat` + commit summary line)
 - [ ] `t7607-merge-state` ░░░░░░░░░░░░░░░░░░░░ 0/1 (1 left) — Test that merge state is as expected after failed merge
 - [ ] `t7423-submodule-symlinks` █████████████░░░░░░░ 4/6 (2 left) — check that submodule operations do not follow symlinks

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -92,7 +92,7 @@ t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
 t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
-t1006-cat-file	t1	yes	290	285	5	false	ok	1
+t1006-cat-file	t1	yes	290	285	5	false	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	32	8	false	ok	0
 t10070-cat-file-batch-format	t1	yes	33	33	0	true	ok	0
@@ -1242,7 +1242,7 @@ t7516-commit-races	t7	yes	2	0	2	false	ok	0
 t7517-per-repo-email	t7	yes	16	16	0	true	ok	0
 t7518-ident-corner-cases	t7	yes	5	3	2	false	ok	0
 t7519-status-fsmonitor	t7	yes	33	14	19	false	ok	0
-t7520-ignored-hook-warning	t7	yes	5	3	2	false	ok	0
+t7520-ignored-hook-warning	t7	yes	5	5	0	true	ok	0
 t7521-ignored-mode	t7	yes	12	1	11	false	ok	0
 t7524-commit-summary	t7	yes	2	2	0	true	ok	0
 t7525-status-rename	t7	yes	15	10	5	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T21:14:28+00:00" class="gen-time" title="2026-04-08 21:14 UTC">2026-04-08 21:14 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,565</div>
+      <div class="summary-big-val">29,575</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>713 files fully passing</span>
+    <span>717 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,7 +212,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">41/141 files · 2 skipped · 3,333/4,611 tests</span>
+        <span class="group-meta">42/141 files · 2 skipped · 3,334/4,611 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.3%"></div></div>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,336/3,949 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,342/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.8%"></div></div>
-        <span class="group-pct pct-red">33.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.0%"></div></div>
+        <span class="group-pct pct-red">34.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -256,11 +256,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">42/126 files · 11 skipped · 1,793/2,944 tests</span>
+        <span class="group-meta">44/126 files · 11 skipped · 1,796/2,944 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>
-        <span class="group-pct pct-blue">60.9%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:61.0%"></div></div>
+        <span class="group-pct pct-blue">61.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T21:14:28+00:00" class="gen-time" title="2026-04-08 21:14 UTC">2026-04-08 21:14 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,864</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,565</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,575</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1085,7 +1085,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">285</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.3%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t10060-hash-object-determinism</td>
@@ -5110,8 +5110,7 @@ tr.row-skip td { opacity: 0.65; }
 <tr class="" data-group="t2" data-tests="15" data-passed="5">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td><span class="badge ok">full pass</span></td>
-  <td class="right">15</td>
+  <td></td>
   <td class="right">15</td>
   <td class="right">5</td>
   <td class="right">ok</td>
@@ -6218,14 +6217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="54" data-passed="38">
+<tr class="" data-group="t3" data-tests="52" data-passed="3">
   <td class="mono">t3420-rebase-autostash</td>
   <td>t3</td>
   <td></td>
-  <td class="right">54</td>
-  <td class="right">38</td>
+  <td class="right">52</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="63" data-passed="11">
@@ -12578,14 +12577,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:42.4%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="5" data-passed="3">
+<tr class="" data-group="t7" data-tests="5" data-passed="5" data-full-pass="1">
   <td class="mono">t7520-ignored-hook-warning</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">5</td>
-  <td class="right">3</td>
+  <td class="right">5</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:60.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="12" data-passed="1">
@@ -12598,7 +12597,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="2" data-passed="2">
+<tr class="" data-group="t7" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t7524-commit-summary</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>

--- a/grit-lib/src/hooks.rs
+++ b/grit-lib/src/hooks.rs
@@ -108,7 +108,7 @@ pub fn run_hook(
                 hook_name
             );
             eprintln!(
-                "hint: You can disable this warning with `git config advice.ignoredHook false`."
+                "hint: You can disable this warning with `git config set advice.ignoredHook false`."
             );
         }
         return HookResult::NotFound;

--- a/logs/2026-04-08_t7520-ignored-hook-warning.md
+++ b/logs/2026-04-08_t7520-ignored-hook-warning.md
@@ -1,0 +1,15 @@
+# t7520-ignored-hook-warning
+
+## Problem
+
+Harness reported 3/5: tests 3–4 failed because `test_hook --disable` was a no-op in `tests/test-lib.sh` (unknown `--disable` broke out of the option loop early, so the hook stayed executable and no "hook was ignored" warning appeared).
+
+## Fix
+
+- Extended `test_hook` to match upstream `git/t/test-lib-functions.sh`: `--disable`, `--remove`, reject unknown `-` flags, resolve `$git_dir/hooks` via `git rev-parse --absolute-git-dir` (works for bare repos with `-C`).
+- Aligned the second line of the ignored-hook hint with current Git: ``git config set advice.ignoredHook false``.
+
+## Verification
+
+- `./scripts/run-tests.sh t7520-ignored-hook-warning.sh` → 5/5
+- `cargo test -p grit-lib --lib` → pass

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   231 |
-| In progress |     2 |
-| Remaining   |   535 |
+| Completed   |   247 |
+| In progress |     4 |
+| Remaining   |   517 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 231 completed (`[x]`), 2 in progress (`[~]`), 535 remaining (`[ ]`).
+Task lines in `PLAN.md`: 247 completed (`[x]`), 4 in progress (`[~]`), 517 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t7520-ignored-hook-warning` — 5/5 tests pass (`tests/test-lib.sh` `test_hook`: `--disable`/`--remove`, resolve hook dir via `git rev-parse --absolute-git-dir`; second hint line uses `git config set advice.ignoredHook false`)
 - `t12820-diff-no-index-symlink` — 41/41 tests pass (symlink add/modify/delete, `diff`/`diff --cached`/`diff-tree`, stat/numstat/name output, multi-symlink and file↔symlink replacements; harness dashboards refreshed)
 - `t7817-grep-sparse-checkout` — 8/8 tests pass (non-cone sparse: `path_in_sparse_checkout` parent walk + last-match-wins; `sparse-checkout init` preserves cone mode and seeds `/*` + `!/*/` when recreating file; `disable` keeps pattern file so re-init reapplies `!b`; submodule `reset --hard` + sparse reapply; `grep` worktree: skip-worktree when absent, CE_VALID vs skip-worktree, unmerged paths grep worktree once; `grep_cached` per-stage for `--cached`)
 - `t7417-submodule-path-url` — 5/5 tests pass (`.gitmodules` dash paths: `mv` updates path + index blob; `escape_value` quotes leading `-`; receive-side `transfer.fsckObjects` via repo-local config only; clone `--recurse-submodules` resolves relative URLs from `origin` repo root + quoted path parsing + `GIT_QUIET` quiet mode)

--- a/test-results.md
+++ b/test-results.md
@@ -2,6 +2,8 @@
 
 **Updated:** 2026-04-08
 
+- `./scripts/run-tests.sh t7520-ignored-hook-warning.sh`: 5/5 passing (`test_hook --disable`/`--remove` + `rev-parse --absolute-git-dir`; ignored-hook hint second line matches `git config set advice.ignoredHook false`; harness CSV/dashboards refreshed).
+- `cargo test -p grit-lib --lib`: 121/121 passing.
 - `./scripts/run-tests.sh t13180-log-patch-stat.sh`: 35/35 passing (`grit log` oneline/graph/decorate/skip/max-count/reverse/format; harness CSV/dashboards refreshed).
 - `./scripts/run-tests.sh t10560-switch-create-detach.sh`: 28/28 passing (`switch -- <branch>` disambiguation; invalid `-c`/`-C`/`--orphan` branch names rejected like Git; harness CSV/dashboards refreshed).
 - `cargo test -p grit-lib --lib`: 110/110 passing.

--- a/tests/test-lib.sh
+++ b/tests/test-lib.sh
@@ -995,13 +995,20 @@ write_script () {
 	chmod +x "$1"
 }
 
-# test_hook [--setup] [--clobber] HOOKNAME — write a hook script from stdin
-# --clobber replaces an existing hook (matches upstream test-lib; implies --setup).
+# test_hook [options] HOOKNAME — write or manipulate a hook (matches git/t/test-lib-functions.sh).
+#   -C <dir>  run git rev-parse from that directory (bare: no .git; non-bare: has .git)
+#   --setup / --clobber  as upstream
+#   --disable  chmod -x an existing hook (must exist)
+#   --remove   rm -f an existing hook (must exist)
 test_hook () {
-	local setup= clobber= indir=
+	local setup= clobber= disable= remove= indir=
 	while test $# != 0
 	do
 		case "$1" in
+		-C)
+			indir="$2"
+			shift 2
+			;;
 		--setup)
 			setup=t
 			shift
@@ -1011,34 +1018,49 @@ test_hook () {
 			setup=t
 			shift
 			;;
-		-C)
-			indir="$2"
-			shift 2
+		--disable)
+			disable=t
+			shift
+			;;
+		--remove)
+			remove=t
+			shift
+			;;
+		-*)
+			echo >&2 "BUG: test_hook: invalid argument: $1"
+			exit 99
 			;;
 		*)
 			break
 			;;
 		esac
 	done
-	local hook_dir
-	if test -n "$indir"
+	local git_dir hook_dir hook_file
+	git_dir=$(git -C "$indir" rev-parse --absolute-git-dir) &&
+	hook_dir="$git_dir/hooks" &&
+	hook_file="$hook_dir/$1" &&
+	if test -n "$disable$remove"
 	then
-		if test -d "$indir/.git"
+		test_path_is_file "$hook_file" &&
+		if test -n "$disable"
 		then
-			hook_dir="$indir/.git/hooks"
-		else
-			# bare repo
-			hook_dir="$indir/hooks"
-		fi
-	else
-		hook_dir=".git/hooks"
-	fi
+			chmod -x "$hook_file"
+		elif test -n "$remove"
+		then
+			rm -f "$hook_file"
+		fi &&
+		return 0
+	fi &&
 	if test -z "$clobber"
 	then
-		test_path_is_missing "$hook_dir/$1"
+		test_path_is_missing "$hook_file"
+	fi &&
+	if test -z "$setup$clobber"
+	then
+		test_when_finished "rm -f \"$hook_file\""
 	fi &&
 	mkdir -p "$hook_dir" &&
-	write_script "$hook_dir/$1"
+	write_script "$hook_file"
 }
 
 # Look for trace2 region enter/leave in a trace file (from GIT_TRACE2_EVENT).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t7520-ignored-hook-warning` was failing because `tests/test-lib.sh` did not implement `test_hook --disable` / `--remove` (upstream `git/t/test-lib-functions.sh` behavior). Unknown `--disable` fell through to the hook name position and the hook stayed executable, so no “hook was ignored” message appeared.

## Changes

- **`tests/test-lib.sh`**: Full `test_hook` parity with upstream: `--disable`, `--remove`, reject unknown flags, resolve hooks dir via `git rev-parse --absolute-git-dir` (bare + `-C` safe), optional `test_when_finished` cleanup when not `--setup`/`--clobber`.
- **`grit-lib/src/hooks.rs`**: Second hint line now matches current Git: ``git config set advice.ignoredHook false``.
- Harness run refreshed `data/test-files.csv` and dashboards; `PLAN.md`, `progress.md`, `test-results.md`, and `logs/2026-04-08_t7520-ignored-hook-warning.md` updated.

## Verification

- `./scripts/run-tests.sh t7520-ignored-hook-warning.sh` → 5/5
- `cargo test -p grit-lib --lib` → 121/121
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fdf86496-3a16-4e1e-8f37-e8ee432ffac5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fdf86496-3a16-4e1e-8f37-e8ee432ffac5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

