### PR TITLE
fix: make t4212-log-corrupt pass (ident dates, fsck, rev-list --until)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -92,7 +92,7 @@ t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
 t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
-t1006-cat-file	t1	yes	290	285	5	false	ok	1
+t1006-cat-file	t1	yes	290	285	5	false	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	32	8	false	ok	0
 t10070-cat-file-batch-format	t1	yes	33	33	0	true	ok	0
@@ -833,7 +833,7 @@ t4208-log-magic-pathspec	t4	yes	21	12	9	false	ok	0
 t4209-log-pickaxe	t4	yes	0	0	0	false	timeout	0
 t4210-log-i18n	t4	yes	21	17	4	false	ok	0
 t4211-line-log	t4	yes	53	21	32	false	ok	0
-t4212-log-corrupt	t4	yes	13	3	10	false	ok	0
+t4212-log-corrupt	t4	yes	13	13	0	true	ok	0
 t4213-log-tabexpand	t4	yes	9	1	8	false	ok	0
 t4214-log-graph-octopus	t4	yes	17	6	11	false	ok	0
 t4215-log-skewed-merges	t4	yes	10	0	10	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T02:08:19+00:00" class="gen-time" title="2026-04-09 02:08 UTC">2026-04-09 02:08 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,565</div>
+      <div class="summary-big-val">29,583</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>713 files fully passing</span>
+    <span>717 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,7 +212,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">41/141 files · 2 skipped · 3,333/4,611 tests</span>
+        <span class="group-meta">42/141 files · 2 skipped · 3,334/4,611 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.3%"></div></div>
@@ -223,22 +223,22 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">63/178 files · 2 skipped · 1,920/3,541 tests</span>
+        <span class="group-meta">64/178 files · 2 skipped · 1,930/3,541 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:54.2%"></div></div>
-        <span class="group-pct pct-orange">54.2%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:54.5%"></div></div>
+        <span class="group-pct pct-orange">54.5%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,336/3,949 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,342/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.8%"></div></div>
-        <span class="group-pct pct-red">33.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.0%"></div></div>
+        <span class="group-pct pct-red">34.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -256,7 +256,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">42/126 files · 11 skipped · 1,793/2,944 tests</span>
+        <span class="group-meta">43/126 files · 11 skipped · 1,794/2,944 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T02:08:19+00:00" class="gen-time" title="2026-04-09 02:08 UTC">2026-04-09 02:08 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,864</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,565</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,583</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1085,7 +1085,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">285</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.3%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t10060-hash-object-determinism</td>
@@ -5110,8 +5110,7 @@ tr.row-skip td { opacity: 0.65; }
 <tr class="" data-group="t2" data-tests="15" data-passed="5">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td><span class="badge ok">full pass</span></td>
-  <td class="right">15</td>
+  <td></td>
   <td class="right">15</td>
   <td class="right">5</td>
   <td class="right">ok</td>
@@ -6218,14 +6217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="54" data-passed="38">
+<tr class="" data-group="t3" data-tests="52" data-passed="3">
   <td class="mono">t3420-rebase-autostash</td>
   <td>t3</td>
   <td></td>
-  <td class="right">54</td>
-  <td class="right">38</td>
+  <td class="right">52</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="63" data-passed="11">
@@ -8488,14 +8487,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:39.6%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="13" data-passed="3">
+<tr class="" data-group="t4" data-tests="13" data-passed="13" data-full-pass="1">
   <td class="mono">t4212-log-corrupt</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">13</td>
-  <td class="right">3</td>
+  <td class="right">13</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:23.1%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="9" data-passed="1">
@@ -12598,7 +12597,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="2" data-passed="2">
+<tr class="" data-group="t7" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t7524-commit-summary</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>

--- a/grit-lib/src/fsck_standalone.rs
+++ b/grit-lib/src/fsck_standalone.rs
@@ -5,6 +5,7 @@
 //! `error: object fails fsck: <camelCaseId>: <detail>`.
 
 use crate::check_ref_format::{check_refname_format, RefNameOptions};
+use crate::git_date::tm::date_overflows;
 use crate::objects::{ObjectId, ObjectKind};
 
 /// Git-compatible fsck failure for loose object validation.
@@ -242,8 +243,27 @@ fn fsck_ident(
         ));
     }
 
