### PR TITLE
fix: make t9510-ls-files-error pass (test cwd reset)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -92,7 +92,7 @@ t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
 t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
-t1006-cat-file	t1	yes	290	285	5	false	ok	1
+t1006-cat-file	t1	yes	290	285	5	false	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	32	8	false	ok	0
 t10070-cat-file-batch-format	t1	yes	33	33	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T22:05:27+00:00" class="gen-time" title="2026-04-08 22:05 UTC">2026-04-08 22:05 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,565</div>
+      <div class="summary-big-val">29,573</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>713 files fully passing</span>
+    <span>716 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,7 +212,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">41/141 files · 2 skipped · 3,333/4,611 tests</span>
+        <span class="group-meta">42/141 files · 2 skipped · 3,334/4,611 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.3%"></div></div>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,336/3,949 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,342/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.8%"></div></div>
-        <span class="group-pct pct-red">33.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.0%"></div></div>
+        <span class="group-pct pct-red">34.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -256,7 +256,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">42/126 files · 11 skipped · 1,793/2,944 tests</span>
+        <span class="group-meta">43/126 files · 11 skipped · 1,794/2,944 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T22:05:27+00:00" class="gen-time" title="2026-04-08 22:05 UTC">2026-04-08 22:05 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,864</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,565</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,573</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1085,7 +1085,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">285</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.3%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t10060-hash-object-determinism</td>
@@ -5110,8 +5110,7 @@ tr.row-skip td { opacity: 0.65; }
 <tr class="" data-group="t2" data-tests="15" data-passed="5">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td><span class="badge ok">full pass</span></td>
-  <td class="right">15</td>
+  <td></td>
   <td class="right">15</td>
   <td class="right">5</td>
   <td class="right">ok</td>
@@ -6218,14 +6217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="54" data-passed="38">
+<tr class="" data-group="t3" data-tests="52" data-passed="3">
   <td class="mono">t3420-rebase-autostash</td>
   <td>t3</td>
   <td></td>
-  <td class="right">54</td>
-  <td class="right">38</td>
+  <td class="right">52</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="63" data-passed="11">
@@ -12598,7 +12597,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="2" data-passed="2">
+<tr class="" data-group="t7" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t7524-commit-summary</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>

--- a/logs/2026-04-08_t9510-ls-files-error.md
+++ b/logs/2026-04-08_t9510-ls-files-error.md
@@ -1,0 +1,15 @@
+# t9510-ls-files-error
+
+## Problem
+
+All cases after the first failed because `tests/test-lib-tap.sh` runs each test body in the same shell without resetting `cwd`. The setup test ends inside `repo/`, so the next test’s `cd repo` tried `repo/repo` and exited 1 before running `grit`.
+
+`tests/test-lib.sh` must not be modified (AGENTS.md), so the fix is confined to this test file.
+
+## Fix
+
+Prefix each test body with `cd "$TRASH_DIRECTORY"` (and combine with `cd repo` or `cd cross-repo` as needed) so every case starts from the trash root.
+
+## Verification
+
+`./scripts/run-tests.sh t9510-ls-files-error.sh` → 32/32 pass.

--- a/tests/t9510-ls-files-error.sh
+++ b/tests/t9510-ls-files-error.sh
@@ -14,6 +14,7 @@ REAL_GIT=/usr/bin/git
 ###########################################################################
 
 test_expect_success 'setup repository' '
+	cd "$TRASH_DIRECTORY" &&
 	grit init repo &&
 	cd repo &&
 	echo "tracked1" >tracked1.txt &&
@@ -29,36 +30,36 @@ test_expect_success 'setup repository' '
 ###########################################################################
 
 test_expect_success 'ls-files --error-unmatch succeeds for tracked file' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY" && cd repo &&
 	grit ls-files --error-unmatch tracked1.txt >actual &&
 	grep "tracked1.txt" actual
 '
 
 test_expect_success 'ls-files --error-unmatch fails for untracked file' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY" && cd repo &&
 	test_must_fail grit ls-files --error-unmatch nonexistent.txt
 '
 
 test_expect_success 'ls-files --error-unmatch with multiple tracked files' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY" && cd repo &&
 	grit ls-files --error-unmatch tracked1.txt tracked2.txt >actual &&
 	grep "tracked1.txt" actual &&
 	grep "tracked2.txt" actual
 '
 
 test_expect_success 'ls-files --error-unmatch fails if any file is untracked' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY" && cd repo &&
 	test_must_fail grit ls-files --error-unmatch tracked1.txt missing.txt
 '
 
 test_expect_success 'ls-files --error-unmatch with subdirectory file' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY" && cd repo &&
 	grit ls-files --error-unmatch sub/deep.txt >actual &&
 	grep "sub/deep.txt" actual
 '
 
 test_expect_success 'ls-files --error-unmatch with deeply nested file' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY" && cd repo &&
 	grit ls-files --error-unmatch sub/deep/leaf.txt >actual &&
 	grep "sub/deep/leaf.txt" actual
 '
