### PR TITLE
fix: pass t4022-diff-rewrite (diff-files -B/--summary, diff -B/-D, commit)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -92,7 +92,7 @@ t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
 t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
-t1006-cat-file	t1	yes	290	285	5	false	ok	1
+t1006-cat-file	t1	yes	290	285	5	false	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	32	8	false	ok	0
 t10070-cat-file-batch-format	t1	yes	33	33	0	true	ok	0
@@ -699,7 +699,7 @@ t4019-diff-wserror	t4	yes	21	5	16	false	ok	0
 t4020-diff-external	t4	yes	0	0	0	false	timeout	0
 t4020-diff-plumbing	t4	yes	21	21	0	true	ok	0
 t4021-format-patch-numbered	t4	yes	14	14	0	true	ok	0
-t4022-diff-rewrite	t4	yes	11	6	5	false	ok	0
+t4022-diff-rewrite	t4	yes	11	11	0	true	ok	0
 t4023-diff-rename-typechange	t4	yes	4	0	4	false	ok	0
 t4024-diff-optimize-common	t4	yes	2	2	0	true	ok	0
 t4025-hunk-header	t4	yes	2	2	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T02:36:36+00:00" class="gen-time" title="2026-04-09 02:36 UTC">2026-04-09 02:36 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,565</div>
+      <div class="summary-big-val">29,578</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>713 files fully passing</span>
+    <span>717 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,7 +212,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">41/141 files · 2 skipped · 3,333/4,611 tests</span>
+        <span class="group-meta">42/141 files · 2 skipped · 3,334/4,611 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.3%"></div></div>
@@ -223,22 +223,22 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">63/178 files · 2 skipped · 1,920/3,541 tests</span>
+        <span class="group-meta">64/178 files · 2 skipped · 1,925/3,541 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:54.2%"></div></div>
-        <span class="group-pct pct-orange">54.2%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:54.4%"></div></div>
+        <span class="group-pct pct-orange">54.4%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,336/3,949 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,342/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.8%"></div></div>
-        <span class="group-pct pct-red">33.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.0%"></div></div>
+        <span class="group-pct pct-red">34.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -256,7 +256,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">42/126 files · 11 skipped · 1,793/2,944 tests</span>
+        <span class="group-meta">43/126 files · 11 skipped · 1,794/2,944 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T02:36:36+00:00" class="gen-time" title="2026-04-09 02:36 UTC">2026-04-09 02:36 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,864</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,565</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,578</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1085,7 +1085,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">285</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.3%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t10060-hash-object-determinism</td>
@@ -5110,8 +5110,7 @@ tr.row-skip td { opacity: 0.65; }
 <tr class="" data-group="t2" data-tests="15" data-passed="5">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td><span class="badge ok">full pass</span></td>
-  <td class="right">15</td>
+  <td></td>
   <td class="right">15</td>
   <td class="right">5</td>
   <td class="right">ok</td>
@@ -6218,14 +6217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="54" data-passed="38">
+<tr class="" data-group="t3" data-tests="52" data-passed="3">
   <td class="mono">t3420-rebase-autostash</td>
   <td>t3</td>
   <td></td>
-  <td class="right">54</td>
-  <td class="right">38</td>
+  <td class="right">52</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="63" data-passed="11">
@@ -7148,14 +7147,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="11" data-passed="6">
+<tr class="" data-group="t4" data-tests="11" data-passed="11" data-full-pass="1">
   <td class="mono">t4022-diff-rewrite</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">11</td>
-  <td class="right">6</td>
+  <td class="right">11</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:54.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="4" data-passed="0">
@@ -12598,7 +12597,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="2" data-passed="2">
+<tr class="" data-group="t7" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t7524-commit-summary</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>

--- a/grit-lib/src/diff.rs
+++ b/grit-lib/src/diff.rs
@@ -2473,6 +2473,30 @@ pub fn should_break_rewrite_for_stat(old: &[u8], new: &[u8]) -> bool {
     should_break_rewrite_inner(old, new, DIFF_DEFAULT_BREAK_SCORE)
 }
 
