### PR TITLE
Improve t5510-fetch: reftable clone, fetch HEAD/FETCH_HEAD, remote set-head

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -92,7 +92,7 @@ t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
 t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
-t1006-cat-file	t1	yes	290	285	5	false	ok	1
+t1006-cat-file	t1	yes	290	285	5	false	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	32	8	false	ok	0
 t10070-cat-file-batch-format	t1	yes	33	33	0	true	ok	0
@@ -925,7 +925,7 @@ t5505-remote	t5	yes	0	0	0	false	timeout	1
 t5506-remote-groups	t5	yes	9	1	8	false	ok	0
 t5507-remote-environment	t5	yes	5	3	2	false	ok	0
 t5509-fetch-push-namespaces	t5	yes	15	4	11	false	ok	0
-t5510-fetch	t5	yes	215	81	134	false	ok	0
+t5510-fetch	t5	yes	215	93	122	false	ok	0
 t5511-refspec	t5	yes	47	24	23	false	ok	0
 t5512-ls-remote	t5	yes	0	0	0	false	timeout	0
 t5513-fetch-track	t5	yes	2	2	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T00:12:49+00:00" class="gen-time" title="2026-04-09 00:12 UTC">2026-04-09 00:12 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,565</div>
+      <div class="summary-big-val">29,585</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>713 files fully passing</span>
+    <span>716 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,7 +212,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">41/141 files · 2 skipped · 3,333/4,611 tests</span>
+        <span class="group-meta">42/141 files · 2 skipped · 3,334/4,611 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.3%"></div></div>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,336/3,949 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,354/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.8%"></div></div>
-        <span class="group-pct pct-red">33.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.3%"></div></div>
+        <span class="group-pct pct-red">34.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -256,7 +256,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">42/126 files · 11 skipped · 1,793/2,944 tests</span>
+        <span class="group-meta">43/126 files · 11 skipped · 1,794/2,944 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T00:12:49+00:00" class="gen-time" title="2026-04-09 00:12 UTC">2026-04-09 00:12 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,864</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,565</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,585</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1085,7 +1085,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">285</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.3%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t10060-hash-object-determinism</td>
@@ -5110,8 +5110,7 @@ tr.row-skip td { opacity: 0.65; }
 <tr class="" data-group="t2" data-tests="15" data-passed="5">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td><span class="badge ok">full pass</span></td>
-  <td class="right">15</td>
+  <td></td>
   <td class="right">15</td>
   <td class="right">5</td>
   <td class="right">ok</td>
@@ -6218,14 +6217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="54" data-passed="38">
+<tr class="" data-group="t3" data-tests="52" data-passed="3">
   <td class="mono">t3420-rebase-autostash</td>
   <td>t3</td>
   <td></td>
-  <td class="right">54</td>
-  <td class="right">38</td>
+  <td class="right">52</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="63" data-passed="11">
@@ -9408,14 +9407,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:26.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="215" data-passed="81">
+<tr class="" data-group="t5" data-tests="215" data-passed="93">
   <td class="mono">t5510-fetch</td>
   <td>t5</td>
   <td></td>
   <td class="right">215</td>
-  <td class="right">81</td>
+  <td class="right">93</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:37.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:43.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="47" data-passed="24">
@@ -12598,7 +12597,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="2" data-passed="2">
+<tr class="" data-group="t7" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t7524-commit-summary</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>

