### PR TITLE
fix: make t7011-skip-worktree-reading fully pass

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -821,7 +821,7 @@ commit → check it off → move on.
 - [ ] `t7418-submodule-sparse-gitmodules` ██████░░░░░░░░░░░░░░ 3/9 (6 left) — Test reading/writing .gitmodules when not in the working tree
 
 - [ ] `t7701-repack-unpack-unreachable` ██████░░░░░░░░░░░░░░ 3/9 (6 left) — git repack works correctly
-- [ ] `t7011-skip-worktree-reading` ██████████░░░░░░░░░░ 8/15 (7 left) — skip-worktree bit test
+- [x] `t7011-skip-worktree-reading` — skip-worktree bit test (15/15)
 - [ ] `t7811-grep-open` ██████░░░░░░░░░░░░░░ 3/10 (7 left) — git grep --open-files-in-pager
 
 - [ ] `t7419-submodule-set-branch` ████░░░░░░░░░░░░░░░░ 2/9 (7 left) — Test submodules set-branch subcommand

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -92,7 +92,7 @@ t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
 t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
-t1006-cat-file	t1	yes	290	285	5	false	ok	1
+t1006-cat-file	t1	yes	290	285	5	false	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	32	8	false	ok	0
 t10070-cat-file-batch-format	t1	yes	33	33	0	true	ok	0
@@ -1154,7 +1154,7 @@ t7007-show	t7	yes	18	9	9	false	ok	0
 t7008-filter-branch-null-sha1	t7	yes	6	5	1	false	ok	0
 t7008-show-stat-raw-name	t7	yes	21	21	0	true	ok	0
 t7010-setup	t7	yes	16	10	6	false	ok	0
-t7011-skip-worktree-reading	t7	yes	15	8	7	false	ok	0
+t7011-skip-worktree-reading	t7	yes	15	15	0	true	ok	0
 t7012-skip-worktree-writing	t7	yes	11	8	3	false	ok	6
 t7020-commit-encoding	t7	yes	26	26	0	true	ok	0
 t7030-verify-tag	t7	skip	16	0	0	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T02:36:36+00:00" class="gen-time" title="2026-04-09 02:36 UTC">2026-04-09 02:36 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,565</div>
+      <div class="summary-big-val">29,580</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>713 files fully passing</span>
+    <span>717 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,7 +212,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">41/141 files · 2 skipped · 3,333/4,611 tests</span>
+        <span class="group-meta">42/141 files · 2 skipped · 3,334/4,611 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.3%"></div></div>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,336/3,949 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,342/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.8%"></div></div>
-        <span class="group-pct pct-red">33.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.0%"></div></div>
+        <span class="group-pct pct-red">34.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -256,11 +256,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">42/126 files · 11 skipped · 1,793/2,944 tests</span>
+        <span class="group-meta">44/126 files · 11 skipped · 1,801/2,944 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>
-        <span class="group-pct pct-blue">60.9%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:61.2%"></div></div>
+        <span class="group-pct pct-blue">61.2%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T02:36:36+00:00" class="gen-time" title="2026-04-09 02:36 UTC">2026-04-09 02:36 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,864</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,565</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,580</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1085,7 +1085,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">285</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.3%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t10060-hash-object-determinism</td>
@@ -5110,8 +5110,7 @@ tr.row-skip td { opacity: 0.65; }
 <tr class="" data-group="t2" data-tests="15" data-passed="5">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td><span class="badge ok">full pass</span></td>
-  <td class="right">15</td>
+  <td></td>
   <td class="right">15</td>
   <td class="right">5</td>
   <td class="right">ok</td>
@@ -6218,14 +6217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="54" data-passed="38">
+<tr class="" data-group="t3" data-tests="52" data-passed="3">
   <td class="mono">t3420-rebase-autostash</td>
   <td>t3</td>
   <td></td>
