### PR TITLE
fix: t5314 pack cycle detection (delta cycles + pack-objects stderr)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -549,7 +549,7 @@ commit → check it off → move on.
 - [ ] `t5330-no-lazy-fetch-with-commit-graph` ███████████████░░░░░ 3/4 (1 left) — test for no lazy fetch with the commit-graph
 - [ ] `t5522-pull-symlink` ███████████████░░░░░ 3/4 (1 left) — pulling from symlinked subdir
 - [ ] `t5406-remote-rejects` █████████████░░░░░░░ 2/3 (1 left) — remote push rejects are reported by client
-- [ ] `t5314-pack-cycle-detection` ██████████░░░░░░░░░░ 1/2 (1 left) — test handling of inter-pack delta cycles during repack
+- [x] `t5314-pack-cycle-detection` — test handling of inter-pack delta cycles during repack
 
 - [ ] `t5581-http-curl-verbose` ██████████░░░░░░░░░░ 1/2 (1 left) — test GIT_CURL_VERBOSE
 - [ ] `t5554-noop-fetch-negotiator` ░░░░░░░░░░░░░░░░░░░░ 0/1 (1 left) — test noop fetch negotiator

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -92,7 +92,7 @@ t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
 t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
-t1006-cat-file	t1	yes	290	285	5	false	ok	1
+t1006-cat-file	t1	yes	290	285	5	false	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	32	8	false	ok	0
 t10070-cat-file-batch-format	t1	yes	33	33	0	true	ok	0
@@ -880,7 +880,7 @@ t5310-pack-bitmaps	t5	yes	236	23	213	false	ok	0
 t5311-pack-bitmaps-shallow	t5	yes	6	6	0	true	ok	0
 t5312-prune-corruption	t5	yes	11	5	6	false	ok	0
 t5313-pack-bounds-checks	t5	yes	9	2	7	false	ok	0
-t5314-pack-cycle-detection	t5	yes	2	1	1	false	ok	0
+t5314-pack-cycle-detection	t5	yes	2	2	0	true	ok	0
 t5315-pack-objects-compression	t5	yes	9	5	4	false	ok	0
 t5316-pack-delta-depth	t5	yes	5	3	2	false	ok	0
 t5317-pack-objects-filter-objects	t5	yes	33	9	24	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T00:27:26+00:00" class="gen-time" title="2026-04-09 00:27 UTC">2026-04-09 00:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,565</div>
+      <div class="summary-big-val">29,574</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>713 files fully passing</span>
+    <span>717 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,7 +212,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">41/141 files · 2 skipped · 3,333/4,611 tests</span>
+        <span class="group-meta">42/141 files · 2 skipped · 3,334/4,611 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.3%"></div></div>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,336/3,949 tests</span>
+        <span class="group-meta">32/167 files · 17 skipped · 1,343/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.8%"></div></div>
-        <span class="group-pct pct-red">33.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.0%"></div></div>
+        <span class="group-pct pct-red">34.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -256,7 +256,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">42/126 files · 11 skipped · 1,793/2,944 tests</span>
+        <span class="group-meta">43/126 files · 11 skipped · 1,794/2,944 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T00:27:26+00:00" class="gen-time" title="2026-04-09 00:27 UTC">2026-04-09 00:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,864</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,565</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,574</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1085,7 +1085,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">285</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.3%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t10060-hash-object-determinism</td>
@@ -5110,8 +5110,7 @@ tr.row-skip td { opacity: 0.65; }
 <tr class="" data-group="t2" data-tests="15" data-passed="5">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td><span class="badge ok">full pass</span></td>
-  <td class="right">15</td>
+  <td></td>
   <td class="right">15</td>
   <td class="right">5</td>
   <td class="right">ok</td>
@@ -6218,14 +6217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="54" data-passed="38">
+<tr class="" data-group="t3" data-tests="52" data-passed="3">
   <td class="mono">t3420-rebase-autostash</td>
   <td>t3</td>
   <td></td>
-  <td class="right">54</td>
-  <td class="right">38</td>
+  <td class="right">52</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="63" data-passed="11">
@@ -8958,14 +8957,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:22.2%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="2" data-passed="1">
+<tr class="" data-group="t5" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t5314-pack-cycle-detection</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">2</td>
-  <td class="right">1</td>
+  <td class="right">2</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="9" data-passed="5">
@@ -12598,7 +12597,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="2" data-passed="2">
+<tr class="" data-group="t7" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t7524-commit-summary</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>

