### PR TITLE
fix: submodule diff for diff-index and diff (t4060 progress)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -92,7 +92,7 @@ t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
 t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
-t1006-cat-file	t1	yes	290	285	5	false	ok	1
+t1006-cat-file	t1	yes	290	285	5	false	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	32	8	false	ok	0
 t10070-cat-file-batch-format	t1	yes	33	33	0	true	ok	0
@@ -740,7 +740,7 @@ t4056-diff-order	t4	yes	23	10	13	false	ok	0
 t4057-diff-combined-paths	t4	yes	4	0	4	false	ok	0
 t4058-diff-duplicates	t4	yes	14	7	7	false	ok	2
 t4059-diff-submodule-not-initialized	t4	yes	8	1	7	false	ok	0
-t4060-diff-submodule-option-diff-format	t4	yes	50	5	45	false	ok	0
+t4060-diff-submodule-option-diff-format	t4	yes	51	29	22	false	ok	0
 t4061-diff-indent	t4	yes	33	5	28	false	ok	0
 t4062-diff-pickaxe	t4	yes	3	3	0	true	ok	0
 t4063-diff-blobs	t4	yes	18	3	15	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T22:56:22+00:00" class="gen-time" title="2026-04-08 22:56 UTC">2026-04-08 22:56 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,11 +150,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,565</div>
+      <div class="summary-big-val">29,597</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">39,864</div>
+      <div class="summary-big-val">39,865</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>713 files fully passing</span>
+    <span>716 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,7 +212,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">41/141 files · 2 skipped · 3,333/4,611 tests</span>
+        <span class="group-meta">42/141 files · 2 skipped · 3,334/4,611 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.3%"></div></div>
@@ -223,22 +223,22 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">63/178 files · 2 skipped · 1,920/3,541 tests</span>
+        <span class="group-meta">63/178 files · 2 skipped · 1,944/3,542 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:54.2%"></div></div>
-        <span class="group-pct pct-orange">54.2%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:54.9%"></div></div>
+        <span class="group-pct pct-orange">54.9%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,336/3,949 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,342/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.8%"></div></div>
-        <span class="group-pct pct-red">33.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.0%"></div></div>
+        <span class="group-pct pct-red">34.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -256,7 +256,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">42/126 files · 11 skipped · 1,793/2,944 tests</span>
+        <span class="group-meta">43/126 files · 11 skipped · 1,794/2,944 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T22:56:22+00:00" class="gen-time" title="2026-04-08 22:56 UTC">2026-04-08 22:56 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">39,864</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,565</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n" id="sum-tests">39,865</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,597</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1085,7 +1085,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">285</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.3%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t10060-hash-object-determinism</td>
@@ -5110,8 +5110,7 @@ tr.row-skip td { opacity: 0.65; }
 <tr class="" data-group="t2" data-tests="15" data-passed="5">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td><span class="badge ok">full pass</span></td>
-  <td class="right">15</td>
+  <td></td>
   <td class="right">15</td>
   <td class="right">5</td>
   <td class="right">ok</td>
@@ -6218,14 +6217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="54" data-passed="38">
+<tr class="" data-group="t3" data-tests="52" data-passed="3">
   <td class="mono">t3420-rebase-autostash</td>
   <td>t3</td>
   <td></td>
-  <td class="right">54</td>
-  <td class="right">38</td>
+  <td class="right">52</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="63" data-passed="11">
@@ -7558,14 +7557,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:12.5%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="50" data-passed="5">
+<tr class="" data-group="t4" data-tests="51" data-passed="29">
   <td class="mono">t4060-diff-submodule-option-diff-format</td>
   <td>t4</td>
   <td></td>
-  <td class="right">50</td>
-  <td class="right">5</td>
+  <td class="right">51</td>
+  <td class="right">29</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:10.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="33" data-passed="5">
@@ -12598,7 +12597,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="2" data-passed="2">
+<tr class="" data-group="t7" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t7524-commit-summary</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>

--- a/grit/src/commands/commit.rs
+++ b/grit/src/commands/commit.rs
@@ -12,7 +12,7 @@ use grit_lib::diff::{
 };
 use grit_lib::error::Error;
 use grit_lib::hooks::{run_hook, HookResult};
-use grit_lib::index::Index;
+use grit_lib::index::{Index, IndexEntry};
 use grit_lib::objects::{serialize_commit, CommitData, ObjectId, ObjectKind};
 use grit_lib::refs::append_reflog;
 use grit_lib::repo::Repository;
@@ -27,6 +27,7 @@ use crate::ident::{resolve_email, resolve_name, IdentRole};
 use std::collections::{BTreeSet, HashSet};
 use std::fs;
 use std::io::{self, Write};
+use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use time::OffsetDateTime;
@@ -203,8 +204,59 @@ struct FixupParsed {
     commit_ref: String,
 }
 
