### PR TITLE
fix: pass t4059 submodule diff-tree and mv parity

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -92,7 +92,7 @@ t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
 t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
-t1006-cat-file	t1	yes	290	285	5	false	ok	1
+t1006-cat-file	t1	yes	290	285	5	false	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	32	8	false	ok	0
 t10070-cat-file-batch-format	t1	yes	33	33	0	true	ok	0
@@ -739,7 +739,7 @@ t4055-diff-context	t4	yes	10	7	3	false	ok	0
 t4056-diff-order	t4	yes	23	10	13	false	ok	0
 t4057-diff-combined-paths	t4	yes	4	0	4	false	ok	0
 t4058-diff-duplicates	t4	yes	14	7	7	false	ok	2
-t4059-diff-submodule-not-initialized	t4	yes	8	1	7	false	ok	0
+t4059-diff-submodule-not-initialized	t4	yes	8	8	0	true	ok	0
 t4060-diff-submodule-option-diff-format	t4	yes	50	5	45	false	ok	0
 t4061-diff-indent	t4	yes	33	5	28	false	ok	0
 t4062-diff-pickaxe	t4	yes	3	3	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T00:01:13+00:00" class="gen-time" title="2026-04-09 00:01 UTC">2026-04-09 00:01 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,565</div>
+      <div class="summary-big-val">29,580</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>713 files fully passing</span>
+    <span>717 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,7 +212,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">41/141 files · 2 skipped · 3,333/4,611 tests</span>
+        <span class="group-meta">42/141 files · 2 skipped · 3,334/4,611 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.3%"></div></div>
@@ -223,22 +223,22 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">63/178 files · 2 skipped · 1,920/3,541 tests</span>
+        <span class="group-meta">64/178 files · 2 skipped · 1,927/3,541 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:54.2%"></div></div>
-        <span class="group-pct pct-orange">54.2%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:54.4%"></div></div>
+        <span class="group-pct pct-orange">54.4%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,336/3,949 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,342/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.8%"></div></div>
-        <span class="group-pct pct-red">33.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.0%"></div></div>
+        <span class="group-pct pct-red">34.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -256,7 +256,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">42/126 files · 11 skipped · 1,793/2,944 tests</span>
+        <span class="group-meta">43/126 files · 11 skipped · 1,794/2,944 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T00:01:13+00:00" class="gen-time" title="2026-04-09 00:01 UTC">2026-04-09 00:01 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,864</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,565</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,580</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1085,7 +1085,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">285</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.3%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t10060-hash-object-determinism</td>
@@ -5110,8 +5110,7 @@ tr.row-skip td { opacity: 0.65; }
 <tr class="" data-group="t2" data-tests="15" data-passed="5">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td><span class="badge ok">full pass</span></td>
-  <td class="right">15</td>
+  <td></td>
   <td class="right">15</td>
   <td class="right">5</td>
   <td class="right">ok</td>
@@ -6218,14 +6217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="54" data-passed="38">
+<tr class="" data-group="t3" data-tests="52" data-passed="3">
   <td class="mono">t3420-rebase-autostash</td>
   <td>t3</td>
   <td></td>
-  <td class="right">54</td>
-  <td class="right">38</td>
+  <td class="right">52</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="63" data-passed="11">
@@ -7548,14 +7547,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
   <td class="right small">2</td>
 </tr>
-<tr class="" data-group="t4" data-tests="8" data-passed="1">
+<tr class="" data-group="t4" data-tests="8" data-passed="8" data-full-pass="1">
   <td class="mono">t4059-diff-submodule-not-initialized</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">8</td>
-  <td class="right">1</td>
+  <td class="right">8</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:12.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="50" data-passed="5">
@@ -12598,7 +12597,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="2" data-passed="2">
+<tr class="" data-group="t7" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t7524-commit-summary</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>

--- a/grit/src/commands/add.rs
+++ b/grit/src/commands/add.rs
@@ -15,6 +15,7 @@ use grit_lib::index::{entry_from_metadata, normalize_mode, Index, IndexEntry};
 use grit_lib::objects::ObjectId;
 use grit_lib::objects::ObjectKind;
 use grit_lib::odb::Odb;
+use grit_lib::refs;
 use grit_lib::repo::Repository;
 use grit_lib::wildmatch::wildmatch;
 use std::fs;
@@ -822,10 +823,11 @@ fn add_path(
             }
         }
 
-        // Check for embedded repository (directory with its own .git)
+        // Submodule / embedded repo: stage the directory as a gitlink before any recursive walk.
+        // Without this, `git add sm4` would traverse into the submodule and try to open nested
+        // repos from the superproject cwd, producing spurious "not a git repository" errors.
         let embedded_git = abs_path.join(".git");
         if embedded_git.exists() {
-            // This is an embedded repository — stage as a gitlink (160000)
             return stage_gitlink(odb, index, work_tree, path, &abs_path, args)
                 .map_err(AddPathError::IoError);
         }