+/// Git `merge_score` from `diffcore-break.c` when a pair is considered broken: how much of the
+/// source blob was removed (0–[`DIFF_MAX_SCORE`] scale). Used for `dissimilarity index` metadata.
+#[must_use]
+pub fn rewrite_merge_score(old: &[u8], new: &[u8]) -> Option<u64> {
+    if old.is_empty() {
+        return None;
+    }
+    let max_size = old.len().max(new.len());
+    if max_size < DIFF_MINIMUM_BREAK_SIZE {
+        return None;
+    }
+    let (src_copied, _) = diffcore_count_changes(old, new);
+    let src_copied = src_copied.min(old.len() as u64);
+    let src_removed = (old.len() as u64).saturating_sub(src_copied);
+    Some(src_removed * DIFF_MAX_SCORE / old.len() as u64)
+}
+
+/// Percentage shown in `dissimilarity index N%` for a rewrite (`similarity_index` in Git's diff.c).
+#[must_use]
+pub fn rewrite_dissimilarity_index_percent(old: &[u8], new: &[u8]) -> Option<u32> {
+    let score = rewrite_merge_score(old, new)?;
+    Some((score * 100 / DIFF_MAX_SCORE).min(100) as u32)
+}
+
 fn should_break_rewrite_inner(src: &[u8], dst: &[u8], break_score: u64) -> bool {
     if src.is_empty() {
         return false;

--- a/grit/src/commands/commit.rs
+++ b/grit/src/commands/commit.rs
@@ -203,8 +203,77 @@ struct FixupParsed {
     commit_ref: String,
 }
 
+/// `git commit` accepts options after path arguments (`commit <path> -m <msg>`). Clap stores those
+/// in the trailing `pathspec` bucket; peel known message/file options back into typed fields.
+fn peel_commit_options_from_pathspec_bucket(args: &mut Args) {
+    let pspec = std::mem::take(&mut args.pathspec);
+    if pspec.is_empty() {
+        return;
+    }
+    let mut out_paths = Vec::new();
+    let mut i = 0usize;
+    while i < pspec.len() {
+        let a = pspec[i].as_str();
+        match a {
+            "-m" | "--message" => {
+                if let Some(v) = pspec.get(i + 1) {
+                    args.message.push(v.clone());
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+            }
+            "-F" | "--file" => {
+                if args.file.is_none() {
+                    if let Some(v) = pspec.get(i + 1) {
+                        args.file = Some(v.clone());
+                        i += 2;
+                        continue;
+                    }
+                }
+                out_paths.push(pspec[i].clone());
+                i += 1;
+            }
+            _ if a.starts_with("--message=") => {
+                args.message
+                    .push(a.trim_start_matches("--message=").to_owned());
+                i += 1;
+            }
+            _ if a.starts_with("--file=") => {
+                if args.file.is_none() {
+                    args.file = Some(a.trim_start_matches("--file=").to_owned());
+                    i += 1;
+                    continue;
+                }
+                out_paths.push(pspec[i].clone());
+                i += 1;
+            }
+            _ if a.len() > 2 && a.starts_with("-m") => {
+                args.message.push(a[2..].to_owned());
+                i += 1;
+            }
+            _ if a.len() > 2 && a.starts_with("-F") => {
+                if args.file.is_none() {
+                    args.file = Some(a[2..].to_owned());
+                    i += 1;
+                    continue;
+                }
+                out_paths.push(pspec[i].clone());
+                i += 1;
+            }
+            _ => {
+                out_paths.push(pspec[i].clone());
+                i += 1;
+            }
+        }
+    }
+    args.pathspec = out_paths;
+}
+
 /// Run the `commit` command.
 pub fn run(mut args: Args) -> Result<()> {
+    peel_commit_options_from_pathspec_bucket(&mut args);
+
     // Tests and some scripts pass `-q` after `-m MSG`; if it lands in the
     // trailing pathspec bucket, strip it so we match Git (quiet is already
     // handled by the top-level flag).

--- a/grit/src/commands/diff.rs
+++ b/grit/src/commands/diff.rs
@@ -16,8 +16,8 @@ use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::diff::{
     anchored_unified_diff, count_changes, count_git_lines, detect_renames, diff_index_to_tree,
-    diff_index_to_worktree, diff_tree_to_worktree, diff_trees, should_break_rewrite_for_stat,
-    unified_diff, zero_oid, DiffEntry, DiffStatus,
+    diff_index_to_worktree, diff_tree_to_worktree, diff_trees, rewrite_dissimilarity_index_percent,
+    should_break_rewrite_for_stat, unified_diff, zero_oid, DiffEntry, DiffStatus,
 };
 use grit_lib::error::Error;
 use grit_lib::index::Index;
@@ -186,6 +186,10 @@ pub struct Args {
     /// Break complete rewrite into delete + add pair.
     #[arg(short = 'B', long = "break-rewrites")]
     pub break_rewrites: bool,
+
+    /// Omit preimage lines for deleted files (irreversible delete).
+    #[arg(short = 'D', long = "irreversible-delete")]
+    pub irreversible_delete: bool,
 
     /// Output a binary diff that can be applied with git-apply.
     #[arg(long = "binary")]
@@ -430,6 +434,14 @@ pub fn run(mut args: Args) -> Result<()> {
     let raw_args: Vec<String> = std::env::args().collect();
     let has_separator = raw_args.iter().any(|a| a == "--");
     let (mut revs, paths) = parse_rev_and_paths(&args.args, has_separator);
+    // Options parsed by clap can remain in the `revs` bucket when `--` separates paths
+    // (`git diff -D -- path`). Drop duplicates so they are not treated as revision names.
+    if args.irreversible_delete {
+        revs.retain(|r| r != "-D" && r != "--irreversible-delete");
+    }
+    if args.break_rewrites {
+        revs.retain(|r| r != "-B" && r != "--break-rewrites");
+    }
 
     let repo = Repository::discover(None).context("not a git repository")?;
 
@@ -962,6 +974,29 @@ pub fn run(mut args: Args) -> Result<()> {
         entries
     };
 
+    if args.break_rewrites {
+        for entry in &mut entries {
+            if entry.status != DiffStatus::Modified {
+                continue;
+            }
+            let old_raw = read_content_raw(&repo.odb, &entry.old_oid);
+            let new_raw = read_content_raw_or_worktree(
+                &repo.odb,
+                &entry.new_oid,
+                wt_for_content,
+                entry.path(),
+            );
+            if is_binary(&old_raw) || is_binary(&new_raw) {
+                continue;
+            }
+            if should_break_rewrite_for_stat(&old_raw, &new_raw) {
+                if let Some(pct) = rewrite_dissimilarity_index_percent(&old_raw, &new_raw) {
+                    entry.score = Some(pct);
+                }
+            }
+        }
+    }
+
     let merge_in_progress = std::fs::metadata(repo.git_dir.join("MERGE_HEAD")).is_ok();
     let mut conflict_combined_patches: Vec<String> = Vec::new();
     if merge_in_progress && !args.cached && revs.is_empty() && work_tree.is_some() {
@@ -1123,7 +1158,7 @@ pub fn run(mut args: Args) -> Result<()> {
                 args.break_rewrites,
             )?;
             if args.summary {
-                write_diff_summary(&mut out, &entries)?;
+                write_diff_summary(&mut out, &entries, args.break_rewrites)?;
             }
         } else if args.raw {
             let oid_len = if args.full_index || args.no_abbrev {
@@ -1147,7 +1182,7 @@ pub fn run(mut args: Args) -> Result<()> {
         } else if args.name_status {
             write_name_status(&mut out, &entries)?;
         } else if args.summary && !stat_enabled {
-            write_diff_summary(&mut out, &entries)?;
+            write_diff_summary(&mut out, &entries, args.break_rewrites)?;
         } else {
             let patch_abbrev = if args.full_index {
                 40
@@ -1178,6 +1213,8 @@ pub fn run(mut args: Args) -> Result<()> {
                     patch_abbrev,
                     args.inter_hunk_context,
                     args.binary,
+                    args.break_rewrites,
+                    args.irreversible_delete,
                     &src_prefix,
                     &dst_prefix,
                 )?;
@@ -2183,6 +2220,9 @@ fn write_diff_header_with_prefix(
                 writeln!(out, "{b}old mode {}{r}", entry.old_mode)?;
                 writeln!(out, "{b}new mode {}{r}", entry.new_mode)?;
             }
+            if let Some(pct) = entry.score {
+                writeln!(out, "{b}dissimilarity index {pct}%{r}")?;
+            }
             // Pure mode change with identical blob: Git omits the `index` line (t3419-rebase-patch-id).
             if entry.old_oid == entry.new_oid && entry.old_mode != entry.new_mode {
                 return Ok(());
@@ -2254,6 +2294,8 @@ fn write_patch_with_prefix(
     abbrev_len: usize,
     _inter_hunk_context: Option<usize>,
     show_binary: bool,
+    break_rewrites: bool,
+    irreversible_delete: bool,
     src_prefix: &str,
     dst_prefix: &str,
 ) -> Result<()> {
@@ -2324,6 +2366,10 @@ fn write_patch_with_prefix(
             continue;
         }
 
+        if entry.status == DiffStatus::Deleted && irreversible_delete {
+            continue;
+        }
+
         if is_binary(&old_content_raw) || is_binary(&new_content_raw) {
             if show_binary {
                 // --binary: output a "GIT binary patch" block
@@ -2358,6 +2404,44 @@ fn write_patch_with_prefix(
         } else {
             new_path
         };
+
+        if break_rewrites
+            && irreversible_delete
+            && entry.status == DiffStatus::Modified
+            && entry.score.is_some()
+        {
+            let new_lc = count_git_lines(&new_content_raw);
+            let new_start = if new_lc == 0 { 0 } else { 1 };
+            writeln!(
+                out,
+                "--- {}",
+                if display_old == "/dev/null" {
+                    "/dev/null".to_owned()
+                } else {
+                    format!("{src_prefix}{display_old}")
+                }
+            )?;
+            writeln!(
+                out,
+                "+++ {}",
+                if display_new == "/dev/null" {
+                    "/dev/null".to_owned()
+                } else {
+                    format!("{dst_prefix}{display_new}")
+                }
+            )?;
+            writeln!(out, "@@ -?,? +{new_start},{new_lc} @@")?;
+            for chunk in new_content.split_inclusive('\n') {
+                if chunk.ends_with('\n') {
+                    let body = chunk.strip_suffix('\n').unwrap_or(chunk);
+                    writeln!(out, "+{body}")?;
+                } else if !chunk.is_empty() {
+                    writeln!(out, "+{chunk}")?;
+                    writeln!(out, "\\ No newline at end of file")?;
+                }
+            }
+            continue;
+        }
 
         if word_diff {
             let patch = word_diff_output(
@@ -2984,7 +3068,11 @@ fn write_numstat(
 
 /// Write only the names of changed files.
 /// Write `--summary` output for rename/copy/mode-change entries.
-fn write_diff_summary(out: &mut impl Write, entries: &[DiffEntry]) -> Result<()> {
+fn write_diff_summary(
+    out: &mut impl Write,
+    entries: &[DiffEntry],
+    break_rewrites: bool,
+) -> Result<()> {
     for entry in entries {
         match entry.status {
             DiffStatus::Renamed => {
@@ -3016,6 +3104,13 @@ fn write_diff_summary(out: &mut impl Write, entries: &[DiffEntry]) -> Result<()>
                     entry.old_mode,
                     quote_c_style(entry.path())
                 )?;
+            }
+            DiffStatus::Modified => {
+                if break_rewrites {
+                    if let Some(pct) = entry.score {
+                        writeln!(out, " rewrite {} ({pct}%)", quote_c_style(entry.path()))?;
+                    }
+                }
             }
             _ => {}
         }
@@ -3050,6 +3145,21 @@ fn write_raw(out: &mut impl Write, entries: &[DiffEntry], abbrev_len: usize) -> 
                 let old_path = entry.old_path.as_deref().unwrap_or("");
                 let new_path = entry.new_path.as_deref().unwrap_or("");
                 writeln!(out, ":{old_mode} {new_mode} {old_oid} {new_oid} {status}{score:03}\t{old_path}\t{new_path}")?;
+            }
+            DiffStatus::Modified => {
+                if let Some(pct) = entry.score {
+                    writeln!(
+                        out,
+                        ":{old_mode} {new_mode} {old_oid} {new_oid} {status}{pct:03}\t{}",
+                        entry.path()
+                    )?;
+                } else {
+                    writeln!(
+                        out,
+                        ":{old_mode} {new_mode} {old_oid} {new_oid} {status}\t{}",
+                        entry.path()
+                    )?;
+                }
             }
             _ => {
                 writeln!(

--- a/grit/src/commands/diff_files.rs
+++ b/grit/src/commands/diff_files.rs
@@ -6,8 +6,8 @@
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::diff::{
-    count_changes, detect_copies, format_stat_line, stat_matches, unified_diff, zero_oid,
-    DiffEntry, DiffStatus,
+    count_changes, detect_copies, format_stat_line, rewrite_dissimilarity_index_percent,
+    should_break_rewrite_for_stat, stat_matches, unified_diff, zero_oid, DiffEntry, DiffStatus,
 };
 use grit_lib::index::{
     Index, IndexEntry, MODE_EXECUTABLE, MODE_GITLINK, MODE_REGULAR, MODE_SYMLINK,
@@ -50,6 +50,43 @@ pub fn run(args: Args) -> Result<()> {
 
     let mut diff_entries: Vec<DiffEntry> = changes.iter().map(change_to_diff_entry).collect();
 
+    if options.break_rewrites {
+        for entry in &mut diff_entries {
+            if entry.status != DiffStatus::Modified {
+                continue;
+            }
+            let old_raw = if entry.old_oid == zero_oid() {
+                Vec::new()
+            } else {
+                match repo.odb.read(&entry.old_oid) {
+                    Ok(obj) => obj.data,
+                    Err(_) => continue,
+                }
+            };
+            let new_raw = if entry.new_oid == zero_oid() {
+                Vec::new()
+            } else {
+                let path = entry.new_path.as_deref().unwrap_or(entry.path());
+                let abs = work_tree.join(path);
+                match fs::read(&abs) {
+                    Ok(b) => b,
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+                    Err(_) => continue,
+                }
+            };
+            if grit_lib::merge_file::is_binary(&old_raw)
+                || grit_lib::merge_file::is_binary(&new_raw)
+            {
+                continue;
+            }
+            if should_break_rewrite_for_stat(&old_raw, &new_raw) {
+                if let Some(pct) = rewrite_dissimilarity_index_percent(&old_raw, &new_raw) {
+                    entry.score = Some(pct);
+                }
+            }
+        }
+    }
+
     if options.reverse {
         diff_entries = diff_entries
             .into_iter()
@@ -86,14 +123,28 @@ pub fn run(args: Args) -> Result<()> {
         diff_entries = grit_lib::diff::detect_renames(&repo.odb, diff_entries, threshold);
     }
 
+    if options.summary {
+        print_diff_files_summary(&diff_entries)?;
+    }
+    if !options.quiet && options.suppress_diff {
+        if (options.exit_code || options.quiet) && !diff_entries.is_empty() {
+            std::process::exit(1);
+        }
+        return Ok(());
+    }
+
     if !options.quiet && !options.suppress_diff {
         match options.format {
             OutputFormat::Raw => {
-                for entry in &diff_entries {
-                    println!(
-                        "{}",
-                        render_raw_diff_entry(entry, &repo, options.abbrev, options.reverse)?
-                    );
+                if options.summary && !options.explicit_raw {
+                    // `git diff-files --summary` replaces default raw output unless `--raw` is given.
+                } else {
+                    for entry in &diff_entries {
+                        println!(
+                            "{}",
+                            render_raw_diff_entry(entry, &repo, options.abbrev, options.reverse)?
+                        );
+                    }
                 }
             }
             OutputFormat::NameOnly => {
@@ -144,6 +195,109 @@ pub fn run(args: Args) -> Result<()> {
     Ok(())
 }
 
+fn quote_c_style_path(name: &str) -> String {
+    let mut out = String::with_capacity(name.len() + 2);
+    let mut needs_quotes = false;
+    for ch in name.chars() {
+        match ch {
+            '"' => {
+                out.push_str("\\\"");
+                needs_quotes = true;
+            }
+            '\\' => {
+                out.push_str("\\\\");
+                needs_quotes = true;
+            }
+            '\t' => {
+                out.push_str("\\t");
+                needs_quotes = true;
+            }
+            '\n' => {
+                out.push_str("\\n");
+                needs_quotes = true;
+            }
+            '\r' => {
+                out.push_str("\\r");
+                needs_quotes = true;
+            }
+            c if c.is_control() => {
+                out.push_str(&format!("\\{:03o}", u32::from(c)));
+                needs_quotes = true;
+            }
+            c => out.push(c),
+        }
+    }
+    if needs_quotes {
+        format!("\"{out}\"")
+    } else {
+        out
+    }
+}
+
+fn format_rename_summary_display(old: &str, new: &str) -> String {
+    let pretty = grit_lib::diff::format_rename_path(old, new);
+    quote_c_style_path(&pretty)
+}
+
+/// Emit `git diff-files --summary` lines (rewrites, deletes, mode changes, renames/copies).
+fn print_diff_files_summary(entries: &[DiffEntry]) -> Result<()> {
+    for entry in entries {
+        match entry.status {
+            DiffStatus::Renamed => {
+                let old = entry.old_path.as_deref().unwrap_or("");
+                let new = entry.new_path.as_deref().unwrap_or("");
+                let display = format_rename_summary_display(old, new);
+                let sim = entry.score.unwrap_or(100);
+                println!(" rename {display} ({sim}%)");
+            }
+            DiffStatus::Copied => {
+                let old = entry.old_path.as_deref().unwrap_or("");
+                let new = entry.new_path.as_deref().unwrap_or("");
+                let display = format_rename_summary_display(old, new);
+                let sim = entry.score.unwrap_or(100);
+                println!(" copy {display} ({sim}%)");
+            }
+            DiffStatus::Added => {
+                println!(
+                    " create mode {} {}",
+                    entry.new_mode,
+                    quote_c_style_path(entry.path())
+                );
+            }
+            DiffStatus::Deleted => {
+                println!(
+                    " delete mode {} {}",
+                    entry.old_mode,
+                    quote_c_style_path(entry.path())
+                );
+            }
+            DiffStatus::TypeChanged => {
+                println!(
+                    " mode change {} => {} {}",
+                    entry.old_mode,
+                    entry.new_mode,
+                    quote_c_style_path(entry.path())
+                );
+            }
+            DiffStatus::Modified => {
+                if entry.old_mode != entry.new_mode && entry.old_oid == entry.new_oid {
+                    println!(
+                        " mode change {} => {} {}",
+                        entry.old_mode,
+                        entry.new_mode,
+                        quote_c_style_path(entry.path())
+                    );
+                }
+                if let Some(pct) = entry.score {
+                    println!(" rewrite {} ({pct}%)", quote_c_style_path(entry.path()));
+                }
+            }
+            DiffStatus::Unmerged => {}
+        }
+    }
+    Ok(())
+}
+
 // ── Internal types ───────────────────────────────────────────────────
 
 /// Output format for `diff-files`.
@@ -178,6 +332,8 @@ struct Options {
     abbrev: Option<usize>,
     /// Chosen output format.
     format: OutputFormat,
+    /// True only when `--raw` was passed (default format is raw but must be suppressed with `--summary`).
+    explicit_raw: bool,
     /// Suppress diff output (-s / --no-patch).
     suppress_diff: bool,
     /// Optional diff-filter specification.
@@ -192,6 +348,10 @@ struct Options {
     find_copies_harder: bool,
     /// Swap old/new sides (reverse diff).
     reverse: bool,
+    /// Emit condensed summary lines (renames, mode changes, rewrites with `-B`).
+    summary: bool,
+    /// Detect complete rewrites (`-B` / `--break-rewrites`) for summary/raw dissimilarity.
+    break_rewrites: bool,
 }
 
 /// A single changed file: index side vs working tree.
@@ -220,6 +380,7 @@ fn parse_options(argv: &[String]) -> Result<Options> {
     let mut exit_code = false;
     let mut abbrev: Option<usize> = None;
     let mut format = OutputFormat::Raw;
+    let mut explicit_raw = false;
     let mut suppress_diff = false;
     let mut diff_filter: Option<String> = None;
     let mut ignore_submodules = false;
@@ -228,6 +389,8 @@ fn parse_options(argv: &[String]) -> Result<Options> {
     let mut find_copies_harder = false;
     let mut c_count = 0u32;
     let mut reverse = false;
+    let mut summary = false;
+    let mut break_rewrites = false;
     let mut end_of_options = false;
 
     let mut idx = 0usize;
@@ -243,6 +406,7 @@ fn parse_options(argv: &[String]) -> Result<Options> {
                 "-R" => reverse = true,
                 "--raw" => {
                     format = OutputFormat::Raw;
+                    explicit_raw = true;
                     suppress_diff = false;
                 }
                 "-p" | "--patch" | "-u" => {
@@ -264,6 +428,20 @@ fn parse_options(argv: &[String]) -> Result<Options> {
                 "--name-status" => {
                     format = OutputFormat::NameStatus;
                     suppress_diff = false;
+                }
+                "--summary" => summary = true,
+                "-B" | "--break-rewrites" => break_rewrites = true,
+                _ if arg.starts_with("--break-rewrites=") => break_rewrites = true,
+                _ if arg.starts_with("-B") && arg.len() > 2 => {
+                    let rest = &arg[2..];
+                    let num = rest.strip_suffix('%').unwrap_or(rest);
+                    if num.is_empty() || num.chars().all(|c| c.is_ascii_digit()) {
+                        break_rewrites = true;
+                    } else if !rest.chars().all(|c| c.is_ascii_digit() || c == '%') {
+                        bail!("unsupported option: {arg}");
+                    } else {
+                        break_rewrites = true;
+                    }
                 }
                 "--exit-code" => exit_code = true,
                 "-q" | "--quiet" => quiet = true,
@@ -384,6 +562,7 @@ fn parse_options(argv: &[String]) -> Result<Options> {
         exit_code,
         abbrev,
         format,
+        explicit_raw,
         suppress_diff,
         diff_filter,
         ignore_submodules,
@@ -391,6 +570,8 @@ fn parse_options(argv: &[String]) -> Result<Options> {
         find_copies,
         find_copies_harder,
         reverse,
+        summary,
+        break_rewrites,
     })
 }
 
@@ -639,6 +820,7 @@ fn render_raw_diff_entry(
     let status_str = match (entry.status, entry.score) {
         (DiffStatus::Renamed, Some(s)) => format!("R{s:03}"),
         (DiffStatus::Copied, Some(s)) => format!("C{s:03}"),
+        (DiffStatus::Modified, Some(pct)) => format!("M{pct:03}"),
         _ => entry.status.letter().to_string(),
     };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes `tests/t4022-diff-rewrite.sh` pass (11/11).

### Changes

- **`grit diff-files`**: Parse `-B` / `--break-rewrites` and `--summary`. Compute rewrite dissimilarity for index↔worktree modified blobs (same break logic as existing stat path). Emit summary lines (`rewrite`, `delete`, renames/copies, mode change). When `--summary` is used without explicit `--raw`, suppress the default raw lines (matches Git).
- **`grit diff`**: Add `-D` / `--irreversible-delete`. After `-R`, apply break-rewrite scores for modified entries; emit `dissimilarity index`, `MNNN` in raw output, and `rewrite` lines in `--summary`. With `-B -D`, show Git-style plus-only hunks for rewrites. Strip duplicate `-B`/`-D` from the revision bucket when `--` separates paths.
- **`grit commit`**: Peel `-m` / `-F` (and `=` / glued forms) out of the trailing pathspec bucket so `commit <path> -m <msg>` works like Git.
- **`grit-lib`**: `rewrite_dissimilarity_index_percent` from Git’s merge_score (source removal ratio).

### Validation

- `./scripts/run-tests.sh t4022-diff-rewrite.sh` — 11/11
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f561672c-80bb-4411-af28-583f121c2e35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f561672c-80bb-4411-af28-583f121c2e35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