@@ -68,26 +69,26 @@ test_expect_success 'ls-files --error-unmatch with deeply nested file' '
 ###########################################################################
 
 test_expect_success 'ls-files --stage shows mode, OID, stage' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY" && cd repo &&
 	grit ls-files --stage >actual &&
 	grep "^100644 [0-9a-f]\{40\} 0	tracked1.txt" actual
 '
 
 test_expect_success 'ls-files -s is same as --stage' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY" && cd repo &&
 	grit ls-files -s >s_out &&
 	grit ls-files --stage >stage_out &&
 	test_cmp s_out stage_out
 '
 
 test_expect_success 'ls-files --stage shows all tracked files' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY" && cd repo &&
 	grit ls-files --stage >actual &&
 	test $(wc -l <actual) -eq 4
 '
 
 test_expect_success 'ls-files --stage OIDs are 40 hex chars' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY" && cd repo &&
 	grit ls-files --stage >actual &&
 	while IFS="	" read info path; do
 		oid=$(echo "$info" | awk "{print \$2}") &&
@@ -96,7 +97,7 @@ test_expect_success 'ls-files --stage OIDs are 40 hex chars' '
 '
 
 test_expect_success 'ls-files --stage all stages are 0' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY" && cd repo &&
 	grit ls-files --stage >actual &&
 	while IFS="	" read info path; do
 		stage=$(echo "$info" | awk "{print \$3}") &&
@@ -105,7 +106,7 @@ test_expect_success 'ls-files --stage all stages are 0' '
 '
 
 test_expect_success 'ls-files --stage OID matches hash-object' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY" && cd repo &&
 	expected_oid=$(grit hash-object tracked1.txt) &&
 	grit ls-files --stage >actual &&
 	grep "tracked1.txt" actual | awk "{print \$2}" >stage_oid &&
@@ -114,7 +115,7 @@ test_expect_success 'ls-files --stage OID matches hash-object' '
 '
 
 test_expect_success 'ls-files --stage OID for sub file matches hash-object' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY" && cd repo &&
 	expected_oid=$(grit hash-object sub/deep.txt) &&
 	grit ls-files --stage >actual &&
 	grep "sub/deep.txt$" actual | awk "{print \$2}" >stage_oid &&
@@ -127,7 +128,7 @@ test_expect_success 'ls-files --stage OID for sub file matches hash-object' '
 ###########################################################################
 
 test_expect_success 'ls-files -z uses NUL terminators' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY" && cd repo &&
 	grit ls-files -z >actual &&
 	tr "\0" "\n" <actual >decoded &&
 	grep "tracked1.txt" decoded &&
@@ -135,14 +136,14 @@ test_expect_success 'ls-files -z uses NUL terminators' '
 '
 
 test_expect_success 'ls-files -z --stage uses NUL terminators' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY" && cd repo &&
 	grit ls-files -z --stage >actual &&
 	tr "\0" "\n" <actual >decoded &&
 	grep "tracked1.txt" decoded
 '
 
 test_expect_success 'ls-files -z entry count matches normal mode' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY" && cd repo &&
 	grit ls-files >normal &&
 	grit ls-files -z | tr "\0" "\n" >z_decoded &&
 	test $(grep -c . normal) -eq $(grep -c . z_decoded)
