### PR TITLE
fix: pass t0027-auto-crlf (CRLF/EOL parity)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -56,7 +56,7 @@ commit → check it off → move on.
 - [ ] `t0040-parse-options` ░░░░░░░░░░░░░░░░░░░░ 0/94 (94 left) — our own option parser
 - [ ] `t0012-help` ██░░░░░░░░░░░░░░░░░░ 15/124 (109 left) — help
 - [ ] `t0060-path-utils` █░░░░░░░░░░░░░░░░░░░ 18/219 (201 left) — Test various path utilities
-- [ ] `t0027-auto-crlf` █████████░░░░░░░░░░░ 1238/2600 (1362 left) — CRLF conversion all combinations
+- [x] `t0027-auto-crlf` ████████████████████ 2600/2600 (0 left) — CRLF conversion all combinations
 
 ## 2. Plumbing (94 files)
 

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -23,7 +23,7 @@ t0023-crlf-am	t0	yes	2	2	0	true	ok	0
 t0024-crlf-archive	t0	yes	3	3	0	true	ok	0
 t0025-crlf-renormalize	t0	yes	3	3	0	true	ok	0
 t0026-eol-config	t0	yes	6	6	0	true	ok	0
-t0027-auto-crlf	t0	yes	2600	1238	1362	false	ok	0
+t0027-auto-crlf	t0	yes	2600	2600	0	true	ok	0
 t0028-working-tree-encoding	t0	yes	22	0	22	false	ok	0
 t0029-core-unsetenvvars	t0	skip	2	0	0	false	ok	0
 t0030-stripspace	t0	yes	30	30	0	true	ok	0
@@ -92,7 +92,7 @@ t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
 t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
-t1006-cat-file	t1	yes	290	285	5	false	ok	1
+t1006-cat-file	t1	yes	290	285	5	false	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	32	8	false	ok	0
 t10070-cat-file-batch-format	t1	yes	33	33	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,16 +141,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T01:07:57+00:00" class="gen-time" title="2026-04-09 01:07 UTC">2026-04-09 01:07 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">74.2%</div>
+      <div class="summary-big-val pct-blue">77.6%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,565</div>
+      <div class="summary-big-val">30,935</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -159,12 +159,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:74.2%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:77.6%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>713 files fully passing</span>
+    <span>717 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -179,11 +179,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t0</span>
         <span class="group-desc">Absolute basics and global stuff</span>
-        <span class="group-meta">37/63 files · 21 skipped · 2,886/4,473 tests</span>
+        <span class="group-meta">38/63 files · 21 skipped · 4,248/4,473 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.5%"></div></div>
-        <span class="group-pct pct-blue">64.5%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:95.0%"></div></div>
+        <span class="group-pct pct-green">95.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t1">
@@ -212,7 +212,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">41/141 files · 2 skipped · 3,333/4,611 tests</span>
+        <span class="group-meta">42/141 files · 2 skipped · 3,334/4,611 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.3%"></div></div>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,336/3,949 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,342/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.8%"></div></div>
-        <span class="group-pct pct-red">33.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.0%"></div></div>
+        <span class="group-pct pct-red">34.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -256,7 +256,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">42/126 files · 11 skipped · 1,793/2,944 tests</span>
+        <span class="group-meta">43/126 files · 11 skipped · 1,794/2,944 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T01:07:57+00:00" class="gen-time" title="2026-04-09 01:07 UTC">2026-04-09 01:07 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,864</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,565</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,935</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">77.6%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -387,14 +387,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t0" data-tests="2600" data-passed="1238">
+<tr class="" data-group="t0" data-tests="2600" data-passed="2600" data-full-pass="1">
   <td class="mono">t0027-auto-crlf</td>
   <td>t0</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">2600</td>
-  <td class="right">1238</td>
+  <td class="right">2600</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:47.6%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t0" data-tests="22" data-passed="0">
@@ -1085,7 +1085,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">285</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.3%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t10060-hash-object-determinism</td>
@@ -5110,8 +5110,7 @@ tr.row-skip td { opacity: 0.65; }
 <tr class="" data-group="t2" data-tests="15" data-passed="5">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td><span class="badge ok">full pass</span></td>
-  <td class="right">15</td>
+  <td></td>
   <td class="right">15</td>
   <td class="right">5</td>
   <td class="right">ok</td>
@@ -6218,14 +6217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="54" data-passed="38">
+<tr class="" data-group="t3" data-tests="52" data-passed="3">
   <td class="mono">t3420-rebase-autostash</td>
   <td>t3</td>
   <td></td>
-  <td class="right">54</td>
-  <td class="right">38</td>
+  <td class="right">52</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="63" data-passed="11">
@@ -12598,7 +12597,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="2" data-passed="2">
+<tr class="" data-group="t7" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t7524-commit-summary</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>

--- a/grit-lib/src/crlf.rs
+++ b/grit-lib/src/crlf.rs
@@ -193,7 +193,8 @@ impl ConversionConfig {
                 "warn" => SafeCrlf::Warn,
                 _ => SafeCrlf::False,
             },
