### PR TITLE
fix: grep -f NUL patterns and binary match (t7816)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -92,7 +92,7 @@ t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
 t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
-t1006-cat-file	t1	yes	290	285	5	false	ok	1
+t1006-cat-file	t1	yes	290	285	5	false	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	32	8	false	ok	0
 t10070-cat-file-batch-format	t1	yes	33	33	0	true	ok	0
@@ -1276,7 +1276,7 @@ t7812-grep-icase-non-ascii	t7	yes	18	18	0	true	ok	0
 t7813-grep-icase-iso	t7	yes	2	2	0	true	ok	0
 t7814-grep-recurse-submodules	t7	yes	27	20	7	false	ok	7
 t7815-grep-binary	t7	yes	21	19	2	false	ok	1
-t7816-grep-binary-pattern	t7	yes	145	97	48	false	ok	0
+t7816-grep-binary-pattern	t7	yes	145	145	0	true	ok	0
 t7817-grep-sparse-checkout	t7	yes	8	4	4	false	ok	0
 t7818-grep-extended	t7	yes	11	11	0	true	ok	0
 t7900-maintenance	t7	yes	0	0	0	false	timeout	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,16 +141,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T01:24:36+00:00" class="gen-time" title="2026-04-09 01:24 UTC">2026-04-09 01:24 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">74.2%</div>
+      <div class="summary-big-val pct-blue">74.3%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,565</div>
+      <div class="summary-big-val">29,621</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -159,12 +159,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:74.2%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:74.3%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>713 files fully passing</span>
+    <span>717 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,7 +212,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">41/141 files · 2 skipped · 3,333/4,611 tests</span>
+        <span class="group-meta">42/141 files · 2 skipped · 3,334/4,611 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.3%"></div></div>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,336/3,949 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,342/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.8%"></div></div>
-        <span class="group-pct pct-red">33.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.0%"></div></div>
+        <span class="group-pct pct-red">34.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -256,11 +256,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">42/126 files · 11 skipped · 1,793/2,944 tests</span>
+        <span class="group-meta">44/126 files · 11 skipped · 1,842/2,944 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>
-        <span class="group-pct pct-blue">60.9%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:62.6%"></div></div>
+        <span class="group-pct pct-blue">62.6%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T01:24:36+00:00" class="gen-time" title="2026-04-09 01:24 UTC">2026-04-09 01:24 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,864</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,565</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,621</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">74.3%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -1085,7 +1085,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">285</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.3%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t10060-hash-object-determinism</td>
@@ -5110,8 +5110,7 @@ tr.row-skip td { opacity: 0.65; }
 <tr class="" data-group="t2" data-tests="15" data-passed="5">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td><span class="badge ok">full pass</span></td>
-  <td class="right">15</td>
+  <td></td>
   <td class="right">15</td>
   <td class="right">5</td>
   <td class="right">ok</td>
@@ -6218,14 +6217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="54" data-passed="38">
+<tr class="" data-group="t3" data-tests="52" data-passed="3">
   <td class="mono">t3420-rebase-autostash</td>
   <td>t3</td>
   <td></td>
-  <td class="right">54</td>
-  <td class="right">38</td>
+  <td class="right">52</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="63" data-passed="11">
@@ -12598,7 +12597,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="2" data-passed="2">
+<tr class="" data-group="t7" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t7524-commit-summary</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>
@@ -12918,14 +12917,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.5%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="145" data-passed="97">
+<tr class="" data-group="t7" data-tests="145" data-passed="145" data-full-pass="1">
   <td class="mono">t7816-grep-binary-pattern</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">145</td>
-  <td class="right">97</td>
+  <td class="right">145</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:66.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="8" data-passed="4">

--- a/grit-lib/src/rev_parse.rs
+++ b/grit-lib/src/rev_parse.rs
@@ -1958,7 +1958,6 @@ hint: Did you mean ':0:{candidate}' aka ':0:./{path}'?"
 }
 
 /// Look up a path in the index (stage 0) and return its OID.
-
 fn resolve_index_path(repo: &Repository, path: &str) -> Result<ObjectId> {
     resolve_index_path_at_stage(repo, path, 0)
 }