--- a/grit-lib/src/repo.rs
+++ b/grit-lib/src/repo.rs
@@ -1672,6 +1672,7 @@ fn write_fresh_git_directory(
     bare: bool,
     initial_branch: &str,
     template_dir: Option<&Path>,
+    ref_storage: &str,
 ) -> Result<()> {
     let mut subs = vec![
         "objects",
@@ -1689,6 +1690,15 @@ fn write_fresh_git_directory(
         fs::create_dir_all(git_dir.join(sub))?;
     }
 
+    if ref_storage == "reftable" {
+        let reftable_dir = git_dir.join("reftable");
+        fs::create_dir_all(&reftable_dir)?;
+        let tables_list = reftable_dir.join("tables.list");
+        if !tables_list.exists() {
+            fs::write(&tables_list, "")?;
+        }
+    }
+
     if let Some(tmpl) = template_dir {
         if tmpl.is_dir() {
             copy_template(tmpl, git_dir)?;
@@ -1698,11 +1708,22 @@ fn write_fresh_git_directory(
     let head_content = format!("ref: refs/heads/{initial_branch}\n");
     fs::write(git_dir.join("HEAD"), head_content)?;
 
-    let config_content = if bare {
-        "[core]\n\trepositoryformatversion = 0\n\tfilemode = true\n\tbare = true\n"
+    let needs_extensions = ref_storage == "reftable";
+    let repo_version = if needs_extensions { 1 } else { 0 };
+
+    let mut config_content = String::from("[core]\n");
+    config_content.push_str(&format!("\trepositoryformatversion = {repo_version}\n"));
+    config_content.push_str("\tfilemode = true\n");
+    if bare {
+        config_content.push_str("\tbare = true\n");
     } else {
-        "[core]\n\trepositoryformatversion = 0\n\tfilemode = true\n\tbare = false\n\tlogallrefupdates = true\n"
-    };
+        config_content.push_str("\tbare = false\n");
+        config_content.push_str("\tlogallrefupdates = true\n");
+    }
+    if needs_extensions {
+        config_content.push_str("[extensions]\n");
+        config_content.push_str("\trefStorage = reftable\n");
+    }
     fs::write(git_dir.join("config"), config_content)?;
 
     // Merge `config` from the template on top of the default (matches `git clone --template`).
@@ -1752,10 +1773,11 @@ pub fn init_repository_separate_git_dir(
     git_dir: &Path,
     initial_branch: &str,
     template_dir: Option<&Path>,
+    ref_storage: &str,
 ) -> Result<Repository> {
     fs::create_dir_all(work_tree)?;
     fs::create_dir_all(git_dir)?;
-    write_fresh_git_directory(git_dir, false, initial_branch, template_dir)?;
+    write_fresh_git_directory(git_dir, false, initial_branch, template_dir, ref_storage)?;
 
     let git_dir_abs = git_dir
         .canonicalize()
@@ -1779,7 +1801,11 @@ pub fn init_repository_separate_git_dir(
 /// # Errors
 ///
 /// Returns [`Error::Io`] on filesystem failures.
-pub fn init_bare_clone_minimal(git_dir: &Path, initial_branch: &str) -> Result<()> {
+pub fn init_bare_clone_minimal(
+    git_dir: &Path,
+    initial_branch: &str,
+    ref_storage: &str,
+) -> Result<()> {
     for sub in &[
         "objects",
         "objects/info",
@@ -1791,11 +1817,28 @@ pub fn init_bare_clone_minimal(git_dir: &Path, initial_branch: &str) -> Result<(
         fs::create_dir_all(git_dir.join(sub))?;
     }
 
+    if ref_storage == "reftable" {
+        let reftable_dir = git_dir.join("reftable");
+        fs::create_dir_all(&reftable_dir)?;
+        let tables_list = reftable_dir.join("tables.list");
+        if !tables_list.exists() {
+            fs::write(&tables_list, "")?;
+        }
+    }
+
     let head_content = format!("ref: refs/heads/{initial_branch}\n");
     fs::write(git_dir.join("HEAD"), head_content)?;
 
-    let config_content =
-        "[core]\n\trepositoryformatversion = 0\n\tfilemode = true\n\tbare = true\n";
+    let needs_extensions = ref_storage == "reftable";
+    let repo_version = if needs_extensions { 1 } else { 0 };
+    let mut config_content = String::from("[core]\n");
+    config_content.push_str(&format!("\trepositoryformatversion = {repo_version}\n"));
+    config_content.push_str("\tfilemode = true\n");
+    config_content.push_str("\tbare = true\n");
+    if needs_extensions {
+        config_content.push_str("[extensions]\n");
+        config_content.push_str("\trefStorage = reftable\n");
+    }
     fs::write(git_dir.join("config"), config_content)?;
 
     fs::write(
@@ -1810,6 +1853,7 @@ pub fn init_repository(
     bare: bool,
     initial_branch: &str,
     template_dir: Option<&Path>,
+    ref_storage: &str,
 ) -> Result<Repository> {
     let git_dir = if bare {
         path.to_path_buf()
@@ -1821,7 +1865,7 @@ pub fn init_repository(
         fs::create_dir_all(path)?;
     }
     fs::create_dir_all(&git_dir)?;
-    write_fresh_git_directory(&git_dir, bare, initial_branch, template_dir)?;
+    write_fresh_git_directory(&git_dir, bare, initial_branch, template_dir, ref_storage)?;
 
     let work_tree = if bare { None } else { Some(path) };
     Repository::open(&git_dir, work_tree)

--- a/grit/src/commands/clone.rs
+++ b/grit/src/commands/clone.rs
@@ -11,6 +11,7 @@ use grit_lib::diff::zero_oid;
 use grit_lib::hooks::{run_hook, HookResult};
 use grit_lib::objects::{parse_commit, parse_tag, parse_tree, ObjectId, ObjectKind};
 use grit_lib::refs;
+use grit_lib::reftable;
 use grit_lib::repo::{
     init_bare_clone_minimal, init_repository, init_repository_separate_git_dir, Repository,
 };
@@ -148,6 +149,10 @@ pub struct Args {
     /// Store the git directory at this path; work tree uses a gitfile `.git`.
     #[arg(long = "separate-git-dir", value_name = "GITDIR")]
     pub separate_git_dir: Option<PathBuf>,
+
+    /// Ref storage backend for the new repository (`files` or `reftable`).
+    #[arg(long = "ref-format", value_name = "FORMAT")]
+    pub ref_format: Option<String>,
 }
 
 /// Returns `true` when `name` is valid as a remote name (same idea as Git's `valid_remote_name`).
@@ -169,6 +174,77 @@ fn default_branch_from_config() -> Option<String> {
 
 fn default_head_branch_fallback() -> String {
     default_branch_from_config().unwrap_or_else(|| "master".to_owned())
+}
+
+fn resolved_clone_ref_storage(args: &Args) -> Result<&'static str> {
+    match args.ref_format.as_deref() {
+        None | Some("files") => Ok("files"),
+        Some("reftable") => Ok("reftable"),
+        Some(other) => bail!("unknown ref storage format: {other}"),
+    }
+}
+
+fn clone_write_direct_ref(git_dir: &Path, refname: &str, oid_hex: &str) -> Result<()> {
+    let oid =
+        ObjectId::from_hex(oid_hex.trim()).with_context(|| format!("invalid OID for {refname}"))?;
+    if grit_lib::reftable::is_reftable_repo(git_dir) {
+        reftable::reftable_write_ref(git_dir, refname, &oid, None, None)
+            .map_err(|e| anyhow::anyhow!("{e}"))
+    } else {
+        let path = git_dir.join(refname);
+        if let Some(p) = path.parent() {
+            fs::create_dir_all(p)?;
+        }
+        fs::write(path, format!("{}\n", oid.to_hex()))
+            .with_context(|| format!("writing ref {refname}"))
+    }
+}
+
+fn clone_write_symref(git_dir: &Path, refname: &str, target: &str) -> Result<()> {
+    let target = target.trim();
+    if grit_lib::reftable::is_reftable_repo(git_dir) {
+        reftable::reftable_write_symref(git_dir, refname, target, None, None)
+            .map_err(|e| anyhow::anyhow!("{e}"))
+    } else {
+        let path = git_dir.join(refname);
+        if let Some(p) = path.parent() {
+            fs::create_dir_all(p)?;
+        }
+        fs::write(path, format!("ref: {target}\n"))
+            .with_context(|| format!("writing symref {refname}"))
+    }
+}
+
+fn clone_ref_file_exists(git_dir: &Path, refname: &str) -> bool {
+    if grit_lib::reftable::is_reftable_repo(git_dir) {
+        grit_lib::refs::resolve_ref(git_dir, refname).is_ok()
+    } else {
+        git_dir.join(refname).is_file()
+    }
+}
+
+fn clone_read_direct_ref_oid(git_dir: &Path, refname: &str) -> Result<String> {
+    if grit_lib::reftable::is_reftable_repo(git_dir) {
+        let oid = grit_lib::refs::resolve_ref(git_dir, refname)
+            .with_context(|| format!("reading ref {refname}"))?;
+        Ok(oid.to_hex())
+    } else {
+        let path = git_dir.join(refname);
+        let s = fs::read_to_string(&path).with_context(|| format!("reading ref file {refname}"))?;
+        Ok(s.trim().to_string())
+    }
+}
+
+fn strip_refs_for_revision_clone(git_dir: &Path) -> Result<()> {
+    if grit_lib::reftable::is_reftable_repo(git_dir) {
+        let refs = grit_lib::refs::list_refs(git_dir, "refs/")?;
+        for (name, _) in refs {
+            reftable::reftable_delete_ref(git_dir, &name).map_err(|e| anyhow::anyhow!("{e}"))?;
+        }
+        Ok(())
+    } else {
+        strip_refs_under(&git_dir.join("refs"))
+    }
 }
 
 fn clone_default_remote_from_c_flags(config: &[String]) -> Option<String> {
@@ -248,7 +324,7 @@ fn head_points_to_missing_ref(repo: &Repository) -> bool {
         return false;
     };
     let refname = refname.trim();
-    !repo.git_dir.join(refname).exists()
+    !clone_ref_file_exists(&repo.git_dir, refname)
 }
 
 /// Clone checked out the remote's unborn default branch (symref exists, branch ref missing on source).
@@ -267,7 +343,7 @@ fn is_unborn_remote_default_checkout(
     let Some(h) = sr.strip_prefix("refs/heads/") else {
         return false;
     };
-    h == branch && !source_git_dir.join(sr).exists() && head_points_to_missing_ref(dest)
+    h == branch && !clone_ref_file_exists(source_git_dir, sr) && head_points_to_missing_ref(dest)
 }
 
 /// Perform checkout of `HEAD` when it points at a missing branch (unborn), matching Git clone.
@@ -282,12 +358,10 @@ fn checkout_head_allow_unborn(repo: &Repository) -> Result<()> {
 
     let oid = if let Some(refname) = head.strip_prefix("ref: ") {
         let refname = refname.trim();
-        let ref_path = repo.git_dir.join(refname);
-        if !ref_path.exists() {
+        if !clone_ref_file_exists(&repo.git_dir, refname) {
             return Ok(());
         }
-        let oid_str =
-            fs::read_to_string(&ref_path).with_context(|| format!("reading ref {refname}"))?;
+        let oid_str = clone_read_direct_ref_oid(&repo.git_dir, refname)?;
         ObjectId::from_hex(oid_str.trim()).with_context(|| format!("invalid OID in {refname}"))?
     } else if head.len() == 40 && head.chars().all(|c| c.is_ascii_hexdigit()) {
         ObjectId::from_hex(head).context("invalid OID in HEAD")?
@@ -425,6 +499,7 @@ pub fn run(mut args: Args) -> Result<()> {
     }
     maybe_warn_shallow_options_ignored(&repo_path_str, &args);
     let remote_name = resolve_remote_name(&args)?;
+    let ref_storage = resolved_clone_ref_storage(&args)?;
 
     // Determine target directory
     let target_name = args.directory.unwrap_or_else(|| {
@@ -491,6 +566,7 @@ pub fn run(mut args: Args) -> Result<()> {
             sep_git,
             initial_branch,
             template_dir.as_deref(),
+            ref_storage,
         )
         .with_context(|| {
             format!(
@@ -499,7 +575,7 @@ pub fn run(mut args: Args) -> Result<()> {
             )
         })?
     } else if args.bare && args.template.as_ref().is_some_and(|s| s.is_empty()) {
-        init_bare_clone_minimal(&target_path, initial_branch).with_context(|| {
+        init_bare_clone_minimal(&target_path, initial_branch, ref_storage).with_context(|| {
             format!(
                 "failed to initialize bare clone '{}'",
                 target_path.display()
@@ -513,6 +589,7 @@ pub fn run(mut args: Args) -> Result<()> {
             args.bare,
             initial_branch,
             template_dir.as_deref(),
+            ref_storage,
         )
         .with_context(|| format!("failed to initialize '{}'", target_path.display()))?
     };
@@ -599,19 +676,12 @@ pub fn run(mut args: Args) -> Result<()> {
         if let Some(branch) =
             resolve_remote_tracked_branch_name(&dest.git_dir, &remote_name, initial_branch)
         {
-            let remote_ref = dest
-                .git_dir
-                .join("refs/remotes")
-                .join(&remote_name)
-                .join(&branch);
-            let oid_str = fs::read_to_string(&remote_ref).context("reading remote ref")?;
-            let oid = oid_str.trim().to_string();
+            let remote_ref_name = format!("refs/remotes/{remote_name}/{branch}");
+            let oid = clone_read_direct_ref_oid(&dest.git_dir, &remote_ref_name)
+                .context("reading remote ref")?;
 
-            let local_ref_path = dest.git_dir.join("refs/heads").join(&branch);
-            if let Some(parent) = local_ref_path.parent() {
-                fs::create_dir_all(parent)?;
-            }
-            fs::write(&local_ref_path, format!("{oid}\n"))?;
+            let local_ref_name = format!("refs/heads/{branch}");
+            clone_write_direct_ref(&dest.git_dir, &local_ref_name, &oid)?;
 
             fs::write(
                 dest.git_dir.join("HEAD"),
@@ -622,7 +692,9 @@ pub fn run(mut args: Args) -> Result<()> {
                 .context("setting up branch tracking")?;
         } else if let Some(ref branch) = head_branch {
             if let Some(sr) = source_head_symref.as_deref() {
-                if sr == format!("refs/heads/{branch}") && !source.git_dir.join(sr).exists() {
+                if sr == format!("refs/heads/{branch}")
+                    && !clone_ref_file_exists(&source.git_dir, sr)
+                {
                     setup_branch_tracking(&dest.git_dir, branch, &remote_name)
                         .context("setting up branch tracking")?;
                 }
@@ -695,7 +767,7 @@ pub fn run(mut args: Args) -> Result<()> {
     // and no remote.fetch (matches git clone --revision).
     if let Some(ref revision) = args.revision {
         let rev_oid = resolve_revision_for_clone(&source, revision, &remote_name)?;
-        strip_refs_under(&dest.git_dir.join("refs"))?;
+        strip_refs_for_revision_clone(&dest.git_dir)?;
         fs::write(dest.git_dir.join("HEAD"), format!("{}\n", rev_oid))?;
         remove_revision_clone_remote_config(&dest.git_dir, &remote_name)?;
     }
@@ -808,6 +880,7 @@ fn run_ssh_clone(args: Args) -> Result<()> {
     }
     maybe_warn_shallow_options_ignored(&args.repository, &args);
     let remote_name = resolve_remote_name(&args)?;
+    let ref_storage = resolved_clone_ref_storage(&args)?;
 
     let path_for_basename = PathBuf::from(&spec.path);
     let target_name = args.directory.clone().unwrap_or_else(|| {
@@ -868,6 +941,7 @@ fn run_ssh_clone(args: Args) -> Result<()> {
             sep_git,
             initial_branch,
             template_dir.as_deref(),
+            ref_storage,
         )
         .with_context(|| {
             format!(
@@ -876,7 +950,7 @@ fn run_ssh_clone(args: Args) -> Result<()> {
             )
         })?
     } else if args.bare && args.template.as_ref().is_some_and(|s| s.is_empty()) {
-        init_bare_clone_minimal(&target_path, initial_branch).with_context(|| {
+        init_bare_clone_minimal(&target_path, initial_branch, ref_storage).with_context(|| {
             format!(
                 "failed to initialize bare clone '{}'",
                 target_path.display()
@@ -890,6 +964,7 @@ fn run_ssh_clone(args: Args) -> Result<()> {
             args.bare,
             initial_branch,
             template_dir.as_deref(),
+            ref_storage,
         )
         .with_context(|| format!("failed to initialize '{}'", target_path.display()))?
     };
@@ -943,19 +1018,12 @@ fn run_ssh_clone(args: Args) -> Result<()> {
         )?;
 
         if let Some(ref branch) = head_branch {
-            let remote_ref = dest
-                .git_dir
-                .join("refs/remotes")
-                .join(&remote_name)
-                .join(branch);
-            if remote_ref.exists() {
-                let oid_str = fs::read_to_string(&remote_ref).context("reading remote ref")?;
-                let oid = oid_str.trim().to_string();
-                let local_ref_path = dest.git_dir.join("refs/heads").join(branch);
-                if let Some(parent) = local_ref_path.parent() {
-                    fs::create_dir_all(parent)?;
-                }
-                fs::write(&local_ref_path, format!("{oid}\n"))?;
+            let remote_ref_name = format!("refs/remotes/{remote_name}/{branch}");
+            if clone_ref_file_exists(&dest.git_dir, &remote_ref_name) {
+                let oid = clone_read_direct_ref_oid(&dest.git_dir, &remote_ref_name)
+                    .context("reading remote ref")?;
+                let local_ref_name = format!("refs/heads/{branch}");
+                clone_write_direct_ref(&dest.git_dir, &local_ref_name, &oid)?;
                 fs::write(
                     dest.git_dir.join("HEAD"),
                     format!("ref: refs/heads/{branch}\n"),
@@ -963,7 +1031,9 @@ fn run_ssh_clone(args: Args) -> Result<()> {
                 setup_branch_tracking(&dest.git_dir, branch, &remote_name)
                     .context("setting up branch tracking")?;
             } else if let Some(sr) = source_head_symref.as_deref() {
-                if sr == format!("refs/heads/{branch}") && !source.git_dir.join(sr).exists() {
+                if sr == format!("refs/heads/{branch}")
+                    && !clone_ref_file_exists(&source.git_dir, sr)
+                {
                     setup_branch_tracking(&dest.git_dir, branch, &remote_name)
                         .context("setting up branch tracking")?;
                 }
@@ -989,7 +1059,7 @@ fn run_ssh_clone(args: Args) -> Result<()> {
 
     if let Some(ref revision) = args.revision {
         let rev_oid = resolve_revision_for_clone(&source, revision, &remote_name)?;
-        strip_refs_under(&dest.git_dir.join("refs"))?;
+        strip_refs_for_revision_clone(&dest.git_dir)?;
         fs::write(dest.git_dir.join("HEAD"), format!("{}\n", rev_oid))?;
         remove_revision_clone_remote_config(&dest.git_dir, &remote_name)?;
     }
@@ -1540,25 +1610,15 @@ fn copy_refs_as_remote(
         .map_err(|e| anyhow::anyhow!("{e}"))?;
     for (refname, oid) in &heads {
         let branch = refname.strip_prefix("refs/heads/").unwrap_or(refname);
-        let dst_ref = dst_git_dir
-            .join("refs/remotes")
-            .join(remote_name)
-            .join(branch);
-        if let Some(parent) = dst_ref.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        fs::write(&dst_ref, format!("{}\n", oid.to_hex()))?;
+        let dst_name = format!("refs/remotes/{remote_name}/{branch}");
+        clone_write_direct_ref(dst_git_dir, &dst_name, &oid.to_hex())?;
     }
 
     if !no_tags {
         let tags = grit_lib::refs::list_refs(src_git_dir, "refs/tags/")
             .map_err(|e| anyhow::anyhow!("{e}"))?;
         for (refname, oid) in &tags {
-            let dst_ref = dst_git_dir.join(refname);
-            if let Some(parent) = dst_ref.parent() {
-                fs::create_dir_all(parent)?;
-            }
-            fs::write(&dst_ref, format!("{}\n", oid.to_hex()))?;
+            clone_write_direct_ref(dst_git_dir, refname, &oid.to_hex())?;
         }
     }
 
@@ -1567,7 +1627,6 @@ fn copy_refs_as_remote(
         let packed_refs = src_git_dir.join("packed-refs");
         if packed_refs.is_file() {
             let content = fs::read_to_string(&packed_refs)?;
-            let dst_remotes = dst_git_dir.join("refs/remotes").join(remote_name);
             for line in content.lines() {
                 if line.is_empty() || line.starts_with('#') || line.starts_with('^') {
                     continue;
@@ -1579,20 +1638,13 @@ fn copy_refs_as_remote(
                 };
 
                 if let Some(branch) = refname.strip_prefix("refs/heads/") {
-                    let dst_ref = dst_remotes.join(branch);
-                    if let Some(parent) = dst_ref.parent() {
-                        fs::create_dir_all(parent)?;
-                    }
-                    if !dst_ref.exists() {
-                        fs::write(&dst_ref, format!("{oid}\n"))?;
+                    let dst_name = format!("refs/remotes/{remote_name}/{branch}");
+                    if !clone_ref_file_exists(dst_git_dir, &dst_name) {
+                        clone_write_direct_ref(dst_git_dir, &dst_name, oid)?;
                     }
                 } else if !no_tags && refname.starts_with("refs/tags/") {
-                    let dst_ref = dst_git_dir.join(refname);
-                    if let Some(parent) = dst_ref.parent() {
-                        fs::create_dir_all(parent)?;
-                    }
-                    if !dst_ref.exists() {
-                        fs::write(&dst_ref, format!("{oid}\n"))?;
+                    if !clone_ref_file_exists(dst_git_dir, refname) {
+                        clone_write_direct_ref(dst_git_dir, refname, oid)?;
                     }
                 }
             }
@@ -1626,11 +1678,7 @@ fn copy_refs_direct(src_git_dir: &Path, dst_git_dir: &Path) -> Result<()> {
         let refs =
             grit_lib::refs::list_refs(src_git_dir, prefix).map_err(|e| anyhow::anyhow!("{e}"))?;
         for (refname, oid) in &refs {
-            let dst_ref = dst_git_dir.join(refname);
-            if let Some(parent) = dst_ref.parent() {
-                fs::create_dir_all(parent)?;
-            }
-            fs::write(&dst_ref, format!("{}\n", oid.to_hex()))?;
+            clone_write_direct_ref(dst_git_dir, refname, &oid.to_hex())?;
         }
     }
 
@@ -1649,12 +1697,8 @@ fn copy_refs_direct(src_git_dir: &Path, dst_git_dir: &Path) -> Result<()> {
             };
 
             if refname.starts_with("refs/heads/") || refname.starts_with("refs/tags/") {
-                let dst_ref = dst_git_dir.join(refname);
-                if let Some(parent) = dst_ref.parent() {
-                    fs::create_dir_all(parent)?;
-                }
-                if !dst_ref.exists() {
-                    fs::write(&dst_ref, format!("{oid}\n"))?;
+                if !clone_ref_file_exists(dst_git_dir, refname) {
+                    clone_write_direct_ref(dst_git_dir, refname, oid)?;
                 }
             }
         }
@@ -2019,13 +2063,11 @@ fn run_post_checkout_after_clone(repo: &Repository) -> Result<()> {
     let head = head_content.trim();
     let new_oid = if let Some(refname) = head.strip_prefix("ref: ") {
         let refname = refname.trim();
-        let ref_path = repo.git_dir.join(refname);
-        if !ref_path.exists() {
+        if !clone_ref_file_exists(&repo.git_dir, refname) {
             // Unborn branch: nothing checked out; no commit for post-checkout.
             return Ok(());
         }
-        let oid_str =
-            fs::read_to_string(&ref_path).with_context(|| format!("reading ref {refname}"))?;
+        let oid_str = clone_read_direct_ref_oid(&repo.git_dir, refname)?;
         ObjectId::from_hex(oid_str.trim()).with_context(|| format!("invalid OID in {refname}"))?
     } else {
         ObjectId::from_hex(head).context("invalid OID in HEAD")?
@@ -2052,8 +2094,7 @@ fn determine_head_branch(src_git_dir: &Path, requested: Option<&str>) -> Result<
         if let Some(rest) = content.strip_prefix("ref: ") {
             let rest = rest.trim();
             if let Some(branch) = rest.strip_prefix("refs/heads/") {
-                let ref_path = src_git_dir.join(rest);
-                if ref_path.is_file() {
+                if clone_ref_file_exists(src_git_dir, rest) {
                     return Ok(Some(branch.to_string()));
                 }
             }
@@ -2086,19 +2127,20 @@ fn resolve_remote_tracked_branch_name(
     remote_name: &str,
     preferred: &str,
 ) -> Option<String> {
-    let remote_dir = dest_git_dir.join("refs/remotes").join(remote_name);
-    let preferred_path = remote_dir.join(preferred);
-    if preferred_path.is_file() {
+    let preferred_name = format!("refs/remotes/{remote_name}/{preferred}");
+    if clone_ref_file_exists(dest_git_dir, &preferred_name) {
         return Some(preferred.to_string());
     }
-    let entries = fs::read_dir(&remote_dir).ok()?;
+    let prefix = format!("refs/remotes/{remote_name}/");
+    let refs = grit_lib::refs::list_refs(dest_git_dir, &prefix).ok()?;
     let mut names: Vec<String> = Vec::new();
-    for entry in entries.flatten() {
-        let name = entry.file_name().to_string_lossy().to_string();
-        if name == "HEAD" || !entry.path().is_file() {
-            continue;
+    for (full, _) in refs {
+        if let Some(rest) = full.strip_prefix(&prefix) {
+            if rest == "HEAD" || rest.contains('/') {
+                continue;
+            }
+            names.push(rest.to_string());
         }
-        names.push(name);
     }
     names.sort();
     if names.len() == 1 {
@@ -2122,8 +2164,7 @@ fn guess_checkout_branch(
 ) -> Result<Option<String>> {
     if let Some(sr) = symref {
         if let Some(branch) = sr.strip_prefix("refs/heads/") {
-            let ref_path = src_git_dir.join(sr);
-            if ref_path.is_file() {
+            if clone_ref_file_exists(src_git_dir, sr) {
                 return Ok(Some(branch.to_string()));
             }
             // Unborn branch: HEAD symref points at refs/heads/<name> but the ref file
@@ -2168,22 +2209,13 @@ fn setup_remote_tracking_head(
     symref: Option<&str>,
     detached_oid: Option<&str>,
 ) -> Result<()> {
-    let origin_head_path = dest_git_dir
-        .join("refs/remotes")
-        .join(remote_name)
-        .join("HEAD");
+    let origin_head_ref = format!("refs/remotes/{remote_name}/HEAD");
 
     if let Some(sr) = symref {
         if let Some(branch) = sr.strip_prefix("refs/heads/") {
-            let ref_path = src_git_dir.join(sr);
-            if ref_path.is_file() {
-                if let Some(parent) = origin_head_path.parent() {
-                    fs::create_dir_all(parent)?;
-                }
-                fs::write(
-                    &origin_head_path,
-                    format!("ref: refs/remotes/{remote_name}/{branch}\n"),
-                )?;
+            if clone_ref_file_exists(src_git_dir, sr) {
+                let sym_target = format!("refs/remotes/{remote_name}/{branch}");
+                clone_write_symref(dest_git_dir, &origin_head_ref, &sym_target)?;
                 return Ok(());
             }
             // Source default branch ref is missing (dangling HEAD): do not create
@@ -2194,13 +2226,8 @@ fn setup_remote_tracking_head(
 
     if let Some(oid_hex) = detached_oid {
         if let Some(branch) = guess_checkout_branch(src_git_dir, None, Some(oid_hex))? {
-            if let Some(parent) = origin_head_path.parent() {
-                fs::create_dir_all(parent)?;
-            }
-            fs::write(
-                &origin_head_path,
-                format!("ref: refs/remotes/{remote_name}/{branch}\n"),
-            )?;
+            let sym_target = format!("refs/remotes/{remote_name}/{branch}");
+            clone_write_symref(dest_git_dir, &origin_head_ref, &sym_target)?;
         }
     }
 
@@ -2216,9 +2243,8 @@ pub(crate) fn ensure_index_from_head_if_missing(repo: &Repository) -> Result<()>
     let head_content = fs::read_to_string(repo.git_dir.join("HEAD")).context("reading HEAD")?;
     let head = head_content.trim();
     let oid = if let Some(refname) = head.strip_prefix("ref: ") {
-        let ref_path = repo.git_dir.join(refname);
-        let oid_str =
-            fs::read_to_string(&ref_path).with_context(|| format!("reading ref {refname}"))?;
+        let refname = refname.trim();
+        let oid_str = clone_read_direct_ref_oid(&repo.git_dir, refname)?;
         ObjectId::from_hex(oid_str.trim()).with_context(|| format!("invalid OID in {refname}"))?
     } else {
         ObjectId::from_hex(head).context("invalid OID in HEAD")?
@@ -2243,9 +2269,7 @@ fn checkout_head(repo: &Repository) -> Result<()> {
     // Resolve to an OID
     let oid = if let Some(refname) = head.strip_prefix("ref: ") {
         let refname = refname.trim();
-        let ref_path = repo.git_dir.join(refname);
-        let oid_str =
-            fs::read_to_string(&ref_path).with_context(|| format!("reading ref {refname}"))?;
+        let oid_str = clone_read_direct_ref_oid(&repo.git_dir, refname)?;
         ObjectId::from_hex(oid_str.trim()).with_context(|| format!("invalid OID in {refname}"))?
     } else {
         ObjectId::from_hex(head).context("invalid OID in HEAD")?
@@ -2520,7 +2544,7 @@ fn run_bundle_clone(args: Args) -> Result<()> {
     }
 
     // Determine target directory
-    let target_name = args.directory.unwrap_or_else(|| {
+    let target_name = args.directory.clone().unwrap_or_else(|| {
         let base = bundle_path
             .file_stem()
             .unwrap_or_default()
@@ -2575,9 +2599,11 @@ fn run_bundle_clone(args: Args) -> Result<()> {
         })
         .unwrap_or_else(|| "master".to_string());
 
+    let ref_storage = resolved_clone_ref_storage(&args)?;
+
     // Initialize target repo
     fs::create_dir_all(&target_path)?;
-    let dest = init_repository(&target_path, args.bare, &head_branch, None)
+    let dest = init_repository(&target_path, args.bare, &head_branch, None, ref_storage)
         .with_context(|| format!("failed to initialize '{}'", target_path.display()))?;
 
     // Unbundle pack data
@@ -2599,19 +2625,12 @@ fn run_bundle_clone(args: Args) -> Result<()> {
         }
         // Write as remote tracking ref
         if let Some(branch) = refname.strip_prefix("refs/heads/") {
-            let remote_ref_path = dest.git_dir.join("refs/remotes/origin").join(branch);
-            if let Some(parent) = remote_ref_path.parent() {
-                fs::create_dir_all(parent)?;
-            }
-            fs::write(&remote_ref_path, format!("{}\n", oid.to_hex()))?;
+            let dst_name = format!("refs/remotes/origin/{branch}");
+            clone_write_direct_ref(&dest.git_dir, &dst_name, &oid.to_hex())?;
         }
         // Also write tags directly
         if refname.starts_with("refs/tags/") {
-            let ref_path = dest.git_dir.join(refname);
-            if let Some(parent) = ref_path.parent() {
-                fs::create_dir_all(parent)?;
-            }
-            fs::write(&ref_path, format!("{}\n", oid.to_hex()))?;
+            clone_write_direct_ref(&dest.git_dir, refname, &oid.to_hex())?;
         }
     }
 
@@ -2620,11 +2639,8 @@ fn run_bundle_clone(args: Args) -> Result<()> {
         .iter()
         .find(|(r, _)| r == &format!("refs/heads/{}", head_branch))
     {
-        let branch_ref_path = dest.git_dir.join("refs/heads").join(&head_branch);
-        if let Some(parent) = branch_ref_path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        fs::write(&branch_ref_path, format!("{}\n", oid.to_hex()))?;
+        let branch_ref_name = format!("refs/heads/{head_branch}");
+        clone_write_direct_ref(&dest.git_dir, &branch_ref_name, &oid.to_hex())?;
     }
 
     // Set up origin remote config

--- a/grit/src/commands/fetch.rs
+++ b/grit/src/commands/fetch.rs
@@ -15,6 +15,7 @@ use grit_lib::refs;
 use grit_lib::repo::Repository;
 use std::collections::HashSet;
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 /// Arguments for `grit fetch`.
@@ -148,7 +149,11 @@ pub fn run(args: Args) -> Result<()> {
         }
         Ok(())
     } else {
-        let remote_name = args.remote.as_deref().unwrap_or("origin");
+        let remote_resolved = args
+            .remote
+            .clone()
+            .unwrap_or_else(|| default_fetch_remote_name(&git_dir, &config));
+        let remote_name = remote_resolved.as_str();
         // Remote config takes precedence over path-like names, even if the
         // remote name contains '/' or matches an existing directory.
         let url_key = format!("remote.{remote_name}.url");
@@ -169,6 +174,106 @@ pub fn run(args: Args) -> Result<()> {
         super::submodule::recursive_fetch_submodules(true)?;
     }
     result
+}
+
+/// When `git fetch` is run with no remote argument, Git uses `branch.<current>.remote`
+/// if set; otherwise `origin`.
+/// Current branch name when `HEAD` is a symbolic ref to `refs/heads/<name>`.
+fn current_branch_from_head(git_dir: &Path) -> Option<String> {
+    let head_raw = fs::read_to_string(git_dir.join("HEAD")).ok()?;
+    let head = head_raw.trim();
+    let target = head.strip_prefix("ref: ")?.trim();
+    let branch = target.strip_prefix("refs/heads/")?;
+    Some(branch.to_string())
+}
+
+/// FETCH_HEAD "for merge" when the current branch tracks this remote and the remote ref
+/// matches `branch.<name>.merge` (Git `branch_merge_matches` / `add_merge_config`).
+fn fetch_head_is_for_merge_with_branch(
+    git_dir: &Path,
+    config: &ConfigSet,
+    remote_name: &str,
+    remote_refname: &str,
+) -> bool {
+    let Some(branch) = current_branch_from_head(git_dir) else {
+        return false;
+    };
+    let remote_key = format!("branch.{branch}.remote");
+    let Some(cfg_remote) = config.get(&remote_key) else {
+        return false;
+    };
+    if cfg_remote.trim() != remote_name {
+        return false;
+    }
+    let merge_key = format!("branch.{branch}.merge");
+    let Some(merge_ref) = config.get(&merge_key) else {
+        return false;
+    };
+    merge_ref.trim() == remote_refname
+}
+
+/// When there is no `branch.*.merge` for HEAD, Git marks only the first ref from the first
+/// non-pattern remote fetch refspec as for-merge (`get_ref_map` in fetch.c).
+fn fetch_head_is_for_merge_first_refspec_only(
+    refspecs: &[FetchRefspec],
+    is_first_remote_head: bool,
+) -> bool {
+    if !is_first_remote_head {
+        return false;
+    }
+    let Some(first) = refspecs.iter().find(|r| !r.negative && !r.src.is_empty()) else {
+        return false;
+    };
+    !first.src.contains('*')
+}
+
+/// True when `HEAD` names `refs/heads/<b>`, `branch.<b>.remote` matches `remote_name`, and
+/// `branch.<b>.merge` is set (Git `branch_has_merge_config` for default fetch).
+fn branch_has_merge_config_for_remote(
+    git_dir: &Path,
+    config: &ConfigSet,
+    remote_name: &str,
+) -> bool {
+    let Some(branch) = current_branch_from_head(git_dir) else {
+        return false;
+    };
+    let remote_key = format!("branch.{branch}.remote");
+    let Some(cfg_remote) = config.get(&remote_key) else {
+        return false;
+    };
+    if cfg_remote.trim() != remote_name {
+        return false;
+    }
+    let merge_key = format!("branch.{branch}.merge");
+    config.get(&merge_key).is_some()
+}
+
+fn default_fetch_remote_name(git_dir: &Path, config: &ConfigSet) -> String {
+    let Ok(head_raw) = fs::read_to_string(git_dir.join("HEAD")) else {
+        return "origin".to_owned();
+    };
+    let head = head_raw.trim();
+    let Some(rest) = head.strip_prefix("ref: ") else {
+        return "origin".to_owned();
+    };
+    let target = rest.trim();
+    let Some(branch) = target.strip_prefix("refs/heads/") else {
+        return "origin".to_owned();
+    };
+    let remote_key = format!("branch.{branch}.remote");
+    let Some(remote) = config.get(&remote_key) else {
+        return "origin".to_owned();
+    };
+    let remote = remote.trim();
+    if remote.is_empty() {
+        return "origin".to_owned();
+    }
+    let url_key = format!("remote.{remote}.url");
+    if config.get(&url_key).is_some() {
+        remote.to_owned()
+    } else {
+        "origin".to_owned()
+    }
 }
 
 fn should_recurse_fetch_submodules(config: &ConfigSet, args: &Args) -> bool {
@@ -673,7 +778,8 @@ fn fetch_remote(
         }
 
         // Standard path: update remote-tracking refs from remote heads
-        for (refname, remote_oid) in &remote_heads {
+        let has_merge_cfg = branch_has_merge_config_for_remote(git_dir, config, remote_name);
+        for (idx, (refname, remote_oid)) in remote_heads.iter().enumerate() {
             // refname is like "refs/heads/main"
             let branch = refname.strip_prefix("refs/heads/").unwrap_or(refname);
 
@@ -688,9 +794,15 @@ fn fetch_remote(
             };
             updated_refs.push(local_ref.clone());
 
-            // Build FETCH_HEAD entry
-            let is_default = remote_head_branch.as_deref() == Some(branch);
-            let not_for_merge = if is_default { "" } else { "\tnot-for-merge" };
+            // Build FETCH_HEAD entry (Git `get_ref_map` / `add_merge_config` semantics)
+            let is_merge = if has_merge_cfg {
+                fetch_head_is_for_merge_with_branch(git_dir, config, remote_name, refname)
+            } else if refspecs.is_empty() {
+                idx == 0
+            } else {
+                fetch_head_is_for_merge_first_refspec_only(&refspecs, idx == 0)
+            };
+            let not_for_merge = if is_merge { "" } else { "\tnot-for-merge" };
             fetch_head_entries.push(format!(
                 "{}{not_for_merge}\tbranch '{branch}' of {url}",
                 remote_oid,
@@ -814,22 +926,45 @@ fn fetch_remote(
         prune_stale_refs(git_dir, &dst_prefix, &updated_refs, remote_name, args.quiet)?;
     }
 
-    // Update refs/remotes/<remote>/HEAD to mirror the remote's default branch.
-    // We store it as a direct ref to keep completion and ref lookups aligned.
-    if let Some(default_branch) = remote_head_branch.as_deref() {
-        let head_source = format!("refs/heads/{default_branch}");
-        let mapped_default = if refspecs.is_empty() {
-            Some(format!("{dst_prefix}{default_branch}"))
-        } else {
-            map_ref_through_refspecs(&head_source, &refspecs)
-        };
-        if let Some(mapped_default_ref) = mapped_default {
-            if let Ok(default_oid) = refs::resolve_ref(git_dir, &mapped_default_ref) {
-                let remote_head_ref = format!("refs/remotes/{remote_name}/HEAD");
-                updated_refs.push(remote_head_ref.clone());
-                if read_ref_oid(git_dir, &remote_head_ref).as_ref() != Some(&default_oid) {
-                    refs::write_ref(git_dir, &remote_head_ref, &default_oid)
-                        .with_context(|| format!("updating ref {remote_head_ref}"))?;
+    // Update `refs/remotes/<remote>/HEAD` to match the remote's default branch (Git `set_head`).
+    let follow = parse_follow_remote_head(config, remote_name);
+    let do_set_head =
+        cli_refspecs.is_empty() && !refspecs.is_empty() && follow.mode != FollowRemoteHead::Never;
+    if do_set_head {
+        if follow.mode != FollowRemoteHead::Never {
+            trace_ls_refs_head_prefix();
+        }
+        if let Some(default_branch) = remote_head_branch.as_deref() {
+            let head_source = format!("refs/heads/{default_branch}");
+            let mapped_default = if refspecs.is_empty() {
+                Some(format!("{dst_prefix}{default_branch}"))
+            } else {
+                map_ref_through_refspecs(&head_source, &refspecs)
+            };
+            if let Some(mapped_default_ref) = mapped_default {
+                if refs::resolve_ref(git_dir, &mapped_default_ref).is_ok() {
+                    let remote_head_ref = format!("refs/remotes/{remote_name}/HEAD");
+                    let previous = read_remote_head_previous(git_dir, remote_name);
+                    let head_missing = matches!(previous, RemoteHeadPrevious::Missing);
+                    // Git: `create_only` is true unless `followRemoteHEAD` is `always`, so
+                    // `create`/`warn` only create `refs/remotes/<r>/HEAD` when missing (no overwrite).
+                    let should_write = match follow.mode {
+                        FollowRemoteHead::Never => false,
+                        FollowRemoteHead::Create | FollowRemoteHead::Warn => head_missing,
+                        FollowRemoteHead::Always => true,
+                    };
+                    if should_write {
+                        refs::write_symbolic_ref(git_dir, &remote_head_ref, &mapped_default_ref)
+                            .with_context(|| format!("updating symbolic ref {remote_head_ref}"))?;
+                        updated_refs.push(remote_head_ref);
+                    }
+                    maybe_warn_follow_remote_head(
+                        &follow,
+                        remote_name,
+                        default_branch,
+                        previous,
+                        args.quiet,
+                    );
                 }
             }
         }
@@ -1494,6 +1629,145 @@ fn write_shallow_info(
     let content = entries.join("\n") + "\n";
     fs::write(&shallow_path, content).context("writing shallow file")?;
     Ok(())
+}
+
+/// `remote.<name>.followRemoteHEAD` (subset matching Git's `remote.h`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FollowRemoteHead {
+    Never,
+    Create,
+    Warn,
+    Always,
+}
+
+/// Parsed `remote.<name>.followRemoteHEAD` plus optional `warn-if-not-<branch>` suffix.
+struct FollowRemoteHeadConfig {
+    mode: FollowRemoteHead,
+    /// When `mode == Warn` and this is `Some`, suppress the warning if the remote HEAD branch
+    /// equals this name (Git's `warn-if-not-<branch>`).
+    no_warn_branch: Option<String>,
+}
+
+fn parse_follow_remote_head(config: &ConfigSet, remote_name: &str) -> FollowRemoteHeadConfig {
+    let key = format!("remote.{remote_name}.followRemoteHEAD");
+    let key_alt = format!("remote.{remote_name}.followremotehead");
+    let raw = config
+        .get(&key)
+        .or_else(|| config.get(&key_alt))
+        .map(|s| s.trim().to_string())
+        .unwrap_or_default();
+    if raw.is_empty() {
+        return FollowRemoteHeadConfig {
+            mode: FollowRemoteHead::Create,
+            no_warn_branch: None,
+        };
+    }
+    let lower = raw.to_ascii_lowercase();
+    if lower == "never" {
+        return FollowRemoteHeadConfig {
+            mode: FollowRemoteHead::Never,
+            no_warn_branch: None,
+        };
+    }
+    if lower == "create" {
+        return FollowRemoteHeadConfig {
+            mode: FollowRemoteHead::Create,
+            no_warn_branch: None,
+        };
+    }
+    if lower == "warn" {
+        return FollowRemoteHeadConfig {
+            mode: FollowRemoteHead::Warn,
+            no_warn_branch: None,
+        };
+    }
+    if lower == "always" {
+        return FollowRemoteHeadConfig {
+            mode: FollowRemoteHead::Always,
+            no_warn_branch: None,
+        };
+    }
+    let prefix = "warn-if-not-";
+    if lower.starts_with(prefix) {
+        let branch = raw[prefix.len()..].to_string();
+        return FollowRemoteHeadConfig {
+            mode: FollowRemoteHead::Warn,
+            no_warn_branch: if branch.is_empty() {
+                None
+            } else {
+                Some(branch)
+            },
+        };
+    }
+    FollowRemoteHeadConfig {
+        mode: FollowRemoteHead::Create,
+        no_warn_branch: None,
+    }
+}
+
+fn trace_ls_refs_head_prefix() {
+    crate::trace_packet::trace_packet_line(b"fetch> ref-prefix HEAD");
+}
+
+/// Previous `refs/remotes/<remote>/HEAD` state for `followRemoteHEAD` warnings.
+enum RemoteHeadPrevious {
+    Symref(String),
+    DetachedOid(ObjectId),
+    Missing,
+}
+
+fn read_remote_head_previous(git_dir: &Path, remote_name: &str) -> RemoteHeadPrevious {
+    let head_ref = format!("refs/remotes/{remote_name}/HEAD");
+    let sym = match refs::read_symbolic_ref(git_dir, &head_ref) {
+        Ok(s) => s,
+        Err(_) => None,
+    };
+    if let Some(target) = sym {
+        let prefix = format!("refs/remotes/{remote_name}/");
+        let short = target
+            .strip_prefix(&prefix)
+            .map(|s| s.to_string())
+            .unwrap_or(target);
+        return RemoteHeadPrevious::Symref(short);
+    }
+    match read_ref_oid(git_dir, &head_ref) {
+        Some(oid) => RemoteHeadPrevious::DetachedOid(oid),
+        None => RemoteHeadPrevious::Missing,
+    }
+}
+
+fn maybe_warn_follow_remote_head(
+    follow: &FollowRemoteHeadConfig,
+    remote_name: &str,
+    remote_default_branch: &str,
+    previous: RemoteHeadPrevious,
+    quiet: bool,
+) {
+    if quiet || follow.mode != FollowRemoteHead::Warn {
+        return;
+    }
+    if let Some(ref skip) = follow.no_warn_branch {
+        if skip == remote_default_branch {
+            return;
+        }
+    }
+    let mut stdout = std::io::stdout();
+    match previous {
+        RemoteHeadPrevious::Symref(prev_short) if prev_short != remote_default_branch => {
+            let _ = writeln!(
+                stdout,
+                "'HEAD' at '{remote_name}' is '{remote_default_branch}', but we have '{prev_short}' locally."
+            );
+        }
+        RemoteHeadPrevious::DetachedOid(oid) => {
+            let _ = writeln!(
+                stdout,
+                "'HEAD' at '{remote_name}' is '{remote_default_branch}', but we have a detached HEAD pointing to '{}' locally.",
+                oid.to_hex()
+            );
+        }
+        _ => {}
+    }
 }
 
 /// A parsed refspec (e.g. "+refs/heads/*:refs/remotes/origin/*").

--- a/grit/src/commands/remote.rs
+++ b/grit/src/commands/remote.rs
@@ -6,6 +6,7 @@
 use anyhow::{bail, Context, Result};
 use clap::{Args as ClapArgs, Subcommand};
 use grit_lib::config::{ConfigFile, ConfigScope, ConfigSet};
+use grit_lib::refs;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
@@ -43,6 +44,9 @@ pub enum RemoteSubcommand {
     /// Configure the set of tracked branches for a remote.
     #[command(name = "set-branches")]
     SetBranches(SetBranchesArgs),
+    /// Set or delete the default branch the remote's `HEAD` points at (`refs/remotes/<name>/HEAD`).
+    #[command(name = "set-head")]
+    SetHead(SetHeadArgs),
     /// Remove stale remote-tracking branches.
     Prune(PruneArgs),
     /// Fetch updates from remote(s).
@@ -115,6 +119,15 @@ pub struct SetBranchesArgs {
     pub branches: Vec<String>,
 }
 
+/// Arguments for `grit remote set-head <remote> <branch>`.
+#[derive(Debug, ClapArgs)]
+pub struct SetHeadArgs {
+    /// Name of the remote.
+    pub remote: String,
+    /// Branch name on the remote (e.g. `main`); becomes a symref to `refs/remotes/<remote>/<branch>`.
+    pub branch: String,
+}
+
 /// Arguments for `grit remote prune`.
 #[derive(Debug, ClapArgs)]
 pub struct PruneArgs {
@@ -142,6 +155,7 @@ pub fn run(args: Args) -> Result<()> {
         Some(RemoteSubcommand::SetUrl(set_url_args)) => cmd_set_url(set_url_args),
         Some(RemoteSubcommand::Show(show_args)) => cmd_show(show_args),
         Some(RemoteSubcommand::SetBranches(sb_args)) => cmd_set_branches(sb_args),
+        Some(RemoteSubcommand::SetHead(sh_args)) => cmd_set_head(sh_args),
         Some(RemoteSubcommand::Prune(prune_args)) => cmd_prune(prune_args),
         Some(RemoteSubcommand::Update(update_args)) => cmd_update(update_args),
         None => cmd_list(args.verbose),
@@ -436,6 +450,30 @@ fn cmd_set_branches(args: SetBranchesArgs) -> Result<()> {
     }
 
     config_file.write().context("writing config")?;
+    Ok(())
+}
+
+fn cmd_set_head(args: SetHeadArgs) -> Result<()> {
+    let git_dir = resolve_git_dir()?;
+    let config = load_local_config(&git_dir)?;
+    let remotes = collect_remotes(&config);
+    if !remotes.contains_key(&args.remote) {
+        bail!("No such remote '{}'", args.remote);
+    }
+
+    let branch = args.branch.trim();
+    let short = branch.strip_prefix("refs/heads/").unwrap_or(branch).trim();
+    if short.is_empty() {
+        bail!("branch name required");
+    }
+    let target = format!("refs/remotes/{}/{}", args.remote, short);
+    refs::resolve_ref(&git_dir, &target)
+        .with_context(|| format!("unknown remote ref '{}'", target))?;
+
+    let head_ref = format!("refs/remotes/{}/HEAD", args.remote);
+    refs::write_symbolic_ref(&git_dir, &head_ref, &target)
+        .with_context(|| format!("could not update {}", head_ref))?;
+    println!("{head_ref} -> {target}");
     Ok(())
 }
 

--- a/logs/2026-04-08_t5510-fetch-progress.md
+++ b/logs/2026-04-08_t5510-fetch-progress.md
@@ -1,0 +1,19 @@
+# t5510-fetch progress (2026-04-08)
+
+## Changes
+
+- **Clone `--ref-format`**: `grit clone` accepts `--ref-format=files|reftable`; init path writes `extensions.refStorage` and empty reftable stack when needed.
+- **Reftable clone**: ref copy / checkout paths use `refs::` + symref writes instead of only loose files under `refs/`.
+- **Fetch default remote**: bare `git fetch` uses `branch.<HEAD>.remote` when set (matches Git).
+- **FETCH_HEAD merge flags**: align with Git `get_ref_map` / `add_merge_config` (merge when `branch.*.merge` matches remote ref; else first ref only for default `+refs/heads/*` refspec).
+- **`remote.<name>.followRemoteHEAD`**: symbolic `refs/remotes/<name>/HEAD`, create/warn/always/never + warnings; trace line for `ref-prefix HEAD` when applicable.
+- **`git remote set-head <remote> <branch>`**: sets symref for tests.
+- **tests/lib-bundle.sh**: removed accidental merge conflict markers.
+
+## Harness
+
+- `./scripts/run-tests.sh t5510-fetch.sh`: **93 pass / 122 fail / 10 skip** (215 total) at time of commit — improved from 81 pass.
+
+## Notes
+
+Full suite still needs bundle, `--atomic`, `--refmap`, HTTP negotiation, etc.

--- a/tests/lib-bundle.sh
+++ b/tests/lib-bundle.sh
@@ -11,11 +11,8 @@ convert_bundle_to_pack () {
 }
 
 # Check count of objects in a bundle file.
-<<<<<<< HEAD
 # We can use "--thin" option to check thin pack, which must be fixed by
 # command `git-index-pack --fix-thin --stdin`.
-=======
->>>>>>> test/batch-GE
 test_bundle_object_count () {
 	thin=
 	if test "$1" = "--thin"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This branch improves compatibility with upstream `t5510-fetch.sh` by fixing several Git semantics gaps in clone/fetch and repairing a corrupted test helper.

## Changes

- **`git clone --ref-format`**: Support `files` and `reftable`; extend `grit-lib` init helpers with a ref-storage parameter and write `extensions.refStorage` / reftable skeleton when needed.
- **Reftable-aware clone**: Ref updates and checkout paths use the refs/reftable APIs instead of assuming loose files under `refs/`.
- **`git fetch` default remote**: When no remote is given, use `branch.<current>.remote` when it points at a configured remote (matches Git).
- **`FETCH_HEAD` merge lines**: Match Git `get_ref_map` / `add_merge_config` behavior (merge when `branch.*.merge` matches the remote ref; otherwise only the first fetched head for the default glob refspec).
- **`remote.<name>.followRemoteHEAD`**: Implement `never` / `create` / `warn` / `warn-if-not-<branch>` / `always` for updating `refs/remotes/<name>/HEAD` as a symbolic ref, with warning messages and a `GIT_TRACE_PACKET` line when HEAD is consulted.
- **`git remote set-head <remote> <branch>`**: Minimal implementation required by t5510.
- **`tests/lib-bundle.sh`**: Remove accidental merge conflict markers that broke sourcing the library.

## Test status

`./scripts/run-tests.sh t5510-fetch.sh`: **93 pass / 122 fail / 10 skip** (was 81 pass). Full pass still requires bundle, `--atomic`, `--refmap`, HTTP v2 negotiation, and more.

## Validation

- `cargo check -p grit-rs -p grit-lib`
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71fa79b6-b381-4cc6-9be1-bca51ffd194a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71fa79b6-b381-4cc6-9be1-bca51ffd194a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

