### PR TITLE
fix: ls-files --with-tree (t3060)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -286,7 +286,7 @@ commit → check it off → move on.
 - [ ] `t3904-stash-patch` ████████░░░░░░░░░░░░ 4/10 (6 left) — stash -p
 - [ ] `t3504-cherry-pick-rerere` ██████░░░░░░░░░░░░░░ 3/9 (6 left) — cherry-pick should rerere for conflicts
 - [ ] `t3509-cherry-pick-merge-df` ██████░░░░░░░░░░░░░░ 3/9 (6 left) — Test cherry-pick with directory/file conflicts
-- [ ] `t3060-ls-files-with-tree` █████░░░░░░░░░░░░░░░ 2/8 (6 left) — git ls-files test (--with-tree).
+- [x] `t3060-ls-files-with-tree` — git ls-files `--with-tree` (overlay tree on index, usage, conflict + missing index cases; 8/8 harness).
 
 - [ ] `t3428-rebase-signoff` ██░░░░░░░░░░░░░░░░░░ 1/7 (6 left) — git rebase --signoff
 

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -92,7 +92,7 @@ t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
 t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
-t1006-cat-file	t1	yes	290	285	5	false	ok	1
+t1006-cat-file	t1	yes	290	285	5	false	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	32	8	false	ok	0
 t10070-cat-file-batch-format	t1	yes	33	33	0	true	ok	0
@@ -550,7 +550,7 @@ t3030-merge-recursive	t3	yes	26	25	1	false	ok	0
 t3040-subprojects-basic	t3	yes	11	10	1	false	ok	0
 t3050-ls-files-unmerged	t3	yes	23	22	1	false	ok	0
 t3050-subprojects-fetch	t3	yes	4	4	0	true	ok	0
-t3060-ls-files-with-tree	t3	yes	0	0	0	false	timeout	0
+t3060-ls-files-with-tree	t3	yes	8	8	0	true	ok	0
 t3070-wildmatch	t3	yes	1901	1901	0	true	ok	3
 t3100-ls-tree-restrict	t3	yes	14	13	1	false	ok	0
 t3101-ls-tree-dirname	t3	yes	19	18	1	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T23:06:05+00:00" class="gen-time" title="2026-04-08 23:06 UTC">2026-04-08 23:06 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,11 +150,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,565</div>
+      <div class="summary-big-val">29,581</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">39,864</div>
+      <div class="summary-big-val">39,872</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>713 files fully passing</span>
+    <span>717 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,11 +212,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">41/141 files · 2 skipped · 3,333/4,611 tests</span>
+        <span class="group-meta">43/141 files · 2 skipped · 3,342/4,619 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.3%"></div></div>
-        <span class="group-pct pct-blue">72.3%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.4%"></div></div>
+        <span class="group-pct pct-blue">72.4%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,336/3,949 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,342/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.8%"></div></div>
-        <span class="group-pct pct-red">33.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.0%"></div></div>
+        <span class="group-pct pct-red">34.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -256,7 +256,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">42/126 files · 11 skipped · 1,793/2,944 tests</span>
+        <span class="group-meta">43/126 files · 11 skipped · 1,794/2,944 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T23:06:05+00:00" class="gen-time" title="2026-04-08 23:06 UTC">2026-04-08 23:06 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">39,864</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,565</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n" id="sum-tests">39,872</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,581</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1085,7 +1085,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">285</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.3%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t10060-hash-object-determinism</td>
@@ -5110,8 +5110,7 @@ tr.row-skip td { opacity: 0.65; }
 <tr class="" data-group="t2" data-tests="15" data-passed="5">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td><span class="badge ok">full pass</span></td>
-  <td class="right">15</td>
+  <td></td>
   <td class="right">15</td>
   <td class="right">5</td>
   <td class="right">ok</td>
@@ -5658,14 +5657,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="0" data-passed="0">
+<tr class="" data-group="t3" data-tests="8" data-passed="8" data-full-pass="1">
   <td class="mono">t3060-ls-files-with-tree</td>
   <td>t3</td>
