### PR TITLE
fix: make t7407-submodule-foreach fully pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -92,7 +92,7 @@ t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
 t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
-t1006-cat-file	t1	yes	290	285	5	false	ok	1
+t1006-cat-file	t1	yes	290	285	5	false	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	32	8	false	ok	0
 t10070-cat-file-batch-format	t1	yes	33	33	0	true	ok	0
@@ -1199,7 +1199,7 @@ t7401-submodule-summary	t7	yes	25	6	19	false	ok	0
 t7402-submodule-rebase	t7	yes	6	2	4	false	ok	0
 t7403-submodule-sync	t7	yes	18	10	8	false	ok	0
 t7406-submodule-update	t7	yes	0	0	0	false	timeout	0
-t7407-submodule-foreach	t7	yes	0	0	0	false	timeout	0
+t7407-submodule-foreach	t7	yes	23	23	0	true	ok	0
 t7408-submodule-reference	t7	yes	16	5	11	false	ok	0
 t7409-submodule-detached-work-tree	t7	yes	3	3	0	true	ok	0
 t7411-submodule-config	t7	yes	20	4	16	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T01:05:06+00:00" class="gen-time" title="2026-04-09 01:05 UTC">2026-04-09 01:05 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,11 +150,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,565</div>
+      <div class="summary-big-val">29,596</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">39,864</div>
+      <div class="summary-big-val">39,887</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>713 files fully passing</span>
+    <span>717 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,7 +212,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">41/141 files · 2 skipped · 3,333/4,611 tests</span>
+        <span class="group-meta">42/141 files · 2 skipped · 3,334/4,611 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.3%"></div></div>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,336/3,949 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,342/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.8%"></div></div>
-        <span class="group-pct pct-red">33.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.0%"></div></div>
+        <span class="group-pct pct-red">34.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -256,11 +256,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">42/126 files · 11 skipped · 1,793/2,944 tests</span>
+        <span class="group-meta">44/126 files · 11 skipped · 1,817/2,967 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>
-        <span class="group-pct pct-blue">60.9%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:61.2%"></div></div>
+        <span class="group-pct pct-blue">61.2%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T01:05:06+00:00" class="gen-time" title="2026-04-09 01:05 UTC">2026-04-09 01:05 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">39,864</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,565</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n" id="sum-tests">39,887</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,596</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1085,7 +1085,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">285</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.3%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t10060-hash-object-determinism</td>
@@ -5110,8 +5110,7 @@ tr.row-skip td { opacity: 0.65; }
 <tr class="" data-group="t2" data-tests="15" data-passed="5">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td><span class="badge ok">full pass</span></td>
-  <td class="right">15</td>
+  <td></td>
   <td class="right">15</td>
   <td class="right">5</td>
   <td class="right">ok</td>
@@ -6218,14 +6217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="54" data-passed="38">
+<tr class="" data-group="t3" data-tests="52" data-passed="3">
   <td class="mono">t3420-rebase-autostash</td>
   <td>t3</td>
   <td></td>
-  <td class="right">54</td>
-  <td class="right">38</td>
+  <td class="right">52</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="63" data-passed="11">
@@ -12148,14 +12147,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="0" data-passed="0">
+<tr class="" data-group="t7" data-tests="23" data-passed="23" data-full-pass="1">
   <td class="mono">t7407-submodule-foreach</td>
   <td>t7</td>
-  <td></td>
-  <td class="right">0</td>
-  <td class="right">0</td>
-  <td class="right">timeout</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td><span class="badge ok">full pass</span></td>
+  <td class="right">23</td>
+  <td class="right">23</td>
+  <td class="right">ok</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="16" data-passed="5">
@@ -12598,7 +12597,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="2" data-passed="2">
+<tr class="" data-group="t7" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t7524-commit-summary</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>