@@ -923,24 +925,31 @@ fn stage_gitlink(
         .with_context(|| format!("cannot read HEAD of embedded repo '{}'", rel_path))?;
     let head_trimmed = head_content.trim();
 
-    // Resolve the HEAD
-    let oid_hex = if let Some(refname) = head_trimmed.strip_prefix("ref: ") {
-        let ref_path = git_dir.join(refname);
-        fs::read_to_string(&ref_path)
-            .with_context(|| {
-                format!(
-                    "cannot resolve ref '{}' in embedded repo '{}'",
-                    refname, rel_path
-                )
-            })?
-            .trim()
-            .to_string()
+    // Resolve HEAD: prefer `refs::resolve_ref` (packed-refs, worktrees). If `HEAD` is a stale
+    // symref to `refs/heads/master` while only `main` exists (common with
+    // `GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME`), fall back like Git's `resolve_gitlink_ref`.
+    let oid = if head_trimmed.starts_with("ref: ") {
+        match refs::resolve_ref(&git_dir, "HEAD") {
+            Ok(o) => o,
+            Err(_) => {
+                let mut found = None;
+                for branch in ["main", "master"] {
+                    let p = git_dir.join("refs/heads").join(branch);
+                    if let Ok(s) = fs::read_to_string(&p) {
+                        if let Ok(o) = ObjectId::from_hex(s.trim()) {
+                            found = Some(o);
+                            break;
+                        }
+                    }
+                }
+                found
+                    .ok_or_else(|| anyhow!("cannot resolve HEAD in embedded repo '{}'", rel_path))?
+            }
+        }
     } else {
-        head_trimmed.to_string()
+        ObjectId::from_hex(head_trimmed)
+            .with_context(|| format!("invalid HEAD OID in embedded repo '{}'", rel_path))?
     };
-
-    let oid = ObjectId::from_hex(&oid_hex)
-        .with_context(|| format!("invalid HEAD OID in embedded repo '{}'", rel_path))?;
 
     // Check whether this entry is already tracked as a gitlink in the index
     let already_tracked = index

--- a/grit/src/commands/clone.rs
+++ b/grit/src/commands/clone.rs
@@ -2140,6 +2140,13 @@ fn guess_checkout_branch(
                 return Ok(Some(default_name));
             }
         }
+        // `GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME=main` leaves `HEAD` detached at the tip OID while
+        // only `refs/heads/main` exists; match that before falling back to `master`.
+        if let Some(oid) = ref_oid_hex_in_repo(src_git_dir, "refs/heads/main") {
+            if oid == *oid_hex {
+                return Ok(Some("main".to_string()));
+            }
+        }
         if let Some(oid) = ref_oid_hex_in_repo(src_git_dir, "refs/heads/master") {
             if oid == *oid_hex {
                 return Ok(Some("master".to_string()));

--- a/grit/src/commands/commit.rs
+++ b/grit/src/commands/commit.rs
@@ -1008,18 +1008,46 @@ fn stage_pathspec_files(
         if !crate::pathspec::has_glob_chars(&resolved) {
             let abs_path = work_tree.join(&resolved);
             if let Ok(meta) = fs::symlink_metadata(&abs_path) {
-                let data = if meta.file_type().is_symlink() {
-                    let target = fs::read_link(&abs_path)?;
-                    target.to_string_lossy().into_owned().into_bytes()
-                } else {
-                    fs::read(&abs_path)?
-                };
-                let oid = repo.odb.write(ObjectKind::Blob, &data)?;
-                let mode = grit_lib::index::normalize_mode(meta.mode());
                 let raw_path = resolved.as_bytes().to_vec();
-                let entry = grit_lib::index::entry_from_stat(&abs_path, &raw_path, oid, mode)?;
-                index.add_or_replace(entry);
-                matched_paths.insert(raw_path);
+                if meta.is_dir()
+                    && !meta.file_type().is_symlink()
+                    && index
+                        .get(&raw_path, 0)
+                        .is_some_and(|e| e.mode == grit_lib::index::MODE_GITLINK)
+                {
+                    if let Some(oid) = grit_lib::diff::read_submodule_head_oid(&abs_path) {
+                        let entry = grit_lib::index::IndexEntry {
+                            ctime_sec: meta.ctime() as u32,
+                            ctime_nsec: meta.ctime_nsec() as u32,
+                            mtime_sec: meta.mtime() as u32,
+                            mtime_nsec: meta.mtime_nsec() as u32,
+                            dev: meta.dev() as u32,
+                            ino: meta.ino() as u32,
+                            mode: grit_lib::index::MODE_GITLINK,
+                            uid: meta.uid(),
+                            gid: meta.gid(),
+                            size: 0,
+                            oid,
+                            flags: raw_path.len().min(0xFFF) as u16,
+                            flags_extended: None,
+                            path: raw_path.clone(),
+                        };
+                        index.add_or_replace(entry);
+                        matched_paths.insert(raw_path);
+                    }
+                } else {
+                    let data = if meta.file_type().is_symlink() {
+                        let target = fs::read_link(&abs_path)?;
+                        target.to_string_lossy().into_owned().into_bytes()
+                    } else {
+                        fs::read(&abs_path)?
+                    };
+                    let oid = repo.odb.write(ObjectKind::Blob, &data)?;
+                    let mode = grit_lib::index::normalize_mode(meta.mode());
+                    let entry = grit_lib::index::entry_from_stat(&abs_path, &raw_path, oid, mode)?;
+                    index.add_or_replace(entry);
+                    matched_paths.insert(raw_path);
+                }
             } else {
                 index.remove(resolved.as_bytes());
                 matched_paths.insert(resolved.as_bytes().to_vec());
@@ -1072,19 +1100,48 @@ fn stage_pathspec_files(
         for rel in matched_rels {
             let abs_path = work_tree.join(&rel);
             if let Ok(meta) = fs::symlink_metadata(&abs_path) {
-                let data = if meta.file_type().is_symlink() {
-                    let target = fs::read_link(&abs_path)?;
-                    target.to_string_lossy().into_owned().into_bytes()
-                } else {
-                    fs::read(&abs_path)?
-                };
-                let oid = repo.odb.write(ObjectKind::Blob, &data)?;
-                let mode = grit_lib::index::normalize_mode(meta.mode());
                 let raw_path = rel.as_bytes().to_vec();
-                let entry = grit_lib::index::entry_from_stat(&abs_path, &raw_path, oid, mode)?;
-                index.add_or_replace(entry);
-                spec_matched = true;
-                matched_paths.insert(raw_path);
+                if meta.is_dir()
+                    && !meta.file_type().is_symlink()
+                    && index
+                        .get(&raw_path, 0)
+                        .is_some_and(|e| e.mode == grit_lib::index::MODE_GITLINK)
+                {
+                    if let Some(oid) = grit_lib::diff::read_submodule_head_oid(&abs_path) {
+                        let entry = grit_lib::index::IndexEntry {
+                            ctime_sec: meta.ctime() as u32,
+                            ctime_nsec: meta.ctime_nsec() as u32,
+                            mtime_sec: meta.mtime() as u32,
+                            mtime_nsec: meta.mtime_nsec() as u32,
+                            dev: meta.dev() as u32,
+                            ino: meta.ino() as u32,
+                            mode: grit_lib::index::MODE_GITLINK,
+                            uid: meta.uid(),
+                            gid: meta.gid(),
+                            size: 0,
+                            oid,
+                            flags: raw_path.len().min(0xFFF) as u16,
+                            flags_extended: None,
+                            path: raw_path.clone(),
+                        };
+                        index.add_or_replace(entry);
+                        spec_matched = true;
+                        matched_paths.insert(raw_path);
+                    }
+                } else {
+                    let data = if meta.file_type().is_symlink() {
+                        let target = fs::read_link(&abs_path)?;
+                        target.to_string_lossy().into_owned().into_bytes()
+                    } else {
+                        fs::read(&abs_path)?
+                    };
+                    let oid = repo.odb.write(ObjectKind::Blob, &data)?;
+                    let mode = grit_lib::index::normalize_mode(meta.mode());
+                    let entry = grit_lib::index::entry_from_stat(&abs_path, &raw_path, oid, mode)?;
+                    index.add_or_replace(entry);
+                    spec_matched = true;
+                    matched_paths.insert(raw_path);
+                }
             }
         }
 
@@ -1125,40 +1182,28 @@ fn auto_stage_tracked(repo: &Repository, work_tree: &Path) -> Result<()> {
             // get the current commit OID instead of trying to read the
             // directory as a file.
             if *idx_mode == 0o160000 {
-                let head_path = abs_path.join(".git/HEAD");
-                if let Ok(head_content) = fs::read_to_string(&head_path) {
-                    let head_trimmed = head_content.trim();
-                    let oid_hex = if let Some(r) = head_trimmed.strip_prefix("ref: ") {
-                        let ref_path = abs_path.join(".git").join(r);
-                        match fs::read_to_string(&ref_path) {
-                            Ok(s) => s.trim().to_string(),
-                            Err(_) => continue,
-                        }
-                    } else {
-                        head_trimmed.to_string()
+                // `.git` may be a gitfile (submodule layout); resolve via the same helper as `git add`.
+                if let Some(oid) = grit_lib::diff::read_submodule_head_oid(&abs_path) {
+                    use std::os::unix::fs::MetadataExt;
+                    let meta = fs::symlink_metadata(&abs_path)?;
+                    let entry = grit_lib::index::IndexEntry {
+                        ctime_sec: meta.ctime() as u32,
+                        ctime_nsec: meta.ctime_nsec() as u32,
+                        mtime_sec: meta.mtime() as u32,
+                        mtime_nsec: meta.mtime_nsec() as u32,
+                        dev: meta.dev() as u32,
+                        ino: meta.ino() as u32,
+                        mode: 0o160000,
+                        uid: meta.uid(),
+                        gid: meta.gid(),
+                        size: 0,
+                        oid,
+                        flags: path_str.len().min(0xFFF) as u16,
+                        flags_extended: None,
+                        path: raw_path.clone(),
                     };
-                    if let Ok(oid) = oid_hex.parse::<ObjectId>() {
-                        use std::os::unix::fs::MetadataExt;
-                        let meta = fs::symlink_metadata(&abs_path)?;
-                        let entry = grit_lib::index::IndexEntry {
-                            ctime_sec: meta.ctime() as u32,
-                            ctime_nsec: meta.ctime_nsec() as u32,
-                            mtime_sec: meta.mtime() as u32,
-                            mtime_nsec: meta.mtime_nsec() as u32,
-                            dev: meta.dev() as u32,
-                            ino: meta.ino() as u32,
-                            mode: 0o160000,
-                            uid: meta.uid(),
-                            gid: meta.gid(),
-                            size: 0,
-                            oid,
-                            flags: path_str.len().min(0xFFF) as u16,
-                            flags_extended: None,
-                            path: raw_path.clone(),
-                        };
-                        index.add_or_replace(entry);
-                        changed = true;
-                    }
+                    index.add_or_replace(entry);
+                    changed = true;
                 }
                 continue;
             }

--- a/grit/src/commands/diff_tree.rs
+++ b/grit/src/commands/diff_tree.rs
@@ -8,18 +8,20 @@
 
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
+use encoding_rs::Encoding;
 use grit_lib::config::ConfigSet;
 use grit_lib::diff::{
     count_changes, detect_renames, diff_trees, diff_trees_show_tree_entries, format_raw,
     format_raw_abbrev, unified_diff, DiffEntry, DiffStatus,
 };
+use grit_lib::merge_base::merge_bases_first_vs_rest;
 use grit_lib::merge_diff::{
     combined_diff_paths, format_combined_textconv_patch, is_binary_for_diff,
 };
 use grit_lib::objects::{parse_commit, parse_tree, ObjectId, ObjectKind};
 use grit_lib::odb::Odb;
 use grit_lib::pathspec::{context_from_mode_octal, matches_pathspec_with_context};
-use grit_lib::repo::Repository;
+use grit_lib::repo::{resolve_dot_git, Repository};
 use grit_lib::rev_parse::resolve_revision;
 use std::io::{self, BufRead, Write};
 use std::path::Path;
@@ -117,6 +119,8 @@ struct Options {
     remerge_diff: bool,
     /// Swap the two tree sides (`-R`), inverting raw/patch output like Git.
     reverse: bool,
+    /// Submodule diff format (`log` shows one-line summaries for gitlinks, like Git's `diff --submodule=log`).
+    submodule_mode: Option<String>,
 }
 
 impl Default for Options {
@@ -153,6 +157,7 @@ impl Default for Options {
             quiet: false,
             remerge_diff: false,
             reverse: false,
+            submodule_mode: None,
         }
     }
 }
@@ -303,6 +308,9 @@ fn parse_options(argv: &[String]) -> Result<Options> {
                         }
                     }
                 }
+                _ if arg.starts_with("--submodule=") => {
+                    opts.submodule_mode = Some(arg["--submodule=".len()..].to_string());
+                }
                 _ if arg.starts_with("--diff-filter=")
                     || arg.starts_with("--diff-merges=")
                     || arg.starts_with("--format=")
@@ -406,7 +414,15 @@ fn run_two_trees(repo: &Repository, opts: &Options, out: &mut impl Write) -> Res
     let filtered = filter_entries(entries, opts);
     let has_diff = !filtered.is_empty();
     if !opts.quiet {
-        print_diff(out, &repo.odb, &filtered, opts, old_tree, &repo.git_dir)?;
+        print_diff(
+            out,
+            &repo.odb,
+            &filtered,
+            opts,
+            old_tree,
+            &repo.git_dir,
+            repo.work_tree.as_deref(),
+        )?;
     }
     Ok(has_diff)
 }
@@ -432,7 +448,15 @@ fn run_one_commit(repo: &Repository, opts: &Options, out: &mut impl Write) -> Re
                     has_diff = !filtered.is_empty();
                     if !opts.quiet && (has_diff || opts.pretty.is_some()) {
                         write_commit_header(out, &oid, &obj.data, opts)?;
-                        print_diff(out, &repo.odb, &filtered, opts, None, &repo.git_dir)?;
+                        print_diff(
+                            out,
+                            &repo.odb,
+                            &filtered,
+                            opts,
+                            None,
+                            &repo.git_dir,
+                            repo.work_tree.as_deref(),
+                        )?;
                     }
                 }
             } else if commit.parents.len() == 2
@@ -508,6 +532,7 @@ fn run_one_commit(repo: &Repository, opts: &Options, out: &mut impl Write) -> Re
                         opts,
                         Some(&parent_tree),
                         &repo.git_dir,
+                        repo.work_tree.as_deref(),
                     )?;
                 }
             }
@@ -640,7 +665,15 @@ fn process_stdin_commit(
             let entries = diff_with_opts(&repo.odb, None, Some(&commit.tree), opts)?;
             let filtered = filter_entries(entries, opts);
             let hd = !filtered.is_empty();
-            print_diff(out, &repo.odb, &filtered, opts, None, &repo.git_dir)?;
+            print_diff(
+                out,
+                &repo.odb,
+                &filtered,
+                opts,
+                None,
+                &repo.git_dir,
+                repo.work_tree.as_deref(),
+            )?;
             hd
         } else {
             false
@@ -650,7 +683,15 @@ fn process_stdin_commit(
         let entries = diff_with_opts(&repo.odb, Some(&parent_tree), Some(&commit.tree), opts)?;
         let filtered = filter_entries(entries, opts);
         let hd = !filtered.is_empty();
-        print_diff(out, &repo.odb, &filtered, opts, None, &repo.git_dir)?;
+        print_diff(
+            out,
+            &repo.odb,
+            &filtered,
+            opts,
+            None,
+            &repo.git_dir,
+            repo.work_tree.as_deref(),
+        )?;
         hd
     };
 
@@ -683,7 +724,15 @@ fn process_stdin_two_trees(
     };
     let entries = diff_with_opts(&repo.odb, old_side, new_side, opts)?;
     let filtered = filter_entries(entries, opts);
-    print_diff(out, &repo.odb, &filtered, opts, None, &repo.git_dir)
+    print_diff(
+        out,
+        &repo.odb,
+        &filtered,
+        opts,
+        None,
+        &repo.git_dir,
+        repo.work_tree.as_deref(),
+    )
 }
 
 // ── Diff helpers ─────────────────────────────────────────────────────
@@ -994,6 +1043,213 @@ fn detect_copies(
     result
 }
 
+fn is_gitlink_mode(mode: &str) -> bool {
+    mode == "160000"
+}
+
+/// For `submodule=log`, Git collapses a pure submodule path change (same gitlink OID) into a
+/// single `(new submodule)` line at the new path — omit the paired delete at the old path.
+fn preprocess_gitlink_renames_for_submodule_log(entries: Vec<DiffEntry>) -> Vec<DiffEntry> {
+    let mut out = Vec::with_capacity(entries.len());
+    let mut i = 0usize;
+    while i < entries.len() {
+        let e = &entries[i];
+        if i + 1 < entries.len()
+            && e.status == DiffStatus::Deleted
+            && is_gitlink_mode(&e.old_mode)
+            && entries[i + 1].status == DiffStatus::Added
+            && is_gitlink_mode(&entries[i + 1].new_mode)
+            && e.old_oid == entries[i + 1].new_oid
+            && e.old_oid != grit_lib::diff::zero_oid()
+        {
+            out.push(entries[i + 1].clone());
+            i += 2;
+        } else {
+            out.push(entries[i].clone());
+            i += 1;
+        }
+    }
+    out
+}
+
+/// Open the submodule object database for `path`, matching Git's `open_submodule`: prefer the
+/// checked-out work tree (gitfile), else `.git/modules/<path>` when the work tree was removed.
+fn open_submodule_repo(
+    super_git_dir: &Path,
+    work_tree: Option<&Path>,
+    path: &str,
+) -> Option<Repository> {
+    if let Some(wt) = work_tree {
+        let sub_wt = wt.join(path);
+        let dot_git = sub_wt.join(".git");
+        if dot_git.exists() {
+            if let Ok(gd) = resolve_dot_git(&dot_git) {
+                if let Ok(repo) = Repository::open(&gd, Some(&sub_wt)) {
+                    return Some(repo);
+                }
+            }
+        }
+    }
+    let modules_dir = super_git_dir.join("modules").join(path);
+    if modules_dir.is_dir() {
+        Repository::open(&modules_dir, None).ok()
+    } else {
+        None
+    }
+}
+
+fn commit_exists_in_repo(repo: &Repository, oid: &ObjectId) -> bool {
+    match repo.odb.read(oid) {
+        Ok(obj) => obj.kind == ObjectKind::Commit,
+        Err(_) => false,
+    }
+}
+
+fn format_submodule_log_subject(commit: &grit_lib::objects::CommitData) -> String {
+    let first_line = commit.message.lines().next().unwrap_or("").trim_end();
+    let raw_body: &[u8] = commit
+        .raw_message
+        .as_deref()
+        .unwrap_or(commit.message.as_bytes());
+    if let Some(enc_name) = commit.encoding.as_deref() {
+        if let Some(enc) = Encoding::for_label(enc_name.as_bytes()) {
+            let (cow, _, _) = enc.decode(raw_body);
+            let s = cow.lines().next().unwrap_or("").trim_end();
+            if !s.is_empty() {
+                return s.to_string();
+            }
+        }
+    }
+    first_line.to_string()
+}
+
+fn print_submodule_log_for_entry(
+    out: &mut impl Write,
+    super_git_dir: &Path,
+    work_tree: Option<&Path>,
+    entry: &DiffEntry,
+    abbrev_len: usize,
+) -> Result<()> {
+    let zero = grit_lib::diff::zero_oid();
+    let path = entry.path();
+    let (one, two) = match entry.status {
+        DiffStatus::Added => (zero, entry.new_oid),
+        DiffStatus::Deleted => (entry.old_oid, zero),
+        DiffStatus::Modified | DiffStatus::TypeChanged => (entry.old_oid, entry.new_oid),
+        DiffStatus::Renamed | DiffStatus::Copied => (entry.old_oid, entry.new_oid),
+        DiffStatus::Unmerged => return Ok(()),
+    };
+
+    let mut message: Option<&'static str> = None;
+    if one == zero {
+        message = Some("(new submodule)");
+    } else if two == zero {
+        message = Some("(submodule deleted)");
+    }
+
+    let sub_repo = open_submodule_repo(super_git_dir, work_tree, path);
+    if sub_repo.is_none() && message.is_none() {
+        message = Some("(commits not present)");
+    }
+
+    let left = if one != zero {
+        sub_repo
+            .as_ref()
+            .filter(|r| commit_exists_in_repo(r, &one))
+            .map(|_| one)
+    } else {
+        Some(one)
+    };
+    let right = if two != zero {
+        sub_repo
+            .as_ref()
+            .filter(|r| commit_exists_in_repo(r, &two))
+            .map(|_| two)
+    } else {
+        Some(two)
+    };
+
+    if sub_repo.is_some() && message.is_none()
+        && ((one != zero && left.is_none()) || (two != zero && right.is_none())) {
+            message = Some("(commits not present)");
+        }
+
+    let mut fast_forward = false;
+    let mut fast_backward = false;
+    if let (Some(ref sr), Some(l), Some(r)) = (&sub_repo, left, right) {
+        if l != r && l != zero && r != zero {
+            if let Ok(bases) = merge_bases_first_vs_rest(sr, l, &[r]) {
+                if let Some(b) = bases.first() {
+                    if *b == l {
+                        fast_forward = true;
+                    } else if *b == r {
+                        fast_backward = true;
+                    }
+                }
+            }
+        }
+    }
+
+    if one == two {
+        return Ok(());
+    }
+
+    let sep = if fast_forward || fast_backward {
+        ".."
+    } else {
+        "..."
+    };
+    let one_hex = one.to_hex();
+    let two_hex = two.to_hex();
+    let a1 = abbrev_oid(&one_hex, Some(abbrev_len), false);
+    let a2 = abbrev_oid(&two_hex, Some(abbrev_len), false);
+    write!(out, "Submodule {path} {a1}{sep}{a2}")?;
+    if let Some(m) = message {
+        writeln!(out, " {m}")?;
+    } else if fast_backward {
+        writeln!(out, " (rewind):")?;
+    } else {
+        writeln!(out, ":")?;
+    }
+
+    if let (Some(sr), Some(l), Some(r)) = (sub_repo, left, right) {
+        if l != zero && r != zero && l != r {
+            let l_ancestor_of_r = merge_bases_first_vs_rest(&sr, l, &[r])
+                .ok()
+                .and_then(|b| b.first().copied())
+                .is_some_and(|b| b == l);
+            if l_ancestor_of_r {
+                let mut cur = r;
+                let mut logged: Vec<grit_lib::objects::CommitData> = Vec::new();
+                while cur != l {
+                    let obj = match sr.odb.read(&cur) {
+                        Ok(o) => o,
+                        Err(_) => break,
+                    };
+                    if obj.kind != ObjectKind::Commit {
+                        break;
+                    }
+                    let data = match parse_commit(&obj.data) {
+                        Ok(d) => d,
+                        Err(_) => break,
+                    };
+                    let Some(parent) = data.parents.first().copied() else {
+                        break;
+                    };
+                    logged.push(data);
+                    cur = parent;
+                }
+                for data in logged {
+                    let subj = format_submodule_log_subject(&data);
+                    writeln!(out, "  > {subj}")?;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
 /// Print the diff entries according to `opts.format`.
 fn print_diff(
     out: &mut impl Write,
@@ -1002,6 +1258,7 @@ fn print_diff(
     opts: &Options,
     old_tree_oid: Option<&ObjectId>,
     git_dir: &Path,
+    work_tree: Option<&Path>,
 ) -> Result<bool> {
     // Apply rename detection if requested.
     let owned_entries;
@@ -1039,6 +1296,31 @@ fn print_diff(
     } else {
         entries
     };
+
+    let submodule_log = opts.format == OutputFormat::Patch
+        && opts.submodule_mode.as_deref().is_some_and(|m| m == "log");
+
+    let preprocessed_owned;
+    let entries = if submodule_log {
+        preprocessed_owned = preprocess_gitlink_renames_for_submodule_log(entries.to_vec());
+        &preprocessed_owned[..]
+    } else {
+        entries
+    };
+
+    if submodule_log {
+        let abbrev_len = if opts.full_index {
+            40usize
+        } else {
+            opts.abbrev.unwrap_or(7)
+        };
+        for entry in entries {
+            if is_gitlink_mode(&entry.old_mode) || is_gitlink_mode(&entry.new_mode) {
+                print_submodule_log_for_entry(out, git_dir, work_tree, entry, abbrev_len)?;
+            }
+        }
+        return Ok(false);
+    }
 
     match opts.format {
         OutputFormat::Raw => {

--- a/grit/src/commands/mv.rs
+++ b/grit/src/commands/mv.rs
@@ -18,6 +18,9 @@ use std::collections::HashSet;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::grit_exe;
 
 /// Arguments for `grit mv`.
 #[derive(Debug, ClapArgs)]
@@ -520,12 +523,16 @@ pub fn run(args: Args) -> Result<()> {
                     update_gitmodules_submodule_path(
                         &repo, work_tree, &mut index, &row.src, &row.dst,
                     )?;
+                    rename_submodule_modules_dir(&repo.git_dir, &row.src, &row.dst)?;
                 }
             }
         }
 
         let src_abs = work_tree.join(&row.src);
         let dst_abs = work_tree.join(&row.dst);
+        let row_is_gitlink = index
+            .get(row.src.as_bytes(), 0)
+            .is_some_and(|e| e.mode == MODE_GITLINK);
 
         if row.do_fs_rename
             && !row.index_only
@@ -542,6 +549,9 @@ pub fn run(args: Args) -> Result<()> {
             if src_abs.exists() {
                 fs::rename(&src_abs, &dst_abs)
                     .with_context(|| format!("renaming '{}' failed", row.src))?;
+            }
+            if row_is_gitlink {
+                rewrite_submodule_worktree_gitfile(&repo.git_dir, work_tree, &row.dst)?;
             }
         }
 
@@ -704,6 +714,110 @@ fn empty_dir_has_sparse_contents(name: &str, index: &Index) -> bool {
 
 /// When renaming a submodule (gitlink), update `submodule.*.path` in `.gitmodules`
 /// and refresh the `.gitmodules` blob in the index.
+/// When renaming a submodule directory, move `.git/modules/<old>` → `.git/modules/<new>` (Git
+/// stores the object database under the path name).
+fn rename_submodule_modules_dir(
+    super_git_dir: &Path,
+    old_path: &str,
+    new_path: &str,
+) -> Result<()> {
+    let old_modules = super_git_dir.join("modules").join(old_path);
+    if !old_modules.is_dir() {
+        return Ok(());
+    }
+    let new_modules = super_git_dir.join("modules").join(new_path);
+    if new_modules.exists() {
+        bail!(
+            "cannot move submodule gitdir: destination '{}' already exists",
+            new_modules.display()
+        );
+    }
+    fs::rename(&old_modules, &new_modules).with_context(|| {
+        format!(
+            "renaming submodule gitdir {} -> {}",
+            old_modules.display(),
+            new_modules.display()
+        )
+    })?;
+    Ok(())
+}
+
+/// Point `<work_tree>/<sub_path>/.git` at `.git/modules/<sub_path>` using a relative path.
+fn rewrite_submodule_worktree_gitfile(
+    super_git_dir: &Path,
+    work_tree: &Path,
+    sub_path: &str,
+) -> Result<()> {
+    let sub_wt = work_tree.join(sub_path);
+    let gitfile = sub_wt.join(".git");
+    if !gitfile.is_file() {
+        return Ok(());
+    }
+    let modules_dir = super_git_dir.join("modules").join(sub_path);
+    if !modules_dir.is_dir() {
+        return Ok(());
+    }
+    let rel = pathdiff_relative(&sub_wt, &modules_dir);
+    fs::write(&gitfile, format!("gitdir: {rel}\n"))
+        .with_context(|| format!("updating submodule gitfile at {}", gitfile.display()))?;
+    refresh_submodule_core_worktree(super_git_dir, work_tree, sub_path)?;
+    Ok(())
+}
+
+/// Update `core.worktree` in `.git/modules/<path>` after the submodule directory was renamed on disk.
+fn refresh_submodule_core_worktree(
+    super_git_dir: &Path,
+    work_tree: &Path,
+    sub_path: &str,
+) -> Result<()> {
+    let modules_dir = super_git_dir.join("modules").join(sub_path);
+    let sub_wt = work_tree.join(sub_path);
+    if !modules_dir.is_dir() || !sub_wt.join(".git").exists() {
+        return Ok(());
+    }
+    let wt = pathdiff_relative(&modules_dir, &sub_wt);
+    let grit_bin = grit_exe::grit_executable();
+    let status = Command::new(&grit_bin)
+        .arg("--git-dir")
+        .arg(&modules_dir)
+        .args(["config", "core.worktree"])
+        .arg(&wt)
+        .status()
+        .with_context(|| format!("setting core.worktree for {}", modules_dir.display()))?;
+    if !status.success() {
+        bail!(
+            "failed to set core.worktree in submodule gitdir {}",
+            modules_dir.display()
+        );
+    }
+    Ok(())
+}
+
+/// Relative path from directory `from` to path `to` (for gitfile `gitdir:` lines).
+fn pathdiff_relative(from: &Path, to: &Path) -> String {
+    let from_abs = from.canonicalize().unwrap_or_else(|_| from.to_path_buf());
+    let to_abs = to.canonicalize().unwrap_or_else(|_| to.to_path_buf());
+
+    let from_parts: Vec<_> = from_abs.components().collect();
+    let to_parts: Vec<_> = to_abs.components().collect();
+
+    let common = from_parts
+        .iter()
+        .zip(to_parts.iter())
+        .take_while(|(a, b)| a == b)
+        .count();
+
+    let mut result = PathBuf::new();
+    for _ in common..from_parts.len() {
+        result.push("..");
+    }
+    for part in &to_parts[common..] {
+        result.push(part);
+    }
+
+    result.to_string_lossy().into_owned()
+}
+
 fn update_gitmodules_submodule_path(
     repo: &Repository,
     work_tree: &Path,

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -2235,6 +2235,58 @@ fn preprocess_status_argv(rest: &[String]) -> Vec<String> {
     out
 }
 
+/// Normalize `git commit` argv for clap's `trailing_var_arg` pathspec bucket.
+///
+/// Only applies to **`-m` / `--message`**. Do not reorder `-F` / `--file` (e.g. `commit -F -`
+/// used by tests); those argv shapes must stay intact.
+///
+/// Handles:
+/// - `commit <paths>... -m <msg>` → `-m <msg> -- <paths>...`
+/// - `commit -q -m <msg>` (and similar) → `-m <msg> -q` so the message is not parsed as a pathspec
+/// - `commit -m <msg> <paths>...` → `-m <msg> -- <paths>...`
+fn preprocess_commit_argv(rest: &[String]) -> Vec<String> {
+    const M_STYLE: [&str; 2] = ["-m", "--message"];
+    let Some(i) = rest.iter().position(|a| M_STYLE.contains(&a.as_str())) else {
+        return rest.to_vec();
+    };
+    if i + 1 >= rest.len() {
+        return rest.to_vec();
+    }
+    let flag = rest[i].as_str();
+    if !matches!(flag, "-m" | "--message") {
+        return rest.to_vec();
+    }
+
+    let before = &rest[..i];
+    let msg_block = &rest[i..i + 2];
+    let after = &rest[i + 2..];
+
+    let before_is_pathspec_prefix =
+        !before.is_empty() && before.iter().all(|a| !a.starts_with('-'));
+
+    let mut out = Vec::with_capacity(rest.len() + 2);
+    out.extend_from_slice(msg_block);
+
+    if before_is_pathspec_prefix {
+        out.push("--".to_owned());
+        out.extend_from_slice(before);
+        out.extend_from_slice(after);
+        return out;
+    }
+
+    if before.is_empty() {
+        if !after.is_empty() && !after[0].starts_with('-') {
+            out.push("--".to_owned());
+        }
+        out.extend_from_slice(after);
+        return out;
+    }
+
+    out.extend_from_slice(before);
+    out.extend_from_slice(after);
+    out
+}
+
 fn parse_cmd_args<T: Args + FromArgMatches>(subcmd: &str, rest: &[String]) -> T {
     if subcmd == "stash"
         && rest.len() >= 2
@@ -2251,7 +2303,12 @@ fn parse_cmd_args<T: Args + FromArgMatches>(subcmd: &str, rest: &[String]) -> T 
     }
 
     let mut argv = vec![format!("git {subcmd}")];
-    argv.extend(rest.iter().cloned());
+    let rest_for_parse = if subcmd == "commit" {
+        preprocess_commit_argv(rest)
+    } else {
+        rest.to_vec()
+    };
+    argv.extend(rest_for_parse);
     match ArgsWrapper::<T>::try_parse_from(&argv) {
         Ok(wrapper) => wrapper.inner,
         Err(e) => {


### PR DESCRIPTION
- Implement diff-tree --submodule=log (gitlink headers, log lines, encoding)
- Submodule mv: rename .git/modules path, refresh gitfile and core.worktree
- Clone: detect main when HEAD is detached at tip
- add: resolve embedded HEAD with main/master fallback; stage dirs with .git as gitlink before walk
- commit: pathspec staging for gitlinks; preprocess argv for path-before -m and -q -m
- main: commit argv reorder for clap trailing pathspec