@@ -153,34 +154,34 @@ test_expect_success 'ls-files -z entry count matches normal mode' '
 ###########################################################################
 
 test_expect_success 'ls-files with pathspec restricts output' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY" && cd repo &&
 	grit ls-files tracked1.txt >actual &&
 	echo "tracked1.txt" >expect &&
 	test_cmp expect actual
 '
 
 test_expect_success 'ls-files with directory pathspec shows files in dir' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY" && cd repo &&
 	grit ls-files sub/ >actual &&
 	grep "sub/deep.txt" actual &&
 	grep "sub/deep/leaf.txt" actual
 '
 
 test_expect_success 'ls-files with directory pathspec excludes other files' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY" && cd repo &&
 	grit ls-files sub/ >actual &&
 	! grep "tracked1.txt" actual &&
 	! grep "tracked2.txt" actual
 '
 
 test_expect_success 'ls-files with non-matching pathspec shows nothing' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY" && cd repo &&
 	grit ls-files nonexistent/ >actual &&
 	test_must_be_empty actual
 '
 
 test_expect_success 'ls-files with multiple pathspecs' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY" && cd repo &&
 	grit ls-files tracked1.txt sub/deep.txt >actual &&
 	grep "tracked1.txt" actual &&
 	grep "sub/deep.txt" actual &&
@@ -192,34 +193,34 @@ test_expect_success 'ls-files with multiple pathspecs' '
 ###########################################################################
 
 test_expect_success 'ls-files default lists all cached files' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY" && cd repo &&
 	grit ls-files >actual &&
 	test $(wc -l <actual) -eq 4
 '
 
 test_expect_success 'ls-files -c same as default' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY" && cd repo &&
 	grit ls-files -c >cached &&
 	grit ls-files >default_out &&
 	test_cmp cached default_out
 '
 
 test_expect_success 'ls-files --cached same as default' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY" && cd repo &&
 	grit ls-files --cached >cached &&
 	grit ls-files >default_out &&
 	test_cmp cached default_out
 '
 
 test_expect_success 'ls-files output is sorted' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY" && cd repo &&
 	grit ls-files >actual &&
 	sort actual >sorted &&
 	test_cmp actual sorted
 '
 
 test_expect_success 'ls-files after adding another file' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY" && cd repo &&
 	echo "extra" >extra.txt &&
 	grit add extra.txt &&
 	grit ls-files >actual &&
@@ -228,7 +229,7 @@ test_expect_success 'ls-files after adding another file' '
 '
 
 test_expect_success 'ls-files after removing a file from index' '
-	cd repo &&
+	cd "$TRASH_DIRECTORY" && cd repo &&
 	grit rm --cached extra.txt &&
 	grit ls-files >actual &&
 	! grep "extra.txt" actual &&
@@ -240,6 +241,7 @@ test_expect_success 'ls-files after removing a file from index' '
 ###########################################################################
 
 test_expect_success 'setup cross-check repo' '
+	cd "$TRASH_DIRECTORY" &&
 	$REAL_GIT init cross-repo &&
 	cd cross-repo &&
 	$REAL_GIT config user.email "t@t.com" &&
@@ -252,21 +254,21 @@ test_expect_success 'setup cross-check repo' '
 '
 
 test_expect_success 'ls-files output matches real git' '
-	cd cross-repo &&
+	cd "$TRASH_DIRECTORY" && cd cross-repo &&
 	grit ls-files >grit_out &&
 	$REAL_GIT ls-files >git_out &&
 	test_cmp grit_out git_out
 '
 
 test_expect_success 'ls-files --stage output matches real git' '
-	cd cross-repo &&
+	cd "$TRASH_DIRECTORY" && cd cross-repo &&
 	grit ls-files --stage >grit_out &&
 	$REAL_GIT ls-files --stage >git_out &&
 	test_cmp grit_out git_out
 '
 
 test_expect_success 'ls-files with pathspec matches real git' '
-	cd cross-repo &&
+	cd "$TRASH_DIRECTORY" && cd cross-repo &&
 	grit ls-files a.txt >grit_out &&
 	$REAL_GIT ls-files a.txt >git_out &&
 	test_cmp grit_out git_out


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t9510-ls-files-error` failed because `test_expect_success` runs each body in the same shell without resetting the working directory. The setup test ends inside `repo/`, so the next test’s `cd repo` attempted `repo/repo` and failed before invoking `grit`.

AGENTS.md forbids editing `tests/test-lib.sh`, so each test body in `tests/t9510-ls-files-error.sh` now starts with `cd "$TRASH_DIRECTORY"` (combined with `cd repo` / `cd cross-repo` as needed).

## Verification

`./scripts/run-tests.sh t9510-ls-files-error.sh` → 32/32 pass.

Harness refresh: `data/test-files.csv`, `docs/index.html`, `docs/testfiles.html`.

## Log

`logs/2026-04-08_t9510-ls-files-error.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c69c6b03-e0d8-4c16-9d93-df6117bbcd4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c69c6b03-e0d8-4c16-9d93-df6117bbcd4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

