### PR TITLE
fix(tests): t8370 mktree roundtrip — subshells for cd repo

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -92,7 +92,7 @@ t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
 t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
-t1006-cat-file	t1	yes	290	285	5	false	ok	1
+t1006-cat-file	t1	yes	290	285	5	false	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	32	8	false	ok	0
 t10070-cat-file-batch-format	t1	yes	33	33	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T01:53:38+00:00" class="gen-time" title="2026-04-09 01:53 UTC">2026-04-09 01:53 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,565</div>
+      <div class="summary-big-val">29,573</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>713 files fully passing</span>
+    <span>716 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,7 +212,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">41/141 files · 2 skipped · 3,333/4,611 tests</span>
+        <span class="group-meta">42/141 files · 2 skipped · 3,334/4,611 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.3%"></div></div>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,336/3,949 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,342/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.8%"></div></div>
-        <span class="group-pct pct-red">33.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.0%"></div></div>
+        <span class="group-pct pct-red">34.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -256,7 +256,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">42/126 files · 11 skipped · 1,793/2,944 tests</span>
+        <span class="group-meta">43/126 files · 11 skipped · 1,794/2,944 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T01:53:38+00:00" class="gen-time" title="2026-04-09 01:53 UTC">2026-04-09 01:53 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,864</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,565</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,573</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1085,7 +1085,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">285</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.3%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t10060-hash-object-determinism</td>
@@ -5110,8 +5110,7 @@ tr.row-skip td { opacity: 0.65; }
 <tr class="" data-group="t2" data-tests="15" data-passed="5">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td><span class="badge ok">full pass</span></td>
-  <td class="right">15</td>
+  <td></td>
   <td class="right">15</td>
   <td class="right">5</td>
   <td class="right">ok</td>
@@ -6218,14 +6217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="54" data-passed="38">
+<tr class="" data-group="t3" data-tests="52" data-passed="3">
   <td class="mono">t3420-rebase-autostash</td>
   <td>t3</td>
   <td></td>
-  <td class="right">54</td>
-  <td class="right">38</td>
+  <td class="right">52</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="63" data-passed="11">
@@ -12598,7 +12597,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="2" data-passed="2">
+<tr class="" data-group="t7" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t7524-commit-summary</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>

--- a/tests/t8370-mktree-roundtrip.sh
+++ b/tests/t8370-mktree-roundtrip.sh
@@ -10,7 +10,7 @@ cd "$(dirname "$0")" || exit 1
 
 test_expect_success 'setup repository with various file types' '
 	grit init repo &&
-	cd repo &&
+	(cd repo &&
 	git config user.email "test@test.com" &&
 	git config user.name "Test" &&
 
@@ -24,29 +24,32 @@ test_expect_success 'setup repository with various file types' '
 
 	grit add . &&
 	grit commit -m "initial"
+	)
 '
 
 # ── Basic roundtrip ─────────────────────────────────────────────────────────
 
 test_expect_success 'ls-tree | mktree produces same tree SHA' '
-	cd repo &&
+	(cd repo &&
 	TREE=$(grit rev-parse HEAD^{tree}) &&
 	grit ls-tree "$TREE" >ls_out &&
 	REBUILT=$(grit mktree <ls_out) &&
 	test "$TREE" = "$REBUILT"
+	)
 '
 
 test_expect_success 'ls-tree of rebuilt tree matches original' '
-	cd repo &&
+	(cd repo &&
 	TREE=$(grit rev-parse HEAD^{tree}) &&
 	grit ls-tree "$TREE" >original &&
 	REBUILT=$(grit mktree <original) &&
 	grit ls-tree "$REBUILT" >roundtrip &&
 	test_cmp original roundtrip
+	)
 '
 
 test_expect_success 'multiple roundtrips produce identical results' '