-  <td></td>
-  <td class="right">0</td>
-  <td class="right">0</td>
-  <td class="right">timeout</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td><span class="badge ok">full pass</span></td>
+  <td class="right">8</td>
+  <td class="right">8</td>
+  <td class="right">ok</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="1901" data-passed="1901" data-full-pass="1">
@@ -6218,14 +6217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="54" data-passed="38">
+<tr class="" data-group="t3" data-tests="52" data-passed="3">
   <td class="mono">t3420-rebase-autostash</td>
   <td>t3</td>
   <td></td>
-  <td class="right">54</td>
-  <td class="right">38</td>
+  <td class="right">52</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="63" data-passed="11">
@@ -12598,7 +12597,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="2" data-passed="2">
+<tr class="" data-group="t7" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t7524-commit-summary</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>

--- a/grit-lib/src/index.rs
+++ b/grit-lib/src/index.rs
@@ -24,8 +24,10 @@ use sha1::{Digest, Sha1};
 
 use crate::config::ConfigSet;
 use crate::error::{Error, Result};
-use crate::objects::{parse_tree, ObjectId, ObjectKind};
+use crate::objects::{parse_tree, ObjectId, ObjectKind, TreeEntry};
 use crate::odb::Odb;
+use crate::repo::Repository;
+use crate::rev_parse;
 
 /// File mode for a regular (non-executable) file.
 pub const MODE_REGULAR: u32 = 0o100644;
