### PR TITLE
test: add t4109 apply-multifrag patch fixtures

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -92,7 +92,7 @@ t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
 t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
-t1006-cat-file	t1	yes	290	285	5	false	ok	1
+t1006-cat-file	t1	yes	290	285	5	false	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	32	8	false	ok	0
 t10070-cat-file-batch-format	t1	yes	33	33	0	true	ok	0
@@ -778,7 +778,7 @@ t4105-apply-fuzz	t4	yes	9	9	0	true	ok	0
 t4106-apply-stdin	t4	yes	3	3	0	true	ok	0
 t4107-apply-ignore-whitespace	t4	yes	11	11	0	true	ok	0
 t4108-apply-threeway	t4	yes	18	3	15	false	ok	0
-t4109-apply-multifrag	t4	yes	3	0	3	false	ok	0
+t4109-apply-multifrag	t4	yes	3	3	0	true	ok	0
 t4110-apply-scan	t4	yes	1	1	0	true	ok	0
 t4111-apply-subdir	t4	yes	10	3	7	false	ok	0
 t4112-apply-renames	t4	yes	2	0	2	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T01:58:45+00:00" class="gen-time" title="2026-04-09 01:58 UTC">2026-04-09 01:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,565</div>
+      <div class="summary-big-val">29,576</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>713 files fully passing</span>
+    <span>717 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,7 +212,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">41/141 files · 2 skipped · 3,333/4,611 tests</span>
+        <span class="group-meta">42/141 files · 2 skipped · 3,334/4,611 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.3%"></div></div>
@@ -223,22 +223,22 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">63/178 files · 2 skipped · 1,920/3,541 tests</span>
+        <span class="group-meta">64/178 files · 2 skipped · 1,923/3,541 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:54.2%"></div></div>
-        <span class="group-pct pct-orange">54.2%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:54.3%"></div></div>
+        <span class="group-pct pct-orange">54.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,336/3,949 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,342/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.8%"></div></div>
-        <span class="group-pct pct-red">33.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.0%"></div></div>
+        <span class="group-pct pct-red">34.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -256,7 +256,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">42/126 files · 11 skipped · 1,793/2,944 tests</span>
+        <span class="group-meta">43/126 files · 11 skipped · 1,794/2,944 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T01:58:45+00:00" class="gen-time" title="2026-04-09 01:58 UTC">2026-04-09 01:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,864</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,565</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,576</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1085,7 +1085,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">285</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.3%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t10060-hash-object-determinism</td>
@@ -5110,8 +5110,7 @@ tr.row-skip td { opacity: 0.65; }
 <tr class="" data-group="t2" data-tests="15" data-passed="5">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td><span class="badge ok">full pass</span></td>
-  <td class="right">15</td>
+  <td></td>
   <td class="right">15</td>
   <td class="right">5</td>
   <td class="right">ok</td>
@@ -6218,14 +6217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="54" data-passed="38">
+<tr class="" data-group="t3" data-tests="52" data-passed="3">
   <td class="mono">t3420-rebase-autostash</td>
   <td>t3</td>
   <td></td>
-  <td class="right">54</td>
-  <td class="right">38</td>
+  <td class="right">52</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="63" data-passed="11">
@@ -7938,14 +7937,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:16.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="3" data-passed="0">
+<tr class="" data-group="t4" data-tests="3" data-passed="3" data-full-pass="1">
   <td class="mono">t4109-apply-multifrag</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">3</td>
-  <td class="right">0</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="1" data-passed="1" data-full-pass="1">
@@ -12598,7 +12597,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="2" data-passed="2">
+<tr class="" data-group="t7" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t7524-commit-summary</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>

--- a/logs/2026-04-09_t4109-apply-multifrag-fixtures.md
+++ b/logs/2026-04-09_t4109-apply-multifrag-fixtures.md
@@ -1,0 +1,16 @@
+# t4109-apply-multifrag
+
+## Issue
+
+Harness reported 0/3: `tests/t4109-apply-multifrag.sh` copies
+`$TEST_DIRECTORY/t4109/patch*.patch`, but only `expect-*` lived under
+`tests/t4109/`; patch files were missing (they exist upstream in `git/t/t4109/`).
+
+## Fix
+
+Copied `patch1.patch` … `patch4.patch` from `git/t/t4109/` into `tests/t4109/`.
+
+## Verification
+
+- `./scripts/run-tests.sh t4109-apply-multifrag.sh` → 3/3
+- `cargo test -p grit-lib --lib` → pass