--- a/grit/src/commands/describe.rs
+++ b/grit/src/commands/describe.rs
@@ -129,7 +129,10 @@ pub fn run(args: Args) -> Result<()> {
         .ok_or_else(|| anyhow::anyhow!("Not a valid commit: {rev}"))?;
 
     // Build a map from commit OID → ref name for all qualifying refs.
-    let ref_map = build_ref_map(&repo, args.tags, args.all, &args.match_pattern)?;
+    // `git describe --contains` considers lightweight tags too (see submodule--helper
+    // `compute_rev_name`, which runs `describe --contains` as the third attempt).
+    let use_all_tags = args.tags || args.contains;
+    let ref_map = build_ref_map(&repo, use_all_tags, args.all, &args.match_pattern)?;
 
     // --contains mode: find the nearest tag that is a descendant of the target
     if args.contains {

--- a/grit/src/commands/pull.rs
+++ b/grit/src/commands/pull.rs
@@ -113,7 +113,8 @@ pub fn run(args: Args) -> Result<()> {
         } else {
             branch.clone()
         }
-    } else if args.remote.is_some() {
+    } else {
+        // Detached HEAD (common in submodules): use the remote's default branch (remote HEAD).
         let Some(path) = local_remote_path.as_ref() else {
             bail!("no tracking branch configured and no branch specified");
         };
@@ -123,8 +124,6 @@ pub fn run(args: Args) -> Result<()> {
             bail!("no tracking branch configured and no branch specified");
         };
         sym.strip_prefix("refs/heads/").unwrap_or(&sym).to_owned()
-    } else {
-        bail!("no tracking branch configured and no branch specified");
     };
 
     if let Some(remote_path) = local_remote_path {

--- a/grit/src/commands/rev_parse.rs
+++ b/grit/src/commands/rev_parse.rs
@@ -905,6 +905,7 @@ pub fn run(args: Args) -> Result<()> {
                 } else if p.is_file() {
                     let content = std::fs::read_to_string(p)
                         .with_context(|| format!("cannot read '{}'", p.display()))?;
+                    let mut found = false;
                     for line in content.lines() {
                         if let Some(rest) = line.strip_prefix("gitdir:") {
                             let rel = rest.trim();
@@ -915,14 +916,16 @@ pub fn run(args: Args) -> Result<()> {
                             };
                             let resolved = git_dir.canonicalize().unwrap_or(git_dir);
                             println!("{}", resolved.display());
-                            return Ok(());
+                            found = true;
+                            break;
                         }
                     }
-                    bail!("not a gitdir: {path_arg}");
+                    if !found {
+                        bail!("not a gitdir: {path_arg}");
+                    }
                 } else {
                     bail!("not a valid directory: {path_arg}");
                 }
-                return Ok(());
             }
             Action::Revision(rev, rev_symbolic_full_name, strict_before_first_dd) => {
                 let Some(current) = repo.as_ref() else {

--- a/grit/src/commands/submodule.rs
+++ b/grit/src/commands/submodule.rs
@@ -12,6 +12,7 @@ use grit_lib::error::Error as LibError;
 use grit_lib::index::MODE_GITLINK;
 use grit_lib::objects::{parse_commit, parse_tree, ObjectKind};
 use grit_lib::repo::Repository;
+use grit_lib::rev_parse;
 use grit_lib::state::resolve_head;
 use std::collections::BTreeMap;
 use std::fs;
@@ -19,7 +20,7 @@ use std::io::{self, Write};
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 /// Spawn grit for a nested operation without inheriting the superproject's `GIT_DIR` /
 /// `GIT_WORK_TREE` (tests and detached work trees set those in the parent shell).
@@ -86,6 +87,10 @@ pub struct StatusArgs {
     #[arg(long)]
     pub recursive: bool,
 
+    /// Compare index gitlinks to the HEAD tree (instead of submodule checkouts).
+    #[arg(long)]
+    pub cached: bool,
+
     /// Restrict to specific submodule paths.
     #[arg(value_name = "PATH")]
     pub paths: Vec<String>,
@@ -119,6 +124,10 @@ pub struct UpdateArgs {
     /// Recurse into nested submodules.
     #[arg(long)]
     pub recursive: bool,
+
+    /// Borrow objects from this repository (repeatable). Writes `objects/info/alternates` in cloned submodules.
+    #[arg(long = "reference", value_name = "REPO", action = clap::ArgAction::Append)]
+    pub reference: Vec<String>,
 }
 
 #[derive(Debug, ClapArgs)]
@@ -144,8 +153,13 @@ pub struct ForeachArgs {
     #[arg(long)]
     pub recursive: bool,
 
-    /// Command to run in each submodule.
-    #[arg(required = true, trailing_var_arg = true, allow_hyphen_values = true)]
+    /// Suppress "Entering" lines (Git also accepts `--quiet` before the command; we only
+    /// implement `-q` so `foreach echo be --quiet` can pass `--quiet` to the shell command).
+    #[arg(short = 'q')]
+    pub quiet: bool,
+
+    /// Command to run in each submodule (default: `:`). Use `--` before arguments that look like options.
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     pub command: Vec<String>,
 }
 
@@ -230,6 +244,7 @@ pub(crate) fn update_after_superproject_merge(init: bool, recursive: bool) -> Re
         checkout: false,
         remote: false,
         recursive,
+        reference: vec![],
     })
 }
 
@@ -311,6 +326,7 @@ pub fn run(args: Args) -> Result<()> {
     match args.command {
         None => run_status(&StatusArgs {
             recursive: false,
+            cached: false,
             paths: vec![],
         }),
         Some(SubmoduleCommand::Status(a)) => run_status(&a),
@@ -809,63 +825,169 @@ fn checkout_submodule_worktree(
 
 // ── Subcommand implementations ───────────────────────────────────────
 
-fn run_status(args: &StatusArgs) -> Result<()> {
-    let repo = Repository::discover(None).context("not a git repository")?;
-    let work_tree = repo.work_tree.as_ref().context("bare repository")?;
-    let modules = parse_gitmodules(work_tree)?;
-    let selected = filter_submodules(&modules, &args.paths);
+/// Matches Git's `compute_rev_name` in `submodule--helper.c`: try `describe` with several
+/// flag sets until one succeeds.
+fn submodule_describe_rev_name(sub_worktree: &Path, oid_hex: &str) -> Option<String> {
+    if oid_hex.len() != 40 || !oid_hex.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    let grit_bin = grit_exe::grit_executable();
+    let attempts: &[&[&str]] = &[&[], &["--tags"], &["--contains"], &["--all", "--always"]];
+    for extra in attempts {
+        let mut cmd = grit_subprocess(&grit_bin);
+        cmd.current_dir(sub_worktree)
+            .stderr(Stdio::null())
+            .stdout(Stdio::piped())
+            .arg("describe");
+        for flag in *extra {
+            cmd.arg(flag);
+        }
+        cmd.arg(oid_hex);
+        let Ok(output) = cmd.output() else {
+            continue;
+        };
+        if !output.status.success() {
+            continue;
+        }
+        let name = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+        if !name.is_empty() {
+            return Some(name);
+        }
+    }
+    None
+}
 
-    let stdout = io::stdout();
-    let mut out = stdout.lock();
+fn emit_submodule_status_lines(
+    super_repo: &Repository,
+    super_work_tree: &Path,
+    super_git_dir: &Path,
+    top_work_tree: &Path,
+    invocation_cwd: &Path,
+    modules: &[SubmoduleInfo],
+    args: &StatusArgs,
+    path_prefix: &str,
+    out: &mut dyn Write,
+) -> Result<()> {
+    let mut sorted: Vec<&SubmoduleInfo> = modules.iter().collect();
+    sorted.sort_by(|a, b| a.path.cmp(&b.path));
 
-    for m in selected {
-        let sub_path = work_tree.join(&m.path);
-        let recorded = read_submodule_commit(&repo, &m.path)?;
+    for m in sorted {
+        let path_in_super = if path_prefix.is_empty() {
+            m.path.replace('\\', "/")
+        } else {
+            format!("{}/{}", path_prefix.trim_end_matches('/'), m.path)
+        };
 
-        // Check if the submodule is checked out (has a .git file/dir in its path).
+        let sub_path = super_work_tree.join(&m.path);
+        // Paths in the immediate superproject's index / HEAD tree use `m.path` (not the
+        // top-level composite path).
+        let gitlink_path = m.path.as_str();
+        let recorded = read_submodule_commit(super_repo, gitlink_path)?;
         let has_checkout = sub_path.join(".git").exists();
 
-        if !sub_path.exists() || !has_checkout {
-            // Not initialized / not checked out.
+        if !args.paths.is_empty() {
+            let under_selected = args
+                .paths
+                .iter()
+                .any(|p| path_in_super == *p || path_in_super.starts_with(&format!("{p}/")));
+            if !under_selected {
+                continue;
+            }
+        }
+
+        let (prefix, display_oid, suffix) = if !sub_path.exists() || !has_checkout {
             let oid = recorded
                 .as_deref()
                 .unwrap_or("0000000000000000000000000000000000000000");
-            writeln!(out, "-{oid} {}", m.path)?;
+            ("-", oid.to_owned(), String::new())
         } else {
-            // Check current HEAD of the submodule.
+            let index_oid = read_gitlink_oid_from_index(super_repo, gitlink_path)?
+                .unwrap_or_else(|| "0000000000000000000000000000000000000000".to_owned());
+
             let head_file = sub_path.join(".git");
             let sub_head = if head_file.exists() {
                 read_submodule_head(&sub_path)
             } else {
-                // gitfile indirection: check .git/modules/<name>/HEAD
-                let modules_head = repo.git_dir.join("modules").join(&m.name).join("HEAD");
+                let modules_head = super_git_dir.join("modules").join(&m.name).join("HEAD");
                 if modules_head.exists() {
                     read_head_from_file(&modules_head)
                 } else {
                     None
                 }
             };
+            let head_oid = sub_head.unwrap_or_default();
 
-            let recorded_oid = recorded.as_deref().unwrap_or("");
-            let current_oid = sub_head.as_deref().unwrap_or("");
+            // Match `git submodule--helper status`: `diff-files` marks the submodule dirty when
+            // the checked-out commit differs from the index gitlink.
+            let dirty = !head_oid.is_empty() && head_oid != index_oid;
 
-            let prefix = if current_oid == recorded_oid {
-                " "
+            let (p, oid_for_line, oid_for_describe) = if !dirty {
+                (" ", index_oid.clone(), index_oid.clone())
+            } else if args.cached {
+                ("+", index_oid.clone(), index_oid.clone())
             } else {
-                "+"
+                ("+", head_oid.clone(), head_oid.clone())
             };
 
-            let display_oid = if current_oid.is_empty() {
-                recorded_oid
-            } else {
-                current_oid
-            };
+            let suf = submodule_describe_rev_name(&sub_path, &oid_for_describe)
+                .map(|n| format!(" ({n})"))
+                .unwrap_or_default();
+            (p, oid_for_line, suf)
+        };
 
-            writeln!(out, "{prefix}{display_oid} {}", m.path)?;
+        let display_path =
+            rev_parse::to_relative_path(&top_work_tree.join(&path_in_super), invocation_cwd)
+                .replace('\\', "/");
+
+        writeln!(out, "{prefix}{display_oid} {display_path}{suffix}")?;
+
+        if args.recursive && has_checkout && sub_path.join(".git").exists() {
+            let Ok(sub_repo) = Repository::discover(Some(&sub_path)) else {
+                continue;
+            };
+            let Some(sub_wt) = sub_repo.work_tree.as_ref() else {
+                continue;
+            };
+            let nested = parse_gitmodules_with_repo(sub_wt, Some(&sub_repo)).unwrap_or_default();
+            if !nested.is_empty() {
+                emit_submodule_status_lines(
+                    &sub_repo,
+                    sub_wt,
+                    &sub_repo.git_dir,
+                    top_work_tree,
+                    invocation_cwd,
+                    &nested,
+                    args,
+                    &path_in_super,
+                    out,
+                )?;
+            }
         }
     }
 
     Ok(())
+}
+
+fn run_status(args: &StatusArgs) -> Result<()> {
+    let repo = Repository::discover(None).context("not a git repository")?;
+    let work_tree = repo.work_tree.as_ref().context("bare repository")?;
+    let modules = parse_gitmodules_with_repo(work_tree, Some(&repo))?;
+
+    let cwd = std::env::current_dir().context("failed to read current directory")?;
+
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
+    emit_submodule_status_lines(
+        &repo,
+        work_tree,
+        &repo.git_dir,
+        work_tree,
+        &cwd,
+        &modules,
+        args,
+        "",
+        &mut out,
+    )
 }
 
 /// Read HEAD of a submodule working directory.
@@ -949,6 +1071,17 @@ fn run_init(args: &InitArgs) -> Result<()> {
 fn run_update(args: &UpdateArgs) -> Result<()> {
     let repo = Repository::discover(None).context("not a git repository")?;
     let work_tree = repo.work_tree.as_ref().context("bare repository")?;
+
+    let mut reference_roots: Vec<PathBuf> = Vec::new();
+    for r in &args.reference {
+        let p = Path::new(r);
+        let resolved = if p.is_absolute() {
+            p.to_path_buf()
+        } else {
+            work_tree.join(p)
+        };
+        reference_roots.push(resolved);
+    }
 
     if args.init {
         run_init(&InitArgs {
@@ -1074,6 +1207,14 @@ fn run_update(args: &UpdateArgs) -> Result<()> {
                 }
                 set_submodule_core_worktree(&grit_bin, &modules_dir, &sub_path);
 
+                if !reference_roots.is_empty() {
+                    write_submodule_object_alternates(
+                        &modules_dir,
+                        &repo.git_dir,
+                        &reference_roots,
+                    )?;
+                }
+
                 let abs_origin = if Path::new(&clone_src_str).is_absolute() {
                     Path::new(&clone_src_str).canonicalize()
                 } else {
@@ -1193,8 +1334,12 @@ fn run_update(args: &UpdateArgs) -> Result<()> {
             if parse_gitmodules(&sub_path).unwrap_or_default().is_empty() {
                 continue;
             }
-            let status = grit_subprocess(&grit_bin)
-                .args(["submodule", "update", "--init", "--recursive"])
+            let mut cmd = grit_subprocess(&grit_bin);
+            cmd.args(["submodule", "update", "--init", "--recursive"]);
+            for r in &reference_roots {
+                cmd.arg("--reference").arg(r);
+            }
+            let status = cmd
                 .current_dir(&sub_path)
                 .status()
                 .with_context(|| format!("nested submodule update in {}", m.path))?;
@@ -1204,6 +1349,37 @@ fn run_update(args: &UpdateArgs) -> Result<()> {
         }
     }
 
+    Ok(())
+}
+
+/// Populate `objects/info/alternates` for a submodule git dir (matches `git clone --reference`).
+fn write_submodule_object_alternates(
+    modules_dir: &Path,
+    super_git_dir: &Path,
+    reference_roots: &[PathBuf],
+) -> Result<()> {
+    let dst_info = modules_dir.join("objects/info");
+    fs::create_dir_all(&dst_info)?;
+
+    let super_objects = super_git_dir.join("objects");
+    let super_objects_abs = super_objects.canonicalize().unwrap_or(super_objects);
+
+    let mut lines = vec![super_objects_abs.to_string_lossy().to_string()];
+    for root in reference_roots {
+        let ref_git = if root.join("HEAD").exists() {
+            root.clone()
+        } else {
+            root.join(".git")
+        };
+        let ref_repo = Repository::open(&ref_git, None)
+            .with_context(|| format!("cannot open reference repository '{}'", root.display()))?;
+        let ref_objects = ref_repo.git_dir.join("objects");
+        let ref_objects_abs = ref_objects.canonicalize().unwrap_or(ref_objects);
+        lines.push(ref_objects_abs.to_string_lossy().to_string());
+    }
+
+    let content = lines.join("\n") + "\n";
+    fs::write(dst_info.join("alternates"), content)?;
     Ok(())
 }
 
@@ -1374,43 +1550,97 @@ fn run_add(args: &AddArgs) -> Result<()> {
 }
 
 fn run_foreach(args: &ForeachArgs) -> Result<()> {
-    let repo = Repository::discover(None).context("not a git repository")?;
-    let work_tree = repo.work_tree.as_ref().context("bare repository")?;
-    let modules = parse_gitmodules(work_tree)?;
+    let command_argv: Vec<String> = if args.command.is_empty() {
+        vec![":".to_owned()]
+    } else {
+        args.command.clone()
+    };
 
-    let cmd_str = args.command.join(" ");
+    if !command_argv.is_empty() && command_argv[0].starts_with("--") {
+        eprintln!("usage: git submodule [--quiet] foreach [--recursive] [--] <command>...");
+        std::process::exit(1);
+    }
 
-    run_foreach_in(work_tree, &modules, &cmd_str, args.recursive, "")
+    let top_repo = Repository::discover(None).context("not a git repository")?;
+    let top_work_tree = top_repo
+        .work_tree
+        .as_ref()
+        .context("bare repository")?
+        .to_path_buf();
+    let cwd = std::env::current_dir().context("failed to read current directory")?;
+
+    let modules = parse_gitmodules_with_repo(&top_work_tree, Some(&top_repo))?;
+    run_foreach_in(
+        &top_repo,
+        &top_work_tree,
+        &cwd,
+        &modules,
+        &command_argv,
+        args.recursive,
+        "",
+        args.quiet,
+    )
 }
 
 fn run_foreach_in(
-    work_tree: &Path,
+    super_repo: &Repository,
+    super_work_tree: &Path,
+    invocation_cwd: &Path,
     modules: &[SubmoduleInfo],
-    cmd_str: &str,
+    command_argv: &[String],
     recursive: bool,
-    prefix: &str,
+    path_prefix: &str,
+    quiet: bool,
 ) -> Result<()> {
-    for m in modules {
-        let sub_path = work_tree.join(&m.path);
-        if !sub_path.exists() {
+    let mut sorted: Vec<&SubmoduleInfo> = modules.iter().collect();
+    sorted.sort_by(|a, b| a.path.cmp(&b.path));
+
+    for m in sorted {
+        let sub_path = super_work_tree.join(&m.path);
+        if !sub_path.join(".git").exists() {
             continue;
         }
 
-        let displaypath = if prefix.is_empty() {
-            m.path.clone()
+        let path_in_super = if path_prefix.is_empty() {
+            m.path.replace('\\', "/")
         } else {
-            format!("{}/{}", prefix, m.path)
+            format!("{}/{}", path_prefix.trim_end_matches('/'), m.path)
         };
 
-        eprintln!("Entering '{}'", displaypath);
-        let status = Command::new("sh")
-            .arg("-c")
-            .arg(cmd_str)
+        let displaypath = rev_parse::to_relative_path(&sub_path, invocation_cwd).replace('\\', "/");
+
+        if !quiet {
+            // Match Git: "Entering" goes to stdout so `submodule foreach cmd >file` captures it.
+            println!("Entering '{}'", displaypath);
+        }
+
+        let sha1 = read_submodule_commit(super_repo, &m.path)?.unwrap_or_default();
+
+        let mut cmd = Command::new("sh");
+        if command_argv.len() == 1 {
+            // One shell snippet (e.g. `git submodule foreach "git submodule update --init"`).
+            cmd.arg("-c").arg(&command_argv[0]);
+        } else {
+            // Multiple argv words: run via `exec` so the command is not parsed twice (matches Git).
+            cmd.arg("-c")
+                .arg("exec \"$@\"")
+                .arg("sh")
+                .args(command_argv);
+        }
+        let status = cmd
             .current_dir(&sub_path)
+            .stdin(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
             .env("name", &m.name)
             .env("sm_path", &m.path)
+            .env("path", &m.path)
+            .env("sha1", &sha1)
+            .env(
+                "toplevel",
+                super_work_tree.to_string_lossy().replace('\\', "/"),
+            )
             .env("displaypath", &displaypath)
-            .env("toplevel", work_tree.to_string_lossy().as_ref())
             .status()
             .context("failed to run foreach command")?;
 
@@ -1422,9 +1652,24 @@ fn run_foreach_in(
         }
 
         if recursive {
-            let nested = parse_gitmodules(&sub_path).unwrap_or_default();
+            let Ok(sub_repo) = Repository::discover(Some(&sub_path)) else {
+                continue;
+            };
+            let Some(sub_wt) = sub_repo.work_tree.as_ref() else {
+                continue;
+            };
+            let nested = parse_gitmodules_with_repo(sub_wt, Some(&sub_repo)).unwrap_or_default();
             if !nested.is_empty() {
-                run_foreach_in(&sub_path, &nested, cmd_str, true, &displaypath)?;
+                run_foreach_in(
+                    &sub_repo,
+                    sub_wt,
+                    invocation_cwd,
+                    &nested,
+                    command_argv,
+                    true,
+                    &path_in_super,
+                    quiet,
+                )?;
             }
         }
     }

--- a/logs/2026-04-09_t7407-submodule-foreach.md
+++ b/logs/2026-04-09_t7407-submodule-foreach.md
@@ -1,0 +1,21 @@
+# t7407-submodule-foreach
+
+## Summary
+
+Made `tests/t7407-submodule-foreach.sh` pass (23/23).
+
+## Changes
+
+- **`grit submodule foreach`**: Git-compatible env (`toplevel`, `path`, `sha1`, `displaypath` from cwd), sorted traversal, recursive nested superproject context, stdout "Entering" lines, `-q`, optional command default `:`, `--` validation, single-arg vs multi-arg shell execution (quoted vs `exec "$@""`).
+- **`grit submodule status`**: `--cached`, `--recursive`, path filtering under prefix, display paths relative to invocation cwd, parentheticals via `grit describe` subprocess (same attempts as Git’s `compute_rev_name`).
+- **`grit submodule update`**: `--reference` (alternates + propagation to nested updates).
+- **`grit pull`**: detached HEAD uses remote’s default branch for local path remotes.
+- **`grit describe`**: `--contains` includes lightweight tags (for `file2~1`-style names).
+- **`grit rev-parse --resolve-git-dir`**: do not exit early so later args still run (matches `d` noise arg in tests).
+- **`tests/test-lib.sh`**: `test_grep` passes pattern with `grep -e` so patterns like `--quiet` are not treated as grep options.
+
+## Validation
+
+- `cargo build --release -p grit-rs`
+- `cargo test -p grit-lib --lib`
+- `./scripts/run-tests.sh t7407-submodule-foreach.sh` → 23/23

--- a/tests/test-lib.sh
+++ b/tests/test-lib.sh
@@ -350,11 +350,12 @@ test_grep () {
 	done
 	local pattern="$1"
 	shift
+	# Always pass the pattern via -e so values like "--quiet" are not parsed as grep options.
 	if test -n "$negate"
 	then
-		! grep "$pattern" "$@"
+		! grep $invert -e "$pattern" "$@"
 	else
-		grep $invert "$pattern" "$@"
+		grep $invert -e "$pattern" "$@"
 	fi
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This branch makes `tests/t7407-submodule-foreach.sh` pass all 23 cases.

## Key changes

- **`git submodule foreach`**: Match Git’s environment (`toplevel`, `path`, `sha1`, `displaypath`), traversal order, nested superproject context, stdout "Entering" lines, `-q`, default command `:`, `--` handling, and correct single-string vs multi-argument execution (no double shell evaluation).
- **`git submodule status`**: Implement `--cached` and `--recursive` with correct dirty semantics vs the index, path-prefix filtering, cwd-relative display paths, and parenthetical names via the same `describe` attempts Git uses in `submodule--helper`.
- **`git submodule update`**: Add `--reference` and write `objects/info/alternates` for cloned submodules; propagate `--reference` into nested recursive updates.
- **`git pull`**: When HEAD is detached and the remote is a local path, use the remote repository’s default branch (fixes submodule `git pull` in the test setup).
- **`git describe --contains`**: Include lightweight tags so names like `file2~1` work for cached status output.
- **`git rev-parse --resolve-git-dir`**: Do not exit the whole command after resolving one path so stray extra arguments do not prevent later actions from running (matches the test’s `rev-parse ... d path` usage).
- **`tests/test-lib.sh`**: Fix `test_grep` to pass the pattern with `grep -e` so patterns beginning with `--` are not parsed as grep options (unblocks test 22’s `test_grep -e "--quiet"`).

## Validation

- `cargo build --release -p grit-rs`
- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t7407-submodule-foreach.sh` → 23/23

## Note

`tests/test-lib.sh` was minimally changed (grep invocation only) to fix a real bug affecting this test file; broader harness refactors were avoided.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75596be1-d7db-4b5b-b196-6725a0972ede"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75596be1-d7db-4b5b-b196-6725a0972ede"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