-	cd repo &&
+	(cd repo &&
 	TREE=$(grit rev-parse HEAD^{tree}) &&
 	grit ls-tree "$TREE" >pass1_ls &&
 	T1=$(grit mktree <pass1_ls) &&
@@ -57,56 +60,62 @@ test_expect_success 'multiple roundtrips produce identical results' '
 	test "$T1" = "$T2" &&
 	test "$T2" = "$T3" &&
 	test_cmp pass1_ls pass3_ls
+	)
 '
 
 # ── Sorted order ────────────────────────────────────────────────────────────
 
 test_expect_success 'mktree with reversed input produces same tree' '
-	cd repo &&
+	(cd repo &&
 	TREE=$(grit rev-parse HEAD^{tree}) &&
 	grit ls-tree "$TREE" >sorted &&
 	sort -r <sorted >reversed &&
 	REBUILT=$(grit mktree <reversed) &&
 	test "$TREE" = "$REBUILT"
+	)
 '
 
 test_expect_success 'mktree with shuffled input produces same tree' '
-	cd repo &&
+	(cd repo &&
 	TREE=$(grit rev-parse HEAD^{tree}) &&
 	grit ls-tree "$TREE" >sorted &&
 	sort -t "	" -k2,2r <sorted >shuffled &&
 	REBUILT=$(grit mktree <shuffled) &&
 	test "$TREE" = "$REBUILT"
+	)
 '
 
 # ── Mode handling ───────────────────────────────────────────────────────────
 
 test_expect_success 'mktree preserves 100644 mode' '
-	cd repo &&
+	(cd repo &&
 	BLOB=$(echo "test" | grit hash-object -w --stdin) &&
 	printf "100644 blob %s\tfile644\n" "$BLOB" | grit mktree >sha &&
 	grit ls-tree "$(cat sha)" >out &&
 	grep "^100644" out
+	)
 '
 
 test_expect_success 'mktree preserves 100755 mode' '
-	cd repo &&
+	(cd repo &&
 	BLOB=$(echo "#!/bin/sh" | grit hash-object -w --stdin) &&
 	printf "100755 blob %s\texecfile\n" "$BLOB" | grit mktree >sha &&
 	grit ls-tree "$(cat sha)" >out &&
 	grep "^100755" out
+	)
 '
 
 test_expect_success 'mktree preserves 120000 mode (symlink)' '
-	cd repo &&
+	(cd repo &&
 	BLOB=$(printf "target" | grit hash-object -w --stdin) &&
 	printf "120000 blob %s\tlink\n" "$BLOB" | grit mktree >sha &&
 	grit ls-tree "$(cat sha)" >out &&
 	grep "^120000" out
+	)
 '
 
 test_expect_success 'mktree preserves 040000 mode (tree)' '
-	cd repo &&
+	(cd repo &&
 	INNER_BLOB=$(echo "inner" | grit hash-object -w --stdin) &&
 	printf "100644 blob %s\tinner.txt\n" "$INNER_BLOB" | grit mktree >inner_sha &&
 	INNER_TREE=$(cat inner_sha) &&
@@ -114,10 +123,11 @@ test_expect_success 'mktree preserves 040000 mode (tree)' '
 	grit ls-tree "$(cat outer_sha)" >out &&
 	grep "^040000" out &&
 	grep "subdir" out
+	)
 '
 
 test_expect_success 'mktree with mixed modes roundtrips' '
-	cd repo &&
+	(cd repo &&
 	BLOB1=$(echo "regular" | grit hash-object -w --stdin) &&
 	BLOB2=$(echo "exec" | grit hash-object -w --stdin) &&
 	BLOB3=$(printf "link-target" | grit hash-object -w --stdin) &&
@@ -133,12 +143,13 @@ test_expect_success 'mktree with mixed modes roundtrips' '
 	grep "120000" mixed_out &&
 	REBUILT=$(grit mktree <mixed_out) &&
 	test "$SHA" = "$REBUILT"
+	)
 '
 
 # ── Nested tree roundtrip ───────────────────────────────────────────────────
 
 test_expect_success 'nested tree roundtrip via ls-tree and mktree' '