--- a/tests/t4109/patch1.patch
+++ b/tests/t4109/patch1.patch
@@ -1,0 +1,28 @@
+diff --git a/main.c b/main.c
+new file mode 100644
+--- /dev/null
++++ b/main.c
+@@ -0,0 +1,23 @@
++#include <stdio.h>
++
++int func(int num);
++void print_int(int num);
++
++int main() {
++	int i;
++
++	for (i = 0; i < 10; i++) {
++		print_int(func(i));
++	}
++
++	return 0;
++}
++
++int func(int num) {
++	return num * num;
++}
++
++void print_int(int num) {
++	printf("%d", num);
++}
++

--- a/tests/t4109/patch2.patch
+++ b/tests/t4109/patch2.patch
@@ -1,0 +1,30 @@
+diff --git a/main.c b/main.c
+--- a/main.c
++++ b/main.c
+@@ -1,7 +1,9 @@
++#include <stdlib.h>
+ #include <stdio.h>
+ 
+ int func(int num);
+ void print_int(int num);
++void print_ln();
+ 
+ int main() {
+ 	int i;
+@@ -10,6 +12,8 @@
+ 		print_int(func(i));
+ 	}
+ 
++	print_ln();
++
+ 	return 0;
+ }
+ 
+@@ -21,3 +25,7 @@
+ 	printf("%d", num);
+ }
+ 
++void print_ln() {
++	printf("\n");
++}
++

--- a/tests/t4109/patch3.patch
+++ b/tests/t4109/patch3.patch
@@ -1,0 +1,31 @@
+cat > patch3.patch <<\EOF
+diff --git a/main.c b/main.c
+--- a/main.c
++++ b/main.c
+@@ -1,9 +1,7 @@
+-#include <stdlib.h>
+ #include <stdio.h>
+ 
+ int func(int num);
+ void print_int(int num);
+-void print_ln();
+ 
+ int main() {
+ 	int i;
+@@ -12,8 +10,6 @@
+ 		print_int(func(i));
+ 	}
+ 
+-	print_ln();
+-
+ 	return 0;
+ }
+ 
+@@ -25,7 +21,3 @@
+ 	printf("%d", num);
+ }
+ 
+-void print_ln() {
+-	printf("\n");
+-}
+-

--- a/tests/t4109/patch4.patch
+++ b/tests/t4109/patch4.patch
@@ -1,0 +1,30 @@
+diff --git a/main.c b/main.c
+--- a/main.c
++++ b/main.c
+@@ -1,13 +1,14 @@
+ #include <stdio.h>
+ 
+ int func(int num);
+-void print_int(int num);
++int func2(int num);
+ 
+ int main() {
+ 	int i;
+ 
+ 	for (i = 0; i < 10; i++) {
+-		print_int(func(i));
++		printf("%d", func(i));
++		printf("%d", func3(i));
+ 	}
+ 
+ 	return 0;
+@@ -17,7 +18,7 @@
+ 	return num * num;
+ }
+ 
+-void print_int(int num) {
+-	printf("%d", num);
++int func2(int num) {
++	return num * num * num;
+ }
+ 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t4109-apply-multifrag.sh` copies `patch1.patch`–`patch4.patch` from `$TEST_DIRECTORY/t4109/`. Only the `expect-*` files had been ported under `tests/t4109/`; the patch inputs were missing, so every subtest failed before exercising `git apply`.

## Changes

- Add `patch1.patch` … `patch4.patch` under `tests/t4109/` (same content as `git/t/t4109/`).
- Refresh harness CSV and dashboards from `./scripts/run-tests.sh t4109-apply-multifrag.sh` (3/3).

## Verification

- `./scripts/run-tests.sh t4109-apply-multifrag.sh` → **3/3**
- `cargo test -p grit-lib --lib` → pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c2024e6-ac51-4561-b91e-af3b0aff6bbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c2024e6-ac51-4561-b91e-af3b0aff6bbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

