### PR TITLE
docs: t1100-commit-tree-options verified (5/5); sync t1-plan

### DIFF
--- a/logs/2026-04-09_t1100-commit-tree-options-verify.md
+++ b/logs/2026-04-09_t1100-commit-tree-options-verify.md
@@ -1,0 +1,8 @@
+# t1100-commit-tree-options — 2026-04-09
+
+Verified on branch `cursor/t1100-commit-tree-options-a3d5`:
+
+- `./scripts/run-tests.sh t1100-commit-tree-options.sh` → **5/5** tests pass.
+- No Rust changes required; `grit commit-tree` already matches upstream expectations (GIT_* identity dates, `-p`/`-m` vs tree argument ordering via clap).
+
+Note: Running the harness can rewrite unrelated CSV/dashboard rows; restored those after the run to avoid noise.

--- a/t1-plan.md
+++ b/t1-plan.md
@@ -60,7 +60,7 @@
 - [ ] t10960-hash-object-empty-binary.sh
 - [ ] t10970-cat-file-blob-tree-tag.sh
 - [ ] t10990-write-tree-clean-dirty.sh
-- [ ] t1100-commit-tree-options.sh
+- [x] t1100-commit-tree-options.sh
 - [ ] t11020-diff-no-index-subdir.sh
 - [ ] t11030-diff-cached-rename.sh
 - [ ] t11140-config-get-regexp.sh


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t1100-commit-tree-options` already passes the full harness (**5/5**). `./scripts/run-tests.sh t1100-commit-tree-options.sh` was run to confirm.

## Changes

- Mark `t1100-commit-tree-options.sh` as done in `t1-plan.md` (it was still unchecked while `PLAN.md` already had it complete).
- Add `logs/2026-04-09_t1100-commit-tree-options-verify.md` with the verification note.

No Rust changes were required; `grit commit-tree` behavior (GIT_* author/committer dates, `-p`/`-m` vs tree ordering) already matches the upstream test expectations.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-930a115d-920f-44e2-8015-990a80273078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-930a115d-920f-44e2-8015-990a80273078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