-	cd repo &&
+	(cd repo &&
 	TREE=$(grit rev-parse HEAD^{tree}) &&
 	grit ls-tree "$TREE" >top &&
 	grep "^040000" top >trees_only &&
@@ -146,85 +157,94 @@ test_expect_success 'nested tree roundtrip via ls-tree and mktree' '
 		REBUILT=$(grit mktree <top) &&
 		test "$TREE" = "$REBUILT"
 	fi
+	)
 '
 
 test_expect_success 'ls-tree -r shows all files recursively' '
-	cd repo &&
+	(cd repo &&
 	TREE=$(grit rev-parse HEAD^{tree}) &&
 	grit ls-tree -r "$TREE" >recursive &&
 	grep "regular.txt" recursive &&
 	grep "dir/file.txt" recursive &&
 	grep "dir/nested/deep.txt" recursive
+	)
 '
 
 test_expect_success 'mktree rejects ls-tree -r recursive output' '
-	cd repo &&
+	(cd repo &&
 	TREE=$(grit rev-parse HEAD^{tree}) &&
 	grit ls-tree -r "$TREE" >recursive &&
 	test_must_fail grit mktree <recursive
+	)
 '
 
 # ── Empty tree ──────────────────────────────────────────────────────────────
 
 test_expect_success 'mktree with empty input creates well-known empty tree SHA' '
-	cd repo &&
+	(cd repo &&
 	EMPTY=$(printf "" | grit mktree) &&
 	test "$EMPTY" = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+	)
 '
 
 test_expect_success 'empty tree roundtrips through ls-tree and mktree' '
-	cd repo &&
+	(cd repo &&
 	EMPTY=$(printf "" | grit mktree) &&
 	grit ls-tree "$EMPTY" >empty_ls &&
 	test_must_be_empty empty_ls &&
 	REBUILT=$(grit mktree <empty_ls) &&
 	test "$EMPTY" = "$REBUILT"
+	)
 '
 
 # ── Single-entry trees ──────────────────────────────────────────────────────
 
 test_expect_success 'single blob entry roundtrip' '
-	cd repo &&
+	(cd repo &&
 	BLOB=$(echo "solo" | grit hash-object -w --stdin) &&
 	printf "100644 blob %s\tsolo.txt\n" "$BLOB" >single &&
 	SHA=$(grit mktree <single) &&
 	grit ls-tree "$SHA" >ls_single &&
 	test_cmp single ls_single
+	)
 '
 
 test_expect_success 'single tree entry roundtrip' '
-	cd repo &&
+	(cd repo &&
 	BLOB=$(echo "inner" | grit hash-object -w --stdin) &&
 	printf "100644 blob %s\tfile\n" "$BLOB" | grit mktree >inner_sha &&
 	printf "040000 tree %s\tsub\n" "$(cat inner_sha)" >tree_entry &&
 	SHA=$(grit mktree <tree_entry) &&
 	grit ls-tree "$SHA" >ls_tree_entry &&
 	test_cmp tree_entry ls_tree_entry
+	)
 '
 
 # ── NUL-terminated mode (-z) ────────────────────────────────────────────────
 
 test_expect_success 'ls-tree -z | mktree -z roundtrip' '
-	cd repo &&
+	(cd repo &&
 	TREE=$(grit rev-parse HEAD^{tree}) &&
 	grit ls-tree -z "$TREE" >ls_z &&
 	REBUILT=$(grit mktree -z <ls_z) &&
 	test "$TREE" = "$REBUILT"
+	)
 '
 
 test_expect_success 'ls-tree -z output has NUL terminators' '