--- a/grit/src/commands/grep.rs
+++ b/grit/src/commands/grep.rs
@@ -262,6 +262,23 @@ impl Args {
     }
 }
 
+/// Append one pattern per line from raw `-f` file bytes.
+///
+/// Lines are split on `\n` only. Each line may contain embedded NUL bytes (preserved
+/// when the line is valid UTF-8), matching `git grep`. Empty lines are skipped. A
+/// trailing `\r` before `\n` is stripped.
+fn append_patterns_from_file_bytes(bytes: &[u8], patterns: &mut Vec<String>) {
+    for line in bytes.split(|&b| b == b'\n') {
+        if line.is_empty() {
+            continue;
+        }
+        let line = line.strip_suffix(b"\r").unwrap_or(line);
+        let s = String::from_utf8(line.to_vec())
+            .unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned());
+        patterns.push(s);
+    }
+}
+
 /// Run `grit grep`.
 pub fn run(mut args: Args) -> Result<()> {
     let has_attr_src = std::env::var("GIT_ATTR_SOURCE")
@@ -372,17 +389,22 @@ pub fn run(mut args: Args) -> Result<()> {
 
     // Read patterns from file if -f is given
     if let Some(ref pattern_file) = args.pattern_file {
-        let content = std::fs::read_to_string(pattern_file)
+        let bytes = std::fs::read(pattern_file)
             .with_context(|| format!("cannot read pattern file: '{pattern_file}'"))?;
-        for line in content.lines() {
-            if !line.is_empty() {
-                patterns.push(line.to_string());
-            }
-        }
+        append_patterns_from_file_bytes(&bytes, &mut patterns);
     }
 
     if patterns.is_empty() {
         bail!("no pattern given");
+    }
+
+    // Match git grep.c: NUL in a pattern is only supported with PCRE v2 (`-P`).
+    for pat in &patterns {
+        if !args.perl_regexp && pat.as_bytes().contains(&0) {
+            bail!(
+                "fatal: given pattern contains NULL byte (via -f <file>). This is only supported with -P under PCRE v2"
+            );
+        }
     }
 
     // Determine matching mode: --all-match or --and means all patterns must match a line
@@ -599,8 +621,7 @@ fn grep_cached(
                         found_any = true;
                     }
                 } else {
-                    let content = String::from_utf8_lossy(&obj.data);
-                    let has_match = matchers.iter().any(|re| re.is_match(&content));
+                    let has_match = matchers.iter().any(|re| regex_matches_bytes(re, &obj.data));
                     if has_match {
                         writeln!(out, "Binary file {} matches", display_path)?;
                         found_any = true;
@@ -661,8 +682,7 @@ fn grep_cached(
                     found_any = true;
                 }
             } else {
-                let content = String::from_utf8_lossy(&obj.data);
-                let has_match = matchers.iter().any(|re| re.is_match(&content));
+                let has_match = matchers.iter().any(|re| regex_matches_bytes(re, &obj.data));
                 if has_match {
                     writeln!(out, "Binary file {} matches", display_path)?;
                     found_any = true;
@@ -797,8 +817,7 @@ fn grep_worktree(
                         found_any = true;
                     }
                 } else {
-                    let content_str = String::from_utf8_lossy(&content);
-                    let has_match = matchers.iter().any(|re| re.is_match(&content_str));
+                    let has_match = matchers.iter().any(|re| regex_matches_bytes(re, &content));
                     if has_match {
                         writeln!(out, "Binary file {} matches", display_path)?;
                         found_any = true;
@@ -867,8 +886,7 @@ fn grep_worktree(
                         found_any = true;
                     }
                 } else {
-                    let content_str = String::from_utf8_lossy(&obj.data);
-                    let has_match = matchers.iter().any(|re| re.is_match(&content_str));
+                    let has_match = matchers.iter().any(|re| regex_matches_bytes(re, &obj.data));
                     if has_match {
                         writeln!(out, "Binary file {} matches", display_path)?;
                         found_any = true;
@@ -929,8 +947,7 @@ fn grep_worktree(
                     found_any = true;
                 }
             } else {
-                let content_str = String::from_utf8_lossy(&content);
-                let has_match = matchers.iter().any(|re| re.is_match(&content_str));
+                let has_match = matchers.iter().any(|re| regex_matches_bytes(re, &content));
                 if has_match {
                     writeln!(out, "Binary file {} matches", display_path)?;
                     found_any = true;
@@ -1206,8 +1223,7 @@ fn grep_filesystem(
                 continue;
             }
             if is_binary && !args.text_mode {
-                let content_str = String::from_utf8_lossy(&content);
-                let has_match = matchers.iter().any(|re| re.is_match(&content_str));
+                let has_match = matchers.iter().any(|re| regex_matches_bytes(re, &content));
                 if has_match {
                     writeln!(out, "Binary file {} matches", display_path)?;
                     found_any = true;
@@ -1489,6 +1505,17 @@ fn build_matchers(patterns: &[String], args: &Args) -> Result<Vec<Regex>> {
         matchers.push(re);
     }
     Ok(matchers)
+}
+
+/// Match `re` against blob or file bytes without stripping embedded NUL (lossy UTF-8 would).
+fn regex_matches_bytes(re: &Regex, haystack: &[u8]) -> bool {
+    match std::str::from_utf8(haystack) {
+        Ok(s) => re.is_match(s),
+        Err(_) => {
+            let lossy = String::from_utf8_lossy(haystack);
+            re.is_match(lossy.as_ref())
+        }
+    }
 }
 
 // Color constants
@@ -1993,8 +2020,7 @@ fn grep_tree(
             }
 
             if is_binary && !args.text_mode {
-                let content = String::from_utf8_lossy(&obj.data);
-                let has_match = matchers.iter().any(|re| re.is_match(&content));
+                let has_match = matchers.iter().any(|re| regex_matches_bytes(re, &obj.data));
                 if has_match {
                     if !args.quiet {
                         let display = match tree_name {

--- a/logs/2026-04-09_t7816-grep-binary-pattern.md
+++ b/logs/2026-04-09_t7816-grep-binary-pattern.md
@@ -1,0 +1,20 @@
+# t7816-grep-binary-pattern
+
+## Problem
+
+`git grep -f` with patterns containing embedded NUL was wrong: `read_to_string` truncated at the first NUL, so matchers saw a shortened pattern and reported spurious "Binary file matches" instead of Git's fatal error (without `-P`) or correct PCRE-style behavior (with `-P`).
+
+## Fix
+
+- Read pattern files as raw bytes; split on `\n` only; preserve NUL in UTF-8 patterns.
+- After loading patterns, if any contains NUL and `-P` is not active, bail with Git's message (exit 128 via `fatal:` prefix).
+- For binary blob/file "matches" output, run regex against valid UTF-8 `&str` when possible so NUL positions align with Git (REG_STARTEND-style), instead of lossy replacement.
+
+## Validation
+
+- `./scripts/run-tests.sh t7816-grep-binary-pattern.sh` → 145/145 pass.
+- `cargo check -p grit-rs`, `cargo test -p grit-lib --lib` pass.
+
+## Misc
+
+- Removed stray blank line between doc comment and `resolve_index_path` in `rev_parse.rs` (clippy `empty_line_after_doc_comment`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes `t7816-grep-binary-pattern` pass (145/145).

### Changes

- **Pattern files (`-f`)**: Read as raw bytes and split on `\n` only so embedded NUL bytes are preserved (Rust `read_to_string` previously truncated at the first NUL).
- **Git compatibility**: If any loaded pattern contains NUL and `-P` is not used, exit with the same fatal message as upstream Git: `given pattern contains NULL byte (via -f <file>). This is only supported with -P under PCRE v2` (exit 128).
- **Binary matches**: When reporting `Binary file … matches`, run the regex against a UTF-8 `&str` when the blob is valid UTF-8 so NUL code points align with the file bytes (matches Git/REG_STARTEND behavior). Invalid UTF-8 still uses lossy conversion.

### Also

- Removed a stray blank line after a doc comment in `grit-lib/src/rev_parse.rs` (fixes `clippy::empty_line_after_doc_comment` when linting that file).

### Validation

- `./scripts/run-tests.sh t7816-grep-binary-pattern.sh`
- `cargo check -p grit-rs`
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c079d81-5922-4e69-af08-bcf606640c57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c079d81-5922-4e69-af08-bcf606640c57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

