### PR TITLE
fix: make t2101-update-index-reupdate pass (update-index --again)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -92,7 +92,7 @@ t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
 t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
-t1006-cat-file	t1	yes	290	285	5	false	ok	1
+t1006-cat-file	t1	yes	290	285	5	false	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	32	8	false	ok	0
 t10070-cat-file-batch-format	t1	yes	33	33	0	true	ok	0
@@ -503,7 +503,7 @@ t2080-parallel-checkout-basics	t2	yes	11	5	6	false	ok	0
 t2081-parallel-checkout-collisions	t2	yes	6	6	0	true	ok	0
 t2082-parallel-checkout-attributes	t2	yes	5	0	5	false	ok	0
 t2100-update-cache-badpath	t2	yes	5	5	0	true	ok	0
-t2101-update-index-reupdate	t2	yes	7	4	3	false	ok	0
+t2101-update-index-reupdate	t2	yes	7	7	0	true	ok	0
 t2102-update-index-symlinks	t2	yes	3	3	0	true	ok	0
 t2103-update-index-ignore-missing	t2	yes	5	3	2	false	ok	0
 t2104-update-index-skip-worktree	t2	yes	7	7	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T00:43:15+00:00" class="gen-time" title="2026-04-09 00:43 UTC">2026-04-09 00:43 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,565</div>
+      <div class="summary-big-val">29,576</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>713 files fully passing</span>
+    <span>717 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -201,18 +201,18 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t2</span>
         <span class="group-desc">Basic commands concerning the working tree</span>
-        <span class="group-meta">29/61 files · 9 skipped · 633/872 tests</span>
+        <span class="group-meta">30/61 files · 9 skipped · 636/872 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.6%"></div></div>
-        <span class="group-pct pct-blue">72.6%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.9%"></div></div>
+        <span class="group-pct pct-blue">72.9%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t3">
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">41/141 files · 2 skipped · 3,333/4,611 tests</span>
+        <span class="group-meta">42/141 files · 2 skipped · 3,334/4,611 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.3%"></div></div>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,336/3,949 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,342/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.8%"></div></div>
-        <span class="group-pct pct-red">33.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.0%"></div></div>
+        <span class="group-pct pct-red">34.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -256,7 +256,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">42/126 files · 11 skipped · 1,793/2,944 tests</span>
+        <span class="group-meta">43/126 files · 11 skipped · 1,794/2,944 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T00:43:15+00:00" class="gen-time" title="2026-04-09 00:43 UTC">2026-04-09 00:43 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,864</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,565</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,576</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1085,7 +1085,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">285</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.3%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t10060-hash-object-determinism</td>
@@ -5110,8 +5110,7 @@ tr.row-skip td { opacity: 0.65; }
 <tr class="" data-group="t2" data-tests="15" data-passed="5">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td><span class="badge ok">full pass</span></td>
-  <td class="right">15</td>
+  <td></td>
   <td class="right">15</td>
   <td class="right">5</td>
   <td class="right">ok</td>
@@ -5188,14 +5187,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t2" data-tests="7" data-passed="4">
+<tr class="" data-group="t2" data-tests="7" data-passed="7" data-full-pass="1">
   <td class="mono">t2101-update-index-reupdate</td>
   <td>t2</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">7</td>
-  <td class="right">4</td>
+  <td class="right">7</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:57.1%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t2" data-tests="3" data-passed="3" data-full-pass="1">
@@ -6218,14 +6217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="54" data-passed="38">
+<tr class="" data-group="t3" data-tests="52" data-passed="3">
   <td class="mono">t3420-rebase-autostash</td>
   <td>t3</td>
   <td></td>
-  <td class="right">54</td>
-  <td class="right">38</td>
+  <td class="right">52</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="63" data-passed="11">
@@ -12598,7 +12597,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="2" data-passed="2">
+<tr class="" data-group="t7" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t7524-commit-summary</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>

--- a/grit/src/commands/update_index.rs
+++ b/grit/src/commands/update_index.rs
@@ -12,9 +12,11 @@ use grit_lib::config::ConfigSet;
 use grit_lib::crlf;
 use grit_lib::diff::read_submodule_head_oid;
 use grit_lib::index::{entry_from_stat, normalize_mode, Index, IndexEntry};
-use grit_lib::objects::ObjectId;
+use grit_lib::objects::{parse_commit, parse_tree, ObjectId, ObjectKind};
 use grit_lib::odb::Odb;
