### PR TITLE
fix: make t3902-quoted pass (Git-compatible path quoting)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -92,7 +92,7 @@ t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
 t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
-t1006-cat-file	t1	yes	290	285	5	false	ok	1
+t1006-cat-file	t1	yes	290	285	5	false	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	32	8	false	ok	0
 t10070-cat-file-batch-format	t1	yes	33	33	0	true	ok	0
@@ -661,7 +661,7 @@ t3705-add-sparse-checkout	t3	yes	20	3	17	false	ok	0
 t3800-mktag	t3	yes	151	62	89	false	ok	0
 t3900-i18n-commit	t3	yes	38	11	27	false	ok	0
 t3901-i18n-patch	t3	yes	20	0	20	false	ok	0
-t3902-quoted	t3	yes	13	5	8	false	ok	0
+t3902-quoted	t3	yes	13	13	0	true	ok	0
 t3902-quoted-ls-tree	t3	yes	8	8	0	true	ok	0
 t3903-stash	t3	yes	0	0	0	false	timeout	0
 t3904-stash-patch	t3	yes	10	4	6	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T01:39:21+00:00" class="gen-time" title="2026-04-09 01:39 UTC">2026-04-09 01:39 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,565</div>
+      <div class="summary-big-val">29,581</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>713 files fully passing</span>
+    <span>717 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,11 +212,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">41/141 files · 2 skipped · 3,333/4,611 tests</span>
+        <span class="group-meta">43/141 files · 2 skipped · 3,342/4,611 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.3%"></div></div>
-        <span class="group-pct pct-blue">72.3%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.5%"></div></div>
+        <span class="group-pct pct-blue">72.5%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,336/3,949 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,342/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.8%"></div></div>
-        <span class="group-pct pct-red">33.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.0%"></div></div>
+        <span class="group-pct pct-red">34.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -256,7 +256,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">42/126 files · 11 skipped · 1,793/2,944 tests</span>
+        <span class="group-meta">43/126 files · 11 skipped · 1,794/2,944 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T01:39:21+00:00" class="gen-time" title="2026-04-09 01:39 UTC">2026-04-09 01:39 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,864</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,565</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,581</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1085,7 +1085,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">285</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.3%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t10060-hash-object-determinism</td>
@@ -5110,8 +5110,7 @@ tr.row-skip td { opacity: 0.65; }
 <tr class="" data-group="t2" data-tests="15" data-passed="5">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td><span class="badge ok">full pass</span></td>
-  <td class="right">15</td>
+  <td></td>
   <td class="right">15</td>
   <td class="right">5</td>
   <td class="right">ok</td>
@@ -6218,14 +6217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="54" data-passed="38">
+<tr class="" data-group="t3" data-tests="52" data-passed="3">
   <td class="mono">t3420-rebase-autostash</td>
   <td>t3</td>
   <td></td>
-  <td class="right">54</td>
-  <td class="right">38</td>
+  <td class="right">52</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="63" data-passed="11">
@@ -6768,14 +6767,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="13" data-passed="5">
+<tr class="" data-group="t3" data-tests="13" data-passed="13" data-full-pass="1">
   <td class="mono">t3902-quoted</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">13</td>
-  <td class="right">5</td>
+  <td class="right">13</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:38.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="8" data-passed="8" data-full-pass="1">
@@ -12598,7 +12597,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="2" data-passed="2">
+<tr class="" data-group="t7" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t7524-commit-summary</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>

--- a/grit-lib/src/config.rs
+++ b/grit-lib/src/config.rs
@@ -1416,6 +1416,19 @@ impl ConfigSet {
         self.get(key).map(|v| parse_bool(&v))
     }
 