+    let ts_start = p;
     while p < ident_end && data[p].is_ascii_digit() {
         p += 1;
+    }
+    let ts_len = p - ts_start;
+    if ts_len > 21 {
+        return Err(FsckError::new(
+            "badDateOverflow",
+            format!("invalid {oid_line} line - date causes integer overflow"),
+        ));
+    }
+    let ts_str = std::str::from_utf8(&data[ts_start..p])
+        .map_err(|_| FsckError::new("badDate", format!("invalid {oid_line} line - bad date")))?;
+    let raw: u128 = ts_str
+        .parse()
+        .map_err(|_| FsckError::new("badDate", format!("invalid {oid_line} line - bad date")))?;
+    if raw > u64::MAX as u128 || date_overflows(raw as u64) {
+        return Err(FsckError::new(
+            "badDateOverflow",
+            format!("invalid {oid_line} line - date causes integer overflow"),
+        ));
     }
 
     if p >= ident_end || data[p] != b' ' {

--- a/grit-lib/src/ident.rs
+++ b/grit-lib/src/ident.rs
@@ -1,0 +1,189 @@
+//! Git author/committer identity lines (`ident` in Git's `fsck.c` / `commit.c`).
+//!
+//! Parses `Name <email> <unix-timestamp> <+HHMM>` with the same edge cases as Git:
+//! overflow, non-digit timestamps, and whitespace-only timestamps (sentinel handling).
+
+use crate::git_date::tm::date_overflows;
+use crate::objects::ObjectKind;
+
+/// Parsed timestamp from a signature line for display and filtering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SignatureTimestamp {
+    /// Parsed seconds since Unix epoch (author/committer field); safe for `time_t` / display.
+    Valid(i64),
+    /// Unparsable, overflowing, or whitespace-only date field — Git uses a sentinel (epoch in
+    /// headers, empty `%ad`, empty `%at` / `%ct` in format).
+    Sentinel,
+}
+
+/// Successful parse of the trailing `<unix> <+HHMM>` portion of a signature.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedSignatureTimes {
+    /// Seconds in the author/committer field (before tz offset).
+    pub unix_seconds: i64,
+    /// Signed offset in seconds (from `+HHMM` / `-HHMM`).
+    pub tz_offset_secs: i64,
+    /// Byte range of the `+HHMM` / `-HHMM` field in the original `ident` string.
+    pub tz_hhmm_range: std::ops::Range<usize>,
+}
+
+/// Scan a decimal timestamp like Git's `parse_timestamp_from_buf` / `strtoumax`.
+/// Returns `None` if there is no digit or more than 21 digits (Git uses a 24-byte buffer).
+fn scan_decimal_timestamp(bytes: &[u8], mut i: usize) -> Option<(u128, usize)> {
+    const MAX_DIGITS: usize = 21;
+    let start = i;
+    let mut count = 0usize;
+    while i < bytes.len() && bytes[i].is_ascii_digit() {
+        count += 1;
+        if count > MAX_DIGITS {
+            return Some((u128::MAX, i));
+        }
+        i += 1;
+    }
+    if count == 0 {
+        return None;
+    }
+    let s = std::str::from_utf8(&bytes[start..i]).ok()?;
+    let v: u128 = s.parse().ok()?;
+    Some((v, i))
+}
+
+/// After `>` and one required space, skip only ASCII spaces and horizontal tabs (Git `fsck_ident`).
+fn skip_fsck_date_leading_ws(bytes: &[u8], mut i: usize) -> usize {
+    while i < bytes.len() && matches!(bytes[i], b' ' | b'\t') {
+        i += 1;
+    }
+    i
+}
+
+fn parse_tz_hhmm_offset(offset: &str) -> Option<i64> {
+    let b = offset.as_bytes();
+    if b.len() < 5 {
+        return None;
+    }
+    if !(b[0] == b'+' || b[0] == b'-') {
+        return None;
+    }
+    let sign = if b[0] == b'-' { -1i64 } else { 1i64 };
+    let hours: i64 = std::str::from_utf8(&b[1..3]).ok()?.parse().ok()?;
+    let minutes: i64 = std::str::from_utf8(&b[3..5]).ok()?.parse().ok()?;
+    Some(sign * (hours * 3600 + minutes * 60))
+}
+
+/// Parse `<unix> <+HHMM>` after the closing `>` of the email (Git commit author/committer line).
+#[must_use]
+pub fn parse_signature_times(ident: &str) -> Option<ParsedSignatureTimes> {
+    match parse_signature_tail(ident)? {
+        SignatureTail::Valid(p) => Some(p),
+        SignatureTail::Overflow | SignatureTail::NonNumeric => None,
+    }
+}
+
+/// Distinguishes a non-numeric date field from a numeric field that fails Git's overflow rules.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SignatureTail {
+    /// Well-formed timestamp and timezone.
+    Valid(ParsedSignatureTimes),
+    /// Digits and timezone present, but the number does not fit Git's `date_overflows` rules.
+    /// Default `%ad` shows the Unix epoch with `+0000` (t4212).
+    Overflow,
+    /// No leading digit after `>` (e.g. `totally_bogus`): `%ad` is empty, headers use epoch `+0000`.
+    NonNumeric,
+}
+
+/// Parse the date/time tail like [`parse_signature_times`], but preserve overflow vs non-numeric.
+#[must_use]
+pub fn parse_signature_tail(ident: &str) -> Option<SignatureTail> {
+    let bytes = ident.as_bytes();
+    let gt = ident.rfind('>')?;
+    let mut i = skip_fsck_date_leading_ws(bytes, gt + 1);
+    if i >= bytes.len() || !bytes[i].is_ascii_digit() {
+        return Some(SignatureTail::NonNumeric);
+    }
+    let (raw, after_digits) = scan_decimal_timestamp(bytes, i)?;
+    if after_digits >= bytes.len() || bytes[after_digits] != b' ' {
+        return None;
+    }
+    i = after_digits + 1;
+    if i + 5 > bytes.len() {
+        return None;
+    }
+    let tz_slice = ident.get(i..i + 5)?;
+    let tz_offset_secs = parse_tz_hhmm_offset(tz_slice)?;
+    let tz_hhmm_range = i..i + 5;
+    if raw == u128::MAX || raw > u64::MAX as u128 || date_overflows(raw as u64) {
+        return Some(SignatureTail::Overflow);
+    }
+    let unix_seconds = i64::try_from(raw).ok()?;
+    Some(SignatureTail::Valid(ParsedSignatureTimes {
+        unix_seconds,
+        tz_offset_secs,
+        tz_hhmm_range,
+    }))
+}
+
+/// Classify the date field for pretty-print / `%at` (t4212 whitespace commits).
+pub fn signature_timestamp_for_pretty(ident: &str) -> SignatureTimestamp {
+    match parse_signature_times(ident) {
+        Some(p) => SignatureTimestamp::Valid(p.unix_seconds),
+        None => SignatureTimestamp::Sentinel,
+    }
+}
+
+/// Unix timestamp for `--until` / `--since` filtering (committer), matching Git's `parse_date`.
+/// Sentinel timestamps (whitespace dates, overflow, etc.) behave like `0` for cutoff comparisons
+/// (see t4212 `rev-list --until`).
+#[must_use]
+pub fn committer_timestamp_for_until_filter(ident: &str) -> i64 {
+    match signature_timestamp_for_pretty(ident) {
+        SignatureTimestamp::Valid(ts) => ts,
+        SignatureTimestamp::Sentinel => 0,
+    }
+}
+
+/// Raw unix seconds as i64 for `%at` when valid; `None` when Git would print nothing.
+#[must_use]
+pub fn timestamp_for_at_ct(ts: SignatureTimestamp) -> Option<i64> {
+    match ts {
+        SignatureTimestamp::Valid(v) => Some(v),
+        SignatureTimestamp::Sentinel => None,
+    }
+}
+
+/// First fsck error Git would report for commit headers (tree/parents/author/committer), or `Ok`.
+/// Message text matches Git's `fsck.c` `report()` shape: `<camelCaseId>: <detail>`.
+pub fn fsck_commit_idents(data: &[u8]) -> Result<(), String> {
+    crate::fsck_standalone::fsck_object(ObjectKind::Commit, data).map_err(|e| e.report_line())
+}
+
+/// Committer seconds for ordering (`rev-list --date-order`, etc.): unknown/corrupt → `0`.
+#[must_use]
+pub fn committer_unix_seconds_for_ordering(ident: &str) -> i64 {
+    match signature_timestamp_for_pretty(ident) {
+        SignatureTimestamp::Valid(ts) => ts,
+        SignatureTimestamp::Sentinel => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_numeric_author_date_is_non_numeric_tail() {
+        let ident = "A <e@x> totally_bogus -0700";
+        assert!(matches!(
+            parse_signature_tail(ident),
+            Some(SignatureTail::NonNumeric)
+        ));
+    }
+
+    #[test]
+    fn u128_max_digit_count_is_overflow_tail() {
+        let ident = "A <e@x> 18446744073709551617 -0700";
+        assert!(matches!(
+            parse_signature_tail(ident),
+            Some(SignatureTail::Overflow)
+        ));
+    }
+}

--- a/grit-lib/src/lib.rs
+++ b/grit-lib/src/lib.rs
@@ -30,6 +30,7 @@ pub mod fsck_standalone;
 pub mod git_date;
 pub mod gitmodules;
 pub mod hooks;
+pub mod ident;
 pub mod ignore;
 pub mod index;
 pub mod line_log;

--- a/grit-lib/src/name_rev.rs
+++ b/grit-lib/src/name_rev.rs
@@ -12,6 +12,7 @@
 //! - Second or later parent of a merge: `<refname>^2`, `<refname>~3^2`, etc.
 
 use crate::error::{Error, Result};
+use crate::ident::committer_unix_seconds_for_ordering;
 use crate::objects::{parse_commit, parse_tag, CommitData, ObjectId, ObjectKind};
 use crate::refs;
 use crate::repo::Repository;
@@ -545,13 +546,7 @@ fn glob_match_inner(pat: &[char], txt: &[char]) -> bool {
 /// the second-to-last whitespace-delimited token parsed as an `i64`, or `0`
 /// on parse failure.
 pub(crate) fn parse_signature_time(sig: &str) -> i64 {
-    let parts: Vec<&str> = sig.split_whitespace().collect();
-    if parts.len() < 2 {
-        return 0;
-    }
-    parts[parts.len().saturating_sub(2)]
-        .parse::<i64>()
-        .unwrap_or(0)
+    committer_unix_seconds_for_ordering(sig)
 }
 
 /// Load and parse a commit object, using a cache to avoid re-reading.

--- a/grit-lib/src/rev_list.rs
+++ b/grit-lib/src/rev_list.rs
@@ -11,6 +11,7 @@ use std::fs;
 use std::path::Path;
 
 use crate::error::{Error, Result};
+use crate::ident::{committer_unix_seconds_for_ordering, parse_signature_times};
 use crate::ignore::{parse_sparse_patterns_from_blob, path_matches_sparse_pattern_list};
 use crate::objects::{parse_commit, parse_tag, parse_tree, ObjectId, ObjectKind};
 use crate::pack;
@@ -392,6 +393,10 @@ pub struct RevListOptions {
     /// With `--use-bitmap-index`, emit OID-only object lines (no paths / trailing space) for filters
     /// that match Git's bitmap object formatting.
     pub bitmap_oid_only_objects: bool,
+    /// Exclude commits with committer date strictly after this Unix timestamp (`--until` / `--before`).
+    pub until_cutoff: Option<i64>,
+    /// Exclude commits with committer date strictly before this Unix timestamp (`--since` / `--after`).
+    pub since_cutoff: Option<i64>,
 }
 
 impl Default for RevListOptions {
@@ -433,6 +438,8 @@ impl Default for RevListOptions {
             use_bitmap_index: false,
             unpacked_only: false,
             bitmap_oid_only_objects: false,
+            until_cutoff: None,
+            since_cutoff: None,
         }
     }
 }
@@ -672,6 +679,25 @@ pub fn rev_list(
     // Cherry-pick: remove equivalent commits
     if options.cherry_pick {
         ordered.retain(|oid| !cherry_equivalent.contains(oid));
+    }
+
+    if options.until_cutoff.is_some() || options.since_cutoff.is_some() {
+        let until = options.until_cutoff;
+        let since = options.since_cutoff;
+        ordered.retain(|oid| {
+            let ts = graph.committer_time(*oid);
+            if let Some(u) = until {
+                if ts > u {
+                    return false;
+                }
+            }
+            if let Some(s) = since {
+                if ts < s {
+                    return false;
+                }
+            }
+            true
+        });
     }
 
     if options.skip > 0 {
@@ -1162,31 +1188,10 @@ pub fn render_commit_with_color(
                 }
                 ""
             }
-            fn extract_timestamp(ident: &str) -> &str {
-                let parts: Vec<&str> = ident.rsplitn(3, ' ').collect();
-                if parts.len() >= 2 {
-                    parts[1]
-                } else {
-                    ""
-                }
-            }
-            fn parse_ident_date(ident: &str) -> Option<(i64, &str)> {
-                let parts: Vec<&str> = ident.rsplitn(3, ' ').collect();
-                if parts.len() < 2 {
-                    return None;
-                }
-                let ts: i64 = parts[1].parse().ok()?;
-                Some((ts, parts[0]))
-            }
-            fn parse_tz(offset_str: &str) -> i64 {
-                let tz_bytes = offset_str.as_bytes();
-                if tz_bytes.len() >= 5 {
-                    let sign = if tz_bytes[0] == b'-' { -1i64 } else { 1i64 };
-                    let h: i64 = offset_str[1..3].parse().unwrap_or(0);
-                    let m: i64 = offset_str[3..5].parse().unwrap_or(0);
-                    sign * (h * 3600 + m * 60)
-                } else {
-                    0
+            fn extract_timestamp(ident: &str) -> String {
+                match parse_signature_times(ident) {
+                    Some(p) => p.unix_seconds.to_string(),
+                    None => String::new(),
                 }
             }
             fn weekday_str(dt: &time::OffsetDateTime) -> &'static str {
@@ -1225,10 +1230,11 @@ pub fn render_commit_with_color(
                 }
             }
             fn extract_date_default(ident: &str) -> String {
-                let Some((ts, offset_str)) = parse_ident_date(ident) else {
+                let Some(p) = parse_signature_times(ident) else {
                     return String::new();
                 };
-                let adjusted = ts + parse_tz(offset_str);
+                let offset_str = ident.get(p.tz_hhmm_range.clone()).unwrap_or("+0000");
+                let adjusted = p.unix_seconds + p.tz_offset_secs;
                 let dt = time::OffsetDateTime::from_unix_timestamp(adjusted)
                     .unwrap_or(time::OffsetDateTime::UNIX_EPOCH);
                 format!(
@@ -1244,10 +1250,11 @@ pub fn render_commit_with_color(
                 )
             }
             fn extract_date_rfc2822(ident: &str) -> String {
-                let Some((ts, offset_str)) = parse_ident_date(ident) else {
+                let Some(p) = parse_signature_times(ident) else {
                     return String::new();
                 };
-                let adjusted = ts + parse_tz(offset_str);
+                let offset_str = ident.get(p.tz_hhmm_range.clone()).unwrap_or("+0000");
+                let adjusted = p.unix_seconds + p.tz_offset_secs;
                 let dt = time::OffsetDateTime::from_unix_timestamp(adjusted)
                     .unwrap_or(time::OffsetDateTime::UNIX_EPOCH);
                 format!(
@@ -1263,19 +1270,20 @@ pub fn render_commit_with_color(
                 )
             }
             fn extract_date_short(ident: &str) -> String {
-                let Some((ts, offset_str)) = parse_ident_date(ident) else {
+                let Some(p) = parse_signature_times(ident) else {
                     return String::new();
                 };
-                let adjusted = ts + parse_tz(offset_str);
+                let adjusted = p.unix_seconds + p.tz_offset_secs;
                 let dt = time::OffsetDateTime::from_unix_timestamp(adjusted)
                     .unwrap_or(time::OffsetDateTime::UNIX_EPOCH);
                 format!("{:04}-{:02}-{:02}", dt.year(), dt.month() as u8, dt.day())
             }
             fn extract_date_iso(ident: &str) -> String {
-                let Some((ts, offset_str)) = parse_ident_date(ident) else {
+                let Some(p) = parse_signature_times(ident) else {
                     return String::new();
                 };
-                let adjusted = ts + parse_tz(offset_str);
+                let offset_str = ident.get(p.tz_hhmm_range.clone()).unwrap_or("+0000");
+                let adjusted = p.unix_seconds + p.tz_offset_secs;
                 let dt = time::OffsetDateTime::from_unix_timestamp(adjusted)
                     .unwrap_or(time::OffsetDateTime::UNIX_EPOCH);
                 format!(
@@ -1521,19 +1529,18 @@ pub fn render_commit_with_color(
                             Some('l') => target.push_str(extract_email_local(&commit.author)),
                             Some('d') => target.push_str(&extract_date_default(&commit.author)),
                             Some('D') => target.push_str(&extract_date_rfc2822(&commit.author)),
-                            Some('t') => target.push_str(extract_timestamp(&commit.author)),
+                            Some('t') => target.push_str(&extract_timestamp(&commit.author)),
                             Some('s') => target.push_str(&extract_date_short(&commit.author)),
                             Some('i') => target.push_str(&extract_date_iso(&commit.author)),
                             Some('I') => {
-                                let Some((ts, offset_str)) = parse_ident_date(&commit.author)
-                                else {
+                                let Some(p) = parse_signature_times(&commit.author) else {
                                     break;
                                 };
-                                let adjusted = ts + parse_tz(offset_str);
+                                let adjusted = p.unix_seconds + p.tz_offset_secs;
                                 let dt = time::OffsetDateTime::from_unix_timestamp(adjusted)
                                     .unwrap_or(time::OffsetDateTime::UNIX_EPOCH);
-                                let sign_ch = if parse_tz(offset_str) >= 0 { '+' } else { '-' };
-                                let abs_off = parse_tz(offset_str).unsigned_abs();
+                                let sign_ch = if p.tz_offset_secs >= 0 { '+' } else { '-' };
+                                let abs_off = p.tz_offset_secs.unsigned_abs();
                                 target.push_str(&format!(
                                     "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}{}{:02}:{:02}",
                                     dt.year(),
@@ -1548,14 +1555,14 @@ pub fn render_commit_with_color(
                                 ));
                             }
                             Some('r') => {
-                                let Some((ts, _)) = parse_ident_date(&commit.author) else {
+                                let Some(p) = parse_signature_times(&commit.author) else {
                                     break;
                                 };
                                 let now = std::time::SystemTime::now()
                                     .duration_since(std::time::UNIX_EPOCH)
                                     .unwrap_or_default()
                                     .as_secs() as i64;
-                                target.push_str(&format_relative_date(now - ts));
+                                target.push_str(&format_relative_date(now - p.unix_seconds));
                             }
                             Some(other) => {
                                 target.push('%');
@@ -1578,19 +1585,18 @@ pub fn render_commit_with_color(
                             Some('l') => target.push_str(extract_email_local(&commit.committer)),
                             Some('d') => target.push_str(&extract_date_default(&commit.committer)),
                             Some('D') => target.push_str(&extract_date_rfc2822(&commit.committer)),
-                            Some('t') => target.push_str(extract_timestamp(&commit.committer)),
+                            Some('t') => target.push_str(&extract_timestamp(&commit.committer)),
                             Some('s') => target.push_str(&extract_date_short(&commit.committer)),
                             Some('i') => target.push_str(&extract_date_iso(&commit.committer)),
                             Some('I') => {
-                                let Some((ts, offset_str)) = parse_ident_date(&commit.committer)
-                                else {
+                                let Some(p) = parse_signature_times(&commit.committer) else {
                                     break;
                                 };
-                                let adjusted = ts + parse_tz(offset_str);
+                                let adjusted = p.unix_seconds + p.tz_offset_secs;
                                 let dt = time::OffsetDateTime::from_unix_timestamp(adjusted)
                                     .unwrap_or(time::OffsetDateTime::UNIX_EPOCH);
-                                let sign_ch = if parse_tz(offset_str) >= 0 { '+' } else { '-' };
-                                let abs_off = parse_tz(offset_str).unsigned_abs();
+                                let sign_ch = if p.tz_offset_secs >= 0 { '+' } else { '-' };
+                                let abs_off = p.tz_offset_secs.unsigned_abs();
                                 target.push_str(&format!(
                                     "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}{}{:02}:{:02}",
                                     dt.year(),
@@ -1605,14 +1611,14 @@ pub fn render_commit_with_color(
                                 ));
                             }
                             Some('r') => {
-                                let Some((ts, _)) = parse_ident_date(&commit.committer) else {
+                                let Some(p) = parse_signature_times(&commit.committer) else {
                                     break;
                                 };
                                 let now = std::time::SystemTime::now()
                                     .duration_since(std::time::UNIX_EPOCH)
                                     .unwrap_or_default()
                                     .as_secs() as i64;
-                                target.push_str(&format_relative_date(now - ts));
+                                target.push_str(&format_relative_date(now - p.unix_seconds));
                             }
                             Some(other) => {
                                 target.push('%');
@@ -2328,15 +2334,6 @@ fn load_commit(repo: &Repository, oid: ObjectId) -> Result<crate::objects::Commi
     parse_commit(&object.data)
 }
 
-fn parse_signature_time(sig: &str) -> i64 {
-    let mut parts = sig.split_whitespace().collect::<Vec<_>>();
-    if parts.len() < 2 {
-        return 0;
-    }
-    let ts = parts.remove(parts.len().saturating_sub(2));
-    ts.parse::<i64>().unwrap_or(0)
-}
-
 /// Merge command-line arguments and `--stdin` input lines for this subset.
 ///
 /// Returns `(positive_specs, negative_specs)`.
@@ -2474,7 +2471,7 @@ impl<'r> CommitGraph<'r> {
             parents.truncate(1);
         }
         self.committer_time
-            .insert(oid, parse_signature_time(&commit.committer));
+            .insert(oid, committer_unix_seconds_for_ordering(&commit.committer));
         self.parents.insert(oid, parents);
         Ok(())
     }

--- a/grit/src/commands/fsck.rs
+++ b/grit/src/commands/fsck.rs
@@ -10,6 +10,7 @@ use clap::Args as ClapArgs;
 use grit_lib::config::ConfigSet;
 use grit_lib::diff::zero_oid;
 use grit_lib::error::Error as LibError;
+use grit_lib::ident::fsck_commit_idents;
 use grit_lib::objects::{parse_commit, parse_tag, parse_tree, ObjectId, ObjectKind};
 use grit_lib::odb::Odb;
 use grit_lib::pack::read_local_pack_indexes;
@@ -187,6 +188,11 @@ pub fn run(args: Args) -> Result<()> {
     if !connectivity_only {
         let git_dir = repo.git_dir.as_path();
         for (oid, path) in &loose_pairs {
+            // Objects reached in the walk were already content-checked; skip to avoid duplicate
+            // diagnostics (e.g. t4212 expects one `git fsck` line per bad commit).
+            if walked_kinds.contains(oid) {
+                continue;
+            }
             validate_loose_object_file(git_dir, path, oid, &mut issues);
         }
         for oid in &all_objects {
@@ -584,11 +590,11 @@ fn validate_object(odb: &Odb, oid: &ObjectId, issues: &mut Vec<Issue>) {
 fn validate_object_data(oid: &ObjectId, kind: &ObjectKind, data: &[u8], issues: &mut Vec<Issue>) {
     match kind {
         ObjectKind::Commit => {
-            if let Err(e) = parse_commit(data) {
+            if let Err(msg) = fsck_commit_idents(data) {
                 issues.push(Issue::BadObject {
                     oid: *oid,
                     kind: *kind,
-                    reason: format!("invalid commit: {e}"),
+                    reason: msg,
                 });
             }
         }

--- a/grit/src/commands/log.rs
+++ b/grit/src/commands/log.rs
@@ -8,6 +8,11 @@ use clap::Args as ClapArgs;
 use grit_lib::diff::{
     count_changes, diff_trees, format_raw, format_stat_line, DiffEntry, DiffStatus,
 };
+use grit_lib::git_date::parse::parse_date_basic;
+use grit_lib::ident::{
+    committer_timestamp_for_until_filter, committer_unix_seconds_for_ordering,
+    parse_signature_tail, signature_timestamp_for_pretty, timestamp_for_at_ct, SignatureTail,
+};
 use grit_lib::line_log::{
     format_line_log_diff, line_log_filter_commits, parse_line_log_ranges, rewritten_first_parent,
 };
@@ -725,18 +730,15 @@ fn run_line_log(repo: &Repository, args: Args) -> Result<()> {
 
 /// Extract epoch timestamp from a Git ident string.
 fn extract_epoch_from_ident(ident: &str) -> i64 {
-    if let Some(gt) = ident.rfind('>') {
-        let after = ident[gt + 1..].trim();
-        if let Some(epoch_str) = after.split_whitespace().next() {
-            return epoch_str.parse::<i64>().unwrap_or(0);
-        }
-    }
-    0
+    committer_timestamp_for_until_filter(ident)
 }
 
 /// Parse a date string into a Unix epoch timestamp.
 fn parse_date_to_epoch(s: &str) -> Option<i64> {
     let s = s.trim();
+    if let Ok((ts, _off_min)) = parse_date_basic(s) {
+        return i64::try_from(ts).ok();
+    }
     if s.len() >= 10 && s.as_bytes()[4] == b'-' && s.as_bytes()[7] == b'-' {
         let parts: Vec<&str> = s[..10].split('-').collect();
         if parts.len() == 3 {
@@ -2628,8 +2630,8 @@ pub fn run_no_walk(repo: &Repository, args: &Args) -> Result<()> {
 
     // Sort by committer timestamp descending (same as regular log)
     commits.sort_by(|a, b| {
-        let ts_a = extract_timestamp(&a.1.committer);
-        let ts_b = extract_timestamp(&b.1.committer);
+        let ts_a = committer_unix_seconds_for_ordering(&a.1.committer);
+        let ts_b = committer_unix_seconds_for_ordering(&b.1.committer);
         ts_b.cmp(&ts_a)
     });
 
@@ -3103,9 +3105,9 @@ fn format_ident_for_header(ident: &str) -> String {
     }
 }
 
-/// Format date from ident for header display.
+/// Format date from ident for header display (`Date:` / `AuthorDate:`).
 fn format_date_for_header(ident: &str) -> String {
-    format_date_with_mode(ident, None)
+    format_author_date_internal(ident, None, true)
 }
 
 /// Parsed commit with its OID.
@@ -3359,33 +3361,61 @@ fn path_matches(path: &str, pathspec: &str) -> bool {
 fn read_commit_timestamp(odb: &Odb, oid: &ObjectId) -> i64 {
     match odb.read(oid) {
         Ok(obj) => match parse_commit(&obj.data) {
-            Ok(commit) => extract_timestamp(&commit.committer),
+            Ok(commit) => committer_unix_seconds_for_ordering(&commit.committer),
             Err(_) => 0,
         },
         Err(_) => 0,
     }
 }
 
-fn extract_timestamp(ident: &str) -> i64 {
-    // Format: "Name <email> timestamp offset"
-    let parts: Vec<&str> = ident.rsplitn(3, ' ').collect();
-    if parts.len() >= 2 {
-        parts[1].parse().unwrap_or(0)
-    } else {
-        0
+fn extract_timestamp(ident: &str) -> String {
+    match timestamp_for_at_ct(signature_timestamp_for_pretty(ident)) {
+        Some(ts) => ts.to_string(),
+        None => String::new(),
     }
 }
 
-/// Parse a timezone offset string like "+0200" or "-0500" into seconds.
-fn parse_tz_offset(offset: &str) -> i64 {
-    let bytes = offset.as_bytes();
-    if bytes.len() < 5 {
-        return 0;
+fn format_relative_from_diff(diff: i64) -> String {
+    if diff < 0 {
+        "in the future".to_owned()
+    } else if diff < 60 {
+        format!("{} seconds ago", diff)
+    } else if diff < 3600 {
+        let m = diff / 60;
+        if m == 1 {
+            "1 minute ago".to_owned()
+        } else {
+            format!("{m} minutes ago")
+        }
+    } else if diff < 86400 {
+        let h = diff / 3600;
+        if h == 1 {
+            "1 hour ago".to_owned()
+        } else {
+            format!("{h} hours ago")
+        }
+    } else if diff < 86400 * 30 {
+        let d = diff / 86400;
+        if d == 1 {
+            "1 day ago".to_owned()
+        } else {
+            format!("{d} days ago")
+        }
+    } else if diff < 86400 * 365 {
+        let months = diff / (86400 * 30);
+        if months == 1 {
+            "1 month ago".to_owned()
+        } else {
+            format!("{months} months ago")
+        }
+    } else {
+        let years = diff / (86400 * 365);
+        if years == 1 {
+            "1 year ago".to_owned()
+        } else {
+            format!("{years} years ago")
+        }
     }
-    let sign = if bytes[0] == b'-' { -1i64 } else { 1i64 };
-    let hours: i64 = offset[1..3].parse().unwrap_or(0);
-    let minutes: i64 = offset[3..5].parse().unwrap_or(0);
-    sign * (hours * 3600 + minutes * 60)
 }
 
 /// Lazily loads the git-notes map on first use so `grit log` does not read every
@@ -3631,7 +3661,7 @@ fn format_commit(
     notes_cache: &mut NotesMapCache<'_>,
     odb: &Odb,
     parent_line_override: Option<&[ObjectId]>,
-    line_log: bool,
+    _line_log: bool,
 ) -> Result<()> {
     let hex = oid.to_hex();
     let abbrev_len = if args.no_abbrev {
@@ -3729,16 +3759,13 @@ fn format_commit(
             writeln!(
                 out,
                 "Date:   {}",
-                format_date_with_mode(&info.author, date_format)
+                format_author_date_internal(&info.author, date_format, true)
             )?;
             writeln!(out)?;
             for line in info.message.lines() {
                 writeln!(out, "    {line}")?;
             }
             write_notes(out, oid, notes_cache, args, odb)?;
-            if !line_log {
-                writeln!(out)?;
-            }
         }
         Some("full") => {
             let dec = format_decoration(&hex, decorations);
@@ -3779,13 +3806,13 @@ fn format_commit(
             writeln!(
                 out,
                 "AuthorDate: {}",
-                format_date_with_mode(&info.author, date_format)
+                format_author_date_internal(&info.author, date_format, true)
             )?;
             writeln!(out, "Commit:     {}", format_ident_display(&info.committer))?;
             writeln!(
                 out,
                 "CommitDate: {}",
-                format_date_with_mode(&info.committer, date_format)
+                format_author_date_internal(&info.committer, date_format, true)
             )?;
             writeln!(out)?;
             for line in info.message.lines() {
@@ -4083,7 +4110,7 @@ fn apply_format_string(
                         }
                         Some('t') => {
                             chars.next();
-                            result.push_str(&format!("{}", extract_timestamp(&info.author)));
+                            result.push_str(&extract_timestamp(&info.author).to_string());
                         }
                         Some('s') => {
                             chars.next();
@@ -4138,7 +4165,7 @@ fn apply_format_string(
                         }
                         Some('t') => {
                             chars.next();
-                            result.push_str(&format!("{}", extract_timestamp(&info.committer)));
+                            result.push_str(&extract_timestamp(&info.committer).to_string());
                         }
                         Some('s') => {
                             chars.next();
@@ -4478,20 +4505,48 @@ fn format_ident_display(ident: &str) -> String {
 }
 
 /// Format the date from an ident string for display, with optional date mode.
-fn format_date_with_mode(ident: &str, date_mode: Option<&str>) -> String {
-    // Git ident: "Name <email> timestamp offset"
-    let parts: Vec<&str> = ident.rsplitn(3, ' ').collect();
-    if parts.len() < 2 {
-        return ident.to_owned();
-    }
-    let ts_str = parts[1];
-    let offset_str = parts[0];
-    let ts = match ts_str.parse::<i64>() {
-        Ok(v) => v,
-        Err(_) => return format!("{ts_str} {offset_str}"),
+///
+/// When `for_header` is true (pretty `Date:` lines), unparsable dates use the Unix epoch in UTC
+/// (`+0000`), matching Git. When false (`%ad` and other format placeholders), unparsable dates
+/// yield an empty string for the default format (t4212).
+fn format_author_date_internal(ident: &str, date_mode: Option<&str>, for_header: bool) -> String {
+    let tail = parse_signature_tail(ident);
+    let (ts, tz_offset_secs, offset_str) = match tail {
+        Some(SignatureTail::Valid(p)) => {
+            let off = ident
+                .get(p.tz_hhmm_range.clone())
+                .unwrap_or("+0000")
+                .to_owned();
+            (p.unix_seconds, p.tz_offset_secs, off)
+        }
+        Some(SignatureTail::Overflow) if for_header => (0i64, 0i64, "+0000".to_owned()),
+        Some(SignatureTail::Overflow) => {
+            return match date_mode {
+                None => "Thu Jan 1 00:00:00 1970 +0000".to_owned(),
+                Some("relative") => {
+                    let now = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_secs() as i64;
+                    format_relative_from_diff(now)
+                }
+                _ => String::new(),
+            };
+        }
+        Some(SignatureTail::NonNumeric) if for_header => (0i64, 0i64, "+0000".to_owned()),
+        Some(SignatureTail::NonNumeric) => {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs() as i64;
+            return match date_mode {
+                Some("relative") => format_relative_from_diff(now),
+                _ => String::new(),
+            };
+        }
+        None if for_header => (0i64, 0i64, "+0000".to_owned()),
+        None => return String::new(),
     };
-
-    let tz_offset_secs = parse_tz_offset(offset_str);
 
     match date_mode {
         Some("short") => {
@@ -4542,52 +4597,11 @@ fn format_date_with_mode(ident: &str, date_mode: Option<&str>) -> String {
             format!("{ts} {offset_str}")
         }
         Some("relative") => {
-            // Show relative time like "2 hours ago", "3 days ago"
             let now = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_secs() as i64;
-            let diff = now - ts;
-            if diff < 0 {
-                "in the future".to_owned()
-            } else if diff < 60 {
-                format!("{} seconds ago", diff)
-            } else if diff < 3600 {
-                let m = diff / 60;
-                if m == 1 {
-                    "1 minute ago".to_owned()
-                } else {
-                    format!("{m} minutes ago")
-                }
-            } else if diff < 86400 {
-                let h = diff / 3600;
-                if h == 1 {
-                    "1 hour ago".to_owned()
-                } else {
-                    format!("{h} hours ago")
-                }
-            } else if diff < 86400 * 30 {
-                let d = diff / 86400;
-                if d == 1 {
-                    "1 day ago".to_owned()
-                } else {
-                    format!("{d} days ago")
-                }
-            } else if diff < 86400 * 365 {
-                let months = diff / (86400 * 30);
-                if months == 1 {
-                    "1 month ago".to_owned()
-                } else {
-                    format!("{months} months ago")
-                }
-            } else {
-                let years = diff / (86400 * 365);
-                if years == 1 {
-                    "1 year ago".to_owned()
-                } else {
-                    format!("{years} years ago")
-                }
-            }
+            format_relative_from_diff(now - ts)
         }
         Some("rfc") | Some("rfc2822") => {
             // RFC 2822: Thu, 07 Apr 2005 22:13:13 +0200
@@ -4633,8 +4647,7 @@ fn format_date_with_mode(ident: &str, date_mode: Option<&str>) -> String {
             format!("{ts}")
         }
         _ => {
-            // Default Git date format: "Thu Apr  7 15:13:13 2005 -0700"
-            // Note: day is right-justified in a 2-char field (space-padded)
+            // Default Git date format: "Thu Apr 7 15:13:13 2005 -0700" (matches C git `show_date`)
             let adjusted = ts + tz_offset_secs;
             let dt = time::OffsetDateTime::from_unix_timestamp(adjusted)
                 .unwrap_or(time::OffsetDateTime::UNIX_EPOCH);
@@ -4662,7 +4675,7 @@ fn format_date_with_mode(ident: &str, date_mode: Option<&str>) -> String {
                 time::Month::December => "Dec",
             };
             format!(
-                "{} {} {:>2} {:02}:{:02}:{:02} {} {}",
+                "{} {} {} {:02}:{:02}:{:02} {} {}",
                 weekday,
                 month,
                 dt.day(),
@@ -4676,7 +4689,10 @@ fn format_date_with_mode(ident: &str, date_mode: Option<&str>) -> String {
     }
 }
 
-/// Format the date from an ident string (legacy, default mode).
+fn format_date_with_mode(ident: &str, date_mode: Option<&str>) -> String {
+    format_author_date_internal(ident, date_mode, false)
+}
+
 /// Resolve a revision string to an ObjectId.
 fn resolve_revision(repo: &Repository, rev: &str) -> Result<ObjectId> {
     // Delegate to the library's full revision parser which handles

--- a/grit/src/commands/rev_list.rs
+++ b/grit/src/commands/rev_list.rs
@@ -3,6 +3,7 @@
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::config::ConfigSet;
+use grit_lib::git_date::parse::parse_date_basic;
 use grit_lib::objects::{parse_commit, parse_tree, ObjectId};
 use grit_lib::pack;
 use grit_lib::promisor::read_promisor_missing_oids;
@@ -410,6 +411,28 @@ pub fn run(args: Args) -> Result<()> {
                             default_rev = Some(val.to_string());
                         }
                     }
+                }
+                "--until" | "--before" => {
+                    i += 1;
+                    let Some(val) = args.args.get(i) else {
+                        bail!("{arg} requires a date");
+                    };
+                    options.until_cutoff = Some(parse_rev_list_date(val)?);
+                }
+                _ if arg.starts_with("--until=") || arg.starts_with("--before=") => {
+                    let val = arg.split_once('=').map(|(_, v)| v).unwrap_or_default();
+                    options.until_cutoff = Some(parse_rev_list_date(val)?);
+                }
+                "--since" | "--after" => {
+                    i += 1;
+                    let Some(val) = args.args.get(i) else {
+                        bail!("{arg} requires a date");
+                    };
+                    options.since_cutoff = Some(parse_rev_list_date(val)?);
+                }
+                _ if arg.starts_with("--since=") || arg.starts_with("--after=") => {
+                    let val = arg.split_once('=').map(|(_, v)| v).unwrap_or_default();
+                    options.since_cutoff = Some(parse_rev_list_date(val)?);
                 }
                 _ => bail!("unsupported option: {arg}"),
             }
@@ -983,6 +1006,32 @@ fn parse_non_negative(text: &str, flag: &str) -> Result<usize> {
         return Ok(usize::MAX);
     }
     Ok(value as usize)
+}
+
+fn parse_rev_list_date(s: &str) -> Result<i64> {
+    let s = s.trim();
+    if let Ok((ts, _)) = parse_date_basic(s) {
+        return i64::try_from(ts).context("date out of range for rev-list cutoff");
+    }
+    if s.len() >= 10 && s.as_bytes()[4] == b'-' && s.as_bytes()[7] == b'-' {
+        let parts: Vec<&str> = s[..10].split('-').collect();
+        if parts.len() == 3 {
+            if let (Ok(y), Ok(m), Ok(d)) = (
+                parts[0].parse::<i32>(),
+                parts[1].parse::<u8>(),
+                parts[2].parse::<u8>(),
+            ) {
+                if let Ok(month) = time::Month::try_from(m) {
+                    if let Ok(date) = time::Date::from_calendar_date(y, month, d) {
+                        let dt = date.with_hms(0, 0, 0).unwrap().assume_utc();
+                        return Ok(dt.unix_timestamp());
+                    }
+                }
+            }
+        }
+    }
+    s.parse::<i64>()
+        .with_context(|| format!("invalid date: '{s}'"))
 }
 
 fn expand_parent_shorthand(repo: &Repository, spec: &str) -> Result<Vec<String>> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible handling of malformed commit author/committer lines so `tests/t4212-log-corrupt.sh` passes (13/13).

## Changes

- **`grit-lib`**: New `ident` module for parsing signature tails (`<unix> <±HHMM>`), distinguishing non-numeric dates from integer/time_t overflow (matches Git `fsck_ident` / pretty-date behavior). `fsck_standalone` now reports `badDateOverflow` for oversized timestamps. `rev_list` uses safe committer seconds for ordering, Git-style default `%ad` day formatting, and optional `until_cutoff` / `since_cutoff` filters.
- **`grit fsck`**: Validates commits with the same rules as `hash-object` fsck; skips re-validating loose objects already checked during the reachable walk (avoids duplicate diagnostics).
- **`grit log`**: `--until`/`--since` use Git date parsing; sentinel dates for headers vs `%ad`; default date string matches C git (`Thu Apr 7` not space-padded day); removed extra trailing blank line after default-format commits.
- **`grit rev-list`**: `--until` / `--before` / `--since` / `--after` with the same epoch cutoffs as log.

## Validation

- `./scripts/run-tests.sh t4212-log-corrupt.sh` → 13/13
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bee7b954-bbf3-4349-a0c9-1c7b2d646eef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bee7b954-bbf3-4349-a0c9-1c7b2d646eef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