+use grit_lib::pathspec::matches_pathspec_for_object;
 use grit_lib::repo::Repository;
+use grit_lib::state::resolve_head;
 
 /// Arguments for `grit update-index`.
 #[derive(Debug, ClapArgs)]
@@ -434,6 +436,25 @@ pub fn run(args: Args, raw_rest: &[String]) -> Result<()> {
         args.files.clone()
     };
 
+    if args.again {
+        if args.null_terminated {
+            bail!("git update-index: --again with -z stdin is not supported");
+        }
+        return run_update_index_again(
+            &repo,
+            work_tree,
+            &cwd,
+            &mut index,
+            &index_path,
+            &args,
+            &paths,
+            symlinks_enabled,
+            &config,
+            &conv,
+            &attrs,
+        );
+    }
+
     let path_modes: Vec<PathMode> = if args.null_terminated {
         vec![global_path_mode(&args); paths.len()]
     } else if args.force_remove && args.add {
@@ -721,93 +742,6 @@ pub fn run(args: Args, raw_rest: &[String]) -> Result<()> {
         }
     }
 
-    // --again: re-add all tracked files that have changed (rehash, update index)
-    if args.again {
-        let mut needs_update = false;
-        let entries_snapshot: Vec<Vec<u8>> = index
-            .entries
-            .iter()
-            .filter(|e| e.stage() == 0)
-            .map(|e| e.path.clone())
-            .collect();
-        for path_bytes in entries_snapshot {
-            let rel_path = String::from_utf8_lossy(&path_bytes).into_owned();
-            let abs_path = work_tree.join(&rel_path);
-            match std::fs::symlink_metadata(&abs_path) {
-                Ok(meta) => {
-                    use std::os::unix::fs::MetadataExt as _;
-                    // Check if the file has changed vs the index entry
-                    if let Some(entry) = index.get(&path_bytes, 0) {
-                        let idx_mtime = entry.mtime_sec as i64;
-                        let file_mtime = meta.mtime();
-                        let idx_size = entry.size as u64;
-                        let file_size = meta.size();
-                        // If mtime or size changed, rehash and update
-                        if idx_mtime != file_mtime || idx_size != file_size {
-                            match std::fs::read(&abs_path) {
-                                Ok(raw) => {
-                                    let mode = entry.mode;
-                                    let data = if mode == grit_lib::index::MODE_SYMLINK {
-                                        raw
-                                    } else {
-                                        let file_attrs =
-                                            crlf::get_file_attrs(&attrs, &rel_path, &config);
-                                        match crlf::convert_to_git(
-                                            &raw,
-                                            &rel_path,
-                                            &conv,
-                                            &file_attrs,
-                                        ) {
-                                            Ok(d) => d,
-                                            Err(e) => {
-                                                return Err(anyhow::anyhow!(e));
-                                            }
-                                        }
-                                    };
-                                    match repo.odb.write(grit_lib::objects::ObjectKind::Blob, &data)
-                                    {
-                                        Ok(new_oid) => {
-                                            let new_entry = entry_from_stat(
-                                                &abs_path,
-                                                &path_bytes,
-                                                new_oid,
-                                                mode,
-                                            )
-                                            .with_context(|| format!("stat '{}'", rel_path))?;
-                                            index.add_or_replace(new_entry);
-                                        }
-                                        Err(_) => {
-                                            eprintln!("{rel_path}: needs update");
-                                            needs_update = true;
-                                        }
-                                    }
-                                }
-                                Err(_) => {
-                                    eprintln!("{rel_path}: needs update");
-                                    needs_update = true;
-                                }
-                            }
-                        }
-                    }
-                }
-                Err(_) => {
-                    if args.remove {
-                        index.entries.retain(|e| e.path != path_bytes);
-                    } else {
-                        eprintln!("{rel_path}: needs update");
-                        needs_update = true;
-                    }
-                }
-            }
-        }
-        repo.write_index_at(&index_path, &mut index)
-            .context("writing index")?;
-        if needs_update {
-            std::process::exit(1);
-        }
-        return Ok(());
-    }
-
     if args.refresh || args.really_refresh {
         // Re-stat all entries; exit 1 if any files need updating.
         let (uptodate, _) = refresh_index(
@@ -1043,6 +977,316 @@ fn refresh_index(
         }
     }
     Ok((all_uptodate, index_modified))
+}
+
+/// CWD-relative prefix for pathspec matching (Git `PATHSPEC_PREFER_CWD` / `prefix_path`).
+fn cwd_prefix_for_pathspec_str(work_tree: &Path, cwd: &Path) -> Result<String> {
+    let rel = cwd.strip_prefix(work_tree).with_context(|| {
+        format!(
+            "current directory '{}' is outside repository work tree '{}'",
+            cwd.display(),
+            work_tree.display()
+        )
+    })?;
+    if rel.as_os_str().is_empty() {
+        return Ok(String::new());
+    }
+    let mut s = rel.to_string_lossy().into_owned().replace('\\', "/");
+    while s.ends_with('/') {
+        s.pop();
+    }
+    if s.is_empty() {
+        Ok(String::new())
+    } else {
+        Ok(format!("{s}/"))
+    }
+}
+
+fn resolve_pathspec_str_for_reupdate(
+    work_tree: &Path,
+    cwd: &Path,
+    raw: &str,
+    cwd_prefix: &str,
+) -> Result<String> {
+    if raw.starts_with(":(") {
+        if let Some(resolved) = crate::pathspec::resolve_magic_pathspec(raw, cwd_prefix) {
+            return Ok(resolved);
+        }
+    }
+    if let Some(rest) = raw.strip_prefix(":/") {
+        if rest.is_empty() || rest == "*" {
+            return Ok(String::new());
+        }
+        return Ok(rest.to_string());
+    }
+    let combined = if Path::new(raw).is_absolute() {
+        PathBuf::from(raw)
+    } else {
+        cwd.join(raw)
+    };
+    let normalized = normalize_path(&combined);
+    let rel = normalized
+        .strip_prefix(work_tree)
+        .with_context(|| format!("pathspec '{raw}' is outside repository work tree"))?;
+    Ok(rel.to_string_lossy().replace('\\', "/"))
+}
+
+fn get_tree_entry_for_path(
+    odb: &Odb,
+    tree_oid: &ObjectId,
+    path: &[u8],
+) -> Result<Option<(ObjectId, u32)>> {
+    if path.is_empty() {
+        return Ok(None);
+    }
+    let mut current_oid = *tree_oid;
+    let mut start = 0usize;
+    loop {
+        let end = path[start..]
+            .iter()
+            .position(|&b| b == b'/')
+            .map(|p| start + p)
+            .unwrap_or(path.len());
+        let name = &path[start..end];
+        if name.is_empty() {
+            return Ok(None);
+        }
+        let tree_obj = odb.read(&current_oid)?;
+        if tree_obj.kind != ObjectKind::Tree {
+            return Ok(None);
+        }
+        let entries = parse_tree(&tree_obj.data)?;
+        let mut found = None;
+        for e in entries {
+            if e.name == name {
+                found = Some((e.oid, e.mode));
+                break;
+            }
+        }
+        let Some((oid, mode)) = found else {
+            return Ok(None);
+        };
+        if end >= path.len() {
+            return Ok(Some((oid, mode)));
+        }
+        if mode != grit_lib::index::MODE_TREE {
+            return Ok(None);
+        }
+        current_oid = oid;
+        start = end + 1;
+    }
+}
+
+fn index_entry_matches_head(odb: &Odb, head_tree: &ObjectId, entry: &IndexEntry) -> Result<bool> {
+    let Some((tree_oid, tree_mode)) = get_tree_entry_for_path(odb, head_tree, &entry.path)? else {
+        return Ok(false);
+    };
+    Ok(entry.mode == tree_mode && entry.oid == tree_oid)
+}
+
+fn is_missing_lstat_error(err: &std::io::Error) -> bool {
+    matches!(
+        err.kind(),
+        std::io::ErrorKind::NotFound | std::io::ErrorKind::NotADirectory
+    )
+}
+
+/// `git update-index --again` / `-g`: refresh index entries that differ from `HEAD` (see Git's `do_reupdate`).
+fn run_update_index_again(
+    repo: &Repository,
+    work_tree: &Path,
+    cwd: &Path,
+    index: &mut Index,
+    index_path: &Path,
+    args: &Args,
+    pathspec_paths: &[PathBuf],
+    symlinks_enabled: bool,
+    config: &ConfigSet,
+    conv: &crlf::ConversionConfig,
+    attrs: &[crlf::AttrRule],
+) -> Result<()> {
+    let head_state = resolve_head(&repo.git_dir).context("resolving HEAD")?;
+    let head_tree_oid: Option<ObjectId> = match head_state.oid() {
+        Some(oid) => {
+            let obj = repo.odb.read(oid).context("reading HEAD commit")?;
+            if obj.kind != ObjectKind::Commit {
+                bail!("HEAD does not point to a commit");
+            }
+            Some(parse_commit(&obj.data)?.tree)
+        }
+        None => None,
+    };
+
+    let cwd_prefix = cwd_prefix_for_pathspec_str(work_tree, cwd)?;
+    let pathspecs: Result<Vec<String>> = pathspec_paths
+        .iter()
+        .map(|p| {
+            let s = p.to_string_lossy();
+            resolve_pathspec_str_for_reupdate(work_tree, cwd, s.as_ref(), &cwd_prefix)
+        })
+        .collect();
+    let pathspecs = pathspecs?;
+
+    let mut pos = 0usize;
+    while pos < index.entries.len() {
+        let ce = &index.entries[pos];
+        if ce.stage() != 0 {
+            pos += 1;
+            continue;
+        }
+        if !pathspecs.is_empty() {
+            let path_str = String::from_utf8_lossy(&ce.path);
+            let matched = pathspecs
+                .iter()
+                .any(|spec| matches_pathspec_for_object(spec, path_str.as_ref(), ce.mode, attrs));
+            if !matched {
+                pos += 1;
+                continue;
+            }
+        }
+
+        if let Some(tree_oid) = head_tree_oid {
+            if index_entry_matches_head(&repo.odb, &tree_oid, ce)? {
+                pos += 1;
+                continue;
+            }
+        }
+
+        if ce.mode == grit_lib::index::MODE_TREE {
+            // Sparse directory placeholder — not handled; skip like unknown.
+            pos += 1;
+            continue;
+        }
+
+        if ce.skip_worktree() {
+            if args.ignore_skip_worktree_entries && args.remove {
+                let path = ce.path.clone();
+                index.remove(&path);
+                pos = 0;
+                continue;
+            }
+            pos += 1;
+            continue;
+        }
+
+        let path_bytes = ce.path.clone();
+        let rel_path = String::from_utf8_lossy(&path_bytes).into_owned();
+        let abs_path = work_tree.join(&rel_path);
+
+        if check_symlink_in_path(work_tree, Path::new(&rel_path)).is_some() {
+            bail!("'{rel_path}' is beyond a symbolic link");
+        }
+
+        let save_nr = index.entries.len();
+        match std::fs::symlink_metadata(&abs_path) {
+            Ok(meta) if meta.is_dir() => {
+                let dot_git = abs_path.join(".git");
+                if dot_git.exists() && ce.mode == grit_lib::index::MODE_GITLINK {
+                    let sub_git_dir = resolve_gitdir(&dot_git)?;
+                    let head_path = sub_git_dir.join("HEAD");
+                    let head_content = std::fs::read_to_string(&head_path)
+                        .with_context(|| format!("reading HEAD of submodule at {rel_path}"))?;
+                    let head_content = head_content.trim();
+                    let oid: ObjectId = if let Some(refname) = head_content.strip_prefix("ref: ") {
+                        let ref_path = sub_git_dir.join(refname);
+                        let ref_content = std::fs::read_to_string(&ref_path)
+                            .with_context(|| "reading ref in submodule".to_string())?;
+                        ref_content.trim().parse().with_context(|| "invalid oid")?
+                    } else {
+                        head_content.parse().with_context(|| "invalid HEAD oid")?
+                    };
+                    let new_entry = IndexEntry {
+                        ctime_sec: 0,
+                        ctime_nsec: 0,
+                        mtime_sec: 0,
+                        mtime_nsec: 0,
+                        dev: 0,
+                        ino: 0,
+                        mode: grit_lib::index::MODE_GITLINK,
+                        uid: 0,
+                        gid: 0,
+                        size: 0,
+                        oid,
+                        flags: path_bytes.len().min(0xFFF) as u16,
+                        flags_extended: None,
+                        path: path_bytes.clone(),
+                    };
+                    index.add_or_replace(new_entry);
+                } else if args.remove {
+                    index.remove(&path_bytes);
+                    pos = 0;
+                    continue;
+                } else {
+                    bail!("{rel_path}: is a directory - add files inside instead");
+                }
+            }
+            Ok(meta) => {
+                let mut mode = {
+                    use std::os::unix::fs::MetadataExt;
+                    normalize_mode(meta.mode())
+                };
+                let existing_mode = index.get(&path_bytes, 0).map(|e| e.mode);
+                if !symlinks_enabled
+                    && !meta.file_type().is_symlink()
+                    && existing_mode == Some(grit_lib::index::MODE_SYMLINK)
+                {
+                    mode = grit_lib::index::MODE_SYMLINK;
+                }
+                let data = if meta.file_type().is_symlink() {
+                    let target = std::fs::read_link(&abs_path)?;
+                    target.to_string_lossy().into_owned().into_bytes()
+                } else {
+                    let raw = std::fs::read(&abs_path)
+                        .with_context(|| format!("cannot read '{}'", abs_path.display()))?;
+                    let file_attrs = crlf::get_file_attrs(attrs, rel_path.as_ref(), config);
+                    crlf::convert_to_git(&raw, rel_path.as_ref(), conv, &file_attrs)
+                        .map_err(|msg| anyhow::anyhow!("{msg}"))?
+                };
+                let oid = match repo.odb.write(ObjectKind::Blob, &data) {
+                    Ok(oid) => oid,
+                    Err(err) => {
+                        if is_permission_denied_error(&err) {
+                            eprintln!(
+                                "error: insufficient permission for adding an object to repository database .git/objects"
+                            );
+                            eprintln!(
+                                "error: {}: failed to insert into database",
+                                abs_path.display()
+                            );
+                            eprintln!("fatal: Unable to process path {}", abs_path.display());
+                            std::process::exit(128);
+                        }
+                        return Err(anyhow::anyhow!("writing blob: {err}"));
+                    }
+                };
+                let new_entry = entry_from_stat(&abs_path, &path_bytes, oid, mode)
+                    .with_context(|| format!("stat failed for '{}'", abs_path.display()))?;
+                index.add_or_replace(new_entry);
+            }
+            Err(e) if is_missing_lstat_error(&e) => {
+                if args.remove {
+                    index.remove(&path_bytes);
+                    pos = 0;
+                    continue;
+                } else {
+                    bail!("{rel_path}: does not exist and --remove not passed");
+                }
+            }
+            Err(e) => {
+                bail!("lstat(\"{}\"): {e}", abs_path.display());
+            }
+        }
+
+        if index.entries.len() != save_nr {
+            pos = 0;
+        } else {
+            pos += 1;
+        }
+    }
+
+    repo.write_index_at(index_path, index)
+        .context("writing index")?;
+    Ok(())
 }
 
 fn read_paths_nul() -> Result<Vec<PathBuf>> {

--- a/logs/2026-04-09_t2101-update-index-again.md
+++ b/logs/2026-04-09_t2101-update-index-again.md
@@ -1,0 +1,20 @@
+# t2101-update-index-reupdate — `update-index --again`
+
+## Problem
+
+Harness showed 4/7: failures on `--again` without `--remove`, reupdate from a subdirectory, and pathspec `dir1/`.
+
+Root cause: `--again` was implemented as “refresh when mtime/size differed from the index”, not Git’s `do_reupdate` (only touch entries that differ from **HEAD**, respect cwd prefix for pathspecs, exit 128 on missing paths without `--remove`).
+
+## Fix
+
+- Early-return when `--again`: trailing paths are **pathspecs**, not immediate update targets.
+- Resolve HEAD → commit tree; walk index stage-0 entries; skip entries whose mode+OID match HEAD tree at that path (or update all when no HEAD / unborn).
+- Apply pathspecs with cwd-relative prefix (same idea as `PATHSPEC_PREFER_CWD`).
+- Re-stat + rehash from work tree; `--remove` removes missing paths; submodule gitlinks updated when `.git` exists.
+
+## Validation
+
+- `cargo build --release -p grit-rs`
+- `./scripts/run-tests.sh t2101-update-index-reupdate.sh` → 7/7
+- `cargo test -p grit-lib --lib`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements `git update-index --again` / `-g` to match upstream `do_reupdate` instead of an mtime/size refresh heuristic.

## Behavior

- When `--again` is present, trailing arguments are **pathspecs** (cwd-relative prefix), not paths to update immediately.
- Resolves `HEAD` to a tree and only processes stage-0 index entries whose mode/OID differ from that tree at the same path (or all entries when there is no resolved commit).
- Refreshes matching entries from the work tree (blobs, symlinks, gitlinks); honors `--remove` for missing paths; errors like Git when a path is missing without `--remove`.

## Tests

- `./scripts/run-tests.sh t2101-update-index-reupdate.sh` → 7/7
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e0f6da3-199c-42cf-8a79-4c964430babf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e0f6da3-199c-42cf-8a79-4c964430babf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

