### PR TITLE
fix: commit --pathspec-from-file (t7526)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -840,7 +840,7 @@ commit → check it off → move on.
 - [ ] `t7611-merge-abort` ██████████░░░░░░░░░░ 10/19 (9 left) — test aborting in-progress merges
 
 - [ ] `t7105-reset-patch` ██████░░░░░░░░░░░░░░ 4/13 (9 left) — git reset --patch
-- [ ] `t7526-commit-pathspec-file` ███░░░░░░░░░░░░░░░░░ 2/11 (9 left) — commit --pathspec-from-file
+- [x] `t7526-commit-pathspec-file` ████████████████████ 11/11 (0 left) — commit --pathspec-from-file
 - [ ] `t7007-show` ████████░░░░░░░░░░░░ 8/18 (10 left) — git show
 - [ ] `t7703-repack-geometric` ████████░░░░░░░░░░░░ 8/18 (10 left) — git repack --geometric works correctly
 - [ ] `t7031-verify-tag-signed-ssh` █████░░░░░░░░░░░░░░░ 4/14 (10 left) — signed tag tests

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -92,7 +92,7 @@ t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
 t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
-t1006-cat-file	t1	yes	290	285	5	false	ok	1
+t1006-cat-file	t1	yes	290	285	5	false	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	32	8	false	ok	0
 t10070-cat-file-batch-format	t1	yes	33	33	0	true	ok	0
@@ -1246,7 +1246,7 @@ t7520-ignored-hook-warning	t7	yes	5	3	2	false	ok	0
 t7521-ignored-mode	t7	yes	12	1	11	false	ok	0
 t7524-commit-summary	t7	yes	2	2	0	true	ok	0
 t7525-status-rename	t7	yes	15	10	5	false	ok	0
-t7526-commit-pathspec-file	t7	yes	11	2	9	false	ok	0
+t7526-commit-pathspec-file	t7	yes	11	11	0	true	ok	0
 t7527-builtin-fsmonitor	t7	yes	0	0	0	false	ok	0
 t7528-signed-commit-ssh	t7	skip	29	0	0	false	ok	3
 t7600-merge	t7	skip	83	0	0	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T01:01:16+00:00" class="gen-time" title="2026-04-09 01:01 UTC">2026-04-09 01:01 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,565</div>
+      <div class="summary-big-val">29,582</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>713 files fully passing</span>
+    <span>717 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,7 +212,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">41/141 files · 2 skipped · 3,333/4,611 tests</span>
+        <span class="group-meta">42/141 files · 2 skipped · 3,334/4,611 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.3%"></div></div>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,336/3,949 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,342/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.8%"></div></div>
-        <span class="group-pct pct-red">33.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.0%"></div></div>
+        <span class="group-pct pct-red">34.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -256,11 +256,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">42/126 files · 11 skipped · 1,793/2,944 tests</span>
+        <span class="group-meta">44/126 files · 11 skipped · 1,803/2,944 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>
-        <span class="group-pct pct-blue">60.9%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:61.2%"></div></div>
+        <span class="group-pct pct-blue">61.2%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T01:01:16+00:00" class="gen-time" title="2026-04-09 01:01 UTC">2026-04-09 01:01 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,864</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,565</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,582</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1085,7 +1085,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">285</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.3%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t10060-hash-object-determinism</td>
@@ -5110,8 +5110,7 @@ tr.row-skip td { opacity: 0.65; }
 <tr class="" data-group="t2" data-tests="15" data-passed="5">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td><span class="badge ok">full pass</span></td>
-  <td class="right">15</td>
+  <td></td>
   <td class="right">15</td>
   <td class="right">5</td>
   <td class="right">ok</td>
@@ -6218,14 +6217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="54" data-passed="38">
+<tr class="" data-group="t3" data-tests="52" data-passed="3">
   <td class="mono">t3420-rebase-autostash</td>
   <td>t3</td>
   <td></td>