--- a/grit/src/commands/pack_objects.rs
+++ b/grit/src/commands/pack_objects.rs
@@ -10,7 +10,7 @@ use flate2::Compression;
 use grit_lib::config::ConfigSet;
 use sha1::{Digest, Sha1};
 use std::collections::{BTreeSet, HashSet};
-use std::io::{self, BufRead, Write};
+use std::io::{self, BufRead, IsTerminal, Write};
 
 use grit_lib::delta_encode::{encode_lcp_delta, encode_prefix_extension_delta};
 use grit_lib::objects::{parse_tree, ObjectId, ObjectKind};
@@ -230,7 +230,7 @@ pub fn run(args: Args) -> Result<()> {
     let pack_list = collect_oids(&repo, &args)?;
 
     if pack_list.oids.is_empty() {
-        if !args.stdout {
+        if !args.stdout && !args.quiet && io::stderr().is_terminal() {
             eprintln!("Total 0 (delta 0), reused 0 (delta 0)");
         }
         return Ok(());
@@ -331,12 +331,14 @@ pub fn run(args: Args) -> Result<()> {
         std::fs::write(&idx_path, &idx_bytes)?;
 
         println!("{pack_hash}");
-        eprintln!(
-            "Total {} (delta {}), reused 0 (delta {})",
-            write_entries.len(),
-            new_deltas + reused_deltas,
-            reused_deltas
-        );
+        if !args.quiet && io::stderr().is_terminal() {
+            eprintln!(
+                "Total {} (delta {}), reused 0 (delta {})",
+                write_entries.len(),
+                new_deltas + reused_deltas,
+                reused_deltas
+            );
+        }
     }
 
     Ok(())
@@ -931,6 +933,8 @@ fn optimize_blob_deltas(
         }
     }
 
+    break_reused_delta_cycles(&mut delta_target_to_base);
+
     if let Some(limit) = max_delta_depth.filter(|&d| d > 0) {
         apply_delta_depth_limit(&mut delta_target_to_base, limit);
     }
@@ -1008,6 +1012,54 @@ fn optimize_blob_deltas(
     }
 
     Ok((out, new_deltas, reused_deltas))
+}
+
+/// Drop reused delta edges that form cycles (Git `break_delta_chains` first pass).
+///
+/// Inter-pack reuse can yield `A → B` from one pack and `B → A` from another (`t5314-pack-cycle-detection`).
+/// Without breaking one edge, the new pack would contain an unresolvable delta cycle.
+fn break_reused_delta_cycles(map: &mut HashMap<ObjectId, ObjectId>) {
+    // White / gray / black DFS on a functional graph (at most one outgoing edge per OID).
+    let mut color: HashMap<ObjectId, u8> = HashMap::new();
+
+    let mut nodes: Vec<ObjectId> = map
+        .keys()
+        .chain(map.values())
+        .copied()
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+    nodes.sort_unstable();
+
+    fn dfs_break(
+        u: ObjectId,
+        map: &mut HashMap<ObjectId, ObjectId>,
+        color: &mut HashMap<ObjectId, u8>,
+    ) {
+        match color.get(&u).copied().unwrap_or(0) {
+            2 => return, // black
+            1 => return, // gray: not expected on entry
+            _ => {}
+        }
+        color.insert(u, 1); // gray
+        if let Some(&v) = map.get(&u) {
+            match color.get(&v).copied().unwrap_or(0) {
+                0 => dfs_break(v, map, color),
+                1 => {
+                    map.remove(&u);
+                }
+                2 => {}
+                _ => {}
+            }
+        }
+        color.insert(u, 2);
+    }
+
+    for start in nodes {
+        if color.get(&start).copied().unwrap_or(0) == 0 {
+            dfs_break(start, map, &mut color);
+        }
+    }
 }
 
 /// Break delta chains that exceed `max_depth` (Git `break_delta_chains` modulo rule).

--- a/logs/2026-04-09_t5314-pack-cycle-detection.md
+++ b/logs/2026-04-09_t5314-pack-cycle-detection.md
@@ -1,0 +1,21 @@
+# t5314-pack-cycle-detection
+
+## Problem
+
+`t5314-pack-cycle-detection.sh` failed on `git repack -ad 2>stderr` + `test_must_be_empty stderr`.
+
+Two causes:
+
+1. **Inter-pack delta cycles** — `optimize_blob_deltas` merged `packed_delta_base_oid` hints from multiple packs, producing `A→B` and `B→A`. The new pack then contained an unresolvable cycle. Git fixes this in `break_delta_chains()` (first DFS pass: drop the edge when the base is already ACTIVE).
+
+2. **Stderr noise** — Grit always printed `Total N (delta …)` to stderr. Git only prints that summary when `progress` is on (effectively `isatty(2)`), so repack with stderr redirected stays silent.
+
+## Fix
+
+- `grit/src/commands/pack_objects.rs`: `break_reused_delta_cycles()` on the blob delta map before depth limiting; gate `eprintln!` on `!args.quiet && std::io::stderr().is_terminal()` (and `IsTerminal` import).
+
+## Verification
+
+- `cargo build --release -p grit-rs`
+- `cd tests && GUST_BIN=... sh t5314-pack-cycle-detection.sh` — 2/2 pass
+- `./scripts/run-tests.sh t5314-pack-cycle-detection.sh` — updates CSV/dashboards

--- a/progress.md
+++ b/progress.md
@@ -1,20 +1,21 @@
 # Progress — Grit Test Coverage
 
-**Updated:** 2026-04-08
+**Updated:** 2026-04-09
 
 ## Counts (derived from plan.md)
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   231 |
-| In progress |     2 |
-| Remaining   |   535 |
+| Completed   |   247 |
+| In progress |     4 |
+| Remaining   |   517 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 231 completed (`[x]`), 2 in progress (`[~]`), 535 remaining (`[ ]`).
+Task lines in `PLAN.md`: 247 completed (`[x]`), 4 in progress (`[~]`), 517 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t5314-pack-cycle-detection` — 2/2 tests pass (`pack-objects`: break inter-pack reused delta cycles like Git `break_delta_chains`; emit `Total …` summary on stderr only when it is a TTY or `-q`, matching Git progress behavior for `repack` stderr checks)
 - `t12820-diff-no-index-symlink` — 41/41 tests pass (symlink add/modify/delete, `diff`/`diff --cached`/`diff-tree`, stat/numstat/name output, multi-symlink and file↔symlink replacements; harness dashboards refreshed)
 - `t7817-grep-sparse-checkout` — 8/8 tests pass (non-cone sparse: `path_in_sparse_checkout` parent walk + last-match-wins; `sparse-checkout init` preserves cone mode and seeds `/*` + `!/*/` when recreating file; `disable` keeps pattern file so re-init reapplies `!b`; submodule `reset --hard` + sparse reapply; `grep` worktree: skip-worktree when absent, CE_VALID vs skip-worktree, unmerged paths grep worktree once; `grep_cached` per-stage for `--cached`)
 - `t7417-submodule-path-url` — 5/5 tests pass (`.gitmodules` dash paths: `mv` updates path + index blob; `escape_value` quotes leading `-`; receive-side `transfer.fsckObjects` via repo-local config only; clone `--recurse-submodules` resolves relative URLs from `origin` repo root + quoted path parsing + `GIT_QUIET` quiet mode)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes `t5314-pack-cycle-detection.sh` pass (2/2).

### pack-objects

1. **Inter-pack delta cycles** — When reusing `REF_DELTA` bases from multiple packs, the merged delta map could contain `A→B` and `B→A`. Added `break_reused_delta_cycles()` (DFS: drop the edge when the base is already on the recursion stack), aligned with Git’s `break_delta_chains` first pass.

2. **Stderr** — The `Total … (delta …)` line is now printed only when stderr is a TTY and `-q` is not set, matching Git’s progress gating so `git repack -ad 2>stderr` stays empty for the test.

### Tracking

- `PLAN.md`: mark `t5314-pack-cycle-detection` complete
- `progress.md`: refreshed counts
- `logs/2026-04-09_t5314-pack-cycle-detection.md`
- Harness CSV + dashboards after `./scripts/run-tests.sh t5314-pack-cycle-detection.sh`

## Verification

- `cargo build --release -p grit-rs`
- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t5314-pack-cycle-detection.sh` → 2/2
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ccd8071-f2d5-4671-8a89-311ae2fcbcdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ccd8071-f2d5-4671-8a89-311ae2fcbcdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

