### PR TITLE
fix: ls-files --others matches Git for t3009 (empty dirs, .git file)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -538,7 +538,7 @@ t3005-ls-files-relative	t3	yes	4	1	3	false	ok	0
 t3006-ls-files-long	t3	yes	3	3	0	true	ok	0
 t3007-ls-files-recurse-submodules	t3	yes	24	1	23	false	ok	0
 t3008-ls-files-lazy-init-name-hash	t3	yes	1	0	1	false	ok	0
-t3009-ls-files-others-nonsubmodule	t3	yes	2	1	1	false	ok	0
+t3009-ls-files-others-nonsubmodule	t3	yes	2	2	0	true	ok	0
 t3010-ls-files-killed-modified	t3	yes	6	3	3	false	ok	0
 t3011-common-prefixes-and-directory-traversal	t3	yes	20	16	4	false	ok	1
 t3011-ls-files-staged	t3	yes	29	29	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T22:06:26+00:00" class="gen-time" title="2026-04-08 22:06 UTC">2026-04-08 22:06 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,565</div>
+      <div class="summary-big-val">29,573</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>713 files fully passing</span>
+    <span>716 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,7 +212,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">41/141 files · 2 skipped · 3,333/4,611 tests</span>
+        <span class="group-meta">42/141 files · 2 skipped · 3,334/4,611 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.3%"></div></div>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,336/3,949 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,342/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.8%"></div></div>
-        <span class="group-pct pct-red">33.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.0%"></div></div>
+        <span class="group-pct pct-red">34.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -256,7 +256,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">42/126 files · 11 skipped · 1,793/2,944 tests</span>
+        <span class="group-meta">43/126 files · 11 skipped · 1,794/2,944 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T22:06:26+00:00" class="gen-time" title="2026-04-08 22:06 UTC">2026-04-08 22:06 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,864</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,565</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,573</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -5110,8 +5110,7 @@ tr.row-skip td { opacity: 0.65; }
 <tr class="" data-group="t2" data-tests="15" data-passed="5">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td><span class="badge ok">full pass</span></td>
-  <td class="right">15</td>
+  <td></td>
   <td class="right">15</td>
   <td class="right">5</td>
   <td class="right">ok</td>
@@ -6218,14 +6217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="54" data-passed="38">
+<tr class="" data-group="t3" data-tests="52" data-passed="3">
   <td class="mono">t3420-rebase-autostash</td>
   <td>t3</td>
   <td></td>
-  <td class="right">54</td>
-  <td class="right">38</td>
+  <td class="right">52</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="63" data-passed="11">
@@ -12598,7 +12597,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="2" data-passed="2">
+<tr class="" data-group="t7" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t7524-commit-summary</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>

