### PR TITLE
docs: t4214-log-graph-octopus fully passing (17/17)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -490,7 +490,7 @@ commit → check it off → move on.
 - [ ] `t4069-remerge-diff` █░░░░░░░░░░░░░░░░░░░ 1/16 (15 left) — remerge-diff handling
 - [ ] `t4019-diff-wserror` ████░░░░░░░░░░░░░░░░ 5/21 (16 left) — diff whitespace error detection
 - [ ] `t4063-diff-blobs` ██░░░░░░░░░░░░░░░░░░ 2/18 (16 left) — test direct comparison of blobs via git-diff
-- [ ] `t4214-log-graph-octopus` █░░░░░░░░░░░░░░░░░░░ 1/17 (16 left) — git log --graph of skewed left octopus merge.
+- [x] `t4214-log-graph-octopus` ████████████████████ 17/17 (0 left) — git log --graph of skewed left octopus merge.
 - [ ] `t4103-apply-binary` █████░░░░░░░░░░░░░░░ 7/24 (17 left) — git apply handling binary patches
 
 - [ ] `t4300-merge-tree` ████░░░░░░░░░░░░░░░░ 5/22 (17 left) — git merge-tree

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -835,7 +835,7 @@ t4210-log-i18n	t4	yes	21	17	4	false	ok	0
 t4211-line-log	t4	yes	53	21	32	false	ok	0
 t4212-log-corrupt	t4	yes	13	3	10	false	ok	0
 t4213-log-tabexpand	t4	yes	9	1	8	false	ok	0
-t4214-log-graph-octopus	t4	yes	17	6	11	false	ok	0
+t4214-log-graph-octopus	t4	yes	17	17	0	true	ok	0
 t4215-log-skewed-merges	t4	yes	10	0	10	false	ok	0
 t4216-log-bloom	t4	yes	167	12	155	false	ok	0
 t4217-log-limit	t4	yes	3	1	2	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,16 +141,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T03:13:47+00:00" class="gen-time" title="2026-04-09 03:13 UTC">2026-04-09 03:13 UTC</time> · <a href="https://github.com/schacon/grit/commit/1dadfd2c33c1c4812878f02237deff3c44bdf86b" style="color:#58a6ff">1dadfd2</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T03:15:33+00:00" class="gen-time" title="2026-04-09 03:15 UTC">2026-04-09 03:15 UTC</time> · <a href="https://github.com/schacon/grit/commit/a2ebecb3809e77f3b1ad9dd2a15e1d9e2ee0259c" style="color:#58a6ff">a2ebecb</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">74.9%</div>
+      <div class="summary-big-val pct-blue">75.0%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,876</div>
+      <div class="summary-big-val">29,887</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -159,12 +159,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:74.9%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:75.0%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>741 files fully passing</span>
+    <span>742 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -223,11 +223,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">65/178 files · 2 skipped · 2,018/3,542 tests</span>
+        <span class="group-meta">66/178 files · 2 skipped · 2,029/3,542 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:57.0%"></div></div>
-        <span class="group-pct pct-orange">57.0%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:57.3%"></div></div>
+        <span class="group-pct pct-orange">57.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T03:13:47+00:00" class="gen-time" title="2026-04-09 03:13 UTC">2026-04-09 03:13 UTC</time> · <a href="https://github.com/schacon/grit/commit/1dadfd2c33c1c4812878f02237deff3c44bdf86b" style="color:#58a6ff">1dadfd2</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T03:15:33+00:00" class="gen-time" title="2026-04-09 03:15 UTC">2026-04-09 03:15 UTC</time> · <a href="https://github.com/schacon/grit/commit/a2ebecb3809e77f3b1ad9dd2a15e1d9e2ee0259c" style="color:#58a6ff">a2ebecb</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,876</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">74.9%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,887</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">75.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -8507,14 +8507,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:11.1%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="17" data-passed="6">
+<tr class="" data-group="t4" data-tests="17" data-passed="17" data-full-pass="1">
   <td class="mono">t4214-log-graph-octopus</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">17</td>
-  <td class="right">6</td>
+  <td class="right">17</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:35.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="10" data-passed="0">

--- a/logs/2026-04-09_t4214-log-graph-octopus.md
+++ b/logs/2026-04-09_t4214-log-graph-octopus.md
@@ -1,0 +1,4 @@
+# t4214-log-graph-octopus
+
+- Verified `./scripts/run-tests.sh t4214-log-graph-octopus.sh`: 17/17 pass on branch `cursor/t4214-log-graph-octopus-666e`.
+- No Rust changes required; refreshed harness `data/test-files.csv` and dashboards, marked task complete in `PLAN.md` / `progress.md`.

--- a/progress.md
+++ b/progress.md
@@ -1,20 +1,21 @@
 # Progress — Grit Test Coverage
 
-**Updated:** 2026-04-08
+**Updated:** 2026-04-09
 
 ## Counts (derived from plan.md)
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   252 |
+| Completed   |   253 |
 | In progress |     4 |
-| Remaining   |   512 |
+| Remaining   |   511 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 252 completed (`[x]`), 4 in progress (`[~]`), 512 remaining (`[ ]`).
+Task lines in `PLAN.md`: 253 completed (`[x]`), 4 in progress (`[~]`), 511 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t4214-log-graph-octopus` — 17/17 tests pass (`git log --graph` skewed-left octopus, crossover, and colored graph lines; harness CSV/dashboards refreshed)
 - `t3060-ls-files-with-tree` — 8/8 tests pass (`ls-files --with-tree`: `Index::overlay_tree_on_index`, `-s/-u`/`--recurse-submodules` incompatibilities with `fatal:` + exit 128, cwd pathspec `sub/` matches `sub/file`; harness CSV refreshed)
 - `t12660-init-shared-perm` — 37/37 tests pass (default `grit init` applies Git-style group-shared chmod on `.git` tree: 775 dirs / 664 HEAD under umask 022; explicit `--shared` / `core.sharedRepository` writes config + `receive.denyNonFastforwards`; reinit without shared config leaves modes unchanged)
 - `t7520-ignored-hook-warning` — 5/5 tests pass (`tests/test-lib.sh` `test_hook`: `--disable`/`--remove`, resolve hook dir via `git rev-parse --absolute-git-dir`; second hint line uses `git config set advice.ignoredHook false`)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`./scripts/run-tests.sh t4214-log-graph-octopus.sh` reports **17/17** passing on this branch. No Rust changes were required; the implementation already matches the expected skewed-left octopus, crossover, and colored `--graph` output.

## Changes

- Refreshed harness artifacts: `data/test-files.csv`, `docs/index.html`, `docs/testfiles.html`
- Marked `t4214-log-graph-octopus` complete in `PLAN.md` and updated counts in `progress.md`
- Added `logs/2026-04-09_t4214-log-graph-octopus.md`

## Verification

```bash
./scripts/run-tests.sh t4214-log-graph-octopus.sh
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7141bd0a-bde8-40bf-a10d-d0cd2aa03f82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7141bd0a-bde8-40bf-a10d-d0cd2aa03f82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