+    /// Whether pathnames in human-readable output should fully C-quote non-ASCII bytes as octal.
+    ///
+    /// Maps to Git's `quote_path_fully` (`core.quotepath`, default true). When false, UTF-8 and
+    /// other high bytes are emitted literally; only ASCII specials are escaped. Also honors
+    /// `core.quotePath` as an alternate spelling.
+    #[must_use]
+    pub fn quote_path_fully(&self) -> bool {
+        let from_key = |key: &str| self.get_bool(key).and_then(|r| r.ok());
+        from_key("core.quotepath")
+            .or_else(|| from_key("core.quotePath"))
+            .unwrap_or(true)
+    }
+
     /// Get an integer value, supporting Git's `k`/`m`/`g` suffixes.
     pub fn get_i64(&self, key: &str) -> Option<std::result::Result<i64, String>> {
         self.get(key).map(|v| parse_i64(&v))

--- a/grit-lib/src/lib.rs
+++ b/grit-lib/src/lib.rs
@@ -48,6 +48,7 @@ pub mod patch_ids;
 pub mod pathspec;
 pub mod promisor;
 pub mod prune_packed;
+pub mod quote_path;
 pub mod reflog;
 pub mod refs;
 pub mod reftable;

--- a/grit-lib/src/quote_path.rs
+++ b/grit-lib/src/quote_path.rs
@@ -1,0 +1,126 @@
+//! C-style path quoting compatible with Git's `quote.c` / `core.quotepath`.
+//!
+//! Git quotes pathnames for human-facing output (`ls-files`, `diff --name-only`,
+//! `ls-tree --name-only`) using a byte lookup table and optional full octal
+//! escaping for non-ASCII bytes when `quote_path_fully` is set (`core.quotepath`,
+//! default true).
+
+/// Lookup table from Git `quote.c` (`cq_lookup`). Values:
+/// - `1`: emit as `\<ooo>` three-digit octal
+/// - `-1`: safe byte (no escape needed inside a quoted string)
+/// - `>= 32`: letter escape (`\n`, `\t`, `\"`, …)
+/// - `0` for `0x80..=0xFF`: octal only when `quote_fully` is true
+const fn cq_byte(b: u8) -> i8 {
+    match b {
+        0x00..=0x06 => 1,
+        0x07 => b'a' as i8,
+        0x08 => b'b' as i8,
+        0x09 => b't' as i8,
+        0x0a => b'n' as i8,
+        0x0b => b'v' as i8,
+        0x0c => b'f' as i8,
+        0x0d => b'r' as i8,
+        0x0e..=0x1f => 1,
+        0x20 | 0x21 => -1,
+        0x22 => b'"' as i8,
+        0x23..=0x5b => -1,
+        0x5c => b'\\' as i8,
+        0x5d..=0x7e => -1,
+        0x7f => 1,
+        0x80..=0xff => 0,
+    }
+}
+
+const fn cq_lookup_table() -> [i8; 256] {
+    let mut t = [0i8; 256];
+    let mut i = 0usize;
+    while i < 256 {
+        t[i] = cq_byte(i as u8);
+        i += 1;
+    }
+    t
+}
+
+static CQ_LOOKUP: [i8; 256] = cq_lookup_table();
+
+#[inline]
+fn cq_must_quote(byte: u8, quote_fully: bool) -> bool {
+    i32::from(CQ_LOOKUP[byte as usize]) + i32::from(quote_fully) > 0
+}
+
+/// Quote `path` in Git C style when needed, matching `quote_c_style` + `core.quotepath`.
+///
+/// When `quote_fully` is true (Git default, `core.quotepath=true`), non-ASCII bytes are
+/// emitted as `\ooo` escapes. When false, UTF-8 / high bytes are copied literally and only
+/// ASCII special characters are escaped.
+#[must_use]
+pub fn quote_c_style(path: &str, quote_fully: bool) -> String {
+    let bytes = path.as_bytes();
+    let mut any = false;
+    for &b in bytes {
+        if cq_must_quote(b, quote_fully) {
+            any = true;
+            break;
+        }
+    }
+    if !any {
+        return path.to_owned();
+    }
+
+    let mut out = String::with_capacity(path.len() + 2);
+    out.push('"');
+    let mut p = 0usize;
+    while p < bytes.len() {
+        let mut len = 0usize;
+        while p + len < bytes.len() && !cq_must_quote(bytes[p + len], quote_fully) {
+            len += 1;
+        }
+        out.push_str(path.get(p..p + len).unwrap_or(""));
+        p += len;
+        if p >= bytes.len() {
+            break;
+        }
+        let ch = bytes[p];
+        p += 1;
+        out.push('\\');
+        let cq = CQ_LOOKUP[ch as usize];
+        if cq >= b' ' as i8 {
+            out.push(cq as u8 as char);
+        } else {
+            out.push(char::from(((ch >> 6) & 3) + b'0'));
+            out.push(char::from(((ch >> 3) & 7) + b'0'));
+            out.push(char::from((ch & 7) + b'0'));
+        }
+    }
+    out.push('"');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ascii_safe_unchanged() {
+        assert_eq!(quote_c_style("Name", true), "Name");
+        assert_eq!(quote_c_style("With SP in it", true), "With SP in it");
+    }
+
+    #[test]
+    fn t3902_expect_quoted() {
+        assert_eq!(quote_c_style("Name and a\nLF", true), "\"Name and a\\nLF\"");
+        assert_eq!(
+            quote_c_style("Name and an\tHT", true),
+            "\"Name and an\\tHT\""
+        );
+        assert_eq!(quote_c_style("Name\"", true), "\"Name\\\"\"");
+    }
+
+    #[test]
+    fn t3902_expect_raw_mode() {
+        let s = "濱野\t純";
+        assert_eq!(quote_c_style(s, false), "\"濱野\\t純\"");
+        let s2 = "濱野 純";
+        assert_eq!(quote_c_style(s2, false), "濱野 純");
+    }
+}

--- a/grit/src/commands/diff.rs
+++ b/grit/src/commands/diff.rs
@@ -432,6 +432,9 @@ pub fn run(mut args: Args) -> Result<()> {
     let (mut revs, paths) = parse_rev_and_paths(&args.args, has_separator);
 
     let repo = Repository::discover(None).context("not a git repository")?;
+    let quote_path_fully = grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true)
+        .unwrap_or_default()
+        .quote_path_fully();
 
     let emit_unified_patch = diff_emit_unified_patch_from_argv(&raw_args);
 
@@ -1121,9 +1124,10 @@ pub fn run(mut args: Args) -> Result<()> {
                 args.stat_width,
                 args.stat_name_width,
                 args.break_rewrites,
+                quote_path_fully,
             )?;
             if args.summary {
-                write_diff_summary(&mut out, &entries)?;
+                write_diff_summary(&mut out, &entries, quote_path_fully)?;
             }
         } else if args.raw {
             let oid_len = if args.full_index || args.no_abbrev {
@@ -1143,11 +1147,11 @@ pub fn run(mut args: Args) -> Result<()> {
                 args.break_rewrites,
             )?;
         } else if args.name_only {
-            write_name_only(&mut out, &entries)?;
+            write_name_only(&mut out, &entries, quote_path_fully)?;
         } else if args.name_status {
-            write_name_status(&mut out, &entries)?;
+            write_name_status(&mut out, &entries, quote_path_fully)?;
         } else if args.summary && !stat_enabled {
-            write_diff_summary(&mut out, &entries)?;
+            write_diff_summary(&mut out, &entries, quote_path_fully)?;
         } else {
             let patch_abbrev = if args.full_index {
                 40
@@ -2764,6 +2768,7 @@ fn write_stat(
     stat_width: Option<usize>,
     stat_name_width: Option<usize>,
     break_rewrites: bool,
+    quote_path_fully: bool,
 ) -> Result<()> {
     if entries.is_empty() {
         return Ok(());
@@ -2776,9 +2781,9 @@ fn write_stat(
             DiffStatus::Renamed | DiffStatus::Copied => {
                 let old = e.old_path.as_deref().unwrap_or("");
                 let new = e.new_path.as_deref().unwrap_or("");
-                format_rename_display(old, new)
+                format_rename_display(old, new, quote_path_fully)
             }
-            _ => quote_c_style(e.path()),
+            _ => grit_lib::quote_path::quote_c_style(e.path(), quote_path_fully),
         })
         .collect();
     let max_path_len = display_paths
@@ -2907,54 +2912,12 @@ fn write_stat(
     Ok(())
 }
 
-/// C-style quote a path if it contains special characters (tab, newline, etc.).
-/// Returns the quoted string (with surrounding double-quotes) if quoting is needed,
-/// otherwise returns the original string.
-fn quote_c_style(name: &str) -> String {
-    let mut out = String::with_capacity(name.len() + 2);
-    let mut needs_quotes = false;
-    for ch in name.chars() {
-        match ch {
-            '"' => {
-                out.push_str("\\\"");
-                needs_quotes = true;
-            }
-            '\\' => {
-                out.push_str("\\\\");
-                needs_quotes = true;
-            }
-            '\t' => {
-                out.push_str("\\t");
-                needs_quotes = true;
-            }
-            '\n' => {
-                out.push_str("\\n");
-                needs_quotes = true;
-            }
-            '\r' => {
-                out.push_str("\\r");
-                needs_quotes = true;
-            }
-            c if c.is_control() => {
-                out.push_str(&format!("\\{:03o}", u32::from(c)));
-                needs_quotes = true;
-            }
-            c => out.push(c),
-        }
-    }
-    if needs_quotes {
-        format!("\"{out}\"")
-    } else {
-        out
-    }
-}
-
 /// Format a rename/copy path for numstat: `{old_quoted}\t{new_quoted}` or
 /// `{old_quoted} => {new_quoted}` depending on format.
-fn format_rename_display(old: &str, new: &str) -> String {
+fn format_rename_display(old: &str, new: &str, quote_path_fully: bool) -> String {
     // Use the pretty-print format with common prefix/suffix like c/{b/a => d/e}
     let pretty = grit_lib::diff::format_rename_path(old, new);
-    quote_c_style(&pretty)
+    grit_lib::quote_path::quote_c_style(&pretty, quote_path_fully)
 }
 
 /// Write machine-readable numstat output: `{insertions}\t{deletions}\t{path}`.
@@ -2971,7 +2934,7 @@ fn write_numstat(
             DiffStatus::Renamed | DiffStatus::Copied => {
                 let old = entry.old_path.as_deref().unwrap_or("");
                 let new = entry.new_path.as_deref().unwrap_or("");
-                let display = format_rename_display(old, new);
+                let display = format_rename_display(old, new, false);
                 writeln!(out, "{ins}\t{del}\t{display}")?;
             }
             _ => {
@@ -2984,20 +2947,24 @@ fn write_numstat(
 
 /// Write only the names of changed files.
 /// Write `--summary` output for rename/copy/mode-change entries.
-fn write_diff_summary(out: &mut impl Write, entries: &[DiffEntry]) -> Result<()> {
+fn write_diff_summary(
+    out: &mut impl Write,
+    entries: &[DiffEntry],
+    quote_path_fully: bool,
+) -> Result<()> {
     for entry in entries {
         match entry.status {
             DiffStatus::Renamed => {
                 let old = entry.old_path.as_deref().unwrap_or("");
                 let new = entry.new_path.as_deref().unwrap_or("");
-                let display = format_rename_display(old, new);
+                let display = format_rename_display(old, new, quote_path_fully);
                 let sim = entry.score.unwrap_or(100);
                 writeln!(out, " rename {display} ({sim}%)")?;
             }
             DiffStatus::Copied => {
                 let old = entry.old_path.as_deref().unwrap_or("");
                 let new = entry.new_path.as_deref().unwrap_or("");
-                let display = format_rename_display(old, new);
+                let display = format_rename_display(old, new, quote_path_fully);
                 let sim = entry.score.unwrap_or(100);
                 writeln!(out, " copy {display} ({sim}%)")?;
             }
@@ -3006,7 +2973,7 @@ fn write_diff_summary(out: &mut impl Write, entries: &[DiffEntry]) -> Result<()>
                     out,
                     " create mode {} {}",
                     entry.new_mode,
-                    quote_c_style(entry.path())
+                    grit_lib::quote_path::quote_c_style(entry.path(), quote_path_fully)
                 )?;
             }
             DiffStatus::Deleted => {
@@ -3014,7 +2981,7 @@ fn write_diff_summary(out: &mut impl Write, entries: &[DiffEntry]) -> Result<()>
                     out,
                     " delete mode {} {}",
                     entry.old_mode,
-                    quote_c_style(entry.path())
+                    grit_lib::quote_path::quote_c_style(entry.path(), quote_path_fully)
                 )?;
             }
             _ => {}
@@ -3023,9 +2990,17 @@ fn write_diff_summary(out: &mut impl Write, entries: &[DiffEntry]) -> Result<()>
     Ok(())
 }
 
-fn write_name_only(out: &mut impl Write, entries: &[DiffEntry]) -> Result<()> {
+fn write_name_only(
+    out: &mut impl Write,
+    entries: &[DiffEntry],
+    quote_path_fully: bool,
+) -> Result<()> {
     for entry in entries {
-        writeln!(out, "{}", entry.path())?;
+        writeln!(
+            out,
+            "{}",
+            grit_lib::quote_path::quote_c_style(entry.path(), quote_path_fully)
+        )?;
     }
     Ok(())
 }
@@ -3063,7 +3038,11 @@ fn write_raw(out: &mut impl Write, entries: &[DiffEntry], abbrev_len: usize) -> 
     Ok(())
 }
 
-fn write_name_status(out: &mut impl Write, entries: &[DiffEntry]) -> Result<()> {
+fn write_name_status(
+    out: &mut impl Write,
+    entries: &[DiffEntry],
+    quote_path_fully: bool,
+) -> Result<()> {
     for entry in entries {
         match entry.status {
             DiffStatus::Renamed => {
@@ -3072,8 +3051,14 @@ fn write_name_status(out: &mut impl Write, entries: &[DiffEntry]) -> Result<()> 
                     out,
                     "R{:03}\t{}\t{}",
                     s,
-                    entry.old_path.as_deref().unwrap_or(""),
-                    entry.new_path.as_deref().unwrap_or("")
+                    grit_lib::quote_path::quote_c_style(
+                        entry.old_path.as_deref().unwrap_or(""),
+                        quote_path_fully,
+                    ),
+                    grit_lib::quote_path::quote_c_style(
+                        entry.new_path.as_deref().unwrap_or(""),
+                        quote_path_fully,
+                    ),
                 )?;
             }
             DiffStatus::Copied => {
@@ -3082,12 +3067,23 @@ fn write_name_status(out: &mut impl Write, entries: &[DiffEntry]) -> Result<()> 
                     out,
                     "C{:03}\t{}\t{}",
                     s,
-                    entry.old_path.as_deref().unwrap_or(""),
-                    entry.new_path.as_deref().unwrap_or("")
+                    grit_lib::quote_path::quote_c_style(
+                        entry.old_path.as_deref().unwrap_or(""),
+                        quote_path_fully,
+                    ),
+                    grit_lib::quote_path::quote_c_style(
+                        entry.new_path.as_deref().unwrap_or(""),
+                        quote_path_fully,
+                    ),
                 )?;
             }
             _ => {
-                writeln!(out, "{}\t{}", entry.status.letter(), entry.path())?;
+                writeln!(
+                    out,
+                    "{}\t{}",
+                    entry.status.letter(),
+                    grit_lib::quote_path::quote_c_style(entry.path(), quote_path_fully)
+                )?;
             }
         }
     }

--- a/grit/src/commands/ls_files.rs
+++ b/grit/src/commands/ls_files.rs
@@ -161,10 +161,7 @@ pub fn run(args: Args) -> Result<()> {
     };
     let cwd_prefix = cwd_prefix_bytes(work_tree, &cwd)?;
     let config = grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
-    let quote_path = match config.get_bool("core.quotePath") {
-        Some(Ok(v)) => v,
-        Some(Err(_)) | None => true,
-    };
+    let quote_fully = config.quote_path_fully();
     let index_path = resolved_env_index_path(&repo);
     let index = if args.sparse {
         grit_lib::index::Index::load(&index_path).context("loading index")?
@@ -396,7 +393,7 @@ pub fn run(args: Args) -> Result<()> {
                 display_path_from_cwd(&entry.path, &cwd_prefix)
             };
             let name = String::from_utf8_lossy(display);
-            let qname = format_ls_path(&name, use_nul, quote_path);
+            let qname = format_ls_path(&name, use_nul, quote_fully);
             if let Some(t) = tag {
                 write!(out, "{} ", t)?;
             }
@@ -430,7 +427,7 @@ pub fn run(args: Args) -> Result<()> {
                 display_path_from_cwd(&entry.path, &cwd_prefix)
             };
             let name = String::from_utf8_lossy(display);
-            let qname = format_ls_path(&name, use_nul, quote_path);
+            let qname = format_ls_path(&name, use_nul, quote_fully);
             if let Some(t) = tag {
                 write!(out, "{} ", t)?;
             }
@@ -539,7 +536,7 @@ pub fn run(args: Args) -> Result<()> {
 
         for display in &output_paths {
             let name = String::from_utf8_lossy(display);
-            let qname = format_ls_path(&name, use_nul, quote_path);
+            let qname = format_ls_path(&name, use_nul, quote_fully);
             if args.show_tag {
                 write!(out, "? {qname}")?;
             } else {
@@ -976,54 +973,12 @@ fn describe_eol(data: &[u8]) -> String {
     }
 }
 
-/// Format a path for `ls-files` output: optionally C-quote per `core.quotePath`.
-fn format_ls_path(name: &str, use_nul: bool, quote_path: bool) -> String {
-    if use_nul || !quote_path {
+/// Format a path for `ls-files` output: C-quote per `core.quotepath` / `core.quotePath`.
+fn format_ls_path(name: &str, use_nul: bool, quote_fully: bool) -> String {
+    if use_nul {
         return name.to_owned();
     }
-    maybe_quote(name)
-}
-
-/// Quote a path name with C-style escaping if it contains special characters.
-fn maybe_quote(name: &str) -> String {
-    let mut out = String::with_capacity(name.len() + 2);
-    let mut needs_quotes = false;
-    for ch in name.chars() {
-        match ch {
-            '"' => {
-                out.push_str("\\\"");
-                needs_quotes = true;
-            }
-            '\\' => {
-                out.push_str("\\\\");
-                needs_quotes = true;
-            }
-            '\t' => {
-                out.push_str("\\t");
-                needs_quotes = true;
-            }
-            '\n' => {
-                out.push_str("\\n");
-                needs_quotes = true;
-            }
-            '\r' => {
-                out.push_str("\\r");
-                needs_quotes = true;
-            }
-            c if c.is_control() || (c as u32) >= 0x80 => {
-                for b in c.to_string().bytes() {
-                    out.push_str(&format!("\\{:03o}", b));
-                }
-                needs_quotes = true;
-            }
-            c => out.push(c),
-        }
-    }
-    if needs_quotes {
-        format!("\"{out}\"")
-    } else {
-        out
-    }
+    grit_lib::quote_path::quote_c_style(name, quote_fully)
 }
 
 fn status_tag(entry: &IndexEntry) -> char {

--- a/grit/src/commands/ls_tree.rs
+++ b/grit/src/commands/ls_tree.rs
@@ -283,6 +283,7 @@ pub fn run(mut args: Args) -> Result<()> {
     let repo = Repository::discover(None).context("not a git repository")?;
     let config = ConfigSet::load(Some(&repo.git_dir), true)?;
     let max_tree_depth = resolve_max_tree_depth(&config)?;
+    let quote_fully = config.quote_path_fully();
 
     apply_ls_tree_implications(&mut args);
 
@@ -405,6 +406,7 @@ pub fn run(mut args: Args) -> Result<()> {
         &mut out,
         term,
         cwd_prefix.as_deref(),
+        quote_fully,
     )?;
 
     Ok(())
@@ -443,6 +445,7 @@ fn list_tree(
     out: &mut impl Write,
     term: u8,
     cwd_prefix: Option<&str>,
+    quote_fully: bool,
 ) -> Result<()> {
     if depth > max_tree_depth {
         bail!(
@@ -502,6 +505,7 @@ fn list_tree(
                     out,
                     term,
                     cwd_prefix,
+                    quote_fully,
                 )?;
                 continue;
             }
@@ -510,7 +514,7 @@ fn list_tree(
         if args.recursive && is_tree && !is_submodule {
             if args.show_trees || args.only_trees {
                 let display_name = make_cwd_relative(&full_name, cwd_prefix);
-                print_entry(repo, entry, &display_name, args, out, term)?;
+                print_entry(repo, entry, &display_name, args, out, term, quote_fully)?;
             }
             let sub_obj = repo.odb.read(&entry.oid)?;
             list_tree(
@@ -523,6 +527,7 @@ fn list_tree(
                 out,
                 term,
                 cwd_prefix,
+                quote_fully,
             )?;
             continue;
         }
@@ -532,7 +537,7 @@ fn list_tree(
         }
 
         let display_name = make_cwd_relative(&full_name, cwd_prefix);
-        print_entry(repo, entry, &display_name, args, out, term)?;
+        print_entry(repo, entry, &display_name, args, out, term, quote_fully)?;
     }
     Ok(())
 }
@@ -544,6 +549,7 @@ fn print_entry(
     args: &Args,
     out: &mut impl Write,
     term: u8,
+    quote_fully: bool,
 ) -> Result<()> {
     let kind_str = match file_type_mask(entry.mode) {
         0o160000 => "commit",
@@ -564,7 +570,11 @@ fn print_entry(
         if args.null_terminated {
             write!(out, "{name}")?;
         } else {
-            write!(out, "{}", quote_path_name(name))?;
+            write!(
+                out,
+                "{}",
+                grit_lib::quote_path::quote_c_style(name, quote_fully)
+            )?;
         }
     } else if args.object_only {
         let hex = entry.oid.to_hex();
@@ -632,47 +642,6 @@ fn expand_hex_escapes(s: &str) -> String {
         }
     }
     result
-}
-
-fn quote_path_name(name: &str) -> String {
-    let mut out = String::with_capacity(name.len() + 2);
-    let mut needs_quotes = false;
-
-    for ch in name.chars() {
-        match ch {
-            '"' => {
-                out.push_str("\\\"");
-                needs_quotes = true;
-            }
-            '\\' => {
-                out.push_str("\\\\");
-                needs_quotes = true;
-            }
-            '\t' => {
-                out.push_str("\\t");
-                needs_quotes = true;
-            }
-            '\n' => {
-                out.push_str("\\n");
-                needs_quotes = true;
-            }
-            '\r' => {
-                out.push_str("\\r");
-                needs_quotes = true;
-            }
-            c if c.is_control() => {
-                out.push_str(&format!("\\{:03o}", u32::from(c)));
-                needs_quotes = true;
-            }
-            c => out.push(c),
-        }
-    }
-
-    if needs_quotes {
-        format!("\"{out}\"")
-    } else {
-        out
-    }
 }
 
 fn resolve_tree_ish(repo: &Repository, s: &str) -> Result<ObjectId> {

--- a/logs/2026-04-09_t3902-quoted-path-quoting.md
+++ b/logs/2026-04-09_t3902-quoted-path-quoting.md
@@ -1,0 +1,16 @@
+# t3902-quoted — path quoting
+
+## Problem
+
+`git ls-files`, `git diff --name-only`, and `git ls-tree --name-only` did not match Git’s C-style quoting (`quote.c`) or `core.quotepath` semantics. Paths with `\n`, `\t`, `"`, or non-ASCII bytes were emitted raw or with wrong escaping.
+
+## Fix
+
+- Added `grit_lib::quote_path::quote_c_style` mirroring Git’s `cq_lookup` + `quote_path_fully` behavior.
+- `ConfigSet::quote_path_fully()` reads `core.quotepath` / `core.quotePath` (default true).
+- Wired quoting through `ls-files`, `ls-tree --name-only`, and `diff` name-only/name-status/stat/summary paths; `numstat` keeps unquoted raw paths.
+
+## Verification
+
+- `./scripts/run-tests.sh t3902-quoted.sh` — 13/13.
+- `cargo test -p grit-lib --lib` — pass.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible C-style path quoting (`quote.c` / `core.quotepath`) so `ls-files`, `diff --name-only` (and related diff output modes), and `ls-tree --name-only` match upstream behavior for tabs, newlines, quotes, and non-ASCII paths.

## Changes

- New `grit_lib::quote_path::quote_c_style` using Git’s byte lookup table and `quote_path_fully` semantics.
- `ConfigSet::quote_path_fully()` reads `core.quotepath` and `core.quotePath` (default true).
- Wired through `ls-files`, `ls-tree --name-only`, and `diff` human-facing path output; `--numstat` keeps raw unquoted paths like git.

## Testing

- `./scripts/run-tests.sh t3902-quoted.sh` — 13/13
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d5b2c038-c398-4071-a308-36e04be4e951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d5b2c038-c398-4071-a308-36e04be4e951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