--- a/grit/src/commands/ls_files.rs
+++ b/grit/src/commands/ls_files.rs
@@ -453,7 +453,14 @@ pub fn run(args: Args) -> Result<()> {
         let indexed_paths: BTreeSet<Vec<u8>> =
             index.entries.iter().map(|e| e.path.clone()).collect();
         let mut untracked = Vec::new();
-        walk_worktree(work_tree, work_tree, &indexed_paths, &mut untracked, true)?;
+        walk_worktree(
+            work_tree,
+            work_tree,
+            &indexed_paths,
+            &mut untracked,
+            true,
+            args.directory,
+        )?;
         untracked.sort();
 
         let mut filtered_untracked: Vec<Vec<u8>> = Vec::new();
@@ -569,16 +576,42 @@ pub fn run(args: Args) -> Result<()> {
     Ok(())
 }
 
+/// Returns true when `dir/.git` denotes an embedded Git repository Git should not recurse into.
+///
+/// Matches Git: a **regular file** named `.git` (non-submodule test in t3000) is ignored; a
+/// **symlink** (gitlink) or a **directory** with `HEAD` / `commondir` (normal or linked worktree)
+/// is treated as a repository boundary.
+fn dot_git_marks_git_repository(dot_git: &std::path::Path) -> bool {
+    let Ok(meta) = std::fs::symlink_metadata(dot_git) else {
+        return false;
+    };
+    if meta.file_type().is_symlink() {
+        return true;
+    }
+    if meta.is_file() {
+        return false;
+    }
+    if meta.is_dir() {
+        return dot_git.join("HEAD").exists() || dot_git.join("commondir").exists();
+    }
+    false
+}
+
 /// Walk the worktree and collect paths of untracked files.
 ///
-/// Returns whether any path was recorded under `dir` (files, nested repo markers, or empty
-/// untracked directories). `is_root` skips emitting a synthetic `""/` entry for the repo root.
+/// Returns whether any path was recorded under `dir` (files, nested repo markers, or when
+/// `emit_empty_directories` is set, empty untracked directory markers ending with `/`).
+/// `is_root` skips emitting a synthetic `""/` entry for the repo root.
+///
+/// `emit_empty_directories` matches Git: plain `ls-files --others` does not list empty
+/// untracked directories; `--directory` adds `name/` markers for empty dirs (used by completion).
 fn walk_worktree(
     root: &std::path::Path,
     dir: &std::path::Path,
     indexed: &BTreeSet<Vec<u8>>,
     out: &mut Vec<Vec<u8>>,
     is_root: bool,
+    emit_empty_directories: bool,
 ) -> Result<bool> {
     let rel_bytes = path_to_bytes(dir.strip_prefix(root).unwrap_or(dir));
 
@@ -622,7 +655,7 @@ fn walk_worktree(
             }
         } else if ft.is_dir() {
             let dot_git = path.join(".git");
-            if dot_git.exists() {
+            if dot_git_marks_git_repository(&dot_git) {
                 // Untracked git repository: emit as a directory entry
                 // (git treats these as opaque and doesn't recurse into them)
                 let dir_prefix_str = format!("{}/", String::from_utf8_lossy(&rel_bytes));
@@ -638,21 +671,25 @@ fn walk_worktree(
                 }
                 continue;
             }
-            if walk_worktree(root, &path, indexed, out, false)? {
+            if walk_worktree(root, &path, indexed, out, false, emit_empty_directories)? {
                 added = true;
             }
         }
     }
 
-    // Git lists empty untracked directories as `name/` when walking for `ls-files -o`
-    // (needed for `--directory` / bash completion).
+    // With `ls-files --others --directory`, Git lists empty untracked dirs as `name/`.
     let has_tracked_under = |prefix: &[u8]| {
         let prefix_slash: Vec<u8> = [prefix, b"/"].concat();
         indexed
             .iter()
             .any(|t| t == prefix || t.starts_with(&prefix_slash))
     };
-    if !added && !is_root && !rel_bytes.is_empty() && !has_tracked_under(&rel_bytes) {
+    if emit_empty_directories
+        && !added
+        && !is_root
+        && !rel_bytes.is_empty()
+        && !has_tracked_under(&rel_bytes)
+    {
         let mut dir_entry = rel_bytes;
         dir_entry.push(b'/');
         out.push(dir_entry);

--- a/logs/2026-04-08_t3009-ls-files-others-nonsubmodule.md
+++ b/logs/2026-04-08_t3009-ls-files-others-nonsubmodule.md
@@ -1,0 +1,15 @@
+# 2026-04-08 — t3009-ls-files-others-nonsubmodule
+
+## Problem
+
+`grit ls-files -o` listed `nonrepo-no-files/` (empty untracked directory). Upstream Git does not list empty dirs unless `--directory` is used.
+
+## Fix
+
+- `walk_worktree`: emit `name/` empty-directory markers only when `args.directory` is true (passed as `emit_empty_directories`).
+- `dot_git_marks_git_repository`: treat only symlink `.git` or directory `.git` with `HEAD`/`commondir` as an embedded repo. A regular file `.git` is not a repo (t3000.6).
+
+## Validation
+
+- `./scripts/run-tests.sh t3009-ls-files-others-nonsubmodule.sh` → 2/2 pass.
+- Manual check: plain `-o` omits empty dir; `-o --directory` matches Git.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns `grit ls-files --others` with upstream Git behavior exercised by `t3009-ls-files-others-nonsubmodule`.

## Changes

- **Empty untracked directories:** Only emit `name/` markers when `--directory` is used. Plain `ls-files -o` no longer lists empty dirs (fixes t3009 vs `nonrepo-no-files/`).
- **Non-submodule `.git`:** A regular file named `.git` inside a directory is not treated as an embedded repository; only a symlink gitlink or a `.git` directory containing `HEAD` or `commondir` is (matches t3000.6).

## Validation

- `./scripts/run-tests.sh t3009-ls-files-others-nonsubmodule.sh` — 2/2 pass
- `cargo check -p grit-rs`

## Note

`cargo clippy -p grit-rs -D warnings` still reports many pre-existing issues in the binary crate; this change was verified with `cargo check` only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7a2b392-1a0a-4cc4-915f-1cd8ea3d58eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7a2b392-1a0a-4cc4-915f-1cd8ea3d58eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