@@ -79,6 +81,10 @@ impl IndexEntry {
     #[must_use]
     pub fn stage(&self) -> u8 {
         ((self.flags >> 12) & 0x3) as u8
+    }
+
+    pub(crate) fn set_stage(&mut self, stage: u8) {
+        self.flags = (self.flags & 0x0FFF) | ((stage as u16 & 0x3) << 12);
     }
 
     /// Whether the assume-unchanged bit is set.
@@ -142,6 +148,27 @@ impl IndexEntry {
     #[must_use]
     pub fn is_sparse_directory_placeholder(&self) -> bool {
         self.mode == MODE_TREE && self.stage() == 0 && self.skip_worktree()
+    }
+
+    /// In-memory only: `ls-files --with-tree` hides stage-1 overlay rows that duplicate stage 0.
+    const FLAG_EXT_OVERLAY_TREE_SKIP: u16 = 0x8000;
+
+    #[must_use]
+    pub fn overlay_tree_skip_output(&self) -> bool {
+        self.flags_extended
+            .is_some_and(|fe| fe & Self::FLAG_EXT_OVERLAY_TREE_SKIP != 0)
+    }
+
+    fn set_overlay_tree_skip_output(&mut self, value: bool) {
+        let fe = self.flags_extended.get_or_insert(0);
+        if value {
+            *fe |= Self::FLAG_EXT_OVERLAY_TREE_SKIP;
+        } else {
+            *fe &= !Self::FLAG_EXT_OVERLAY_TREE_SKIP;
+            if *fe == 0 {
+                self.flags_extended = None;
+            }
+        }
     }
 }
 
@@ -783,6 +810,166 @@ impl Index {
         self.entries
             .iter_mut()
             .find(|e| e.path == path && e.stage() == stage)
+    }
+
+    /// Merge tree contents from `treeish` into this index as virtual stage-1 entries, matching
+    /// Git's `overlay_tree_on_index` used by `git ls-files --with-tree`.
+    ///
+    /// Existing unmerged entries (stages 1–3) are shifted to stage 3 so stage 1 is free for the
+    /// overlay. Stage-1 paths that already exist at stage 0 are marked so `ls-files` can skip
+    /// them (Git's `CE_UPDATE` on the stage-1 entry).
+    ///
+    /// # Parameters
+    ///
+    /// - `repo` — repository whose object database is used to read the tree.
+    /// - `treeish` — revision or tree OID string (`HEAD`, `HEAD~1`, full SHA, etc.).
+    /// - `prefix` — optional path prefix (bytes, no trailing slash except empty); only paths under
+    ///   this prefix are considered from the tree. Pass empty slice for the full tree.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error`] if `treeish` cannot be resolved, the tree cannot be read, or an object is
+    /// missing from the ODB.
+    pub fn overlay_tree_on_index(
+        &mut self,
+        repo: &Repository,
+        treeish: &str,
+        prefix: &[u8],
+    ) -> Result<()> {
+        let oid = rev_parse::resolve_revision(repo, treeish)?;
+        let tree_oid = peel_to_tree_oid(repo, oid)?;
+        for e in self.entries.iter_mut() {
+            if e.stage() != 0 {
+                e.set_stage(3);
+            }
+        }
+        self.sort();
+        let has_stage1 = self.entries.iter().any(|e| e.stage() == 1);
+        let mut appended: Vec<IndexEntry> = Vec::new();
+        read_tree_into_overlay(repo, &tree_oid, prefix, &[], has_stage1, &mut appended)?;
+        for e in appended {
+            self.add_or_replace(e);
+        }
+        if !has_stage1 {
+            self.sort();
+        }
+        let mut last_stage0: Option<&[u8]> = None;
+        for e in &mut self.entries {
+            match e.stage() {
+                0 => {
+                    last_stage0 = Some(e.path.as_slice());
+                }
+                1 => {
+                    if last_stage0.is_some_and(|p| p == e.path.as_slice()) {
+                        e.set_overlay_tree_skip_output(true);
+                    }
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+}
+
+fn peel_to_tree_oid(repo: &Repository, oid: ObjectId) -> Result<ObjectId> {
+    let obj = repo.odb.read(&oid)?;
+    match obj.kind {
+        ObjectKind::Tree => Ok(oid),
+        ObjectKind::Commit => {
+            let commit = crate::objects::parse_commit(&obj.data)?;
+            Ok(commit.tree)
+        }
+        ObjectKind::Tag => {
+            let tag = crate::objects::parse_tag(&obj.data)?;
+            peel_to_tree_oid(repo, tag.object)
+        }
+        _ => Err(Error::ObjectNotFound(format!(
+            "cannot peel {oid} to tree for --with-tree"
+        ))),
+    }
+}
+
+fn read_tree_into_overlay(
+    repo: &Repository,
+    tree_oid: &ObjectId,
+    prefix: &[u8],
+    rel_base: &[u8],
+    use_replace_path: bool,
+    out: &mut Vec<IndexEntry>,
+) -> Result<()> {
+    let obj = repo.odb.read(tree_oid)?;
+    if obj.kind != ObjectKind::Tree {
+        return Err(Error::ObjectNotFound(format!(
+            "object {tree_oid} is not a tree"
+        )));
+    }
+    let entries = parse_tree(&obj.data)?;
+    for TreeEntry { mode, name, oid } in entries {
+        if mode == MODE_TREE {
+            let mut path = rel_base.to_vec();
+            if !path.is_empty() {
+                path.push(b'/');
+            }
+            path.extend_from_slice(&name);
+            if !prefix_under_or_equal(prefix, &path) {
+                continue;
+            }
+            read_tree_into_overlay(repo, &oid, prefix, &path, use_replace_path, out)?;
+            continue;
+        }
+        if mode == MODE_GITLINK {
+            continue;
+        }
+        let mut path = rel_base.to_vec();
+        if !path.is_empty() {
+            path.push(b'/');
+        }
+        path.extend_from_slice(&name);
+        if !prefix_under_or_equal(prefix, &path) {
+            continue;
+        }
+        let entry = synthetic_stage1_index_entry(mode, &path, oid);
+        if use_replace_path {
+            if let Some(pos) = out.iter().position(|e| e.path == path && e.stage() == 1) {
+                out[pos] = entry;
+            } else {
+                out.push(entry);
+            }
+        } else {
+            out.push(entry);
+        }
+    }
+    Ok(())
+}
+
+fn prefix_under_or_equal(prefix: &[u8], path: &[u8]) -> bool {
+    if prefix.is_empty() {
+        return true;
+    }
+    if path == prefix {
+        return true;
+    }
+    path.len() > prefix.len() && path.starts_with(prefix) && path[prefix.len()] == b'/'
+}
+
+fn synthetic_stage1_index_entry(mode: u32, path: &[u8], oid: ObjectId) -> IndexEntry {
+    let path_len = path.len().min(0xFFF) as u16;
+    let flags = (1u16 << 12) | path_len;
+    IndexEntry {
+        ctime_sec: 0,
+        ctime_nsec: 0,
+        mtime_sec: 0,
+        mtime_nsec: 0,
+        dev: 0,
+        ino: 0,
+        mode,
+        uid: 0,
+        gid: 0,
+        size: 0,
+        oid,
+        flags,
+        flags_extended: None,
+        path: path.to_vec(),
     }
 }
 

--- a/grit/src/commands/ls_files.rs
+++ b/grit/src/commands/ls_files.rs
@@ -129,6 +129,14 @@ pub struct Args {
     #[arg(short = 'C', value_name = "DIR")]
     pub change_dir: Option<PathBuf>,
 
+    /// Pretend paths removed since this tree are still in the index (for cached listings).
+    #[arg(long = "with-tree", value_name = "TREEISH")]
+    pub with_tree: Option<String>,
+
+    /// Recurse into submodules (not compatible with all `ls-files` modes).
+    #[arg(long = "recurse-submodules")]
+    pub recurse_submodules: bool,
+
     /// Pathspecs to restrict output.
     pub pathspecs: Vec<PathBuf>,
 }
@@ -166,11 +174,26 @@ pub fn run(args: Args) -> Result<()> {
         Some(Err(_)) | None => true,
     };
     let index_path = resolved_env_index_path(&repo);
-    let index = if args.sparse {
+    let mut index = if args.sparse {
         grit_lib::index::Index::load(&index_path).context("loading index")?
     } else {
         repo.load_index_at(&index_path).context("loading index")?
     };
+
+    if args.recurse_submodules
+        && (args.deleted
+            || args.others
+            || args.unmerged
+            || args.killed
+            || args.modified
+            || args.with_tree.is_some())
+    {
+        anyhow::bail!("fatal: ls-files --recurse-submodules unsupported mode");
+    }
+
+    if args.with_tree.is_some() && (args.unmerged || args.stage) {
+        anyhow::bail!("fatal: options 'ls-files --with-tree' and '-s/-u' cannot be used together");
+    }
 
     let stdout = io::stdout();
     let mut out = stdout.lock();
@@ -198,6 +221,16 @@ pub fn run(args: Args) -> Result<()> {
         .collect::<Result<Vec<_>>>()?;
     if pathspec_filter.is_empty() && !cwd_prefix.is_empty() && !args.full_name {
         pathspec_filter.push(Pathspec::Literal(cwd_prefix.clone()));
+    }
+
+    if let Some(ref treeish) = args.with_tree {
+        let mut overlay_prefix = common_pathspec_prefix_for_overlay(&pathspec_filter);
+        while overlay_prefix.last() == Some(&b'/') {
+            overlay_prefix.pop();
+        }
+        index
+            .overlay_tree_on_index(&repo, treeish, &overlay_prefix)
+            .with_context(|| format!("overlay tree '{treeish}' on index"))?;
     }
 
     // Track which pathspecs matched at least one entry (for --error-unmatch).
@@ -231,6 +264,9 @@ pub fn run(args: Args) -> Result<()> {
 
     let mut last_dedup_path: Option<Vec<u8>> = None;
     for entry in &index.entries {
+        if entry.overlay_tree_skip_output() {
+            continue;
+        }
         // Filter by pathspec
         if !pathspec_filter.is_empty() {
             let idx = pathspec_filter
@@ -676,10 +712,17 @@ impl Pathspec {
             // Directory pathspecs match the path itself and children (`dir/`),
             // but not unrelated paths that merely share a prefix (`dirfoo`).
             Pathspec::Literal(spec) => {
-                path == spec.as_slice()
-                    || (path.starts_with(spec)
-                        && path.len() > spec.len()
-                        && path[spec.len()] == b'/')
+                let spec = spec.as_slice();
+                // `cwd_prefix` uses a trailing slash (`sub/`); Git pathspecs treat that as the
+                // directory `sub`, so `sub/file` must match (see t3060 from a subdirectory).
+                let dir_prefix = spec
+                    .strip_suffix(b"/")
+                    .filter(|p| !p.is_empty())
+                    .unwrap_or(spec);
+                path == spec
+                    || path == dir_prefix
+                    || (path.starts_with(dir_prefix)
+                        && (path.len() == dir_prefix.len() || path[dir_prefix.len()] == b'/'))
             }
             Pathspec::Glob(pattern) => {
                 // Try literal match first (for files with glob chars in names)
@@ -1036,4 +1079,34 @@ fn status_tag(entry: &IndexEntry) -> char {
     } else {
         'H' // regular cached
     }
+}
+
+/// Longest common byte prefix of all literal pathspecs, or empty when unknown (globs / magic / none).
+///
+/// Used for `ls-files --with-tree` to limit the tree overlay like Git's `common_prefix` pathspec.
+fn common_pathspec_prefix_for_overlay(filters: &[Pathspec]) -> Vec<u8> {
+    if filters.is_empty() {
+        return Vec::new();
+    }
+    let mut literals: Vec<&[u8]> = Vec::new();
+    for f in filters {
+        match f {
+            Pathspec::Literal(p) => literals.push(p.as_slice()),
+            Pathspec::Glob(_) | Pathspec::Magic(_) => return Vec::new(),
+        }
+    }
+    if literals.is_empty() {
+        return Vec::new();
+    }
+    let first = literals[0];
+    let mut end = first.len();
+    for lit in literals.iter().skip(1) {
+        end = end.min(
+            lit.iter()
+                .zip(first.iter())
+                .take_while(|(a, b)| a == b)
+                .count(),
+        );
+    }
+    first[..end].to_vec()
 }

--- a/logs/2026-04-08_t3060-ls-files-with-tree.md
+++ b/logs/2026-04-08_t3060-ls-files-with-tree.md
@@ -1,0 +1,20 @@
+# t3060-ls-files-with-tree
+
+## Goal
+
+Make `tests/t3060-ls-files-with-tree.sh` pass (8 tests): `git ls-files --with-tree`.
+
+## Changes
+
+- **`grit-lib`**: `Index::overlay_tree_on_index` mirrors Git `overlay_tree_on_index`: shift existing stages 1–3 to stage 3, walk the named tree (respecting common pathspec prefix), add synthetic stage-1 entries, mark duplicates of stage 0 with an in-memory extended flag so output skips them (`overlay_tree_skip_output`).
+- **`grit` `ls-files`**: `--with-tree`, `--recurse-submodules`; reject incompatible combinations with `fatal:` messages (exit 128 via main’s `fatal:` handling); strip trailing slash from overlay prefix to match Git `get_common_prefix_len`.
+- **Pathspec**: literal specs with trailing `/` (cwd prefix) now match paths under that directory (e.g. `sub/` matches `sub/file`), fixing listing from a subdirectory.
+
+## Verification
+
+- `bash tests/t3060-ls-files-with-tree.sh` with `GUST_BIN=tests/grit`: 8/8 pass.
+- `cargo test -p grit-lib --lib`: pass.
+
+## Note
+
+Workspace `cargo clippy -- -D warnings` reports many pre-existing issues; only touched files were lint-clean via IDE diagnostics.

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   231 |
-| In progress |     2 |
-| Remaining   |   535 |
+| Completed   |   247 |
+| In progress |     4 |
+| Remaining   |   517 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 231 completed (`[x]`), 2 in progress (`[~]`), 535 remaining (`[ ]`).
+Task lines in `PLAN.md`: 247 completed (`[x]`), 4 in progress (`[~]`), 517 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t3060-ls-files-with-tree` — 8/8 tests pass (`ls-files --with-tree`: `Index::overlay_tree_on_index`, `-s/-u`/`--recurse-submodules` incompatibilities with `fatal:` + exit 128, cwd pathspec `sub/` matches `sub/file`; harness CSV refreshed)
 - `t12820-diff-no-index-symlink` — 41/41 tests pass (symlink add/modify/delete, `diff`/`diff --cached`/`diff-tree`, stat/numstat/name output, multi-symlink and file↔symlink replacements; harness dashboards refreshed)
 - `t7817-grep-sparse-checkout` — 8/8 tests pass (non-cone sparse: `path_in_sparse_checkout` parent walk + last-match-wins; `sparse-checkout init` preserves cone mode and seeds `/*` + `!/*/` when recreating file; `disable` keeps pattern file so re-init reapplies `!b`; submodule `reset --hard` + sparse reapply; `grep` worktree: skip-worktree when absent, CE_VALID vs skip-worktree, unmerged paths grep worktree once; `grep_cached` per-stage for `--cached`)
 - `t7417-submodule-path-url` — 5/5 tests pass (`.gitmodules` dash paths: `mv` updates path + index blob; `escape_value` quotes leading `-`; receive-side `transfer.fsckObjects` via repo-local config only; clone `--recurse-submodules` resolves relative URLs from `origin` repo root + quoted path parsing + `GIT_QUIET` quiet mode)

--- a/test-results.md
+++ b/test-results.md
@@ -2,6 +2,8 @@
 
 **Updated:** 2026-04-08
 
+- `./scripts/run-tests.sh t3060-ls-files-with-tree.sh`: 8/8 passing (`ls-files --with-tree`: tree overlay on index, usage incompatibilities, conflict + missing-index cases; harness CSV/dashboards refreshed).
+- `cargo test -p grit-lib --lib`: 121/121 passing.
 - `./scripts/run-tests.sh t13180-log-patch-stat.sh`: 35/35 passing (`grit log` oneline/graph/decorate/skip/max-count/reverse/format; harness CSV/dashboards refreshed).
 - `./scripts/run-tests.sh t10560-switch-create-detach.sh`: 28/28 passing (`switch -- <branch>` disambiguation; invalid `-c`/`-C`/`--orphan` branch names rejected like Git; harness CSV/dashboards refreshed).
 - `cargo test -p grit-lib --lib`: 110/110 passing.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements `git ls-files --with-tree` so `tests/t3060-ls-files-with-tree.sh` passes (8/8).

## Changes

- **`grit-lib`**: `Index::overlay_tree_on_index` — shift conflict stages to stage 3, walk the resolved tree into synthetic stage-1 entries, skip overlay lines that duplicate stage 0 (in-memory flag, never written to disk).
- **`grit` `ls-files`**: `--with-tree` and `--recurse-submodules` parsing; reject incompatible option combinations with Git-style `fatal:` messages (exit 128). Strip trailing slash from the common pathspec prefix before overlay (matches Git `get_common_prefix_len`).
- **Pathspec**: literal pathspecs ending with `/` (cwd prefix) now match all paths under that directory, fixing `ls-files` from a subdirectory.

## Testing

- `./scripts/run-tests.sh t3060-ls-files-with-tree.sh` → 8/8
- `cargo test -p grit-lib --lib` → 121/121

## Notes

Workspace-wide `cargo clippy -D warnings` still fails on pre-existing issues; touched files are clean under IDE diagnostics.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ccda6fee-0d48-462a-8c6b-77ba419f138b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ccda6fee-0d48-462a-8c6b-77ba419f138b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