-  <td class="right">54</td>
-  <td class="right">38</td>
+  <td class="right">52</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="63" data-passed="11">
@@ -11698,14 +11697,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:62.5%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="15" data-passed="8">
+<tr class="" data-group="t7" data-tests="15" data-passed="15" data-full-pass="1">
   <td class="mono">t7011-skip-worktree-reading</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">15</td>
-  <td class="right">8</td>
+  <td class="right">15</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:53.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="11" data-passed="8">
@@ -12598,7 +12597,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="2" data-passed="2">
+<tr class="" data-group="t7" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t7524-commit-summary</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>

--- a/grit/src/commands/commit.rs
+++ b/grit/src/commands/commit.rs
@@ -1003,9 +1003,17 @@ fn stage_pathspec_files(
 
     let mut matched_paths = HashSet::new();
 
+    let reject_skip_worktree = |idx: &Index, path: &[u8]| -> Result<()> {
+        if idx.get(path, 0).is_some_and(|e| e.skip_worktree()) {
+            bail!("cannot update skip-worktree entry");
+        }
+        Ok(())
+    };
+
     for spec in pathspecs {
         let resolved = crate::pathspec::resolve_pathspec(spec, work_tree, prefix.as_deref());
         if !crate::pathspec::has_glob_chars(&resolved) {
+            reject_skip_worktree(&index, resolved.as_bytes())?;
             let abs_path = work_tree.join(&resolved);
             if let Ok(meta) = fs::symlink_metadata(&abs_path) {
                 let data = if meta.file_type().is_symlink() {
@@ -1070,6 +1078,7 @@ fn stage_pathspec_files(
         }
 
         for rel in matched_rels {
+            reject_skip_worktree(&index, rel.as_bytes())?;
             let abs_path = work_tree.join(&rel);
             if let Ok(meta) = fs::symlink_metadata(&abs_path) {
                 let data = if meta.file_type().is_symlink() {

--- a/grit/src/commands/diff_index.rs
+++ b/grit/src/commands/diff_index.rs
@@ -723,6 +723,13 @@ fn diff_tree_vs_worktree(
     for (path, index_snapshot) in index_map {
         let abs = work_tree.join(path);
 
+        // Git `diff-lib.c:do_oneway_diff`: do not examine the work tree for skip-worktree entries.
+        if let Some(ie) = index_entries.get(path.as_bytes()) {
+            if ie.skip_worktree() {
+                continue;
+            }
+        }
+
         if index_snapshot.mode == MODE_GITLINK {
             if ignore_submodules {
                 continue;

--- a/grit/src/commands/reset.rs
+++ b/grit/src/commands/reset.rs
@@ -29,6 +29,31 @@ fn zero_oid() -> ObjectId {
     ObjectId::zero()
 }
 
+/// When rebuilding the index from a tree (`reset` mixed/hard/merge), preserve cache-entry flags
+/// from the previous index for paths that still exist at stage 0.
+///
+/// Git keeps `CE_SKIP_WORKTREE` and `CE_VALID` (assume-unchanged) across this rebuild so sparse
+/// checkout state is not lost (`t7011-skip-worktree-reading`).
+fn preserve_index_cache_flags_from(old: &Index, new: &mut Index) {
+    for ne in new.entries.iter_mut() {
+        if ne.stage() != 0 {
+            continue;
+        }
+        let Some(oe) = old.get(&ne.path, 0) else {
+            continue;
+        };
+        if oe.assume_unchanged() {
+            ne.set_assume_unchanged(true);
+        }
+        if oe.skip_worktree() {
+            ne.set_skip_worktree(true);
+            if new.version < 3 {
+                new.version = 3;
+            }
+        }
+    }
+}
+
 /// The reset mode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 enum ResetMode {
@@ -610,6 +635,9 @@ fn reset_commit(
     let mut new_index = Index::new();
     new_index.entries = tree_entries;
     new_index.sort();
+    // Git keeps cache-entry flags (assume-unchanged, skip-worktree) across mixed/hard/merge
+    // index rebuilds so sparse/skip-worktree paths stay marked (t7011).
+    preserve_index_cache_flags_from(&old_index, &mut new_index);
 
     if mode == ResetMode::Hard || mode == ResetMode::Keep || mode == ResetMode::Merge {
         // Hard/Keep/Merge require a working tree

--- a/grit/src/commands/update_index.rs
+++ b/grit/src/commands/update_index.rs
@@ -480,29 +480,32 @@ pub fn run(args: Args, raw_rest: &[String]) -> Result<()> {
             continue;
         }
 
+        // Git `read-cache.c:process_path`: skip-worktree entries are not refreshed from disk.
+        // Plain `update-index <path>` is a no-op; `--remove` drops the index entry even when
+        // the file still exists, unless `--ignore-skip-worktree-entries` is set.
+        if let Some(e) = index.get(&rel_bytes, 0) {
+            if e.skip_worktree() {
+                if path_mode == PathMode::Remove && !args.ignore_skip_worktree_entries {
+                    let _ = index.remove(&rel_bytes);
+                }
+                continue;
+            }
+        }
+
         // --remove: if the file doesn't exist on disk (or is a directory
         // that replaced it), remove the entry from the index.  If the file
         // *does* exist on disk, fall through to the normal update/add logic
         // so the index entry gets refreshed.
         if path_mode == PathMode::Remove {
-            // --ignore-skip-worktree-entries: skip entries with skip-worktree bit
-            if args.ignore_skip_worktree_entries {
-                if let Some(e) = index.get(&rel_bytes, 0) {
-                    if e.skip_worktree() {
-                        continue; // leave this entry alone
-                    }
-                }
-            }
             let file_exists = match std::fs::symlink_metadata(&abs_path) {
                 Ok(m) => !m.is_dir(),
                 Err(_) => false,
             };
             if !file_exists {
-                if !index.remove(&rel_bytes) && !args.ignore_missing {
-                    // Entry wasn't in the index — only error if the file is
-                    // truly gone (not just a directory replacement).
-                    bail!("'{}' is not in the index", input_path.display());
-                }
+                // Git `remove_one_path`: missing worktree files are dropped from the index
+                // when `--remove` is in effect; there is no error if the path was not tracked
+                // (`read-cache.c: remove_file_from_index` always succeeds).
+                let _ = index.remove(&rel_bytes);
                 continue;
             }
             // File exists on disk — fall through to update it in the index.

--- a/logs/2026-04-09_t7011-skip-worktree-reading.md
+++ b/logs/2026-04-09_t7011-skip-worktree-reading.md
@@ -1,0 +1,27 @@
+# t7011-skip-worktree-reading
+
+## Goal
+
+Make `tests/t7011-skip-worktree-reading.sh` pass 15/15 with grit.
+
+## Changes
+
+1. **`grit update-index`** (`grit/src/commands/update_index.rs`)
+   - Match Git `process_path`: stage-0 entries with `skip-worktree` are not refreshed from disk; plain `update-index <path>` is a no-op.
+   - `update-index --remove <path>` removes the entry even when the file still exists (unless `--ignore-skip-worktree-entries`).
+   - When the worktree file is missing, `--remove` drops the index entry if present and does **not** error if the path was never tracked (Git `remove_one_path` / `remove_file_from_index`).
+
+2. **`grit diff-index`** (`grit/src/commands/diff_index.rs`)
+   - Skip worktree examination for index paths with `skip-worktree` (Git `do_oneway_diff` cached path).
+
+3. **`grit commit`** (`grit/src/commands/commit.rs`)
+   - Pathspec staging fails with `cannot update skip-worktree entry` when the path matches a skip-worktree index entry (tests 14–15).
+
+4. **`grit reset`** (`grit/src/commands/reset.rs`)
+   - When rebuilding the index from the target tree, preserve `assume-unchanged` and `skip-worktree` from the previous index for matching stage-0 paths so `git reset` does not clear sparse flags (Git behavior; fixes test 6 after prior tests leave the repo dirty).
+
+## Validation
+
+- `cargo fmt`, `cargo clippy --fix --allow-dirty -p grit-rs`
+- `cargo test -p grit-lib --lib`
+- `./scripts/run-tests.sh t7011-skip-worktree-reading.sh` → 15/15

--- a/progress.md
+++ b/progress.md
@@ -1,20 +1,21 @@
 # Progress — Grit Test Coverage
 
-**Updated:** 2026-04-08
+**Updated:** 2026-04-09
 
 ## Counts (derived from plan.md)
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   231 |
-| In progress |     2 |
-| Remaining   |   535 |
+| Completed   |   247 |
+| In progress |     4 |
+| Remaining   |   517 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 231 completed (`[x]`), 2 in progress (`[~]`), 535 remaining (`[ ]`).
+Task lines in `PLAN.md`: 247 completed (`[x]`), 4 in progress (`[~]`), 517 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t7011-skip-worktree-reading` — 15/15 tests pass (`update-index` skip-worktree no-op / `--remove` clears entry; `--remove` on missing untracked path is silent; `reset` preserves skip-worktree; `diff-index` skips worktree for skip-worktree; `commit` pathspec rejects skip-worktree)
 - `t12820-diff-no-index-symlink` — 41/41 tests pass (symlink add/modify/delete, `diff`/`diff --cached`/`diff-tree`, stat/numstat/name output, multi-symlink and file↔symlink replacements; harness dashboards refreshed)
 - `t7817-grep-sparse-checkout` — 8/8 tests pass (non-cone sparse: `path_in_sparse_checkout` parent walk + last-match-wins; `sparse-checkout init` preserves cone mode and seeds `/*` + `!/*/` when recreating file; `disable` keeps pattern file so re-init reapplies `!b`; submodule `reset --hard` + sparse reapply; `grep` worktree: skip-worktree when absent, CE_VALID vs skip-worktree, unmerged paths grep worktree once; `grep_cached` per-stage for `--cached`)
 - `t7417-submodule-path-url` — 5/5 tests pass (`.gitmodules` dash paths: `mv` updates path + index blob; `escape_value` quotes leading `-`; receive-side `transfer.fsckObjects` via repo-local config only; clone `--recurse-submodules` resolves relative URLs from `origin` repo root + quoted path parsing + `GIT_QUIET` quiet mode)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible **skip-worktree** behavior for the scenarios covered by `t7011-skip-worktree-reading.sh` (15/15).

## Changes

- **`update-index`**: Stage-0 entries with skip-worktree are not refreshed from the work tree; plain `update-index <path>` is a no-op. `update-index --remove` removes the index entry even when the file still exists (unless `--ignore-skip-worktree-entries`). When the worktree file is missing, `--remove` drops the entry if present and does not error if the path was never tracked (matches Git `remove_one_path`).
- **`diff-index`**: Skips worktree examination for skip-worktree index entries (Git `do_oneway_diff` “cached” path).
- **`commit`**: Pathspec staging fails with `cannot update skip-worktree entry` when the resolved path matches a skip-worktree index entry.
- **`reset`**: When rebuilding the index from the target tree, preserves **assume-unchanged** and **skip-worktree** from the previous index for matching stage-0 paths so `git reset` does not clear sparse flags.

Harness: `./scripts/run-tests.sh t7011-skip-worktree-reading.sh` → 15/15; `data/test-files.csv` and dashboards updated.

Also updates `PLAN.md` / `progress.md` and adds `logs/2026-04-09_t7011-skip-worktree-reading.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cfda342f-ec94-4287-8c2f-046cf605c0c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cfda342f-ec94-4287-8c2f-046cf605c0c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

