### PR TITLE
fix: no-index histogram diff headers and whitespace-aware hunks

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -92,7 +92,7 @@ t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
 t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
-t1006-cat-file	t1	yes	290	285	5	false	ok	1
+t1006-cat-file	t1	yes	290	285	5	false	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	32	8	false	ok	0
 t10070-cat-file-batch-format	t1	yes	33	33	0	true	ok	0
@@ -758,7 +758,7 @@ t4071-diff-empty-tree	t4	yes	32	29	3	false	ok	0
 t4071-diff-minimal	t4	yes	1	1	0	true	ok	0
 t4072-diff-max-depth	t4	yes	50	47	3	false	ok	0
 t4073-diff-stat-name-width	t4	yes	6	4	2	false	ok	0
-t4074-diff-shifted-matched-group	t4	yes	0	0	0	false	timeout	0
+t4074-diff-shifted-matched-group	t4	yes	4	4	0	true	ok	0
 t4075-diff-full-index-abbrev	t4	yes	7	7	0	true	ok	0
 t4076-diff-ignore-submodules	t4	yes	4	4	0	true	ok	0
 t4077-diff-color-moved	t4	yes	5	5	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-08T23:13:34+00:00" class="gen-time" title="2026-04-08 23:13 UTC">2026-04-08 23:13 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,11 +150,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,565</div>
+      <div class="summary-big-val">29,577</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">39,864</div>
+      <div class="summary-big-val">39,868</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>713 files fully passing</span>
+    <span>717 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,7 +212,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">41/141 files · 2 skipped · 3,333/4,611 tests</span>
+        <span class="group-meta">42/141 files · 2 skipped · 3,334/4,611 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.3%"></div></div>
@@ -223,22 +223,22 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">63/178 files · 2 skipped · 1,920/3,541 tests</span>
+        <span class="group-meta">64/178 files · 2 skipped · 1,924/3,545 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:54.2%"></div></div>
-        <span class="group-pct pct-orange">54.2%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:54.3%"></div></div>
+        <span class="group-pct pct-orange">54.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,336/3,949 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,342/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.8%"></div></div>
-        <span class="group-pct pct-red">33.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.0%"></div></div>
+        <span class="group-pct pct-red">34.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -256,7 +256,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">42/126 files · 11 skipped · 1,793/2,944 tests</span>
+        <span class="group-meta">43/126 files · 11 skipped · 1,794/2,944 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T23:13:34+00:00" class="gen-time" title="2026-04-08 23:13 UTC">2026-04-08 23:13 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">39,864</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,565</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n" id="sum-tests">39,868</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,577</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1085,7 +1085,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">285</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.3%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t10060-hash-object-determinism</td>
@@ -5110,8 +5110,7 @@ tr.row-skip td { opacity: 0.65; }
 <tr class="" data-group="t2" data-tests="15" data-passed="5">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td><span class="badge ok">full pass</span></td>
-  <td class="right">15</td>
+  <td></td>
   <td class="right">15</td>
   <td class="right">5</td>
   <td class="right">ok</td>
@@ -6218,14 +6217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="54" data-passed="38">
+<tr class="" data-group="t3" data-tests="52" data-passed="3">
   <td class="mono">t3420-rebase-autostash</td>
   <td>t3</td>
   <td></td>
-  <td class="right">54</td>
-  <td class="right">38</td>
+  <td class="right">52</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="63" data-passed="11">
@@ -7738,14 +7737,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:66.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="0" data-passed="0">
+<tr class="" data-group="t4" data-tests="4" data-passed="4" data-full-pass="1">
   <td class="mono">t4074-diff-shifted-matched-group</td>
   <td>t4</td>
-  <td></td>
-  <td class="right">0</td>
-  <td class="right">0</td>
-  <td class="right">timeout</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td><span class="badge ok">full pass</span></td>
+  <td class="right">4</td>
+  <td class="right">4</td>
+  <td class="right">ok</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="7" data-passed="7" data-full-pass="1">
@@ -12598,7 +12597,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="2" data-passed="2">
+<tr class="" data-group="t7" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t7524-commit-summary</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>