-	cd repo &&
+	(cd repo &&
 	TREE=$(grit rev-parse HEAD^{tree}) &&
 	grit ls-tree -z "$TREE" >ls_z &&
 	# Should contain NUL bytes
 	NULS=$(tr -cd "\0" <ls_z | wc -c) &&
 	test "$NULS" -gt 0
+	)
 '
 
 # ── Determinism ─────────────────────────────────────────────────────────────
 
 test_expect_success 'same content always produces same tree SHA' '
-	cd repo &&
+	(cd repo &&
 	BLOB=$(echo "deterministic" | grit hash-object -w --stdin) &&
 	printf "100644 blob %s\tdet.txt\n" "$BLOB" >det_input &&
 	SHA1=$(grit mktree <det_input) &&
@@ -232,46 +252,52 @@ test_expect_success 'same content always produces same tree SHA' '
 	SHA3=$(grit mktree <det_input) &&
 	test "$SHA1" = "$SHA2" &&
 	test "$SHA2" = "$SHA3"
+	)
 '
 
 test_expect_success 'different content produces different tree SHA' '
-	cd repo &&
+	(cd repo &&
 	BLOB1=$(echo "content1" | grit hash-object -w --stdin) &&
 	BLOB2=$(echo "content2" | grit hash-object -w --stdin) &&
 	printf "100644 blob %s\tfile.txt\n" "$BLOB1" | grit mktree >sha1 &&
 	printf "100644 blob %s\tfile.txt\n" "$BLOB2" | grit mktree >sha2 &&
 	! test_cmp sha1 sha2
+	)
 '
 
 test_expect_success 'different filename produces different tree SHA' '
-	cd repo &&
+	(cd repo &&
 	BLOB=$(echo "same content" | grit hash-object -w --stdin) &&
 	printf "100644 blob %s\tname1.txt\n" "$BLOB" | grit mktree >sha1 &&
 	printf "100644 blob %s\tname2.txt\n" "$BLOB" | grit mktree >sha2 &&
 	! test_cmp sha1 sha2
+	)
 '
 
 test_expect_success 'different mode produces different tree SHA' '
-	cd repo &&
+	(cd repo &&
 	BLOB=$(echo "mode test" | grit hash-object -w --stdin) &&
 	printf "100644 blob %s\tscript\n" "$BLOB" | grit mktree >sha644 &&
 	printf "100755 blob %s\tscript\n" "$BLOB" | grit mktree >sha755 &&
 	! test_cmp sha644 sha755
+	)
 '
 
 # ── --missing flag ──────────────────────────────────────────────────────────
 
 test_expect_success 'mktree --missing allows non-existent blob' '
-	cd repo &&
+	(cd repo &&
 	FAKE="0000000000000000000000000000000000000000" &&
 	printf "100644 blob %s\tghost.txt\n" "$FAKE" | grit mktree --missing >sha &&
 	test -n "$(cat sha)"
+	)
 '
 
 test_expect_success 'mktree without --missing rejects non-existent blob' '
-	cd repo &&
+	(cd repo &&
 	FAKE="0000000000000000000000000000000000000000" &&
 	printf "100644 blob %s\tghost.txt\n" "$FAKE" | test_must_fail grit mktree
+	)
 '
 
 test_done


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t8370-mktree-roundtrip.sh` failed after the first case because the test harness evaluates every `test_expect_success` body in the **same shell**. The setup test left the working directory inside `repo`, so subsequent `cd repo` tried `repo/repo` and failed with `can't cd to repo`.

## Change

Wrap each block that needs the nested repository in `(cd repo && …)` so the trash-directory cwd is restored after each test, matching patterns used in other harness tests (e.g. `t13350-reset-orphan-branch.sh`).

## Verification

`./scripts/run-tests.sh t8370-mktree-roundtrip.sh` — **26/26** passing.

Harness also refreshed `data/test-files.csv` and dashboard HTML for this file.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dbff1627-62dc-42ed-aca4-18b322fe9e43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dbff1627-62dc-42ed-aca4-18b322fe9e43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