-            None => SafeCrlf::False,
+            // Git warns on round-trip EOL issues by default when unset.
+            None => SafeCrlf::Warn,
         };
 
         ConversionConfig {
@@ -530,6 +531,244 @@ pub fn is_binary(data: &[u8]) -> bool {
     data[..check_len].contains(&0)
 }
 
+// Git `convert.c` `CONVERT_STAT_BITS_*` / `gather_convert_stats_ascii` (for `ls-files --eol`).
+const CONVERT_STAT_BITS_TXT_LF: u32 = 0x1;
+const CONVERT_STAT_BITS_TXT_CRLF: u32 = 0x2;
+const CONVERT_STAT_BITS_BIN: u32 = 0x4;
+
+#[derive(Default, Clone)]
+struct TextStat {
+    nul: u32,
+    lonecr: u32,
+    lonelf: u32,
+    crlf: u32,
+    printable: u32,
+    nonprintable: u32,
+}
+
+fn gather_text_stat(data: &[u8]) -> TextStat {
+    let mut s = TextStat::default();
+    let mut i = 0usize;
+    while i < data.len() {
+        let c = data[i];
+        if c == b'\r' {
+            if i + 1 < data.len() && data[i + 1] == b'\n' {
+                s.crlf += 1;
+                i += 2;
+            } else {
+                s.lonecr += 1;
+                i += 1;
+            }
+            continue;
+        }
+        if c == b'\n' {
+            s.lonelf += 1;
+            i += 1;
+            continue;
+        }
+        if c == 127 {
+            s.nonprintable += 1;
+        } else if c < 32 {
+            match c {
+                b'\t' | b'\x08' | b'\x1b' | b'\x0c' => s.printable += 1,
+                0 => {
+                    s.nul += 1;
+                    s.nonprintable += 1;
+                }
+                _ => s.nonprintable += 1,
+            }
+        } else {
+            s.printable += 1;
+        }
+        i += 1;
+    }
+    s
+}
+
+fn convert_is_binary(stats: &TextStat) -> bool {
+    stats.lonecr > 0 || stats.nul > 0 || (stats.printable >> 7) < stats.nonprintable
+}
+
+fn git_text_stat(data: &[u8]) -> TextStat {
+    let mut stats = gather_text_stat(data);
+    if !data.is_empty() && data[data.len() - 1] == 0x1a {
+        stats.nonprintable = stats.nonprintable.saturating_sub(1);
+    }
+    stats
+}
+
+/// Git `will_convert_lf_to_crlf` using [`TextStat`] (same rules as [`should_convert_to_crlf`] on bytes).
+fn will_convert_lf_to_crlf_from_stats(
+    stats: &TextStat,
+    conv: &ConversionConfig,
+    attrs: &FileAttrs,
+) -> bool {
+    let has_lone_lf = stats.lonelf > 0;
+    let is_bin = convert_is_binary(stats);
+
+    match attrs.crlf_legacy {
+        CrlfLegacyAttr::Unset | CrlfLegacyAttr::Input => return false,
+        CrlfLegacyAttr::Crlf => {
+            if attrs.text == TextAttr::Unset {
+                return false;
+            }
+            return has_lone_lf;
+        }
+        CrlfLegacyAttr::Unspecified => {}
+    }
+
+    if attrs.text == TextAttr::Unset {
+        return false;
+    }
+
+    if attrs.eol != EolAttr::Unspecified {
+        if attrs.text == TextAttr::Auto && is_bin {
+            return false;
+        }
+        if attrs.eol != EolAttr::Crlf {
+            return false;
+        }
+        if attrs.text == TextAttr::Auto {
+            return auto_crlf_should_smudge_lf_to_crlf_from_stats(stats);
+        }
+        return has_lone_lf;
+    }
+
+    if attrs.text == TextAttr::Set {
+        if !output_eol_is_crlf(conv) {
+            return false;
+        }
+        return has_lone_lf;
+    }
+
+    if attrs.text == TextAttr::Auto {
+        if is_bin || !output_eol_is_crlf(conv) {
+            return false;
+        }
+        return auto_crlf_should_smudge_lf_to_crlf_from_stats(stats);
+    }
+
+    match conv.autocrlf {
+        AutoCrlf::True => {
+            if is_bin {
+                return false;
+            }
+            auto_crlf_should_smudge_lf_to_crlf_from_stats(stats)
+        }
+        AutoCrlf::Input | AutoCrlf::False => false,
+    }
+}
+
+fn auto_crlf_should_smudge_lf_to_crlf_from_stats(stats: &TextStat) -> bool {
+    if stats.lonelf == 0 {
+        return false;
+    }
+    if stats.lonecr > 0 || stats.crlf > 0 {
+        return false;
+    }
+    !convert_is_binary(stats)
+}
+
+fn gather_convert_stats(data: &[u8]) -> u32 {
+    if data.is_empty() {
+        return 0;
+    }
+    let mut stats = gather_text_stat(data);
+    if !data.is_empty() && data[data.len() - 1] == 0x1a {
+        stats.nonprintable = stats.nonprintable.saturating_sub(1);
+    }
+    let mut ret = 0u32;
+    if convert_is_binary(&stats) {
+        ret |= CONVERT_STAT_BITS_BIN;
+    }
+    if stats.crlf > 0 {
+        ret |= CONVERT_STAT_BITS_TXT_CRLF;
+    }
+    if stats.lonelf > 0 {
+        ret |= CONVERT_STAT_BITS_TXT_LF;
+    }
+    ret
+}
+
+/// Git `convert.c` `gather_convert_stats_ascii` — worktree/index blob EOL stats for `ls-files --eol`.
+#[must_use]
+pub fn gather_convert_stats_ascii(data: &[u8]) -> &'static str {
+    let convert_stats = gather_convert_stats(data);
+    if convert_stats & CONVERT_STAT_BITS_BIN != 0 {
+        return "-text";
+    }
+    match convert_stats {
+        CONVERT_STAT_BITS_TXT_LF => "lf",
+        CONVERT_STAT_BITS_TXT_CRLF => "crlf",
+        x if x == (CONVERT_STAT_BITS_TXT_LF | CONVERT_STAT_BITS_TXT_CRLF) => "mixed",
+        _ => "none",
+    }
+}
+
+/// Git `convert.c` `get_convert_attr_ascii` — ASCII summary of EOL-related attributes for
+/// `git ls-files --eol` (matches `attr_action` after attribute merge, before clean/smudge).
+#[must_use]
+pub fn convert_attr_ascii_for_ls_files(
+    rules: &[AttrRule],
+    rel_path: &str,
+    config: &ConfigSet,
+) -> String {
+    let fa = get_file_attrs(rules, rel_path, config);
+    // Mirror `git_path_check_crlf` for `text` then legacy `crlf` (Git checks `text` first).
+    let mut action = match fa.text {
+        TextAttr::Set => 1,   // CRLF_TEXT
+        TextAttr::Unset => 2, // CRLF_BINARY
+        TextAttr::Auto => 5,  // CRLF_AUTO
+        TextAttr::Unspecified => 0,
+    };
+    if action == 0 {
+        action = match fa.crlf_legacy {
+            CrlfLegacyAttr::Crlf => 1,
+            CrlfLegacyAttr::Unset => 2,
+            CrlfLegacyAttr::Input => 3, // CRLF_TEXT_INPUT
+            CrlfLegacyAttr::Unspecified => 0,
+        };
+    }
+    if action == 2 {
+        return "-text".to_string();
+    }
+    // Bare `eol=lf` / `eol=crlf` without `text` still implies text mode (`convert_attrs`).
+    if action == 0 {
+        if fa.eol == EolAttr::Unspecified {
+            return String::new();
+        }
+        action = 1; // CRLF_TEXT
+    }
+
+    // Merge `eol=` like `convert_attrs` (only when not already binary).
+    if fa.eol == EolAttr::Lf {
+        if action == 5 {
+            action = 7; // CRLF_AUTO_INPUT
+        } else {
+            action = 3; // CRLF_TEXT_INPUT
+        }
+    } else if fa.eol == EolAttr::Crlf {
+        if action == 5 {
+            action = 6; // CRLF_AUTO_CRLF
+        } else {
+            action = 4; // CRLF_TEXT_CRLF
+        }
+    }
+
+    // `attr_action` snapshot (Git assigns before splitting bare `text` / applying autocrlf).
+    let attr_action = action;
+
+    match attr_action {
+        1 => "text".to_string(),
+        3 => "text eol=lf".to_string(),
+        4 => "text eol=crlf".to_string(),
+        5 => "text=auto".to_string(),
+        6 => "text=auto eol=crlf".to_string(),
+        7 => "text=auto eol=lf".to_string(),
+        _ => String::new(),
+    }
+}
+
 /// Returns true if data contains any CRLF sequences.
 pub fn has_crlf(data: &[u8]) -> bool {
     data.windows(2).any(|w| w == b"\r\n")
@@ -580,6 +819,53 @@ pub fn is_all_lf(data: &[u8]) -> bool {
     has_lone_lf(data) && !has_crlf(data)
 }
 
+/// Git `convert.c` `has_crlf_in_index`: index blob already contains CRLF pairs (non-binary).
+#[must_use]
+pub fn has_crlf_in_index_blob(data: &[u8]) -> bool {
+    if !data.contains(&b'\r') {
+        return false;
+    }
+    let st = gather_convert_stats(data);
+    st & CONVERT_STAT_BITS_BIN == 0 && (st & CONVERT_STAT_BITS_TXT_CRLF) != 0
+}
+
+/// Whether clean conversion uses Git's `has_crlf_in_index` guard (`convert.c` only for
+/// `CRLF_AUTO`, `CRLF_AUTO_INPUT`, `CRLF_AUTO_CRLF`). Bare `eol=` without `text=auto` becomes
+/// `CRLF_TEXT_*` and must not use this guard.
+#[must_use]
+pub fn clean_uses_autocrlf_index_guard(attrs: &FileAttrs, conv: &ConversionConfig) -> bool {
+    if attrs.text == TextAttr::Unset || attrs.crlf_legacy == CrlfLegacyAttr::Unset {
+        return false;
+    }
+    if attrs.eol != EolAttr::Unspecified && attrs.text != TextAttr::Auto {
+        return false;
+    }
+    attrs.text == TextAttr::Auto
+        || (attrs.text == TextAttr::Unspecified
+            && matches!(conv.autocrlf, AutoCrlf::True | AutoCrlf::Input))
+}
+
+/// Optional inputs for [`convert_to_git_with_opts`] (Git `CONV_EOL_RENORMALIZE` / index blob).
+#[derive(Debug, Clone, Copy)]
+pub struct ConvertToGitOpts<'a> {
+    /// Stage-0 blob bytes for this path before the current add (for safer-autocrlf).
+    pub index_blob: Option<&'a [u8]>,
+    /// When true, always apply CRLF→LF when configured (merge/cherry-pick renormalize).
+    pub renormalize: bool,
+    /// When false, skip `core.safecrlf` simulation (used for internal diff/hashing — must not spam stderr).
+    pub check_safecrlf: bool,
+}
+
+impl Default for ConvertToGitOpts<'_> {
+    fn default() -> Self {
+        Self {
+            index_blob: None,
+            renormalize: false,
+            check_safecrlf: true,
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Input (add / clean) direction
 // ---------------------------------------------------------------------------
@@ -597,6 +883,23 @@ pub fn convert_to_git(
     rel_path: &str,
     conv: &ConversionConfig,
     file_attrs: &FileAttrs,
+) -> Result<Vec<u8>, String> {
+    convert_to_git_with_opts(
+        data,
+        rel_path,
+        conv,
+        file_attrs,
+        ConvertToGitOpts::default(),
+    )
+}
+
+/// Like [`convert_to_git`] with Git-compatible safer-autocrlf index handling.
+pub fn convert_to_git_with_opts(
+    data: &[u8],
+    rel_path: &str,
+    conv: &ConversionConfig,
+    file_attrs: &FileAttrs,
+    opts: ConvertToGitOpts<'_>,
 ) -> Result<Vec<u8>, String> {
     let mut buf = data.to_vec();
 
@@ -634,14 +937,22 @@ pub fn convert_to_git(
     // 2. Determine if we should do CRLF→LF conversion
     let would_convert = would_convert_on_input(conv, file_attrs, &buf);
 
-    // 3. safecrlf check — always check if conversion is configured,
-    // even if no actual conversion is needed for this particular file.
-    if would_convert {
-        check_safecrlf_input(conv, &buf, rel_path)?;
+    let mut convert_crlf_into_lf = would_convert && has_crlf(&buf);
+    if convert_crlf_into_lf
+        && clean_uses_autocrlf_index_guard(file_attrs, conv)
+        && !opts.renormalize
+        && opts.index_blob.is_some_and(has_crlf_in_index_blob)
+    {
+        convert_crlf_into_lf = false;
+    }
+
+    // 3. safecrlf check — Git simulates clean then smudge (`check_global_conv_flags_eol`).
+    if would_convert && opts.check_safecrlf {
+        check_safecrlf_roundtrip(conv, file_attrs, &buf, rel_path, convert_crlf_into_lf)?;
     }
 
     // 4. Actually convert CRLF → LF if the file has CRLFs
-    if would_convert && has_crlf(&buf) {
+    if convert_crlf_into_lf {
         buf = crlf_to_lf(&buf);
     }
 
@@ -723,63 +1034,42 @@ fn eprint_safecrlf_warn_lf_to_crlf(rel_path: &str) {
     );
 }
 
-/// Check safecrlf constraints on input.
-fn check_safecrlf_input(
+/// Git `convert.c` `check_global_conv_flags_eol` after simulating clean + smudge.
+fn check_safecrlf_roundtrip(
     conv: &ConversionConfig,
+    file_attrs: &FileAttrs,
     data: &[u8],
     rel_path: &str,
+    convert_crlf_into_lf: bool,
 ) -> Result<(), String> {
     if conv.safecrlf == SafeCrlf::False {
         return Ok(());
     }
 
-    if is_binary(data) {
-        return Ok(());
+    let old_stats = git_text_stat(data);
+
+    let mut new_stats = old_stats.clone();
+    if convert_crlf_into_lf && new_stats.crlf > 0 {
+        new_stats.lonelf += new_stats.crlf;
+        new_stats.crlf = 0;
+    }
+    if will_convert_lf_to_crlf_from_stats(&new_stats, conv, file_attrs) {
+        new_stats.crlf += new_stats.lonelf;
+        new_stats.lonelf = 0;
     }
 
-    let mixed = has_crlf(data) && has_lone_lf(data);
-
-    // Mixed line endings: clean would change some lines; unsafe for both autocrlf modes.
-    if mixed {
-        if conv.autocrlf == AutoCrlf::Input {
-            let msg = format!("fatal: CRLF would be replaced by LF in {rel_path}");
-            if conv.safecrlf == SafeCrlf::True {
-                return Err(msg);
-            }
-            eprint_safecrlf_warn_crlf_to_lf(rel_path);
-            return Ok(());
-        }
-        if conv.autocrlf == AutoCrlf::True {
-            let msg = format!("fatal: LF would be replaced by CRLF in {rel_path}");
-            if conv.safecrlf == SafeCrlf::True {
-                return Err(msg);
-            }
-            eprint_safecrlf_warn_lf_to_crlf(rel_path);
-            return Ok(());
-        }
-    }
-
-    // safecrlf with autocrlf=input: reject if file is all CRLF
-    // (the conversion would be irreversible — CRLF→LF, but checkout won't
-    // add CR back because autocrlf=input only strips on input)
-    if conv.autocrlf == AutoCrlf::Input && is_all_crlf(data) {
+    if old_stats.crlf > 0 && new_stats.crlf == 0 {
         let msg = format!("fatal: CRLF would be replaced by LF in {rel_path}");
         if conv.safecrlf == SafeCrlf::True {
             return Err(msg);
         }
         eprint_safecrlf_warn_crlf_to_lf(rel_path);
-        return Ok(());
-    }
-
-    // safecrlf with autocrlf=true: reject if file is all LF
-    // (LF→LF on input, then LF→CRLF on checkout changes the file)
-    if conv.autocrlf == AutoCrlf::True && is_all_lf(data) {
+    } else if old_stats.lonelf > 0 && new_stats.lonelf == 0 {
         let msg = format!("fatal: LF would be replaced by CRLF in {rel_path}");
         if conv.safecrlf == SafeCrlf::True {
             return Err(msg);
         }
         eprint_safecrlf_warn_lf_to_crlf(rel_path);
-        return Ok(());
     }
 
     Ok(())
@@ -947,7 +1237,10 @@ fn should_convert_to_crlf(conv: &ConversionConfig, attrs: &FileAttrs, data: &[u8
 
 /// Whether the output EOL should be CRLF based on config.
 fn output_eol_is_crlf(conv: &ConversionConfig) -> bool {
-    // autocrlf=true overrides core.eol
+    // Git `text_eol_is_crlf`: autocrlf=input forces LF output before `core.eol` is consulted.
+    if conv.autocrlf == AutoCrlf::Input {
+        return false;
+    }
     if conv.autocrlf == AutoCrlf::True {
         return true;
     }

--- a/grit-lib/src/diff.rs
+++ b/grit-lib/src/diff.rs
@@ -625,6 +625,7 @@ pub fn diff_index_to_worktree(
                         &conv,
                         &file_attrs,
                         path_str_ref,
+                        None,
                     )?;
                     let worktree_mode = mode_from_metadata(&meta);
                     result.push(DiffEntry {
@@ -711,7 +712,15 @@ pub fn diff_index_to_worktree(
                 // contents can share the same size (e.g. `foo` vs `bar`), and rapid edits can
                 // leave timestamps looking "unchanged" relative to the index (t4015-diff-whitespace).
                 let file_attrs = crlf::get_file_attrs(&attrs, path_str_ref, &config);
-                let worktree_oid = hash_worktree_file(odb, &file_path, &meta, &conv, &file_attrs, path_str_ref)?;
+                let worktree_oid = hash_worktree_file(
+                    odb,
+                    &file_path,
+                    &meta,
+                    &conv,
+                    &file_attrs,
+                    path_str_ref,
+                    Some(ie),
+                )?;
 
                 // If clean conversion disagrees with the index but raw bytes match the
                 // blob (e.g. mixed line endings committed with autocrlf off), Git reports
@@ -788,7 +797,15 @@ pub fn diff_index_to_worktree(
 
         if let Some(meta) = wt_meta {
             let file_attrs = crlf::get_file_attrs(&attrs, &path, &config);
-            let wt_oid = hash_worktree_file(odb, &file_path, &meta, &conv, &file_attrs, &path)?;
+            let wt_oid = hash_worktree_file(
+                odb,
+                &file_path,
+                &meta,
+                &conv,
+                &file_attrs,
+                &path,
+                Some(base_entry),
+            )?;
             let wt_mode = mode_from_metadata(&meta);
             if wt_oid != base_entry.oid || wt_mode != base_entry.mode {
                 result.push(DiffEntry {
@@ -854,8 +871,15 @@ pub fn worktree_differs_from_index_entry(
     let conv = crlf::ConversionConfig::from_config(&config);
     let attrs = crlf::load_gitattributes(work_tree);
     let file_attrs = crlf::get_file_attrs(&attrs, path_str_ref, &config);
-    let worktree_oid =
-        hash_worktree_file(odb, &file_path, &meta, &conv, &file_attrs, path_str_ref)?;
+    let worktree_oid = hash_worktree_file(
+        odb,
+        &file_path,
+        &meta,
+        &conv,
+        &file_attrs,
+        path_str_ref,
+        Some(ie),
+    )?;
 
     let mut eff_oid = worktree_oid;
     if eff_oid != ie.oid {
@@ -916,21 +940,31 @@ fn has_symlink_in_path(work_tree: &Path, rel_path: &str) -> bool {
 }
 
 pub(crate) fn hash_worktree_file(
-    _odb: &Odb,
+    odb: &Odb,
     path: &Path,
     meta: &fs::Metadata,
     conv: &crate::crlf::ConversionConfig,
     file_attrs: &crate::crlf::FileAttrs,
     rel_path: &str,
+    index_entry: Option<&IndexEntry>,
 ) -> Result<ObjectId> {
+    let prior_blob: Option<Vec<u8>> = index_entry
+        .filter(|e| e.oid != zero_oid())
+        .and_then(|e| odb.read(&e.oid).ok().map(|o| o.data));
     let data = if meta.file_type().is_symlink() {
         // For symlinks, hash the target path
         let target = fs::read_link(path)?;
         target.to_string_lossy().into_owned().into_bytes()
     } else {
         let raw = fs::read(path)?;
-        // Apply clean conversion (CRLF→LF) so hash matches index blob
-        crate::crlf::convert_to_git(&raw, rel_path, conv, file_attrs).unwrap_or(raw)
+        // Apply clean conversion (CRLF→LF) so hash matches index blob.
+        // Do not run safecrlf here: diff/commit use this for hashing and must not print warnings.
+        let opts = crate::crlf::ConvertToGitOpts {
+            index_blob: prior_blob.as_deref(),
+            renormalize: false,
+            check_safecrlf: false,
+        };
+        crate::crlf::convert_to_git_with_opts(&raw, rel_path, conv, file_attrs, opts).unwrap_or(raw)
     };
 
     Ok(Odb::hash_object_data(ObjectKind::Blob, &data))
@@ -1054,7 +1088,15 @@ pub fn diff_tree_to_worktree(
 
                 // Stat or content differs — hash the file
                 let file_attrs = crlf::get_file_attrs(&attrs, path, &config);
-                let wt_oid = hash_worktree_file(odb, &file_path, meta, &conv, &file_attrs, path)?;
+                let wt_oid = hash_worktree_file(
+                    odb,
+                    &file_path,
+                    meta,
+                    &conv,
+                    &file_attrs,
+                    path,
+                    index_entries.get(path.as_bytes()).copied(),
+                )?;
                 let wt_mode = mode_from_metadata(meta);
                 if wt_oid != te.oid || wt_mode != te.mode {
                     result.push(DiffEntry {
@@ -1085,7 +1127,15 @@ pub fn diff_tree_to_worktree(
             (None, Some(ref meta)) => {
                 // In index but not in tree, and exists in worktree
                 let file_attrs = crlf::get_file_attrs(&attrs, path, &config);
-                let wt_oid = hash_worktree_file(odb, &file_path, meta, &conv, &file_attrs, path)?;
+                let wt_oid = hash_worktree_file(
+                    odb,
+                    &file_path,
+                    meta,
+                    &conv,
+                    &file_attrs,
+                    path,
+                    index_entries.get(path.as_bytes()).copied(),
+                )?;
                 let wt_mode = mode_from_metadata(meta);
                 result.push(DiffEntry {
                     status: DiffStatus::Added,

--- a/grit-lib/src/pathspec.rs
+++ b/grit-lib/src/pathspec.rs
@@ -55,6 +55,12 @@ fn literal_global() -> bool {
     git_env_bool("GIT_LITERAL_PATHSPECS", false)
 }
 
+/// Whether `GIT_LITERAL_PATHSPECS` is enabled (shell `*` and `?` are literal, not globs).
+#[must_use]
+pub fn literal_pathspecs_enabled() -> bool {
+    literal_global()
+}
+
 fn glob_global() -> bool {
     git_env_bool("GIT_GLOB_PATHSPECS", false)
 }

--- a/grit/src/commands/add.rs
+++ b/grit/src/commands/add.rs
@@ -9,6 +9,7 @@ use grit_lib::attributes::{parse_gitattributes_file_content, validate_rules_for_
 use grit_lib::config::ConfigSet;
 use grit_lib::crlf::{self, ConversionConfig, GitAttributes};
 use grit_lib::diff::stat_matches;
+use grit_lib::error::Error;
 use grit_lib::ignore::IgnoreMatcher;
 use grit_lib::index::{entry_from_metadata, normalize_mode, Index, IndexEntry};
 #[allow(unused_imports)]
@@ -17,6 +18,7 @@ use grit_lib::objects::ObjectKind;
 use grit_lib::odb::Odb;
 use grit_lib::repo::Repository;
 use grit_lib::wildmatch::wildmatch;
+use std::collections::HashSet;
 use std::fs;
 use std::io::Read;
 use std::os::unix::fs::MetadataExt;
@@ -115,6 +117,37 @@ pub struct Args {
     /// NUL-terminated pathspec input (requires --pathspec-from-file).
     #[arg(long = "pathspec-file-nul")]
     pub pathspec_file_nul: bool,
+}
+
+/// Flags for [`stage_file`] shared by `git add` and `git commit <paths>`.
+pub(crate) struct StageFileContext<'a> {
+    pub dry_run: bool,
+    pub verbose: bool,
+    pub intent_to_add: bool,
+    pub chmod: Option<&'a str>,
+}
+
+impl StageFileContext<'_> {
+    /// Staging as performed by `git commit` pathspecs (no dry-run, no chmod, no intent-to-add).
+    pub fn for_commit() -> Self {
+        Self {
+            dry_run: false,
+            verbose: false,
+            intent_to_add: false,
+            chmod: None,
+        }
+    }
+}
+
+impl<'a> From<&'a Args> for StageFileContext<'a> {
+    fn from(a: &'a Args) -> Self {
+        Self {
+            dry_run: a.dry_run,
+            verbose: a.verbose,
+            intent_to_add: a.intent_to_add,
+            chmod: a.chmod.as_deref(),
+        }
+    }
 }
 
 /// Run the `add` command.
@@ -293,6 +326,7 @@ pub fn run(mut args: Args) -> Result<()> {
             work_tree,
             prefix.as_deref(),
             &args,
+            &repo,
             &add_cfg,
         )?;
     } else {
@@ -375,12 +409,144 @@ pub fn run(mut args: Args) -> Result<()> {
     Ok(())
 }
 
-struct AddConfig {
-    core_filemode: bool,
-    ignore_errors: bool,
-    conv: ConversionConfig,
-    attrs: GitAttributes,
-    config: ConfigSet,
+pub(crate) struct AddConfig {
+    pub core_filemode: bool,
+    pub ignore_errors: bool,
+    pub conv: ConversionConfig,
+    pub attrs: GitAttributes,
+    pub config: ConfigSet,
+}
+
+/// Stage pathspecs the same way `git commit <paths>` does (recursive dirs, CRLF clean, etc.).
+pub(crate) fn stage_pathspecs_for_commit(
+    repo: &Repository,
+    work_tree: &Path,
+    pathspecs: &[String],
+    add_cfg: &AddConfig,
+) -> Result<HashSet<Vec<u8>>> {
+    let index_path = resolved_env_index_path(repo);
+    let mut index = match repo.load_index_at(&index_path) {
+        Ok(idx) => idx,
+        Err(Error::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => Index::new(),
+        Err(e) => return Err(e.into()),
+    };
+
+    let cwd = std::env::current_dir().unwrap_or_else(|_| work_tree.to_path_buf());
+    let prefix = crate::pathspec::pathdiff(&cwd, work_tree);
+
+    let mut ignore_matcher = Some(IgnoreMatcher::from_repository(repo)?);
+    let odb = &repo.odb;
+    let ctx = StageFileContext::for_commit();
+
+    let mut matched_paths = HashSet::new();
+
+    for spec in pathspecs {
+        let resolved = crate::pathspec::resolve_pathspec(spec, work_tree, prefix.as_deref());
+
+        if !crate::pathspec::has_glob_chars(&resolved) {
+            let abs_path = work_tree.join(&resolved);
+            let meta = match fs::symlink_metadata(&abs_path) {
+                Ok(m) => m,
+                Err(_) => {
+                    index.remove(resolved.as_bytes());
+                    matched_paths.insert(resolved.as_bytes().to_vec());
+                    continue;
+                }
+            };
+
+            let is_real_dir = !meta.file_type().is_symlink() && meta.file_type().is_dir();
+            if is_real_dir {
+                if is_nested_embedded_git_repo(&abs_path, repo) {
+                    stage_gitlink(
+                        odb, &mut index, work_tree, &resolved, &abs_path, false, false, false,
+                    )?;
+                    matched_paths.insert(resolved.as_bytes().to_vec());
+                    continue;
+                }
+                let rels = collect_paths_for_stage_from_directory(
+                    &abs_path,
+                    work_tree,
+                    repo,
+                    &mut ignore_matcher,
+                    false,
+                )?;
+                for rel in rels {
+                    let file_abs = work_tree.join(&rel);
+                    stage_file(
+                        odb, &mut index, work_tree, &rel, &file_abs, repo, &ctx, add_cfg,
+                    )?;
+                    matched_paths.insert(rel.as_bytes().to_vec());
+                }
+                continue;
+            }
+
+            stage_file(
+                odb, &mut index, work_tree, &resolved, &abs_path, repo, &ctx, add_cfg,
+            )?;
+            matched_paths.insert(resolved.as_bytes().to_vec());
+            continue;
+        }
+
+        let (dir_prefix, pattern) = if let Some(slash_pos) = resolved.rfind('/') {
+            (&resolved[..slash_pos], &resolved[slash_pos + 1..])
+        } else {
+            ("", resolved.as_str())
+        };
+
+        let search_dir = if dir_prefix.is_empty() {
+            work_tree.to_path_buf()
+        } else {
+            work_tree.join(dir_prefix)
+        };
+
+        let mut spec_matched = false;
+        let mut matched_rels: Vec<String> = Vec::new();
+        if let Ok(entries) = fs::read_dir(&search_dir) {
+            for entry in entries.flatten() {
+                let name_str = entry.file_name().to_string_lossy().to_string();
+                if name_str == ".git" {
+                    continue;
+                }
+                if !wildmatch(pattern.as_bytes(), name_str.as_bytes(), 0) {
+                    continue;
+                }
+                let rel = if dir_prefix.is_empty() {
+                    name_str.clone()
+                } else {
+                    format!("{dir_prefix}/{name_str}")
+                };
+                matched_rels.push(rel);
+            }
+        }
+        if pattern.contains('[') && fs::symlink_metadata(search_dir.join(pattern)).is_ok() {
+            let rel = if dir_prefix.is_empty() {
+                pattern.to_string()
+            } else {
+                format!("{dir_prefix}/{pattern}")
+            };
+            if !matched_rels.contains(&rel) {
+                matched_rels.push(rel);
+            }
+        }
+
+        for rel in matched_rels {
+            let abs_path = work_tree.join(&rel);
+            if fs::symlink_metadata(&abs_path).is_ok() {
+                stage_file(
+                    odb, &mut index, work_tree, &rel, &abs_path, repo, &ctx, add_cfg,
+                )?;
+                spec_matched = true;
+                matched_paths.insert(rel.as_bytes().to_vec());
+            }
+        }
+
+        if !spec_matched {
+            bail!("pathspec '{spec}' did not match any file(s) known to git");
+        }
+    }
+
+    repo.write_index_at(&index_path, &mut index)?;
+    Ok(matched_paths)
 }
 
 #[allow(dead_code)]
@@ -578,7 +744,16 @@ fn add_all(
 
     for rel_path in &paths {
         let abs_path = work_tree.join(rel_path);
-        if let Err(e) = stage_file(odb, index, work_tree, rel_path, &abs_path, args, add_cfg) {
+        if let Err(e) = stage_file(
+            odb,
+            index,
+            work_tree,
+            rel_path,
+            &abs_path,
+            repo,
+            &StageFileContext::from(args),
+            add_cfg,
+        ) {
             if add_cfg.ignore_errors {
                 eprintln!("warning: {e}");
             } else {
@@ -630,6 +805,7 @@ fn update_tracked(
     work_tree: &Path,
     prefix: Option<&str>,
     args: &Args,
+    repo: &Repository,
     add_cfg: &AddConfig,
 ) -> Result<()> {
     // If explicit pathspecs given with -u, validate that each matches a tracked file.
@@ -713,7 +889,16 @@ fn update_tracked(
                     }
                 }
             } else {
-                stage_file(odb, index, work_tree, path_str, &abs_path, args, add_cfg)?;
+                stage_file(
+                    odb,
+                    index,
+                    work_tree,
+                    path_str,
+                    &abs_path,
+                    repo,
+                    &StageFileContext::from(args),
+                    add_cfg,
+                )?;
             }
         } else {
             if args.verbose || args.dry_run {
@@ -822,12 +1007,20 @@ fn add_path(
             }
         }
 
-        // Check for embedded repository (directory with its own .git)
-        let embedded_git = abs_path.join(".git");
-        if embedded_git.exists() {
+        // Nested repository (subdirectory with its own .git, not the superproject root).
+        if is_nested_embedded_git_repo(&abs_path, repo) {
             // This is an embedded repository — stage as a gitlink (160000)
-            return stage_gitlink(odb, index, work_tree, path, &abs_path, args)
-                .map_err(AddPathError::IoError);
+            return stage_gitlink(
+                odb,
+                index,
+                work_tree,
+                path,
+                &abs_path,
+                args.dry_run,
+                args.verbose,
+                args.no_warn_embedded_repo,
+            )
+            .map_err(AddPathError::IoError);
         }
 
         let mut paths = Vec::new();
@@ -841,7 +1034,16 @@ fn add_path(
         )?;
         for rel_path in &paths {
             let file_abs = work_tree.join(rel_path);
-            if let Err(e) = stage_file(odb, index, work_tree, rel_path, &file_abs, args, add_cfg) {
+            if let Err(e) = stage_file(
+                odb,
+                index,
+                work_tree,
+                rel_path,
+                &file_abs,
+                repo,
+                &StageFileContext::from(args),
+                add_cfg,
+            ) {
                 if add_cfg.ignore_errors {
                     eprintln!("warning: {e}");
                 } else {
@@ -870,8 +1072,17 @@ fn add_path(
                 }
             }
         }
-        stage_file(odb, index, work_tree, path, &abs_path, args, add_cfg)
-            .map_err(AddPathError::IoError)?;
+        stage_file(
+            odb,
+            index,
+            work_tree,
+            path,
+            &abs_path,
+            repo,
+            &StageFileContext::from(args),
+            add_cfg,
+        )
+        .map_err(AddPathError::IoError)?;
     }
 
     Ok(())
@@ -915,7 +1126,9 @@ fn stage_gitlink(
     _work_tree: &Path,
     rel_path: &str,
     abs_path: &Path,
-    args: &Args,
+    dry_run: bool,
+    verbose: bool,
+    no_warn_embedded_repo: bool,
 ) -> Result<()> {
     let git_dir = embedded_repository_git_dir(abs_path)?;
     let embedded_head_path = git_dir.join("HEAD");
@@ -949,7 +1162,7 @@ fn stage_gitlink(
         .unwrap_or(false);
 
     // Warn about embedded repository unless suppressed
-    if !args.no_warn_embedded_repo && !already_tracked {
+    if !no_warn_embedded_repo && !already_tracked {
         eprintln!("warning: adding embedded git repository: {}", rel_path);
         eprintln!("hint: You've added another git repository inside your current repository.");
         eprintln!("hint: Clones of the outer repository will not contain the contents of");
@@ -966,7 +1179,7 @@ fn stage_gitlink(
         eprintln!("hint: See \"git help submodule\" for more information.");
     }
 
-    if args.dry_run {
+    if dry_run {
         println!("add '{}'", rel_path);
         return Ok(());
     }
@@ -993,7 +1206,7 @@ fn stage_gitlink(
     };
     index.add_or_replace(entry);
 
-    if args.verbose {
+    if verbose {
         println!("add '{}'", rel_path);
     }
 
@@ -1004,6 +1217,21 @@ fn path_is_symlink(abs_path: &Path) -> bool {
     fs::symlink_metadata(abs_path)
         .map(|m| m.file_type().is_symlink())
         .unwrap_or(false)
+}
+
+/// True when `abs_path/.git` is a **nested** repository, not this repo's own `.git` at the work tree root.
+fn is_nested_embedded_git_repo(abs_path: &Path, repo: &Repository) -> bool {
+    let embedded = abs_path.join(".git");
+    if !embedded.exists() {
+        return false;
+    }
+    let Ok(emb) = fs::canonicalize(&embedded) else {
+        return true;
+    };
+    let Ok(super_git) = fs::canonicalize(&repo.git_dir) else {
+        return true;
+    };
+    emb != super_git
 }
 
 fn remove_obstructing_parent_file_entries(index: &mut Index, rel_path: &str) {
@@ -1023,17 +1251,18 @@ fn remove_obstructing_parent_file_entries(index: &mut Index, rel_path: &str) {
 }
 
 /// Stage a single file into the index.
-fn stage_file(
+pub(crate) fn stage_file(
     odb: &Odb,
     index: &mut Index,
     _work_tree: &Path,
     rel_path: &str,
     abs_path: &Path,
-    args: &Args,
+    repo: &Repository,
+    ctx: &StageFileContext<'_>,
     add_cfg: &AddConfig,
 ) -> Result<()> {
-    if args.dry_run {
-        if args.chmod.is_some() {
+    if ctx.dry_run {
+        if ctx.chmod.is_some() {
             // Don't actually stage, just check if the file exists
             return Ok(());
         }
@@ -1058,11 +1287,23 @@ fn stage_file(
 
     // Submodule / embedded repo roots appear as directories with `.git`; `walk_directory` records
     // the directory path without recursing, so we must stage them as gitlinks here.
-    if meta.is_dir() && !meta.file_type().is_symlink() && abs_path.join(".git").exists() {
-        return stage_gitlink(odb, index, _work_tree, rel_path, abs_path, args);
+    if meta.is_dir()
+        && !meta.file_type().is_symlink()
+        && is_nested_embedded_git_repo(abs_path, repo)
+    {
+        return stage_gitlink(
+            odb,
+            index,
+            _work_tree,
+            rel_path,
+            abs_path,
+            ctx.dry_run,
+            ctx.verbose,
+            false,
+        );
     }
 
-    if args.intent_to_add {
+    if ctx.intent_to_add {
         // Don't clobber existing entries — only add the intent marker if not already staged
         if index.get(rel_path.as_bytes(), 0).is_some() {
             return Ok(());
@@ -1092,7 +1333,7 @@ fn stage_file(
         };
         entry.set_intent_to_add(true);
         index.add_or_replace(entry);
-        if args.verbose {
+        if ctx.verbose {
             println!("add '{rel_path}'");
         }
         return Ok(());
@@ -1117,7 +1358,7 @@ fn stage_file(
     };
 
     // Handle --chmod flag
-    let final_mode = if let Some(ref chmod_val) = args.chmod {
+    let final_mode = if let Some(chmod_val) = ctx.chmod {
         if is_symlink {
             let display_path = rel_path;
             eprintln!("warning: cannot chmod {} '{}'", chmod_val, display_path);
@@ -1127,7 +1368,7 @@ fn stage_file(
                 display_path
             ));
         }
-        match chmod_val.as_str() {
+        match chmod_val {
             "+x" => 0o100755,
             "-x" => 0o100644,
             other => bail!("unrecognized --chmod value: {}", other),
@@ -1137,7 +1378,7 @@ fn stage_file(
     };
 
     // Skip if index already has this file with matching stat data and no chmod override
-    if args.chmod.is_none() {
+    if ctx.chmod.is_none() {
         if let Some(existing) = index.get(rel_path.as_bytes(), 0) {
             if stat_matches(existing, &meta) && existing.mode == final_mode {
                 return Ok(());
@@ -1164,7 +1405,17 @@ fn stage_file(
         } else {
             raw
         };
-        match crlf::convert_to_git(&raw, rel_path, &add_cfg.conv, &file_attrs) {
+        let prior_blob: Option<Vec<u8>> = index
+            .get(rel_path.as_bytes(), 0)
+            .filter(|e| e.oid != ObjectId::zero())
+            .and_then(|e| odb.read(&e.oid).ok())
+            .map(|o| o.data);
+        let opts = crlf::ConvertToGitOpts {
+            index_blob: prior_blob.as_deref(),
+            renormalize: false,
+            check_safecrlf: true,
+        };
+        match crlf::convert_to_git_with_opts(&raw, rel_path, &add_cfg.conv, &file_attrs, opts) {
             Ok(converted) => converted,
             Err(msg) => bail!("{msg}"),
         }
@@ -1179,7 +1430,7 @@ fn stage_file(
                              // path — this is how `git add` resolves merge/cherry-pick conflicts.
     index.stage_file(entry);
 
-    if args.verbose {
+    if ctx.verbose {
         println!("add '{rel_path}'");
     }
 
@@ -1269,6 +1520,20 @@ fn is_pid_running(pid: u32) -> bool {
         let _ = pid;
         false
     }
+}
+
+/// Collect repository-relative paths under `dir` for staging (same rules as `git add <dir>`:
+/// skips `.git`, ignored paths unless `force`, records embedded repos as single paths).
+pub(crate) fn collect_paths_for_stage_from_directory(
+    dir: &Path,
+    work_tree: &Path,
+    repo: &Repository,
+    ignore_matcher: &mut Option<IgnoreMatcher>,
+    force: bool,
+) -> Result<Vec<String>> {
+    let mut out = Vec::new();
+    walk_directory(dir, work_tree, &mut out, repo, ignore_matcher, force)?;
+    Ok(out)
 }
 
 /// Recursively walk a directory, collecting relative paths (skipping .git and ignored files).
@@ -1393,7 +1658,7 @@ fn check_symlink_in_path(work_tree: &Path, rel_path: &Path) -> Option<PathBuf> {
 ///
 /// If the pathspec does not contain glob characters, returns it unchanged.
 /// Otherwise, matches it against files/dirs in the working tree directory.
-fn expand_glob_pathspec(pathspec: &str, work_tree: &Path) -> Vec<String> {
+pub(crate) fn expand_glob_pathspec(pathspec: &str, work_tree: &Path) -> Vec<String> {
     if !crate::pathspec::has_glob_chars(pathspec) {
         return vec![pathspec.to_owned()];
     }

--- a/grit/src/commands/checkout.rs
+++ b/grit/src/commands/checkout.rs
@@ -3532,8 +3532,10 @@ fn write_blob_to_worktree(
         bail!("cannot checkout non-blob at '{rel_path}'");
     }
 
-    // Path-only checkout: if the work tree already matches the index blob (clean pipeline agrees),
-    // skip smudge entirely — matches Git / t0021 filter log expectations.
+    // Path-only checkout: if the work tree already matches the *smudged* blob Git would write
+    // (EOL + ident + filters), skip rewriting — matches Git / t0021 filter log expectations.
+    // Compare against smudge output, not clean: `core.eol=crlf` can change bytes without changing
+    // the index blob (t0027).
     if !full_smudge_meta && mode != MODE_SYMLINK {
         let config = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
         let conv = crlf::ConversionConfig::from_config(&config);
@@ -3542,8 +3544,17 @@ fn write_blob_to_worktree(
         if file_attrs.working_tree_encoding.is_none() {
             let abs_path = work_tree.join(rel_path);
             if let Ok(wt_raw) = std::fs::read(&abs_path) {
-                if let Ok(cleaned) = crlf::convert_to_git(&wt_raw, rel_path, &conv, &file_attrs) {
-                    if cleaned == obj.data {
+                let oid_hex = format!("{oid}");
+                let smudge_meta = filter_process::smudge_meta_blob_only(&oid_hex);
+                if let Ok(smudged) = crlf::convert_to_worktree(
+                    &obj.data,
+                    rel_path,
+                    &conv,
+                    &file_attrs,
+                    Some(&oid_hex),
+                    Some(&smudge_meta),
+                ) {
+                    if smudged == wt_raw {
                         return Ok(false);
                     }
                 }

--- a/grit/src/commands/commit.rs
+++ b/grit/src/commands/commit.rs
@@ -327,7 +327,24 @@ pub fn run(mut args: Args) -> Result<()> {
         let Some(wt) = work_tree else {
             bail!("pathspec requires a work tree");
         };
-        Some(stage_pathspec_files(&repo, wt, &args.pathspec)?)
+        let config = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+        let core_filemode = config
+            .get_bool("core.filemode")
+            .and_then(|r| r.ok())
+            .unwrap_or(true);
+        let add_cfg = crate::commands::add::AddConfig {
+            core_filemode,
+            ignore_errors: false,
+            conv: grit_lib::crlf::ConversionConfig::from_config(&config),
+            attrs: grit_lib::crlf::load_gitattributes(wt),
+            config,
+        };
+        Some(crate::commands::add::stage_pathspecs_for_commit(
+            &repo,
+            wt,
+            &args.pathspec,
+            &add_cfg,
+        )?)
     } else {
         None
     };
@@ -979,122 +996,6 @@ fn walk_untracked(
         }
     }
     Ok(())
-}
-
-/// Stage specific files given as pathspec arguments to `commit`.
-///
-/// Returns the set of repository-relative paths that were staged (or removed) for this commit.
-fn stage_pathspec_files(
-    repo: &Repository,
-    work_tree: &Path,
-    pathspecs: &[String],
-) -> Result<HashSet<Vec<u8>>> {
-    use std::os::unix::fs::MetadataExt;
-
-    let index_path = resolved_index_path(repo);
-    let mut index = match repo.load_index_at(&index_path) {
-        Ok(idx) => idx,
-        Err(Error::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => Index::new(),
-        Err(e) => return Err(e.into()),
-    };
-
-    let cwd = std::env::current_dir().unwrap_or_else(|_| work_tree.to_path_buf());
-    let prefix = crate::pathspec::pathdiff(&cwd, work_tree);
-
-    let mut matched_paths = HashSet::new();
-
-    for spec in pathspecs {
-        let resolved = crate::pathspec::resolve_pathspec(spec, work_tree, prefix.as_deref());
-        if !crate::pathspec::has_glob_chars(&resolved) {
-            let abs_path = work_tree.join(&resolved);
-            if let Ok(meta) = fs::symlink_metadata(&abs_path) {
-                let data = if meta.file_type().is_symlink() {
-                    let target = fs::read_link(&abs_path)?;
-                    target.to_string_lossy().into_owned().into_bytes()
-                } else {
-                    fs::read(&abs_path)?
-                };
-                let oid = repo.odb.write(ObjectKind::Blob, &data)?;
-                let mode = grit_lib::index::normalize_mode(meta.mode());
-                let raw_path = resolved.as_bytes().to_vec();
-                let entry = grit_lib::index::entry_from_stat(&abs_path, &raw_path, oid, mode)?;
-                index.add_or_replace(entry);
-                matched_paths.insert(raw_path);
-            } else {
-                index.remove(resolved.as_bytes());
-                matched_paths.insert(resolved.as_bytes().to_vec());
-            }
-            continue;
-        }
-
-        let (dir_prefix, pattern) = if let Some(slash_pos) = resolved.rfind('/') {
-            (&resolved[..slash_pos], &resolved[slash_pos + 1..])
-        } else {
-            ("", resolved.as_str())
-        };
-
-        let search_dir = if dir_prefix.is_empty() {
-            work_tree.to_path_buf()
-        } else {
-            work_tree.join(dir_prefix)
-        };
-
-        let mut spec_matched = false;
-        let mut matched_rels: Vec<String> = Vec::new();
-        if let Ok(entries) = fs::read_dir(&search_dir) {
-            for entry in entries.flatten() {
-                let name_str = entry.file_name().to_string_lossy().to_string();
-                if name_str == ".git" {
-                    continue;
-                }
-                if !grit_lib::wildmatch::wildmatch(pattern.as_bytes(), name_str.as_bytes(), 0) {
-                    continue;
-                }
-                let rel = if dir_prefix.is_empty() {
-                    name_str.clone()
-                } else {
-                    format!("{dir_prefix}/{name_str}")
-                };
-                matched_rels.push(rel);
-            }
-        }
-        if pattern.contains('[') && fs::symlink_metadata(search_dir.join(pattern)).is_ok() {
-            let rel = if dir_prefix.is_empty() {
-                pattern.to_string()
-            } else {
-                format!("{dir_prefix}/{pattern}")
-            };
-            if !matched_rels.contains(&rel) {
-                matched_rels.push(rel);
-            }
-        }
-
-        for rel in matched_rels {
-            let abs_path = work_tree.join(&rel);
-            if let Ok(meta) = fs::symlink_metadata(&abs_path) {
-                let data = if meta.file_type().is_symlink() {
-                    let target = fs::read_link(&abs_path)?;
-                    target.to_string_lossy().into_owned().into_bytes()
-                } else {
-                    fs::read(&abs_path)?
-                };
-                let oid = repo.odb.write(ObjectKind::Blob, &data)?;
-                let mode = grit_lib::index::normalize_mode(meta.mode());
-                let raw_path = rel.as_bytes().to_vec();
-                let entry = grit_lib::index::entry_from_stat(&abs_path, &raw_path, oid, mode)?;
-                index.add_or_replace(entry);
-                spec_matched = true;
-                matched_paths.insert(raw_path);
-            }
-        }
-
-        if !spec_matched {
-            bail!("pathspec '{spec}' did not match any file(s) known to git");
-        }
-    }
-
-    repo.write_index_at(&index_path, &mut index)?;
-    Ok(matched_paths)
 }
 
 /// Auto-stage tracked files (for `commit -a`).

--- a/grit/src/commands/ls_files.rs
+++ b/grit/src/commands/ls_files.rs
@@ -200,6 +200,8 @@ pub fn run(args: Args) -> Result<()> {
         pathspec_filter.push(Pathspec::Literal(cwd_prefix.clone()));
     }
 
+    pathspec_filter = expand_ls_files_globs(pathspec_filter, work_tree, &index);
+
     // Track which pathspecs matched at least one entry (for --error-unmatch).
     let mut matched: Vec<bool> = vec![false; pathspec_filter.len()];
 
@@ -228,6 +230,8 @@ pub fn run(args: Args) -> Result<()> {
     } else {
         None
     };
+
+    let attrs_for_eol = grit_lib::crlf::load_gitattributes(work_tree);
 
     let mut last_dedup_path: Option<Vec<u8>> = None;
     for entry in &index.entries {
@@ -323,45 +327,26 @@ pub fn run(args: Args) -> Result<()> {
             let name = String::from_utf8_lossy(display);
             let path_str = std::str::from_utf8(&entry.path).unwrap_or("");
 
-            // Determine index line endings
+            // Index / worktree EOL stats: match Git `convert.c` `gather_convert_stats_ascii`.
             let index_eol = if entry.oid != grit_lib::diff::zero_oid() {
                 if let Ok(obj) = repo.odb.read(&entry.oid) {
-                    describe_eol(&obj.data)
+                    grit_lib::crlf::gather_convert_stats_ascii(&obj.data).to_string()
                 } else {
                     "binary".to_string()
                 }
             } else {
-                "".to_string()
+                String::new()
             };
 
-            // Determine worktree line endings
             let wt_path = work_tree.join(path_str);
             let wt_eol = if let Ok(data) = std::fs::read(&wt_path) {
-                describe_eol(&data)
+                grit_lib::crlf::gather_convert_stats_ascii(&data).to_string()
             } else {
-                "".to_string()
+                String::new()
             };
 
-            // Determine attribute setting
-            let attr_str = {
-                use grit_lib::crlf;
-                let attrs = crlf::load_gitattributes(work_tree);
-                let file_attrs = crlf::get_file_attrs(&attrs, path_str, &config);
-                match file_attrs.text {
-                    crlf::TextAttr::Set => match file_attrs.eol {
-                        crlf::EolAttr::Lf => "text=auto eol=lf".to_string(),
-                        crlf::EolAttr::Crlf => "text=auto eol=crlf".to_string(),
-                        crlf::EolAttr::Unspecified => "text".to_string(),
-                    },
-                    crlf::TextAttr::Auto => match file_attrs.eol {
-                        crlf::EolAttr::Lf => "text=auto eol=lf".to_string(),
-                        crlf::EolAttr::Crlf => "text=auto eol=crlf".to_string(),
-                        crlf::EolAttr::Unspecified => "text=auto".to_string(),
-                    },
-                    crlf::TextAttr::Unset => "binary".to_string(),
-                    crlf::TextAttr::Unspecified => "".to_string(),
-                }
-            };
+            let attr_str =
+                grit_lib::crlf::convert_attr_ascii_for_ls_files(&attrs_for_eol, path_str, &config);
 
             write!(out, "i/{index_eol} w/{wt_eol} attr/{attr_str}\t{name}")?;
             out.write_all(&[term])?;
@@ -540,7 +525,21 @@ pub fn run(args: Args) -> Result<()> {
         for display in &output_paths {
             let name = String::from_utf8_lossy(display);
             let qname = format_ls_path(&name, use_nul, quote_path);
-            if args.show_tag {
+            if args.eol {
+                let path_str = String::from_utf8_lossy(display);
+                let full = work_tree.join(path_str.as_ref());
+                let wt_eol = if let Ok(data) = std::fs::read(&full) {
+                    grit_lib::crlf::gather_convert_stats_ascii(&data).to_string()
+                } else {
+                    String::new()
+                };
+                let attr_str = grit_lib::crlf::convert_attr_ascii_for_ls_files(
+                    &attrs_for_eol,
+                    path_str.as_ref(),
+                    &config,
+                );
+                write!(out, "i/ w/{wt_eol} attr/{attr_str}\t{qname}")?;
+            } else if args.show_tag {
                 write!(out, "? {qname}")?;
             } else {
                 write!(out, "{qname}")?;
@@ -670,6 +669,36 @@ enum Pathspec {
     Magic(String),
 }
 
+/// When a glob pathspec matches nothing in the index, expand it against the working tree
+/// (Git-compatible with shell-expanded argv and `expand_glob_pathspec`-style matching).
+fn expand_ls_files_globs(
+    specs: Vec<Pathspec>,
+    work_tree: &std::path::Path,
+    index: &grit_lib::index::Index,
+) -> Vec<Pathspec> {
+    let mut out = Vec::new();
+    for spec in specs {
+        match &spec {
+            Pathspec::Glob(pat) => {
+                let matches_index = index.entries.iter().any(|e| spec.matches(&e.path));
+                if matches_index {
+                    out.push(spec);
+                } else {
+                    for e in crate::commands::add::expand_glob_pathspec(pat, work_tree) {
+                        out.push(if has_glob_chars(&e) {
+                            Pathspec::Glob(e)
+                        } else {
+                            Pathspec::Literal(path_to_bytes(std::path::Path::new(&e)))
+                        });
+                    }
+                }
+            }
+            _ => out.push(spec),
+        }
+    }
+    out
+}
+
 impl Pathspec {
     fn matches(&self, path: &[u8]) -> bool {
         match self {
@@ -697,8 +726,11 @@ impl Pathspec {
     }
 }
 
-/// Check if a string contains glob meta-characters.
+/// Check if a string contains glob meta-characters (honours `GIT_LITERAL_PATHSPECS`).
 fn has_glob_chars(s: &str) -> bool {
+    if grit_lib::pathspec::literal_pathspecs_enabled() {
+        return false;
+    }
     s.contains('*') || s.contains('?') || s.contains('[')
 }
 
@@ -960,22 +992,6 @@ fn is_modified(entry: &IndexEntry, path: &std::path::Path) -> bool {
 }
 
 /// Return the status tag character for an index entry (used by `-t`).
-/// Describe the line ending style of file data.
-fn describe_eol(data: &[u8]) -> String {
-    use grit_lib::crlf;
-    if crlf::is_binary(data) {
-        return "binary".to_string();
-    }
-    let has_crlf = crlf::has_crlf(data);
-    let has_lf = crlf::has_lone_lf(data);
-    match (has_crlf, has_lf) {
-        (true, true) => "mixed".to_string(),
-        (true, false) => "crlf".to_string(),
-        (false, true) => "lf".to_string(),
-        (false, false) => "".to_string(),
-    }
-}
-
 /// Format a path for `ls-files` output: optionally C-quote per `core.quotePath`.
 fn format_ls_path(name: &str, use_nul: bool, quote_path: bool) -> String {
     if use_nul || !quote_path {

--- a/logs/2026-04-09_t0027-auto-crlf.md
+++ b/logs/2026-04-09_t0027-auto-crlf.md
@@ -1,0 +1,38 @@
+# t0027-auto-crlf — full pass (2026-04-09)
+
+## Goal
+
+Make `tests/t0027-auto-crlf.sh` (2600 cases) pass against `grit`.
+
+## Fixes (summary)
+
+- **CRLF / safecrlf (`grit-lib/src/crlf.rs`)**
+  - Default `core.safecrlf` to `warn` when unset (matches Git `global_conv_flags_eol`).
+  - `gather_convert_stats_ascii` + `has_crlf_in_index_blob` aligned with Git `convert.c` (incl. EOF `^Z` handling).
+  - `convert_to_git_with_opts`: `has_crlf_in_index` guard only for AUTO/autocrlf paths; `ConvertToGitOpts` for index blob + optional safecrlf.
+  - `check_safecrlf_roundtrip`: simulate clean then smudge like Git; do not skip on NUL for explicit text.
+  - `convert_attr_ascii_for_ls_files`: bare `eol=` implies text; match `get_convert_attr_ascii`.
+  - `output_eol_is_crlf`: `autocrlf=input` forces LF before `core.eol` (Git `text_eol_is_crlf`).
+
+- **add / commit (`grit/src/commands/add.rs`, `commit.rs`)**
+  - `stage_file` + `stage_pathspecs_for_commit`: directory `.`/`path/` staging like `git add`; reuse CRLF clean + index blob for safer autocrlf.
+  - `is_nested_embedded_git_repo`: do not treat superproject `.git` as embedded repo when path is `.`.
+  - `expand_glob_pathspec` exported for `ls-files`.
+
+- **diff / status hashing (`grit-lib/src/diff.rs`)**
+  - `hash_worktree_file`: pass index entry, load prior blob for clean guard; `check_safecrlf: false` to avoid stderr spam during `commit`/`status`.
+
+- **checkout (`grit/src/commands/checkout.rs`)**
+  - Skip smudge only when **smudged** bytes equal worktree (not clean==index), so `-c core.eol=crlf` applies.
+
+- **ls-files (`grit/src/commands/ls_files.rs`)**
+  - `--eol` for `-o` paths; expand globs that match nothing in index via worktree scan; honour `GIT_LITERAL_PATHSPECS` in local `has_glob_chars`.
+
+- **pathspec (`grit-lib/src/pathspec.rs`)**
+  - `literal_pathspecs_enabled()` for `ls-files`.
+
+## Validation
+
+- `./scripts/run-tests.sh t0027-auto-crlf.sh` → 2600/2600
+- `bash tests/t0020-crlf.sh` → 36/36
+- `cargo test -p grit-lib --lib`

--- a/progress.md
+++ b/progress.md
@@ -1,20 +1,21 @@
 # Progress — Grit Test Coverage
 
-**Updated:** 2026-04-08
+**Updated:** 2026-04-09
 
 ## Counts (derived from plan.md)
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   231 |
-| In progress |     2 |
-| Remaining   |   535 |
+| Completed   |   247 |
+| In progress |     4 |
+| Remaining   |   517 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 231 completed (`[x]`), 2 in progress (`[~]`), 535 remaining (`[ ]`).
+Task lines in `PLAN.md`: 247 completed (`[x]`), 4 in progress (`[~]`), 517 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t0027-auto-crlf` — 2600/2600 tests pass (Git `convert.c` parity: safer `has_crlf_in_index` clean path, default `core.safecrlf=warn` + round-trip simulation, `text_eol_is_crlf` with `autocrlf=input`; `ls-files --eol` attr ASCII + `gather_convert_stats_ascii`; glob pathspec expansion when index has no `*` match; checkout skip-smudge compares smudged bytes; `commit` pathspec staging matches `git add` for dirs/CRLF; embedded `.git` at worktree root no longer stages as gitlink; diff hashing uses prior index blob + no safecrlf spam)
 - `t12820-diff-no-index-symlink` — 41/41 tests pass (symlink add/modify/delete, `diff`/`diff --cached`/`diff-tree`, stat/numstat/name output, multi-symlink and file↔symlink replacements; harness dashboards refreshed)
 - `t7817-grep-sparse-checkout` — 8/8 tests pass (non-cone sparse: `path_in_sparse_checkout` parent walk + last-match-wins; `sparse-checkout init` preserves cone mode and seeds `/*` + `!/*/` when recreating file; `disable` keeps pattern file so re-init reapplies `!b`; submodule `reset --hard` + sparse reapply; `grep` worktree: skip-worktree when absent, CE_VALID vs skip-worktree, unmerged paths grep worktree once; `grep_cached` per-stage for `--cached`)
 - `t7417-submodule-path-url` — 5/5 tests pass (`.gitmodules` dash paths: `mv` updates path + index blob; `escape_value` quotes leading `-`; receive-side `transfer.fsckObjects` via repo-local config only; clone `--recurse-submodules` resolves relative URLs from `origin` repo root + quoted path parsing + `GIT_QUIET` quiet mode)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Brings Grit in line with Git `convert.c` / checkout behavior so **`tests/t0027-auto-crlf.sh` passes 2600/2600**.

### Key changes

- **`grit-lib` / `crlf`**: safer-autocrlf `has_crlf_in_index` guard, default `core.safecrlf=warn` with Git-style round-trip simulation, `gather_convert_stats_ascii` / `get_convert_attr_ascii` parity, `autocrlf=input` vs `core.eol` for explicit `text` (`text_eol_is_crlf`).
- **`add` / `commit`**: pathspec staging matches `git add` for directories; CRLF clean uses prior index blob; worktree root `.git` is not treated as an embedded gitlink.
- **`diff`**: `hash_worktree_file` uses index blob for clean guard and disables safecrlf side effects during internal hashing.
- **`checkout`**: skip-smudge optimization compares **smudged** output to worktree (so `-c core.eol=crlf` still applies).
- **`ls-files`**: `--eol` for untracked; glob fallback when pattern matches nothing in index; respect `GIT_LITERAL_PATHSPECS`.

### Validation

- `./scripts/run-tests.sh t0027-auto-crlf.sh` → **2600/2600**
- `tests/t0020-crlf.sh` → **36/36**
- `cargo test -p grit-lib --lib`

Also updates `PLAN.md`, `progress.md`, `data/test-files.csv`, and generated dashboards.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-938137ba-30df-4e43-a020-83b98456045f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-938137ba-30df-4e43-a020-83b98456045f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