--- a/grit-lib/src/diff.rs
+++ b/grit-lib/src/diff.rs
@@ -1850,6 +1850,8 @@ pub fn unified_diff_with_prefix_and_funcname_and_algorithm(
 /// forced to match, splitting the diff into segments around those anchor points.
 /// This produces diffs where the anchored text stays as context and surrounding
 /// lines are shown as additions/removals.
+///
+/// Segment diffs use `algorithm` (Git maps `--histogram` to patience-style line diff in our stack).
 pub fn anchored_unified_diff(
     old_content: &str,
     new_content: &str,
@@ -1857,6 +1859,7 @@ pub fn anchored_unified_diff(
     new_path: &str,
     context_lines: usize,
     anchors: &[String],
+    algorithm: similar::Algorithm,
 ) -> String {
     use similar::TextDiff;
 
@@ -1893,7 +1896,17 @@ pub fn anchored_unified_diff(
 
     // If no valid anchors, fall back to normal diff
     if anchor_pairs.is_empty() {
-        return unified_diff(old_content, new_content, old_path, new_path, context_lines);
+        return unified_diff_with_prefix_and_funcname_and_algorithm(
+            old_content,
+            new_content,
+            old_path,
+            new_path,
+            context_lines,
+            "a/",
+            "b/",
+            None,
+            algorithm,
+        );
     }
 
     // Sort anchor pairs by their position in the old file
@@ -1945,7 +1958,9 @@ pub fn anchored_unified_diff(
             } else {
                 format!("{}\n", new_seg_text)
             };
-            let seg_diff = TextDiff::from_lines(&old_seg_input, &new_seg_input);
+            let seg_diff = TextDiff::configure()
+                .algorithm(algorithm)
+                .diff_lines(&old_seg_input, &new_seg_input);
             for change in seg_diff.iter_all_changes() {
                 let tag = match change.tag() {
                     similar::ChangeTag::Equal => ' ',
@@ -1986,7 +2001,9 @@ pub fn anchored_unified_diff(
         } else {
             format!("{}\n", new_seg_text)
         };
-        let seg_diff = TextDiff::from_lines(&old_seg_input, &new_seg_input);
+        let seg_diff = TextDiff::configure()
+            .algorithm(algorithm)
+            .diff_lines(&old_seg_input, &new_seg_input);
         for change in seg_diff.iter_all_changes() {
             let tag = match change.tag() {
                 similar::ChangeTag::Equal => ' ',

--- a/grit/src/commands/diff.rs
+++ b/grit/src/commands/diff.rs
@@ -26,6 +26,7 @@ use grit_lib::objects::{parse_commit, ObjectId, ObjectKind};
 use grit_lib::odb::Odb;
 use grit_lib::repo::Repository;
 use grit_lib::rev_parse::{resolve_revision, split_treeish_colon};
+use similar::{ChangeTag, TextDiff};
 use std::fs;
 use std::io::{self, IsTerminal, Write};
 use std::path::Path;
@@ -108,6 +109,251 @@ impl WhitespaceMode {
 
         s
     }
+
+    /// Byte-oriented line normalisation for diffing (aligned with merge three-way compare rules).
+    fn normalize_line_bytes(&self, line: &[u8]) -> Vec<u8> {
+        let mut bytes = line.to_vec();
+
+        if self.ignore_cr_at_eol && bytes.ends_with(b"\r\n") {
+            let len = bytes.len();
+            bytes.remove(len - 2);
+        }
+
+        if self.ignore_all_space {
+            return bytes
+                .into_iter()
+                .filter(|b| !b.is_ascii_whitespace())
+                .collect();
+        }
+
+        if self.ignore_space_change {
+            let mut out = Vec::with_capacity(bytes.len());
+            let mut in_ws = false;
+            for ch in bytes {
+                if ch.is_ascii_whitespace() {
+                    if !in_ws {
+                        out.push(b' ');
+                        in_ws = true;
+                    }
+                } else {
+                    out.push(ch);
+                    in_ws = false;
+                }
+            }
+            while out.last().is_some_and(|b| b.is_ascii_whitespace()) {
+                out.pop();
+            }
+            return out;
+        }
+
+        if self.ignore_space_at_eol {
+            if bytes.last().copied() == Some(b'\n') {
+                let mut body = bytes[..bytes.len() - 1].to_vec();
+                while body.last().is_some_and(|b| b.is_ascii_whitespace()) {
+                    body.pop();
+                }
+                body.push(b'\n');
+                bytes = body;
+            } else {
+                while bytes.last().is_some_and(|b| b.is_ascii_whitespace()) {
+                    bytes.pop();
+                }
+            }
+        }
+
+        bytes
+    }
+}
+
+/// One logical line for `--no-index` diffing: compare key plus original bytes for output.
+struct NoIndexLineSlot {
+    display: Vec<u8>,
+    compare: Vec<u8>,
+}
+
+/// Split blob bytes into lines, each retaining a trailing `\n` when present (Git line convention).
+fn no_index_split_lines(data: &[u8]) -> Vec<Vec<u8>> {
+    if data.is_empty() {
+        return Vec::new();
+    }
+    let mut lines = Vec::new();
+    let mut start = 0;
+    for i in 0..data.len() {
+        if data[i] == b'\n' {
+            lines.push(data[start..=i].to_vec());
+            start = i + 1;
+        }
+    }
+    if start < data.len() {
+        lines.push(data[start..].to_vec());
+    }
+    lines
+}
+
+fn no_index_line_body_is_blank(line: &[u8]) -> bool {
+    let end = if line.last().copied() == Some(b'\n') {
+        line.len().saturating_sub(1)
+    } else {
+        line.len()
+    };
+    let end = if end > 0 && line.get(end - 1) == Some(&b'\r') {
+        end - 1
+    } else {
+        end
+    };
+    line[..end].iter().all(|b| b.is_ascii_whitespace())
+}
+
+fn no_index_build_line_slots(data: &[u8], mode: &WhitespaceMode) -> Vec<NoIndexLineSlot> {
+    no_index_split_lines(data)
+        .into_iter()
+        .filter(|line| !mode.ignore_blank_lines || !no_index_line_body_is_blank(line))
+        .map(|line| NoIndexLineSlot {
+            compare: mode.normalize_line_bytes(&line),
+            display: line,
+        })
+        .collect()
+}
+
+/// Unified diff body (`---` / `+++` / hunks) for `--no-index`, optional algorithm and whitespace rules.
+fn no_index_unified_patch_body(
+    old_bytes: &[u8],
+    new_bytes: &[u8],
+    old_path: &str,
+    new_path: &str,
+    context_lines: usize,
+    mode: &WhitespaceMode,
+    algorithm: similar::Algorithm,
+) -> String {
+    let old_slots = no_index_build_line_slots(old_bytes, mode);
+    let new_slots = no_index_build_line_slots(new_bytes, mode);
+
+    // Compare keys must not include trailing `\n`: `similar`'s unified writer adds a newline
+    // when `newline_terminated` is false (slice diff); a `\n` in the value would double spacing.
+    let line_key = |bytes: &[u8]| -> String {
+        let mut end = bytes.len();
+        if end > 0 && bytes[end - 1] == b'\n' {
+            end -= 1;
+        }
+        if end > 0 && bytes[end - 1] == b'\r' {
+            end -= 1;
+        }
+        String::from_utf8_lossy(&bytes[..end]).into_owned()
+    };
+    let old_compare_owned: Vec<String> = old_slots.iter().map(|s| line_key(&s.compare)).collect();
+    let new_compare_owned: Vec<String> = new_slots.iter().map(|s| line_key(&s.compare)).collect();
+    let old_compare: Vec<&str> = old_compare_owned.iter().map(|s| s.as_str()).collect();
+    let new_compare: Vec<&str> = new_compare_owned.iter().map(|s| s.as_str()).collect();
+
+    let diff = TextDiff::configure()
+        .algorithm(algorithm)
+        .diff_slices(&old_compare, &new_compare);
+
+    let old_label = if old_path == "/dev/null" {
+        "--- /dev/null\n".to_string()
+    } else {
+        format!("--- a/{old_path}\n")
+    };
+    let new_label = if new_path == "/dev/null" {
+        "+++ /dev/null\n".to_string()
+    } else {
+        format!("+++ b/{new_path}\n")
+    };
+
+    let line_body_for_patch = |line: &[u8]| -> String {
+        let mut end = line.len();
+        if end > 0 && line[end - 1] == b'\n' {
+            end -= 1;
+        }
+        if end > 0 && line[end - 1] == b'\r' {
+            end -= 1;
+        }
+        String::from_utf8_lossy(&line[..end]).into_owned()
+    };
+
+    let mut output = String::new();
+    output.push_str(&old_label);
+    output.push_str(&new_label);
+
+    for hunk in diff
+        .unified_diff()
+        .context_radius(context_lines)
+        .iter_hunks()
+    {
+        output.push_str(&format!("{}\n", hunk.header()));
+        for change in hunk.iter_changes() {
+            match change.tag() {
+                ChangeTag::Equal => {
+                    let idx = change.new_index().expect("equal change has new_index");
+                    let raw = &new_slots[idx].display;
+                    output.push(' ');
+                    output.push_str(&line_body_for_patch(raw));
+                    output.push('\n');
+                }
+                ChangeTag::Delete => {
+                    let idx = change.old_index().expect("delete has old_index");
+                    let raw = &old_slots[idx].display;
+                    output.push('-');
+                    output.push_str(&line_body_for_patch(raw));
+                    output.push('\n');
+                }
+                ChangeTag::Insert => {
+                    let idx = change.new_index().expect("insert has new_index");
+                    let raw = &new_slots[idx].display;
+                    output.push('+');
+                    output.push_str(&line_body_for_patch(raw));
+                    output.push('\n');
+                }
+            }
+        }
+    }
+
+    output
+}
+
+/// Resolve line-diff algorithm for `git diff` from flags and argv order (last wins).
+fn effective_line_diff_algorithm(args: &Args) -> similar::Algorithm {
+    let raw: Vec<String> = std::env::args().collect();
+    let mut best: Option<(usize, similar::Algorithm)> = None;
+    let mut record = |pos: Option<usize>, algo: similar::Algorithm| {
+        if let Some(p) = pos {
+            if best.is_none_or(|(bp, _)| p >= bp) {
+                best = Some((p, algo));
+            }
+        }
+    };
+    record(
+        raw.iter().rposition(|a| a == "--histogram"),
+        similar::Algorithm::Patience,
+    );
+    record(
+        raw.iter().rposition(|a| a == "--patience"),
+        similar::Algorithm::Patience,
+    );
+    record(
+        raw.iter().rposition(|a| a == "--minimal"),
+        similar::Algorithm::Myers,
+    );
+    if let Some(name) = args.diff_algorithm.as_deref() {
+        let pos = raw
+            .iter()
+            .rposition(|a| a == "--diff-algorithm" || a.starts_with("--diff-algorithm="));
+        let algo = match name.to_lowercase().as_str() {
+            "histogram" | "patience" => similar::Algorithm::Patience,
+            "minimal" | "myers" => similar::Algorithm::Myers,
+            _ => similar::Algorithm::Myers,
+        };
+        record(pos, algo);
+    }
+    best.map(|(_, a)| a).unwrap_or(similar::Algorithm::Myers)
+}
+
+/// Short blob id for `index` lines (matches `git rev-parse --short` default length).
+fn no_index_blob_abbrev(data: &[u8]) -> String {
+    let oid = Odb::hash_object_data(ObjectKind::Blob, data);
+    let hex = oid.to_hex();
+    let len = 7_usize.min(hex.len());
+    hex[..len].to_owned()
 }
 
 /// Arguments for `grit diff`.
@@ -1418,7 +1664,8 @@ fn run_no_index(args: &Args) -> Result<()> {
     } else {
         false
     };
-    let diff_output = if use_anchored {
+    let line_algo = effective_line_diff_algorithm(args);
+    let diff_body = if use_anchored {
         anchored_unified_diff(
             &text_a,
             &text_b,
@@ -1426,9 +1673,35 @@ fn run_no_index(args: &Args) -> Result<()> {
             paths[1],
             context_lines,
             &args.anchored,
+            line_algo,
         )
     } else {
-        unified_diff(&text_a, &text_b, paths[0], paths[1], context_lines)
+        let algo = line_algo;
+        no_index_unified_patch_body(
+            &data_a,
+            &data_b,
+            paths[0],
+            paths[1],
+            context_lines,
+            &ws_mode,
+            algo,
+        )
+    };
+
+    let old_abbrev = no_index_blob_abbrev(&data_a);
+    let new_abbrev = no_index_blob_abbrev(&data_b);
+    let mode_str = if path_a
+        .symlink_metadata()
+        .ok()
+        .is_some_and(|m| m.file_type().is_symlink())
+        || path_b
+            .symlink_metadata()
+            .ok()
+            .is_some_and(|m| m.file_type().is_symlink())
+    {
+        "120000"
+    } else {
+        "100644"
     };
 
     // Determine color mode
@@ -1440,7 +1713,12 @@ fn run_no_index(args: &Args) -> Result<()> {
     };
 
     if use_color {
-        for line in diff_output.lines() {
+        writeln!(out, "{BOLD}diff --git a/{} b/{}{RESET}", paths[0], paths[1])?;
+        writeln!(
+            out,
+            "{BOLD}index {old_abbrev}..{new_abbrev} {mode_str}{RESET}"
+        )?;
+        for line in diff_body.lines() {
             if line.starts_with("@@") {
                 writeln!(out, "{CYAN}{line}{RESET}")?;
             } else if line.starts_with('+') && !line.starts_with("+++") {
@@ -1457,7 +1735,9 @@ fn run_no_index(args: &Args) -> Result<()> {
             }
         }
     } else {
-        write!(out, "{diff_output}")?;
+        writeln!(out, "diff --git a/{} b/{}", paths[0], paths[1])?;
+        writeln!(out, "index {old_abbrev}..{new_abbrev} {mode_str}")?;
+        write!(out, "{diff_body}")?;
     }
 
     // Exit with code 1 to indicate differences (like git)

--- a/grit/src/commands/show.rs
+++ b/grit/src/commands/show.rs
@@ -875,6 +875,11 @@ fn show_commit(
             blob_text_for_diff(git_dir, &config, path_for_attrs, &new_raw, use_textconv);
 
         let patch = if !args.anchored.is_empty() {
+            let line_algo = if args.patience {
+                similar::Algorithm::Patience
+            } else {
+                similar::Algorithm::Myers
+            };
             anchored_unified_diff(
                 &old_content,
                 &new_content,
@@ -882,6 +887,7 @@ fn show_commit(
                 new_path,
                 context,
                 &args.anchored,
+                line_algo,
             )
         } else {
             unified_diff(&old_content, &new_content, old_path, new_path, context)

--- a/logs/2026-04-08_t4074-no-index-histogram-diff.md
+++ b/logs/2026-04-08_t4074-no-index-histogram-diff.md
@@ -1,0 +1,15 @@
+## t4074-diff-shifted-matched-group
+
+### Problem
+`grit diff --no-index --histogram` omitted `diff --git` / `index` headers and used Myers line diff, so shifted/histogram hunks and `--ignore-all-space` output did not match Git.
+
+### Fix
+- **`grit/src/commands/diff.rs`**: For file `--no-index`, emit `diff --git` and `index <short>..<short> <mode>` (blob hash via `Odb::hash_object_data`). Resolve effective line algorithm from argv order (`--histogram` / `--patience` → `similar::Patience`, `--minimal` → Myers, `--diff-algorithm=`). Build line slots with byte-normalised compare keys (merge-style rules) and original bytes for output; emit hunks manually so context uses the **new** file’s text when whitespace is ignored (matches Git’s ` b` vs `b`).
+- **`grit-lib/src/diff.rs`**: `anchored_unified_diff` takes `similar::Algorithm` and uses it for segment diffs (and fallback unified diff), so `--anchored=c --histogram` vs `--histogram --anchored=c` matches Git (t4065).
+- **`grit/src/commands/show.rs`**: Pass Myers vs Patience into `anchored_unified_diff` when `--patience` is set.
+
+### Validation
+- `t4074-diff-shifted-matched-group.sh` 4/4
+- `t4065-diff-anchored.sh` 7/7
+- `cargo test -p grit-lib --lib`
+- `./scripts/run-tests.sh t4074-diff-shifted-matched-group.sh`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes `t4074-diff-shifted-matched-group` pass by aligning `grit diff --no-index` with Git when using `--histogram` and whitespace-ignore flags.

## Changes

- Emit `diff --git` and `index <abbrev>..<abbrev> <mode>` before `---`/`+++` for single-file `--no-index` diffs (blob OIDs from `Odb::hash_object_data`).
- Resolve the effective line-diff algorithm from argv order: `--histogram` / `--patience` map to patience-style diff in `similar`, `--minimal` to Myers, plus `--diff-algorithm=` handling.
- For whitespace-ignore modes, diff using normalised line keys (merge-style byte rules) but print **original** line text; equal/context lines use the **new** file’s text so `-w` output matches Git (e.g. ` b` not `b`).
- Extend `anchored_unified_diff` in `grit-lib` with an explicit `similar::Algorithm` so anchored segment diffs respect `--histogram` vs `--anchored` ordering (`t4065`).

## Validation

- `./scripts/run-tests.sh t4074-diff-shifted-matched-group.sh` — 4/4
- `t4065-diff-anchored.sh` — 7/7
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f33d22dd-2714-431c-919c-ad109ca2bd54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f33d22dd-2714-431c-919c-ad109ca2bd54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

