### PR TITLE
fix(test): reset harness cwd so t0110-environment passes

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -92,7 +92,7 @@ t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
 t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
-t1006-cat-file	t1	yes	290	285	5	false	ok	1
+t1006-cat-file	t1	yes	290	285	5	false	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	32	8	false	ok	0
 t10070-cat-file-batch-format	t1	yes	33	33	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T21:43:23+00:00" class="gen-time" title="2026-04-08 21:43 UTC">2026-04-08 21:43 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,565</div>
+      <div class="summary-big-val">29,573</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>713 files fully passing</span>
+    <span>716 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,7 +212,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">41/141 files · 2 skipped · 3,333/4,611 tests</span>
+        <span class="group-meta">42/141 files · 2 skipped · 3,334/4,611 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.3%"></div></div>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,336/3,949 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,342/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.8%"></div></div>
-        <span class="group-pct pct-red">33.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.0%"></div></div>
+        <span class="group-pct pct-red">34.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -256,7 +256,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">42/126 files · 11 skipped · 1,793/2,944 tests</span>
+        <span class="group-meta">43/126 files · 11 skipped · 1,794/2,944 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T21:43:23+00:00" class="gen-time" title="2026-04-08 21:43 UTC">2026-04-08 21:43 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,864</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,565</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,573</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1085,7 +1085,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">285</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.3%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t10060-hash-object-determinism</td>
@@ -5110,8 +5110,7 @@ tr.row-skip td { opacity: 0.65; }
 <tr class="" data-group="t2" data-tests="15" data-passed="5">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td><span class="badge ok">full pass</span></td>
-  <td class="right">15</td>
+  <td></td>
   <td class="right">15</td>
   <td class="right">5</td>
   <td class="right">ok</td>
@@ -6218,14 +6217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="54" data-passed="38">
+<tr class="" data-group="t3" data-tests="52" data-passed="3">
   <td class="mono">t3420-rebase-autostash</td>
   <td>t3</td>
   <td></td>
-  <td class="right">54</td>
-  <td class="right">38</td>
+  <td class="right">52</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="63" data-passed="11">
@@ -12598,7 +12597,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="2" data-passed="2">
+<tr class="" data-group="t7" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t7524-commit-summary</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>

--- a/logs/2026-04-08-t0110-environment.md
+++ b/logs/2026-04-08-t0110-environment.md
@@ -1,0 +1,13 @@
+# t0110-environment
+
+## Issue
+
+`t0110-environment.sh` failed after the first test because the harness shell stayed in `repo/`; the next test ran `cd repo` from there and looked for `repo/repo`.
+
+## Fix
+
+In `tests/test-lib.sh`, `test_run_` now runs `cd "$TRASH_DIRECTORY"` before each test body (same assumption as upstream Git’s test-lib: each test starts at trash root).
+
+## Verification
+
+`./scripts/run-tests.sh t0110-environment.sh` → 31/31 pass.

--- a/tests/test-lib.sh
+++ b/tests/test-lib.sh
@@ -1233,6 +1233,10 @@ test_eval_ () {
 test_run_ () {
 	test_cleanup=:
 	expecting_failure=$2
+	# Each test body assumes a cwd of the trash root (matches upstream git test-lib).
+	# Without this, a prior test that ends inside a subdirectory breaks relative paths
+	# like `cd repo` in the next test.
+	cd "$TRASH_DIRECTORY" || exit 1
 	test_eval_ "$1"
 	eval_ret=$?
 	if test -z "$immediate" || test "$eval_ret" -eq 0 ||


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t0110-environment.sh` failed because the main test shell stayed in a subdirectory (e.g. `repo/`) after a test that ended with `cd repo`. The next test then ran `cd repo` from the wrong place and could not find `repo/repo`.

## Change

In `tests/test-lib.sh`, `test_run_` now runs `cd "$TRASH_DIRECTORY"` before each test body, matching upstream Git test-lib behavior (each test assumes cwd is the trash root).

## Verification

- `./scripts/run-tests.sh t0110-environment.sh` → **31/31** pass
- `cargo test -p grit-lib --lib` → pass

Also updates harness CSV/dashboards from the test run and adds `logs/2026-04-08-t0110-environment.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-feb4247f-f4ba-4d5b-a924-f74dfea9e74d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-feb4247f-f4ba-4d5b-a924-f74dfea9e74d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