+/// Split `-m` / `-F` (and `=` forms) out of the trailing pathspec bucket.
+///
+/// Clap routes all trailing tokens into `pathspec`; Git allows `git commit <path> -m msg`.
+fn peel_message_flags_from_pathspec(args: &mut Args) {
+    let ps = std::mem::take(&mut args.pathspec);
+    let mut out = Vec::new();
+    let mut i = 0usize;
+    while i < ps.len() {
+        let a = ps[i].as_str();
+        if a == "-m" || a == "--message" {
+            if i + 1 < ps.len() {
+                args.message.push(ps[i + 1].clone());
+                i += 2;
+            } else {
+                i += 1;
+            }
+            continue;
+        }
+        if let Some(rest) = a.strip_prefix("--message=") {
+            if !rest.is_empty() {
+                args.message.push(rest.to_owned());
+            }
+            i += 1;
+            continue;
+        }
+        if a == "-F" || a == "--file" {
+            if i + 1 < ps.len() {
+                if args.file.is_none() {
+                    args.file = Some(ps[i + 1].clone());
+                }
+                i += 2;
+            } else {
+                i += 1;
+            }
+            continue;
+        }
+        if let Some(rest) = a.strip_prefix("--file=") {
+            if !rest.is_empty() && args.file.is_none() {
+                args.file = Some(rest.to_owned());
+            }
+            i += 1;
+            continue;
+        }
+        out.push(ps[i].clone());
+        i += 1;
+    }
+    args.pathspec = out;
+}
+
 /// Run the `commit` command.
 pub fn run(mut args: Args) -> Result<()> {
+    peel_message_flags_from_pathspec(&mut args);
+
     // Tests and some scripts pass `-q` after `-m MSG`; if it lands in the
     // trailing pathspec bucket, strip it so we match Git (quiet is already
     // handled by the top-level flag).
@@ -981,6 +1033,123 @@ fn walk_untracked(
     Ok(())
 }
 
+fn commit_embedded_repository_git_dir(worktree: &Path) -> Result<PathBuf> {
+    let dot_git = worktree.join(".git");
+    let meta = fs::symlink_metadata(&dot_git)
+        .with_context(|| format!("cannot stat .git in embedded repo {}", worktree.display()))?;
+    if meta.file_type().is_dir() {
+        return Ok(dot_git);
+    }
+    let content = fs::read_to_string(&dot_git)
+        .with_context(|| format!("cannot read .git file in {}", worktree.display()))?;
+    let line = content.lines().next().unwrap_or("").trim();
+    let rest = line.strip_prefix("gitdir:").map(str::trim).ok_or_else(|| {
+        anyhow::anyhow!(
+            "invalid .git file in {} (expected gitdir:)",
+            worktree.display()
+        )
+    })?;
+    let p = Path::new(rest);
+    Ok(if p.is_absolute() {
+        p.to_path_buf()
+    } else {
+        worktree.join(p)
+    })
+}
+
+fn commit_remove_obstructing_parent_file_entries(index: &mut Index, rel_path: &str) {
+    for (i, ch) in rel_path.char_indices() {
+        if ch != '/' {
+            continue;
+        }
+        let prefix = &rel_path[..i];
+        let prefix_bytes = prefix.as_bytes();
+        if let Some(e) = index.get(prefix_bytes, 0) {
+            let is_tree = e.mode & 0o170000 == 0o040000;
+            if !is_tree {
+                index.remove(prefix_bytes);
+            }
+        }
+    }
+}
+
+/// Stage an embedded repository path as a gitlink (matches `git add` for submodules).
+fn commit_stage_gitlink(index: &mut Index, rel_path: &str, abs_path: &Path) -> Result<()> {
+    let git_dir = commit_embedded_repository_git_dir(abs_path)?;
+    let embedded_head_path = git_dir.join("HEAD");
+    let head_content = fs::read_to_string(&embedded_head_path)
+        .with_context(|| format!("cannot read HEAD of embedded repo '{rel_path}'"))?;
+    let head_trimmed = head_content.trim();
+    let oid_hex = if let Some(refname) = head_trimmed.strip_prefix("ref: ") {
+        let ref_path = git_dir.join(refname);
+        fs::read_to_string(&ref_path)
+            .with_context(|| {
+                format!("cannot resolve ref '{refname}' in embedded repo '{rel_path}'")
+            })?
+            .trim()
+            .to_string()
+    } else {
+        head_trimmed.to_string()
+    };
+    let oid = ObjectId::from_hex(&oid_hex)
+        .with_context(|| format!("invalid HEAD OID in embedded repo '{rel_path}'"))?;
+    commit_remove_obstructing_parent_file_entries(index, rel_path);
+    index.remove_descendants_under_path(rel_path);
+    let meta = fs::metadata(abs_path)?;
+    let entry = IndexEntry {
+        ctime_sec: meta.ctime() as u32,
+        ctime_nsec: meta.ctime_nsec() as u32,
+        mtime_sec: meta.mtime() as u32,
+        mtime_nsec: meta.mtime_nsec() as u32,
+        dev: meta.dev() as u32,
+        ino: meta.ino() as u32,
+        mode: 0o160000,
+        uid: meta.uid(),
+        gid: meta.gid(),
+        size: 0,
+        oid,
+        flags: rel_path.len().min(0xFFF) as u16,
+        flags_extended: None,
+        path: rel_path.as_bytes().to_vec(),
+    };
+    index.add_or_replace(entry);
+    Ok(())
+}
+
+fn stage_pathspec_worktree_path(
+    repo: &Repository,
+    index: &mut Index,
+    work_tree: &Path,
+    resolved: &str,
+) -> Result<()> {
+    let abs_path = work_tree.join(resolved);
+    let meta = fs::symlink_metadata(&abs_path)
+        .with_context(|| format!("pathspec '{resolved}' did not match any file(s) known to git"))?;
+    if meta.file_type().is_symlink() {
+        let target = fs::read_link(&abs_path)?;
+        let data = target.to_string_lossy().into_owned().into_bytes();
+        let oid = repo.odb.write(ObjectKind::Blob, &data)?;
+        let mode = grit_lib::index::normalize_mode(meta.mode());
+        let raw_path = resolved.as_bytes().to_vec();
+        let entry = grit_lib::index::entry_from_stat(&abs_path, &raw_path, oid, mode)?;
+        index.add_or_replace(entry);
+        return Ok(());
+    }
+    if meta.file_type().is_dir() {
+        if commit_embedded_repository_git_dir(&abs_path).is_ok() {
+            return commit_stage_gitlink(index, resolved, &abs_path);
+        }
+        bail!("fatal: '{resolved}' is a directory");
+    }
+    let data = fs::read(&abs_path)?;
+    let oid = repo.odb.write(ObjectKind::Blob, &data)?;
+    let mode = grit_lib::index::normalize_mode(meta.mode());
+    let raw_path = resolved.as_bytes().to_vec();
+    let entry = grit_lib::index::entry_from_stat(&abs_path, &raw_path, oid, mode)?;
+    index.add_or_replace(entry);
+    Ok(())
+}
+
 /// Stage specific files given as pathspec arguments to `commit`.
 ///
 /// Returns the set of repository-relative paths that were staged (or removed) for this commit.
@@ -989,8 +1158,6 @@ fn stage_pathspec_files(
     work_tree: &Path,
     pathspecs: &[String],
 ) -> Result<HashSet<Vec<u8>>> {
-    use std::os::unix::fs::MetadataExt;
-
     let index_path = resolved_index_path(repo);
     let mut index = match repo.load_index_at(&index_path) {
         Ok(idx) => idx,
@@ -1007,19 +1174,9 @@ fn stage_pathspec_files(
         let resolved = crate::pathspec::resolve_pathspec(spec, work_tree, prefix.as_deref());
         if !crate::pathspec::has_glob_chars(&resolved) {
             let abs_path = work_tree.join(&resolved);
-            if let Ok(meta) = fs::symlink_metadata(&abs_path) {
-                let data = if meta.file_type().is_symlink() {
-                    let target = fs::read_link(&abs_path)?;
-                    target.to_string_lossy().into_owned().into_bytes()
-                } else {
-                    fs::read(&abs_path)?
-                };
-                let oid = repo.odb.write(ObjectKind::Blob, &data)?;
-                let mode = grit_lib::index::normalize_mode(meta.mode());
-                let raw_path = resolved.as_bytes().to_vec();
-                let entry = grit_lib::index::entry_from_stat(&abs_path, &raw_path, oid, mode)?;
-                index.add_or_replace(entry);
-                matched_paths.insert(raw_path);
+            if fs::symlink_metadata(&abs_path).is_ok() {
+                stage_pathspec_worktree_path(repo, &mut index, work_tree, &resolved)?;
+                matched_paths.insert(resolved.as_bytes().to_vec());
             } else {
                 index.remove(resolved.as_bytes());
                 matched_paths.insert(resolved.as_bytes().to_vec());
@@ -1071,20 +1228,10 @@ fn stage_pathspec_files(
 
         for rel in matched_rels {
             let abs_path = work_tree.join(&rel);
-            if let Ok(meta) = fs::symlink_metadata(&abs_path) {
-                let data = if meta.file_type().is_symlink() {
-                    let target = fs::read_link(&abs_path)?;
-                    target.to_string_lossy().into_owned().into_bytes()
-                } else {
-                    fs::read(&abs_path)?
-                };
-                let oid = repo.odb.write(ObjectKind::Blob, &data)?;
-                let mode = grit_lib::index::normalize_mode(meta.mode());
-                let raw_path = rel.as_bytes().to_vec();
-                let entry = grit_lib::index::entry_from_stat(&abs_path, &raw_path, oid, mode)?;
-                index.add_or_replace(entry);
+            if fs::symlink_metadata(&abs_path).is_ok() {
+                stage_pathspec_worktree_path(repo, &mut index, work_tree, &rel)?;
                 spec_matched = true;
-                matched_paths.insert(raw_path);
+                matched_paths.insert(rel.as_bytes().to_vec());
             }
         }
 

--- a/grit/src/commands/diff.rs
+++ b/grit/src/commands/diff.rs
@@ -25,7 +25,101 @@ use grit_lib::merge_diff::format_worktree_conflict_combined;
 use grit_lib::objects::{parse_commit, ObjectId, ObjectKind};
 use grit_lib::odb::Odb;
 use grit_lib::repo::Repository;
-use grit_lib::rev_parse::{resolve_revision, split_treeish_colon};
+use grit_lib::rev_list::{rev_list, RevListOptions};
+use grit_lib::rev_parse::{abbreviate_object_id, resolve_revision, split_treeish_colon};
+
+use crate::commands::diff_index::{write_patch_entry, SubmoduleIgnoreFlags};
+
+fn submodule_ignore_flags_from_diff_arg(ignore_sm: &str) -> SubmoduleIgnoreFlags {
+    match ignore_sm {
+        "all" => SubmoduleIgnoreFlags {
+            ignore_all: true,
+            ignore_untracked: false,
+            ignore_dirty: false,
+        },
+        "untracked" => SubmoduleIgnoreFlags {
+            ignore_all: false,
+            ignore_untracked: true,
+            ignore_dirty: false,
+        },
+        "dirty" => SubmoduleIgnoreFlags {
+            ignore_all: false,
+            ignore_untracked: false,
+            ignore_dirty: true,
+        },
+        _ => SubmoduleIgnoreFlags {
+            ignore_all: false,
+            ignore_untracked: false,
+            ignore_dirty: false,
+        },
+    }
+}
+
+fn write_submodule_log_lines(
+    out: &mut impl Write,
+    repo: &Repository,
+    entry: &DiffEntry,
+) -> Result<()> {
+    let z = zero_oid();
+    if entry.old_oid == z || entry.new_oid == z {
+        return Ok(());
+    }
+    let old_a = abbreviate_object_id(repo, entry.old_oid, 7)?;
+    let new_a = abbreviate_object_id(repo, entry.new_oid, 7)?;
+    writeln!(out, "Submodule {} {}..{}:", entry.path(), old_a, new_a)?;
+    let Some(wt) = repo.work_tree.as_deref() else {
+        return Ok(());
+    };
+    let sub_path = wt.join(entry.path());
+    let Ok(sub_repo) = Repository::discover(Some(&sub_path)) else {
+        return Ok(());
+    };
+    let mut opts = RevListOptions::default();
+    opts.first_parent = true;
+    let Ok(res) = rev_list(
+        &sub_repo,
+        &[entry.new_oid.to_hex()],
+        &[entry.old_oid.to_hex()],
+        &opts,
+    ) else {
+        return Ok(());
+    };
+    for oid in res.commits.iter().rev() {
+        let Ok(obj) = sub_repo.odb.read(oid) else {
+            continue;
+        };
+        if obj.kind != ObjectKind::Commit {
+            continue;
+        }
+        let Ok(c) = parse_commit(&obj.data) else {
+            continue;
+        };
+        let subject = submodule_commit_subject_line(&c);
+        writeln!(out, "  > {subject}")?;
+    }
+    Ok(())
+}
+
+fn submodule_commit_subject_line(c: &grit_lib::objects::CommitData) -> String {
+    let enc = c.encoding.as_deref().unwrap_or("UTF-8");
+    let is_latin1 = enc.eq_ignore_ascii_case("ISO8859-1")
+        || enc.eq_ignore_ascii_case("ISO-8859-1")
+        || enc.eq_ignore_ascii_case("LATIN1")
+        || enc.eq_ignore_ascii_case("ISO-8859-15");
+    if let Some(raw) = c.raw_message.as_deref() {
+        let line = raw.split(|b| *b == b'\n').next().unwrap_or(raw);
+        if is_latin1 {
+            return line
+                .iter()
+                .map(|&b| b as char)
+                .collect::<String>()
+                .trim()
+                .to_owned();
+        }
+        return String::from_utf8_lossy(line).trim().to_string();
+    }
+    c.message.lines().next().unwrap_or("").trim().to_owned()
+}
 use std::fs;
 use std::io::{self, IsTerminal, Write};
 use std::path::Path;
@@ -318,8 +412,8 @@ pub struct Args {
     #[arg(short = 'M', long = "find-renames", value_name = "N", default_missing_value = "50", num_args = 0..=1, require_equals = true)]
     pub find_renames: Option<String>,
 
-    /// Suppress diff output for submodules.
-    #[arg(long = "submodule", value_name = "FORMAT", default_missing_value = "short", num_args = 0..=1, require_equals = true)]
+    /// Submodule diff output (`log` is the default for bare `--submodule`, matching Git).
+    #[arg(long = "submodule", value_name = "FORMAT", default_missing_value = "log", num_args = 0..=1)]
     pub submodule: Option<String>,
 
     /// Disable external diff drivers (no-op, for compatibility).
@@ -1168,6 +1262,7 @@ pub fn run(mut args: Args) -> Result<()> {
             if show_unified {
                 write_patch_with_prefix(
                     &mut out,
+                    &repo,
                     &entries,
                     &repo.odb,
                     context_lines,
@@ -1180,6 +1275,8 @@ pub fn run(mut args: Args) -> Result<()> {
                     args.binary,
                     &src_prefix,
                     &dst_prefix,
+                    args.submodule.as_deref(),
+                    submodule_ignore_flags_from_diff_arg(ignore_sm),
                 )?;
             }
         }
@@ -1743,6 +1840,10 @@ fn diff_emit_unified_patch_from_argv(argv: &[String]) -> bool {
             emit = true;
             continue;
         }
+        if arg == "--submodule" || arg.starts_with("--submodule=") {
+            emit = true;
+            continue;
+        }
         if arg.starts_with("-U") || arg.starts_with("--unified") {
             emit = true;
             continue;
@@ -2244,6 +2345,7 @@ fn write_diff_header_with_prefix(
 
 fn write_patch_with_prefix(
     out: &mut impl Write,
+    repo: &Repository,
     entries: &[DiffEntry],
     odb: &Odb,
     context_lines: usize,
@@ -2256,10 +2358,43 @@ fn write_patch_with_prefix(
     show_binary: bool,
     src_prefix: &str,
     dst_prefix: &str,
+    submodule_fmt: Option<&str>,
+    submodule_ignore: SubmoduleIgnoreFlags,
 ) -> Result<()> {
     for entry in entries {
         let old_path = entry.old_path.as_deref().unwrap_or("/dev/null");
         let new_path = entry.new_path.as_deref().unwrap_or("/dev/null");
+
+        if let Some(fmt) = submodule_fmt {
+            if entry.old_mode == "160000" || entry.new_mode == "160000" {
+                if fmt == "log"
+                    && entry.old_mode == "160000"
+                    && entry.new_mode == "160000"
+                    && matches!(
+                        entry.status,
+                        DiffStatus::Modified | DiffStatus::Renamed | DiffStatus::Copied
+                    )
+                    && entry.old_oid != entry.new_oid
+                {
+                    write_submodule_log_lines(out, repo, entry)?;
+                    continue;
+                }
+                if fmt == "diff" {
+                    write_patch_entry(
+                        out,
+                        repo,
+                        odb,
+                        entry,
+                        context_lines,
+                        work_tree,
+                        true,
+                        submodule_ignore,
+                        entry.path(),
+                    )?;
+                    continue;
+                }
+            }
+        }
 
         write_diff_header_with_prefix(out, entry, use_color, abbrev_len, src_prefix, dst_prefix)?;
 

--- a/grit/src/commands/diff_index.rs
+++ b/grit/src/commands/diff_index.rs
@@ -3,16 +3,17 @@
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::diff::{
-    detect_copies, detect_renames, read_submodule_head_oid, stat_matches, zero_oid, DiffEntry,
-    DiffStatus,
+    detect_copies, detect_renames, diff_trees, read_submodule_head_oid, stat_matches, zero_oid,
+    DiffEntry, DiffStatus,
 };
 use grit_lib::index::{
-    Index, IndexEntry, MODE_EXECUTABLE, MODE_GITLINK, MODE_REGULAR, MODE_SYMLINK,
+    Index, IndexEntry, MODE_EXECUTABLE, MODE_GITLINK, MODE_REGULAR, MODE_SYMLINK, MODE_TREE,
 };
 use grit_lib::objects::{parse_commit, parse_tree, ObjectId, ObjectKind};
 use grit_lib::odb::Odb;
 use grit_lib::pathspec::{context_from_mode_bits, matches_pathspec_with_context};
 use grit_lib::repo::Repository;
+use grit_lib::rev_list::merge_bases;
 use grit_lib::rev_parse::{abbreviate_object_id, resolve_revision};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
@@ -65,12 +66,78 @@ pub fn run(args: Args) -> Result<()> {
             &index_map,
             &index,
             options.match_missing,
-            options.ignore_submodules,
+            SubmoduleIgnoreFlags {
+                ignore_all: options.ignore_submodules_all,
+                ignore_untracked: options.ignore_untracked_in_submodules,
+                ignore_dirty: options.ignore_dirty_submodules,
+            },
         )?
     };
 
     // Convert to DiffEntry for rename detection and output.
-    let diff_entries: Vec<DiffEntry> = changes.iter().map(raw_change_to_diff_entry).collect();
+    let mut diff_entries: Vec<DiffEntry> = changes.iter().map(raw_change_to_diff_entry).collect();
+
+    if options.ignore_submodules_all {
+        diff_entries.retain(|e| e.old_mode != "160000" && e.new_mode != "160000");
+    }
+
+    if options.patch
+        && options.submodule_diff
+        && !options.cached
+        && !options.ignore_submodules_all
+        && !options.ignore_dirty_submodules
+    {
+        if let Some(wt) = repo.work_tree.as_deref() {
+            let sm_ignore = SubmoduleIgnoreFlags {
+                ignore_all: options.ignore_submodules_all,
+                ignore_untracked: options.ignore_untracked_in_submodules,
+                ignore_dirty: options.ignore_dirty_submodules,
+            };
+            for (path, snap) in &index_map {
+                if snap.mode != MODE_GITLINK {
+                    continue;
+                }
+                if !entry_matches_pathspecs(
+                    path,
+                    &options.pathspecs,
+                    context_from_mode_bits(snap.mode),
+                ) {
+                    continue;
+                }
+                let tree_snap = tree_map.get(path);
+                let same_recorded =
+                    tree_snap.is_some_and(|t| t.mode == MODE_GITLINK && t.oid == snap.oid);
+                if !same_recorded {
+                    continue;
+                }
+                let dirty = submodule_dirty_flags(
+                    wt,
+                    path,
+                    &snap.oid,
+                    sm_ignore.ignore_untracked,
+                    sm_ignore.ignore_dirty,
+                );
+                if !dirty.untracked && !dirty.modified {
+                    continue;
+                }
+                if diff_entries.iter().any(|e| {
+                    e.path() == path.as_str() && (e.old_mode == "160000" || e.new_mode == "160000")
+                }) {
+                    continue;
+                }
+                diff_entries.push(DiffEntry {
+                    status: DiffStatus::Modified,
+                    old_path: Some(path.clone()),
+                    new_path: Some(path.clone()),
+                    old_mode: "160000".to_owned(),
+                    new_mode: "160000".to_owned(),
+                    old_oid: snap.oid,
+                    new_oid: snap.oid,
+                    score: None,
+                });
+            }
+        }
+    }
 
     let diff_entries = if options.find_copies {
         let threshold = options.find_renames.unwrap_or(50);
@@ -157,8 +224,24 @@ pub fn run(args: Args) -> Result<()> {
             let stdout = std::io::stdout();
             let mut out = stdout.lock();
             let wt = repo.work_tree.as_deref();
+            let sm_ignore = SubmoduleIgnoreFlags {
+                ignore_all: options.ignore_submodules_all,
+                ignore_untracked: options.ignore_untracked_in_submodules,
+                ignore_dirty: options.ignore_dirty_submodules,
+            };
             for entry in &diff_entries {
-                write_patch_entry(&mut out, &repo, &repo.odb, entry, options.context_lines, wt)?;
+                let p = entry.path();
+                write_patch_entry(
+                    &mut out,
+                    &repo,
+                    &repo.odb,
+                    entry,
+                    options.context_lines,
+                    wt,
+                    options.submodule_diff,
+                    sm_ignore,
+                    p,
+                )?;
             }
         } else if options.name_status {
             for entry in &diff_entries {
@@ -337,8 +420,14 @@ struct Options {
     pathspecs: Vec<String>,
     cached: bool,
     match_missing: bool,
-    /// When true, submodule (gitlink) paths are not compared against the work tree.
-    ignore_submodules: bool,
+    /// When true, omit gitlink paths entirely (like Git `ignore_submodules`).
+    ignore_submodules_all: bool,
+    /// When true, do not report untracked-only dirtiness inside submodules.
+    ignore_untracked_in_submodules: bool,
+    /// When true, skip submodule dirty detection (no "contains …" lines; no worktree diff inside submodule).
+    ignore_dirty_submodules: bool,
+    /// Emit recursive unified diff for submodule commits (`--submodule=diff`).
+    submodule_diff: bool,
     quiet: bool,
     exit_code: bool,
     abbrev: Option<usize>,
@@ -380,10 +469,23 @@ struct RawChange {
     new: Option<Snapshot>,
 }
 
+/// Submodule ignore flags mirroring Git's `handle_ignore_submodules_arg`.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SubmoduleIgnoreFlags {
+    pub(crate) ignore_all: bool,
+    pub(crate) ignore_untracked: bool,
+    pub(crate) ignore_dirty: bool,
+}
+
 fn parse_options(argv: &[String]) -> Result<Options> {
     let mut cached = false;
     let mut match_missing = false;
-    let mut ignore_submodules = false;
+    let mut ignore_submodules_all = false;
+    // Match Git: `diff-index` defaults to ignoring untracked files inside submodules
+    // unless `--ignore-submodules=none` is passed (see t4060).
+    let mut ignore_untracked_in_submodules = true;
+    let mut ignore_dirty_submodules = false;
+    let mut submodule_diff = false;
     let mut quiet = false;
     let mut exit_code = false;
     let mut abbrev: Option<usize> = None;
@@ -523,13 +625,40 @@ fn parse_options(argv: &[String]) -> Result<Options> {
                 }
                 "--check" => { /* accepted for compatibility */ }
                 "--ignore-submodules" => {
-                    ignore_submodules = true;
+                    ignore_submodules_all = true;
                 }
                 _ if arg.starts_with("--ignore-submodules=") => {
                     let val = arg.trim_start_matches("--ignore-submodules=");
-                    ignore_submodules = match val {
-                        "none" => false,
-                        "all" | "dirty" | "untracked" => true,
+                    match val {
+                        "all" => {
+                            ignore_submodules_all = true;
+                            ignore_untracked_in_submodules = false;
+                            ignore_dirty_submodules = false;
+                        }
+                        "untracked" => {
+                            ignore_untracked_in_submodules = true;
+                            ignore_submodules_all = false;
+                        }
+                        "dirty" => {
+                            ignore_dirty_submodules = true;
+                            ignore_submodules_all = false;
+                        }
+                        "none" => {
+                            ignore_submodules_all = false;
+                            ignore_untracked_in_submodules = false;
+                            ignore_dirty_submodules = false;
+                        }
+                        _ => bail!("unsupported option: {arg}"),
+                    };
+                }
+                "--submodule" => {
+                    submodule_diff = true;
+                }
+                _ if arg.starts_with("--submodule=") => {
+                    let val = arg.trim_start_matches("--submodule=");
+                    submodule_diff = match val {
+                        "diff" => true,
+                        "short" | "log" => false,
                         _ => bail!("unsupported option: {arg}"),
                     };
                 }
@@ -556,7 +685,10 @@ fn parse_options(argv: &[String]) -> Result<Options> {
         pathspecs,
         cached,
         match_missing,
-        ignore_submodules,
+        ignore_submodules_all,
+        ignore_untracked_in_submodules,
+        ignore_dirty_submodules,
+        submodule_diff,
         quiet,
         exit_code,
         abbrev,
@@ -701,7 +833,7 @@ fn diff_tree_vs_worktree(
     index_map: &BTreeMap<String, Snapshot>,
     index: &Index,
     match_missing: bool,
-    ignore_submodules: bool,
+    submodule_ignore: SubmoduleIgnoreFlags,
 ) -> Result<Vec<RawChange>> {
     let Some(work_tree) = &repo.work_tree else {
         bail!("this operation must be run in a work tree");
@@ -724,7 +856,7 @@ fn diff_tree_vs_worktree(
         let abs = work_tree.join(path);
 
         if index_snapshot.mode == MODE_GITLINK {
-            if ignore_submodules {
+            if submodule_ignore.ignore_all {
                 continue;
             }
             let sub_head = read_submodule_head_oid(&abs);
@@ -958,14 +1090,460 @@ fn render_raw_diff_entry(
     ))
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct SubmoduleDirtyFlags {
+    untracked: bool,
+    modified: bool,
+}
+
+pub(crate) fn submodule_worktree_has_untracked(super_wt: &Path, path: &str) -> bool {
+    let sub = super_wt.join(path);
+    let Ok(sub_repo) = Repository::discover(Some(&sub)) else {
+        return false;
+    };
+    let Ok(index) = sub_repo.load_index() else {
+        return false;
+    };
+    let tracked: BTreeSet<String> = index
+        .entries
+        .iter()
+        .filter(|e| e.stage() == 0 && e.mode != MODE_TREE)
+        .map(|e| String::from_utf8_lossy(&e.path).into_owned())
+        .collect();
+    submodule_dir_has_untracked_files(&sub, &sub, &tracked)
+}
+
+fn submodule_dir_has_untracked_files(dir: &Path, root: &Path, tracked: &BTreeSet<String>) -> bool {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return false;
+    };
+    for e in entries.flatten() {
+        let name = e.file_name().to_string_lossy().to_string();
+        if name == ".git" {
+            continue;
+        }
+        let path = e.path();
+        let rel = path
+            .strip_prefix(root)
+            .map(|p| p.to_string_lossy().replace('\\', "/"))
+            .unwrap_or_else(|_| name.clone());
+        let is_dir = e.file_type().map(|ft| ft.is_dir()).unwrap_or(false);
+        if is_dir {
+            if submodule_dir_has_untracked_files(&path, root, tracked) {
+                return true;
+            }
+        } else if !tracked.contains(&rel) {
+            return true;
+        }
+    }
+    false
+}
+
+fn submodule_has_unstaged_changes(super_wt: &Path, path: &str) -> bool {
+    let sub = super_wt.join(path);
+    let Ok(sub_repo) = Repository::discover(Some(&sub)) else {
+        return false;
+    };
+    let Ok(idx) = sub_repo.load_index() else {
+        return false;
+    };
+    grit_lib::diff::diff_index_to_worktree(&sub_repo.odb, &idx, &sub)
+        .map(|v| !v.is_empty())
+        .unwrap_or(false)
+}
+
+pub(crate) fn submodule_dirty_flags(
+    super_wt: &Path,
+    path: &str,
+    _index_gitlink_oid: &ObjectId,
+    ignore_untracked: bool,
+    ignore_dirty: bool,
+) -> SubmoduleDirtyFlags {
+    let sub = super_wt.join(path);
+    if read_submodule_head_oid(&sub).is_none() {
+        return SubmoduleDirtyFlags::default();
+    }
+    let untracked = !ignore_untracked && submodule_worktree_has_untracked(super_wt, path);
+    let modified = !ignore_dirty && submodule_has_unstaged_changes(super_wt, path);
+    SubmoduleDirtyFlags {
+        untracked,
+        modified,
+    }
+}
+
+fn read_commit_tree(odb: &Odb, commit_oid: &ObjectId) -> Option<ObjectId> {
+    let obj = odb.read(commit_oid).ok()?;
+    if obj.kind != ObjectKind::Commit {
+        return None;
+    }
+    parse_commit(&obj.data).ok().map(|c| c.tree)
+}
+
+fn submodule_display_name(full_path: &str) -> &str {
+    full_path.rsplit('/').next().unwrap_or(full_path)
+}
+
+pub(crate) fn write_submodule_diff_recursive(
+    out: &mut impl Write,
+    super_repo: &Repository,
+    full_path_from_root: &str,
+    old_commit: ObjectId,
+    new_commit: ObjectId,
+    dirty: SubmoduleDirtyFlags,
+    ignore_dirty_for_inner: bool,
+    submodule_ignore: SubmoduleIgnoreFlags,
+    context_lines: usize,
+) -> Result<()> {
+    let z = zero_oid();
+    let super_wt = super_repo
+        .work_tree
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("this operation must be run in a work tree"))?;
+    let sub_path = super_wt.join(full_path_from_root);
+    let sub_name = submodule_display_name(full_path_from_root);
+
+    if dirty.untracked {
+        writeln!(out, "Submodule {sub_name} contains untracked content")?;
+    }
+    if dirty.modified {
+        writeln!(out, "Submodule {sub_name} contains modified content")?;
+    }
+
+    let sub_repo = Repository::discover(Some(&sub_path)).ok();
+    let odb_for = sub_repo.as_ref().map(|r| &r.odb).unwrap_or(&super_repo.odb);
+
+    let old_tree = if old_commit == z {
+        None
+    } else {
+        read_commit_tree(odb_for, &old_commit)
+    };
+    let new_tree = if new_commit == z {
+        None
+    } else {
+        read_commit_tree(odb_for, &new_commit)
+    };
+
+    let mut message: Option<&'static str> = None;
+    if old_commit == z {
+        message = Some("(new submodule)");
+    } else if new_commit == z {
+        message = Some("(submodule deleted)");
+    }
+
+    if (old_commit != z && old_tree.is_none()) || (new_commit != z && new_tree.is_none()) {
+        message = Some("(commits not present)");
+    }
+
+    let mut fast_forward = false;
+    let mut fast_backward = false;
+    if message.is_none()
+        && old_commit != z
+        && new_commit != z
+        && old_tree.is_some()
+        && new_tree.is_some()
+    {
+        if let Some(ref sr) = sub_repo {
+            let bases = merge_bases(sr, old_commit, new_commit, true).unwrap_or_default();
+            if let Some(b) = bases.first() {
+                if *b == old_commit {
+                    fast_forward = true;
+                } else if *b == new_commit {
+                    fast_backward = true;
+                }
+            }
+        }
+    }
+
+    if old_commit == new_commit && message.is_none() {
+        if !dirty.untracked && !dirty.modified {
+            return Ok(());
+        }
+        if !dirty.modified {
+            // Untracked only: `Submodule … contains untracked content` — no commit-range header or patches.
+            return Ok(());
+        }
+        // Modified working tree vs same recorded commit: show inner diff only (no `Submodule a..b:` line).
+        let use_worktree_for_right =
+            !ignore_dirty_for_inner && new_commit != z && sub_repo.is_some();
+        if use_worktree_for_right {
+            let sr = sub_repo.as_ref().unwrap();
+            let idx = sr.load_index().unwrap_or_else(|_| Index::new());
+            let inner =
+                grit_lib::diff::diff_tree_to_worktree(&sr.odb, old_tree.as_ref(), &sub_path, &idx)?;
+            for e in &inner {
+                let inner_full = format!("{full_path_from_root}/{}", e.path());
+                if e.old_mode == "160000" || e.new_mode == "160000" {
+                    write_patch_entry(
+                        out,
+                        super_repo,
+                        &sr.odb,
+                        e,
+                        context_lines,
+                        Some(&sub_path),
+                        true,
+                        submodule_ignore,
+                        &inner_full,
+                    )?;
+                } else {
+                    write_patch_entry_inner(
+                        out,
+                        super_repo,
+                        &sr.odb,
+                        e,
+                        context_lines,
+                        Some(&sub_path),
+                        full_path_from_root,
+                    )?;
+                }
+            }
+        } else {
+            let odb_inner = sub_repo.as_ref().map(|r| &r.odb).unwrap_or(&super_repo.odb);
+            let inner = diff_trees(odb_inner, old_tree.as_ref(), new_tree.as_ref(), "")?;
+            for e in &inner {
+                let inner_full = format!("{full_path_from_root}/{}", e.path());
+                if e.old_mode == "160000" || e.new_mode == "160000" {
+                    write_patch_entry(
+                        out,
+                        super_repo,
+                        odb_inner,
+                        e,
+                        context_lines,
+                        None,
+                        true,
+                        submodule_ignore,
+                        &inner_full,
+                    )?;
+                } else {
+                    write_patch_entry_inner(
+                        out,
+                        super_repo,
+                        odb_inner,
+                        e,
+                        context_lines,
+                        None,
+                        full_path_from_root,
+                    )?;
+                }
+            }
+        }
+        return Ok(());
+    }
+
+    let old_abbr = abbreviate_object_id(super_repo, old_commit, 7)?;
+    let new_abbr = abbreviate_object_id(super_repo, new_commit, 7)?;
+    let sep = if fast_forward || fast_backward {
+        ".."
+    } else {
+        "..."
+    };
+    write!(out, "Submodule {sub_name} {old_abbr}{sep}{new_abbr}")?;
+    if let Some(m) = message {
+        writeln!(out, " {m}")?;
+    } else if fast_backward {
+        writeln!(out, " (rewind):")?;
+    } else {
+        writeln!(out, ":")?;
+    }
+
+    if message == Some("(commits not present)") || old_tree.is_none() && new_tree.is_none() {
+        return Ok(());
+    }
+
+    let use_worktree_for_right =
+        dirty.modified && !ignore_dirty_for_inner && new_commit != z && sub_repo.is_some();
+
+    if use_worktree_for_right {
+        let sr = sub_repo.as_ref().unwrap();
+        let idx = sr.load_index().unwrap_or_else(|_| Index::new());
+        let inner =
+            grit_lib::diff::diff_tree_to_worktree(&sr.odb, old_tree.as_ref(), &sub_path, &idx)?;
+        for e in &inner {
+            let inner_full = format!("{full_path_from_root}/{}", e.path());
+            if e.old_mode == "160000" || e.new_mode == "160000" {
+                write_patch_entry(
+                    out,
+                    super_repo,
+                    &sr.odb,
+                    e,
+                    context_lines,
+                    Some(&sub_path),
+                    true,
+                    submodule_ignore,
+                    &inner_full,
+                )?;
+            } else {
+                write_patch_entry_inner(
+                    out,
+                    super_repo,
+                    &sr.odb,
+                    e,
+                    context_lines,
+                    Some(&sub_path),
+                    full_path_from_root,
+                )?;
+            }
+        }
+    } else {
+        let odb_inner = sub_repo.as_ref().map(|r| &r.odb).unwrap_or(&super_repo.odb);
+        let inner = diff_trees(odb_inner, old_tree.as_ref(), new_tree.as_ref(), "")?;
+        for e in &inner {
+            let inner_full = format!("{full_path_from_root}/{}", e.path());
+            if e.old_mode == "160000" || e.new_mode == "160000" {
+                write_patch_entry(
+                    out,
+                    super_repo,
+                    odb_inner,
+                    e,
+                    context_lines,
+                    None,
+                    true,
+                    submodule_ignore,
+                    &inner_full,
+                )?;
+            } else {
+                write_patch_entry_inner(
+                    out,
+                    super_repo,
+                    odb_inner,
+                    e,
+                    context_lines,
+                    None,
+                    full_path_from_root,
+                )?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
 /// Write a unified-diff block for one entry (diff-index -p).
-fn write_patch_entry(
+pub(crate) fn write_patch_entry(
     out: &mut impl std::io::Write,
     repo: &Repository,
     odb: &Odb,
     entry: &DiffEntry,
     context_lines: usize,
     work_tree: Option<&Path>,
+    submodule_diff: bool,
+    submodule_ignore: SubmoduleIgnoreFlags,
+    full_path_from_root: &str,
+) -> Result<()> {
+    let z = zero_oid();
+
+    if submodule_diff {
+        // Typechange blob→gitlink: tree had a blob, index records a gitlink.
+        let is_blob_to_gitlink = entry.old_mode != "000000"
+            && entry.old_mode != "160000"
+            && entry.new_mode == "160000"
+            && entry.new_oid != z;
+        // Typechange gitlink→blob: tree had gitlink, index/worktree has a regular file.
+        let is_gitlink_to_blob = entry.old_mode == "160000"
+            && entry.old_oid != z
+            && entry.new_mode != "160000"
+            && entry.new_mode != "000000";
+
+        if is_gitlink_to_blob {
+            // Index gitlink, worktree blob: blob delete first, then submodule as new.
+            let mut blob_del = entry.clone();
+            blob_del.status = DiffStatus::Deleted;
+            blob_del.old_mode = entry.new_mode.clone();
+            blob_del.old_oid = entry.new_oid;
+            blob_del.new_path = None;
+            blob_del.new_mode = "000000".to_owned();
+            blob_del.new_oid = z;
+            write_patch_entry_inner(out, repo, odb, &blob_del, context_lines, work_tree, "")?;
+            write_submodule_diff_recursive(
+                out,
+                repo,
+                full_path_from_root,
+                z,
+                entry.old_oid,
+                SubmoduleDirtyFlags::default(),
+                submodule_ignore.ignore_dirty,
+                submodule_ignore,
+                context_lines,
+            )?;
+            return Ok(());
+        }
+
+        if is_blob_to_gitlink {
+            // Tree blob, index gitlink: submodule deleted first, then blob as new.
+            write_submodule_diff_recursive(
+                out,
+                repo,
+                full_path_from_root,
+                entry.old_oid,
+                z,
+                SubmoduleDirtyFlags::default(),
+                submodule_ignore.ignore_dirty,
+                submodule_ignore,
+                context_lines,
+            )?;
+            let mut blob_add = entry.clone();
+            blob_add.status = DiffStatus::Added;
+            blob_add.old_path = None;
+            blob_add.old_mode = "000000".to_owned();
+            blob_add.old_oid = z;
+            blob_add.new_mode = entry.new_mode.clone();
+            blob_add.new_oid = entry.new_oid;
+            return write_patch_entry_inner(
+                out,
+                repo,
+                odb,
+                &blob_add,
+                context_lines,
+                work_tree,
+                "",
+            );
+        }
+
+        if entry.old_mode == "160000" || entry.new_mode == "160000" {
+            let super_wt = repo.work_tree.as_deref().unwrap_or(Path::new(""));
+            let index_oid = if entry.new_mode == "160000" && entry.new_oid != z {
+                entry.new_oid
+            } else if entry.old_mode == "160000" && entry.old_oid != z {
+                entry.old_oid
+            } else {
+                z
+            };
+            let dirty = if !super_wt.as_os_str().is_empty() && index_oid != z {
+                submodule_dirty_flags(
+                    super_wt,
+                    full_path_from_root,
+                    &index_oid,
+                    submodule_ignore.ignore_untracked,
+                    submodule_ignore.ignore_dirty,
+                )
+            } else {
+                SubmoduleDirtyFlags::default()
+            };
+            write_submodule_diff_recursive(
+                out,
+                repo,
+                full_path_from_root,
+                entry.old_oid,
+                entry.new_oid,
+                dirty,
+                submodule_ignore.ignore_dirty,
+                submodule_ignore,
+                context_lines,
+            )?;
+            return Ok(());
+        }
+    }
+
+    write_patch_entry_inner(out, repo, odb, entry, context_lines, work_tree, "")
+}
+
+pub(crate) fn write_patch_entry_inner(
+    out: &mut impl std::io::Write,
+    repo: &Repository,
+    odb: &Odb,
+    entry: &DiffEntry,
+    context_lines: usize,
+    work_tree: Option<&Path>,
+    path_prefix: &str,
 ) -> Result<()> {
     use grit_lib::diff::unified_diff;
 
@@ -980,7 +1558,117 @@ fn write_patch_entry(
         .as_deref()
         .unwrap_or(entry.old_path.as_deref().unwrap_or(""));
 
-    writeln!(out, "diff --git a/{old_path} b/{new_path}")?;
+    let (disp_old, disp_new) = if path_prefix.is_empty() {
+        (old_path.to_string(), new_path.to_string())
+    } else {
+        (
+            format!("{path_prefix}/{old_path}"),
+            format!("{path_prefix}/{new_path}"),
+        )
+    };
+
+    if entry.old_mode == "160000" || entry.new_mode == "160000" {
+        writeln!(out, "diff --git a/{disp_old} b/{disp_new}")?;
+        match entry.status {
+            DiffStatus::Added => {
+                writeln!(out, "new file mode {}", entry.new_mode)?;
+                writeln!(
+                    out,
+                    "index {}..{}",
+                    &entry.old_oid.to_hex()[..7],
+                    &entry.new_oid.to_hex()[..7]
+                )?;
+                writeln!(out, "--- /dev/null")?;
+                writeln!(out, "+++ b/{disp_new}")?;
+                writeln!(out, "@@ -0,0 +1 @@")?;
+                writeln!(out, "+Subproject commit {}", entry.new_oid.to_hex())?;
+            }
+            DiffStatus::Deleted => {
+                writeln!(out, "deleted file mode {}", entry.old_mode)?;
+                writeln!(
+                    out,
+                    "index {}..{}",
+                    &entry.old_oid.to_hex()[..7],
+                    &entry.new_oid.to_hex()[..7]
+                )?;
+                writeln!(out, "--- a/{disp_old}")?;
+                writeln!(out, "+++ /dev/null")?;
+                writeln!(out, "@@ -1 +0,0 @@")?;
+                writeln!(out, "-Subproject commit {}", entry.old_oid.to_hex())?;
+            }
+            DiffStatus::Modified | DiffStatus::Renamed | DiffStatus::Copied => {
+                if entry.old_mode == "160000" && entry.new_mode == "160000" {
+                    writeln!(
+                        out,
+                        "index {}..{} {}",
+                        &entry.old_oid.to_hex()[..7],
+                        &entry.new_oid.to_hex()[..7],
+                        entry.old_mode
+                    )?;
+                    writeln!(out, "--- a/{disp_old}")?;
+                    writeln!(out, "+++ b/{disp_new}")?;
+                    writeln!(out, "@@ -1 +1 @@")?;
+                    writeln!(out, "-Subproject commit {}", entry.old_oid.to_hex())?;
+                    writeln!(out, "+Subproject commit {}", entry.new_oid.to_hex())?;
+                } else if entry.old_mode == "160000" {
+                    writeln!(
+                        out,
+                        "index {}..{} {}",
+                        &entry.old_oid.to_hex()[..7],
+                        &entry.new_oid.to_hex()[..7],
+                        entry.old_mode
+                    )?;
+                    writeln!(out, "--- a/{disp_old}")?;
+                    writeln!(out, "+++ b/{disp_new}")?;
+                    writeln!(out, "@@ -1 +0,0 @@")?;
+                    writeln!(out, "-Subproject commit {}", entry.old_oid.to_hex())?;
+                } else {
+                    writeln!(
+                        out,
+                        "index {}..{} {}",
+                        &entry.old_oid.to_hex()[..7],
+                        &entry.new_oid.to_hex()[..7],
+                        entry.new_mode
+                    )?;
+                    writeln!(out, "--- a/{disp_old}")?;
+                    writeln!(out, "+++ b/{disp_new}")?;
+                    writeln!(out, "@@ -0,0 +1 @@")?;
+                    writeln!(out, "+Subproject commit {}", entry.new_oid.to_hex())?;
+                }
+            }
+            DiffStatus::TypeChanged => {
+                if entry.old_mode == "160000" {
+                    writeln!(
+                        out,
+                        "index {}..{} {}",
+                        &entry.old_oid.to_hex()[..7],
+                        &entry.new_oid.to_hex()[..7],
+                        entry.old_mode
+                    )?;
+                    writeln!(out, "--- a/{disp_old}")?;
+                    writeln!(out, "+++ b/{disp_new}")?;
+                    writeln!(out, "@@ -1 +0,0 @@")?;
+                    writeln!(out, "-Subproject commit {}", entry.old_oid.to_hex())?;
+                } else if entry.new_mode == "160000" {
+                    writeln!(
+                        out,
+                        "index {}..{} {}",
+                        &entry.old_oid.to_hex()[..7],
+                        &entry.new_oid.to_hex()[..7],
+                        entry.new_mode
+                    )?;
+                    writeln!(out, "--- a/{disp_old}")?;
+                    writeln!(out, "+++ b/{disp_new}")?;
+                    writeln!(out, "@@ -0,0 +1 @@")?;
+                    writeln!(out, "+Subproject commit {}", entry.new_oid.to_hex())?;
+                }
+            }
+            DiffStatus::Unmerged => {}
+        }
+        return Ok(());
+    }
+
+    writeln!(out, "diff --git a/{disp_old} b/{disp_new}")?;
 
     match entry.status {
         DiffStatus::Added => {
@@ -1103,21 +1791,21 @@ fn write_patch_entry(
     let new_content = String::from_utf8_lossy(&new_raw).into_owned();
 
     let display_old = if entry.status == DiffStatus::Added {
-        "/dev/null"
+        "/dev/null".to_owned()
     } else {
-        old_path
+        disp_old.clone()
     };
     let display_new = if entry.status == DiffStatus::Deleted {
-        "/dev/null"
+        "/dev/null".to_owned()
     } else {
-        new_path
+        disp_new.clone()
     };
 
     let patch = unified_diff(
         &old_content,
         &new_content,
-        display_old,
-        display_new,
+        &display_old,
+        &display_new,
         context_lines,
     );
     write!(out, "{patch}")?;

--- a/logs/2026-04-08_t4060-submodule-diff.md
+++ b/logs/2026-04-08_t4060-submodule-diff.md
@@ -1,0 +1,7 @@
+# t4060 submodule diff work
+
+- Implemented `diff-index -p --submodule=diff` with recursive tree diffs, dirty/untracked lines, typechange ordering, nested path prefixes.
+- Default `diff-index` ignore for untracked-in-submodule matches Git (`--ignore-submodules=none` to show).
+- `git commit` pathspec: stage embedded repos as gitlinks; peel `-m` from trailing args (`commit path -m msg`).
+- `git diff --submodule` / `--submodule=diff` / `--submodule=log`: submodule log uses submodule ODB + encoding-aware subject; diff mode skips outer gitlink patch.
+- Remaining: ~22 failures in t4060 (typechange cached/worktree, deleted submodule, multi-submodule, nested submodule, absorbgitdirs).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements a large slice of `git diff-index` / `git diff` submodule behavior needed by `t4060-diff-submodule-option-diff-format.sh`.

### Changes

- **`diff-index`**: Parses `--submodule=diff`, granular `--ignore-submodules` (default ignores untracked in submodules like Git), recursive unified diffs under submodule paths, dirty/untracked banner lines, and safer handling when submodule objects are missing from the superproject ODB.
- **`commit`**: Pathspec staging stages embedded repos as **gitlinks** (fixes EISDIR on `commit sm1`). Peels `-m` / `-F` out of the trailing pathspec bucket so `commit <path> -m msg` works.
- **`diff`**: `--submodule` (log), `--submodule=diff`, `--submodule=short`; log mode walks the **submodule** repo for `rev-list`; subject lines respect `encoding` / raw message bytes (ICONV tests). `--submodule=diff` omits the outer `diff --git a/sm1 b/sm1` hunk (matches Git).

### Test status

`t4060-diff-submodule-option-diff-format`: **29 / 51** passing (was 5 / 50). Remaining failures cluster around cached/worktree typechanges, deleted submodule + multi-submodule output, and nested submodule / `.git` file cases.

### Notes

- Harness CSV/dashboards refreshed via `./scripts/run-tests.sh t4060-diff-submodule-option-diff-format.sh`.
- Log: `logs/2026-04-08_t4060-submodule-diff.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9db83c19-e0fa-43f0-913c-5213393608d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9db83c19-e0fa-43f0-913c-5213393608d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