-  <td class="right">54</td>
-  <td class="right">38</td>
+  <td class="right">52</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="63" data-passed="11">
@@ -12598,7 +12597,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="2" data-passed="2">
+<tr class="" data-group="t7" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t7524-commit-summary</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>
@@ -12618,14 +12617,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:66.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="11" data-passed="2">
+<tr class="" data-group="t7" data-tests="11" data-passed="11" data-full-pass="1">
   <td class="mono">t7526-commit-pathspec-file</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">11</td>
-  <td class="right">2</td>
+  <td class="right">11</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:18.2%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="0" data-passed="0">

--- a/grit/src/commands/commit.rs
+++ b/grit/src/commands/commit.rs
@@ -26,7 +26,7 @@ use crate::ident::{resolve_email, resolve_name, IdentRole};
 
 use std::collections::{BTreeSet, HashSet};
 use std::fs;
-use std::io::{self, Write};
+use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use time::OffsetDateTime;
@@ -183,6 +183,14 @@ pub struct Args {
     #[arg(long = "reset-author")]
     pub reset_author: bool,
 
+    /// Read pathspecs from a file (use `-` for stdin), same rules as `git add`.
+    #[arg(long = "pathspec-from-file", value_name = "FILE")]
+    pub pathspec_from_file: Option<String>,
+
+    /// NUL-separated entries for `--pathspec-from-file` (C-quoting not allowed).
+    #[arg(long = "pathspec-file-nul")]
+    pub pathspec_file_nul: bool,
+
     /// Pathspec — files to include in the commit (stages them first).
     #[arg(trailing_var_arg = true, allow_hyphen_values = false)]
     pub pathspec: Vec<String>,
@@ -214,6 +222,35 @@ pub fn run(mut args: Args) -> Result<()> {
         .is_some_and(|s| s == "-q" || s == "--quiet")
     {
         args.pathspec.pop();
+    }
+
+    if args.pathspec_file_nul && args.pathspec_from_file.is_none() {
+        bail!("fatal: the option '--pathspec-file-nul' requires '--pathspec-from-file'");
+    }
+
+    if let Some(ref psf) = args.pathspec_from_file {
+        if args.interactive || args.patch {
+            bail!(
+                "fatal: options '--pathspec-from-file' and '--interactive/--patch' cannot be used together"
+            );
+        }
+        if args.all {
+            bail!("fatal: options '--pathspec-from-file' and '-a' cannot be used together");
+        }
+        if !args.pathspec.is_empty() {
+            bail!("fatal: '--pathspec-from-file' and pathspec arguments cannot be used together");
+        }
+        let data = if psf == "-" {
+            let mut buf = Vec::new();
+            std::io::stdin()
+                .read_to_end(&mut buf)
+                .context("reading pathspecs from stdin")?;
+            buf
+        } else {
+            fs::read(psf).with_context(|| format!("cannot read pathspec file '{psf}'"))?
+        };
+        args.pathspec =
+            crate::pathspec::parse_pathspecs_from_source(&data, args.pathspec_file_nul)?;
     }
 
     // Validate conflicting options
@@ -300,6 +337,18 @@ pub fn run(mut args: Args) -> Result<()> {
         if args.file.is_some() {
             bail!("fatal: options '-F' and '--fixup' cannot be used together");
         }
+    }
+
+    let fixup_amend_style = fixup_parsed
+        .as_ref()
+        .is_some_and(|f| matches!(f.mode, FixupMode::AmendStyle { .. }));
+    if args.pathspec.is_empty()
+        && (args.include
+            || (args.only
+                && !args.allow_empty
+                && (!args.amend || (fixup_parsed.is_some() && !fixup_amend_style))))
+    {
+        bail!("fatal: No paths with --include/--only does not make sense.");
     }
 
     let repo = Repository::discover(None).context("not a git repository")?;

--- a/logs/2026-04-09_t7526-commit-pathspec-file.md
+++ b/logs/2026-04-09_t7526-commit-pathspec-file.md
@@ -1,0 +1,17 @@
+# t7526-commit-pathspec-file
+
+## Goal
+
+Make `tests/t7526-commit-pathspec-file.sh` pass against grit (commit `--pathspec-from-file`).
+
+## Changes
+
+- `grit/src/commands/commit.rs`: added `--pathspec-from-file` and `--pathspec-file-nul` (clap), read stdin (`-`) or file as raw bytes, parse via `crate::pathspec::parse_pathspecs_from_source` (same as `git add`).
+- Validations aligned with upstream `git/builtin/commit.c`: `--pathspec-file-nul` requires `--pathspec-from-file`; conflicts with `--interactive`/`--patch`, `-a`, and trailing pathspec args; fatal messages prefixed with `fatal:` for harness `test_grep`.
+- Empty pathspec with `--include` or `--only` (when Git would die in `prepare_index`): `No paths with --include/--only does not make sense.` — uses same `fixup` amend-style exception as Git (`fixup_prefix == "amend"`).
+
+## Verification
+
+- `cargo fmt`, `cargo build --release -p grit-rs`, `cargo clippy -p grit-rs -- -D warnings`
+- `cargo test -p grit-lib --lib`
+- `./scripts/run-tests.sh t7526-commit-pathspec-file.sh` → 11/11

--- a/progress.md
+++ b/progress.md
@@ -1,20 +1,21 @@
 # Progress — Grit Test Coverage
 
-**Updated:** 2026-04-08
+**Updated:** 2026-04-09
 
 ## Counts (derived from plan.md)
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   231 |
+| Completed   |   232 |
 | In progress |     2 |
-| Remaining   |   535 |
+| Remaining   |   534 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 231 completed (`[x]`), 2 in progress (`[~]`), 535 remaining (`[ ]`).
+Task lines in `PLAN.md`: 232 completed (`[x]`), 2 in progress (`[~]`), 534 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t7526-commit-pathspec-file` — 11/11 tests pass (`commit --pathspec-from-file` / `--pathspec-file-nul`: shared `parse_pathspecs_from_source`, Git-compatible option conflicts and empty `--include`/`--only` pathspec check; harness CSV/dashboards refreshed)
 - `t12820-diff-no-index-symlink` — 41/41 tests pass (symlink add/modify/delete, `diff`/`diff --cached`/`diff-tree`, stat/numstat/name output, multi-symlink and file↔symlink replacements; harness dashboards refreshed)
 - `t7817-grep-sparse-checkout` — 8/8 tests pass (non-cone sparse: `path_in_sparse_checkout` parent walk + last-match-wins; `sparse-checkout init` preserves cone mode and seeds `/*` + `!/*/` when recreating file; `disable` keeps pattern file so re-init reapplies `!b`; submodule `reset --hard` + sparse reapply; `grep` worktree: skip-worktree when absent, CE_VALID vs skip-worktree, unmerged paths grep worktree once; `grep_cached` per-stage for `--cached`)
 - `t7417-submodule-path-url` — 5/5 tests pass (`.gitmodules` dash paths: `mv` updates path + index blob; `escape_value` quotes leading `-`; receive-side `transfer.fsckObjects` via repo-local config only; clone `--recurse-submodules` resolves relative URLs from `origin` repo root + quoted path parsing + `GIT_QUIET` quiet mode)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements `git commit --pathspec-from-file` and `--pathspec-file-nul` in grit, using the same `parse_pathspecs_from_source` helper as `git add`. Adds Git-compatible validation (conflicts with `-a`, `--interactive`/`--patch`, trailing pathspecs; `--pathspec-file-nul` requires `--pathspec-from-file`) and the empty pathspec error for `--include`/`--only` when appropriate (matching upstream `prepare_index` logic for `--fixup` amend-style).

## Testing

- `./scripts/run-tests.sh t7526-commit-pathspec-file.sh` → 11/11
- `cargo build --release -p grit-rs`
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ddb807bf-a7c9-49c8-81c8-d37671618694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ddb807bf-a7c9-49c8-81c8-d37671618694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

