### PR TITLE
fix(apply): weird diff filenames for t4135

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -494,7 +494,7 @@ commit → check it off → move on.
 - [ ] `t4103-apply-binary` █████░░░░░░░░░░░░░░░ 7/24 (17 left) — git apply handling binary patches
 
 - [ ] `t4300-merge-tree` ████░░░░░░░░░░░░░░░░ 5/22 (17 left) — git merge-tree
-- [ ] `t4135-apply-weird-filenames` ███░░░░░░░░░░░░░░░░░ 3/20 (17 left) — git apply with weird postimage filenames
+- [x] `t4135-apply-weird-filenames` ███████████████████░ 19/20 (1 left) — git apply with weird postimage filenames (traditional + git headers: timestamps, C-quoted paths, `/dev/null`; one `test_expect_failure` quote case remains)
 - [ ] `t4030-diff-textconv` ██░░░░░░░░░░░░░░░░░░ 2/19 (17 left) — diff.*.textconv tests
 - [ ] `t4151-am-abort` ██░░░░░░░░░░░░░░░░░░ 2/20 (18 left) — am --abort
 - [ ] `t4002-diff-basic` █████████████░░░░░░░ 44/63 (19 left) — Test diff raw-output.

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -92,7 +92,7 @@ t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
 t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
-t1006-cat-file	t1	yes	290	285	5	false	ok	1
+t1006-cat-file	t1	yes	290	285	5	false	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	32	8	false	ok	0
 t10070-cat-file-batch-format	t1	yes	33	33	0	true	ok	0
@@ -804,7 +804,7 @@ t4131-apply-fake-ancestor	t4	yes	3	3	0	true	ok	0
 t4132-apply-removal	t4	yes	14	7	7	false	ok	0
 t4133-apply-filenames	t4	yes	4	4	0	true	ok	0
 t4134-apply-submodule	t4	yes	2	1	1	false	ok	0
-t4135-apply-weird-filenames	t4	yes	19	9	10	false	ok	0
+t4135-apply-weird-filenames	t4	yes	20	19	0	true	ok	0
 t4136-apply-check	t4	yes	6	3	3	false	ok	0
 t4137-apply-submodule	t4	yes	28	0	28	false	ok	0
 t4138-apply-ws-expansion	t4	yes	5	5	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T03:15:36+00:00" class="gen-time" title="2026-04-09 03:15 UTC">2026-04-09 03:15 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,11 +150,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,565</div>
+      <div class="summary-big-val">29,583</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">39,864</div>
+      <div class="summary-big-val">39,865</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>713 files fully passing</span>
+    <span>717 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,7 +212,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">41/141 files · 2 skipped · 3,333/4,611 tests</span>
+        <span class="group-meta">42/141 files · 2 skipped · 3,334/4,611 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.3%"></div></div>
@@ -223,22 +223,22 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">63/178 files · 2 skipped · 1,920/3,541 tests</span>
+        <span class="group-meta">64/178 files · 2 skipped · 1,930/3,542 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:54.2%"></div></div>
-        <span class="group-pct pct-orange">54.2%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:54.5%"></div></div>
+        <span class="group-pct pct-orange">54.5%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,336/3,949 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,342/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.8%"></div></div>
-        <span class="group-pct pct-red">33.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.0%"></div></div>
+        <span class="group-pct pct-red">34.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -256,7 +256,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">42/126 files · 11 skipped · 1,793/2,944 tests</span>
+        <span class="group-meta">43/126 files · 11 skipped · 1,794/2,944 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T03:15:36+00:00" class="gen-time" title="2026-04-09 03:15 UTC">2026-04-09 03:15 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">39,864</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,565</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n" id="sum-tests">39,865</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,583</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1085,7 +1085,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">285</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.3%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t10060-hash-object-determinism</td>
@@ -5110,8 +5110,7 @@ tr.row-skip td { opacity: 0.65; }
 <tr class="" data-group="t2" data-tests="15" data-passed="5">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td><span class="badge ok">full pass</span></td>
-  <td class="right">15</td>
+  <td></td>
   <td class="right">15</td>
   <td class="right">5</td>
   <td class="right">ok</td>
@@ -6218,14 +6217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="54" data-passed="38">
+<tr class="" data-group="t3" data-tests="52" data-passed="3">
   <td class="mono">t3420-rebase-autostash</td>
   <td>t3</td>
   <td></td>
-  <td class="right">54</td>
-  <td class="right">38</td>
+  <td class="right">52</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="63" data-passed="11">
@@ -8198,14 +8197,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="19" data-passed="9">
+<tr class="" data-group="t4" data-tests="20" data-passed="19" data-full-pass="1">
   <td class="mono">t4135-apply-weird-filenames</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
+  <td class="right">20</td>
   <td class="right">19</td>
-  <td class="right">9</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:47.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:95.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="6" data-passed="3">
@@ -12598,7 +12597,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="2" data-passed="2">
+<tr class="" data-group="t7" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t7524-commit-summary</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>

--- a/grit/src/commands/apply.rs
+++ b/grit/src/commands/apply.rs
@@ -21,11 +21,13 @@ use grit_lib::objects::ObjectKind;
 use grit_lib::repo::Repository;
 use grit_lib::rev_parse::resolve_revision;
 use grit_lib::ws::{self, WhitespaceGitAttr, WS_BLANK_AT_EOF, WS_DEFAULT_RULE, WS_INCOMPLETE_LINE};
+use regex::Regex;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fs;
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 /// Arguments for `grit apply`.
 #[derive(Debug, ClapArgs)]
@@ -448,6 +450,584 @@ fn sanitize_file_patch_headers(fp: &mut FilePatch) {
     }
 }
 
+/// Collapse runs of `/` to a single slash (Git `squash_slash`).
+fn squash_slash_path(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut prev_slash = false;
+    for ch in s.chars() {
+        if ch == '/' {
+            if !prev_slash {
+                out.push('/');
+            }
+            prev_slash = true;
+        } else {
+            prev_slash = false;
+            out.push(ch);
+        }
+    }
+    out
+}
+
+/// Unquote a leading C-style `"..."` from `line`; returns decoded bytes and remainder after closing `"`.
+/// Matches Git `unquote_c_style` / `quote.c` escapes used in diff headers.
+fn unquote_c_style_diff_prefix(line: &str) -> Option<(Vec<u8>, &str)> {
+    let b = line.as_bytes();
+    if b.first() != Some(&b'"') {
+        return None;
+    }
+    let mut q = &b[1..];
+    let mut out = Vec::new();
+    loop {
+        let len = q
+            .iter()
+            .position(|&c| c == b'"' || c == b'\\')
+            .unwrap_or(q.len());
+        out.extend_from_slice(&q[..len]);
+        q = &q[len..];
+        if q.is_empty() {
+            return None;
+        }
+        match q[0] {
+            b'"' => {
+                let rest = std::str::from_utf8(&q[1..]).ok()?;
+                return Some((out, rest));
+            }
+            b'\\' => {
+                q = &q[1..];
+                if q.is_empty() {
+                    return None;
+                }
+                let ch = q[0];
+                q = &q[1..];
+                match ch {
+                    b'a' => out.push(0x07),
+                    b'b' => out.push(0x08),
+                    b'f' => out.push(0x0c),
+                    b'n' => out.push(b'\n'),
+                    b'r' => out.push(b'\r'),
+                    b't' => out.push(b'\t'),
+                    b'v' => out.push(0x0b),
+                    b'\\' => out.push(b'\\'),
+                    b'"' => out.push(b'"'),
+                    b'0'..=b'3' => {
+                        if q.len() < 2 {
+                            return None;
+                        }
+                        let ch2 = q[0];
+                        let ch3 = q[1];
+                        if !(b'0'..=b'7').contains(&ch2) || !(b'0'..=b'7').contains(&ch3) {
+                            return None;
+                        }
+                        let ac = u32::from(ch - b'0') * 64
+                            + u32::from(ch2 - b'0') * 8
+                            + u32::from(ch3 - b'0');
+                        out.push(ac as u8);
+                        q = &q[2..];
+                    }
+                    _ => return None,
+                }
+            }
+            _ => return None,
+        }
+    }
+}
+
+fn bytes_to_path_string(bytes: &[u8]) -> Result<String> {
+    let s = String::from_utf8(bytes.to_vec()).context("diff path is not valid UTF-8")?;
+    Ok(squash_slash_path(&s))
+}
+
+/// Skip `p_value` leading path components (Git `skip_tree_prefix`); `p_value == 0` allows absolute paths.
+fn skip_tree_prefix_bytes(line: &[u8], p_value: usize) -> Option<&[u8]> {
+    if p_value == 0 {
+        return Some(line);
+    }
+    let mut nslash = p_value;
+    let mut i = 0usize;
+    while i < line.len() {
+        if line[i] == b'/' {
+            nslash = nslash.saturating_sub(1);
+            if nslash == 0 {
+                return if i == 0 { None } else { Some(&line[i + 1..]) };
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Strip `p_value` leading `/`-separated components from a UTF-8 path (for `rename from` etc.).
+fn skip_tree_prefix_str(path: &str, p_value: usize) -> Option<String> {
+    let stripped = skip_tree_prefix_bytes(path.as_bytes(), p_value)?;
+    Some(String::from_utf8_lossy(stripped).into_owned())
+}
+
+fn sane_tz_len(line: &[u8]) -> usize {
+    const SUFFIX: &[u8] = b" +0500";
+    if line.len() < SUFFIX.len() || line[line.len() - SUFFIX.len()] != b' ' {
+        return 0;
+    }
+    let tz = &line[line.len() - SUFFIX.len()..];
+    if tz[1] != b'+' && tz[1] != b'-' {
+        return 0;
+    }
+    for p in &tz[2..] {
+        if !p.is_ascii_digit() {
+            return 0;
+        }
+    }
+    SUFFIX.len()
+}
+
+fn tz_with_colon_len(line: &[u8]) -> usize {
+    // Git: suffix is ` ±HH:MM` (space, sign, two hour digits, colon, two minute digits) = 7 bytes.
+    const SUFFIX_LEN: usize = 7;
+    if line.len() < SUFFIX_LEN || line[line.len() - 3] != b':' {
+        return 0;
+    }
+    let tz = &line[line.len() - SUFFIX_LEN..];
+    if tz[0] != b' ' || (tz[1] != b'+' && tz[1] != b'-') {
+        return 0;
+    }
+    let p = &tz[2..];
+    if p.len() != 5
+        || !p[0].is_ascii_digit()
+        || !p[1].is_ascii_digit()
+        || p[2] != b':'
+        || !p[3].is_ascii_digit()
+        || !p[4].is_ascii_digit()
+    {
+        return 0;
+    }
+    SUFFIX_LEN
+}
+
+fn date_len(line: &[u8]) -> usize {
+    const SHORT: &[u8] = b"72-02-05";
+    if line.len() < SHORT.len() || line[line.len() - 3] != b'-' {
+        return 0;
+    }
+    let mut p = line.len() - SHORT.len();
+    let date = &line[p..];
+    if !date[0].is_ascii_digit()
+        || !date[1].is_ascii_digit()
+        || date[2] != b'-'
+        || !date[3].is_ascii_digit()
+        || !date[4].is_ascii_digit()
+        || date[5] != b'-'
+        || !date[6].is_ascii_digit()
+        || !date[7].is_ascii_digit()
+    {
+        return 0;
+    }
+    if p >= 2 {
+        let y1 = line[p - 1];
+        let y2 = line[p - 2];
+        if y1.is_ascii_digit() && y2.is_ascii_digit() {
+            p -= 2;
+        }
+    }
+    line.len() - p
+}
+
+fn short_time_len(line: &[u8]) -> usize {
+    const PAT: &[u8] = b" 07:01:32";
+    if line.len() < PAT.len() || line[line.len() - 3] != b':' {
+        return 0;
+    }
+    let p = line.len() - PAT.len();
+    let time = &line[p..];
+    if time[0] != b' '
+        || !time[1].is_ascii_digit()
+        || !time[2].is_ascii_digit()
+        || time[3] != b':'
+        || !time[4].is_ascii_digit()
+        || !time[5].is_ascii_digit()
+        || time[6] != b':'
+        || !time[7].is_ascii_digit()
+        || !time[8].is_ascii_digit()
+    {
+        return 0;
+    }
+    PAT.len()
+}
+
+fn fractional_time_len(line: &[u8]) -> usize {
+    if line.is_empty() || !line[line.len() - 1].is_ascii_digit() {
+        return 0;
+    }
+    let mut p = line.len() - 1;
+    while p > 0 && line[p].is_ascii_digit() {
+        p -= 1;
+    }
+    if p == 0 || line[p] != b'.' {
+        return 0;
+    }
+    let n = short_time_len(&line[..p]);
+    if n == 0 {
+        return 0;
+    }
+    line.len() - p + n
+}
+
+fn trailing_spaces_len(line: &[u8]) -> usize {
+    if line.is_empty() || line[line.len() - 1] != b' ' {
+        return 0;
+    }
+    let mut p = line.len();
+    while p > 0 {
+        p -= 1;
+        if line[p] != b' ' {
+            return line.len() - (p + 1);
+        }
+    }
+    line.len()
+}
+
+fn diff_timestamp_len(line: &[u8]) -> usize {
+    if line.is_empty() || !line[line.len() - 1].is_ascii_digit() {
+        return 0;
+    }
+    let mut end = line.len();
+    let mut n = sane_tz_len(&line[..end]);
+    if n == 0 {
+        n = tz_with_colon_len(&line[..end]);
+    }
+    if n == 0 {
+        return 0;
+    }
+    end -= n;
+
+    n = short_time_len(&line[..end]);
+    if n == 0 {
+        n = fractional_time_len(&line[..end]);
+    }
+    if n == 0 {
+        return 0;
+    }
+    end -= n;
+
+    n = date_len(&line[..end]);
+    if n == 0 {
+        return 0;
+    }
+    end -= n;
+
+    if end == 0 {
+        return 0;
+    }
+    match line[end - 1] {
+        b'\t' => {
+            end -= 1;
+            line.len() - end
+        }
+        b' ' => {
+            end -= trailing_spaces_len(&line[..end]);
+            line.len() - end
+        }
+        _ => 0,
+    }
+}
+
+/// Git `find_name_common` with optional `end` bound (exclusive).
+fn find_name_common_bounded(
+    line: &[u8],
+    def: Option<&[u8]>,
+    p_value: usize,
+    end: usize,
+) -> Option<Vec<u8>> {
+    let end = end.min(line.len());
+    let mut start: Option<usize> = if p_value == 0 { Some(0) } else { None };
+    let mut p = p_value;
+    let mut i = 0usize;
+    while i < end {
+        let c = line[i];
+        i += 1;
+        if c == b'/' && p > 0 {
+            p -= 1;
+            if p == 0 {
+                start = Some(i);
+            }
+        }
+    }
+    let start = start?;
+    let len = i - start;
+    if len == 0 {
+        return def.map(|d| d.to_vec());
+    }
+    let slice = &line[start..i];
+    if let Some(d) = def {
+        if d.len() < len && slice.starts_with(d) {
+            return Some(d.to_vec());
+        }
+    }
+    Some(slice.to_vec())
+}
+
+/// Git `find_name_traditional` on the line after `--- ` / `+++ ` (no prefix).
+fn find_name_traditional(line: &[u8], def: Option<&[u8]>, p_value: usize) -> Option<Vec<u8>> {
+    if line.first() == Some(&b'"') {
+        let (decoded, _) = unquote_c_style_diff_prefix(std::str::from_utf8(line).ok()?)?;
+        let skip = skip_tree_prefix_bytes(&decoded, p_value)?;
+        return Some(skip.to_vec());
+    }
+    let ts = diff_timestamp_len(line);
+    let name_end = line.len().saturating_sub(ts);
+    find_name_common_bounded(line, def, p_value, name_end)
+}
+
+fn find_name_tab_terminated(line: &[u8], p_value: usize) -> Option<Vec<u8>> {
+    if line.first() == Some(&b'"') {
+        let (decoded, _) = unquote_c_style_diff_prefix(std::str::from_utf8(line).ok()?)?;
+        let skip = skip_tree_prefix_bytes(&decoded, p_value)?;
+        return Some(skip.to_vec());
+    }
+    let end = line
+        .iter()
+        .position(|&b| b == b'\t' || b == b'\n' || b == b'\r')
+        .unwrap_or(line.len());
+    find_name_common_bounded(line, None, p_value, end)
+}
+
+fn is_dev_null_nameline(line: &[u8]) -> bool {
+    line.strip_prefix(b"/dev/null")
+        .map(|rest| rest.is_empty() || rest.first().is_some_and(|b| b.is_ascii_whitespace()))
+        .unwrap_or(false)
+}
+
+fn guess_p_value_from_nameline(line: &[u8]) -> Option<usize> {
+    if is_dev_null_nameline(line) {
+        return None;
+    }
+    let name = find_name_traditional(line, None, 0)?;
+    let name_str = String::from_utf8_lossy(&name);
+    if !name_str.contains('/') {
+        return Some(0);
+    }
+    None
+}
+
+fn epoch_stamp_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"^([0-2][0-9]):([0-5][0-9]):00(?:\.0+)? ([-+][0-2][0-9]:?[0-5][0-9])")
+            .expect("epoch stamp regex")
+    })
+}
+
+/// True when the `---`/`+++` line has a tab-separated epoch timestamp (Git `has_epoch_timestamp`).
+fn has_epoch_timestamp(nameline: &[u8]) -> bool {
+    let Some(tab) = nameline.iter().position(|&b| b == b'\t') else {
+        return false;
+    };
+    let mut ts = &nameline[tab + 1..];
+    let epoch_hour = if let Some(r) = ts.strip_prefix(b"1969-12-31 ") {
+        ts = r;
+        24i32
+    } else if let Some(r) = ts.strip_prefix(b"1970-01-01 ") {
+        ts = r;
+        0i32
+    } else {
+        return false;
+    };
+    let end = ts.iter().position(|&b| b == b'\n').unwrap_or(ts.len());
+    let stamp = &ts[..end];
+    let stamp_str = match std::str::from_utf8(stamp) {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+    let caps = match epoch_stamp_regex().captures(stamp_str) {
+        Some(c) => c,
+        None => return false,
+    };
+    let hour: i32 = caps
+        .get(1)
+        .and_then(|m| m.as_str().parse().ok())
+        .unwrap_or(-1);
+    let minute: i32 = caps
+        .get(2)
+        .and_then(|m| m.as_str().parse().ok())
+        .unwrap_or(-1);
+    let tz_s = match caps.get(3).map(|m| m.as_str()) {
+        Some(s) if !s.is_empty() => s,
+        _ => return false,
+    };
+    if hour < 0 || minute < 0 {
+        return false;
+    }
+    let tz_byte = tz_s.as_bytes()[0];
+    let tz_rest = &tz_s[1..];
+    let zoneoffset: i32 = if let Some(colon_pos) = tz_rest.find(':') {
+        let h: i32 = tz_rest[..colon_pos].parse().unwrap_or(0);
+        let mm: i32 = tz_rest[colon_pos + 1..].parse().unwrap_or(0);
+        h * 60 + mm
+    } else if tz_rest.len() >= 4 {
+        let n: i32 = tz_rest[..4].parse().unwrap_or(0);
+        (n / 100) * 60 + (n % 100)
+    } else {
+        return false;
+    };
+    let zoneoffset = if tz_byte == b'-' {
+        -zoneoffset
+    } else {
+        zoneoffset
+    };
+    hour * 60 + minute - zoneoffset == epoch_hour * 60
+}
+
+/// Parse `---` / `+++` pair for a traditional unified diff (Git `parse_traditional_patch`).
+fn parse_traditional_patch_pair(
+    old_line: &[u8],
+    new_line: &[u8],
+    strip: usize,
+    p_guess: &mut Option<usize>,
+) -> Result<FilePatch> {
+    let old_p = old_line.strip_prefix(b"--- ").unwrap_or(old_line);
+    let new_p = new_line.strip_prefix(b"+++ ").unwrap_or(new_line);
+
+    if p_guess.is_none() {
+        let p = guess_p_value_from_nameline(old_p);
+        let q = guess_p_value_from_nameline(new_p);
+        let chosen = match (p, q) {
+            (None, None) => None,
+            (Some(a), None) => Some(a),
+            (None, Some(b)) => Some(b),
+            (Some(a), Some(b)) if a == b => Some(a),
+            _ => None,
+        };
+        *p_guess = chosen;
+    }
+    let p_val = p_guess.unwrap_or(strip);
+
+    let mut fp = FilePatch {
+        diff_old_path: None,
+        diff_new_path: None,
+        old_path: None,
+        new_path: None,
+        saw_old_header: true,
+        saw_new_header: true,
+        old_mode: None,
+        new_mode: None,
+        is_new: false,
+        is_deleted: false,
+        is_rename: false,
+        is_copy: false,
+        similarity_index: None,
+        dissimilarity_index: None,
+        old_oid: None,
+        new_oid: None,
+        binary_patch: None,
+        hunks: Vec::new(),
+        ws_rule: 0,
+    };
+
+    if is_dev_null_nameline(old_p) {
+        fp.is_new = true;
+        let name = find_name_traditional(new_p, None, p_val)
+            .ok_or_else(|| anyhow::anyhow!("unable to find filename in traditional patch"))?;
+        fp.new_path = Some(bytes_to_path_string(&name)?);
+    } else if is_dev_null_nameline(new_p) {
+        fp.is_deleted = true;
+        let name = find_name_traditional(old_p, None, p_val)
+            .ok_or_else(|| anyhow::anyhow!("unable to find filename in traditional patch"))?;
+        fp.old_path = Some(bytes_to_path_string(&name)?);
+    } else {
+        let first_name = find_name_traditional(old_p, None, p_val)
+            .ok_or_else(|| anyhow::anyhow!("unable to find filename in traditional patch"))?;
+        let name = find_name_traditional(new_p, Some(&first_name), p_val)
+            .ok_or_else(|| anyhow::anyhow!("unable to find filename in traditional patch"))?;
+        let name_str = bytes_to_path_string(&name)?;
+        if has_epoch_timestamp(old_p) {
+            fp.is_new = true;
+            fp.new_path = Some(name_str);
+        } else if has_epoch_timestamp(new_p) {
+            fp.is_deleted = true;
+            fp.old_path = Some(name_str);
+        } else {
+            // Git uses the `+++` filename for both sides when neither line carries an epoch
+            // marker; the `---` line only participates via `def` when shortening `.orig` etc.
+            fp.old_path = Some(name_str.clone());
+            fp.new_path = Some(name_str);
+        }
+    }
+
+    Ok(fp)
+}
+
+/// Default filename from `diff --git` when both sides agree (Git `git_header_name`).
+fn git_header_def_name(line: &str, p_value: usize) -> Option<String> {
+    let rest = line.strip_prefix("diff --git ").unwrap_or(line);
+    let rest_b = rest.as_bytes();
+
+    if rest_b.first() == Some(&b'"') {
+        let (first_decoded, second_raw) = unquote_c_style_diff_prefix(rest)?;
+        let rel_first = skip_tree_prefix_bytes(&first_decoded, p_value)?;
+        let second = second_raw.trim_start_matches(|c: char| c.is_ascii_whitespace());
+        if second.is_empty() {
+            return None;
+        }
+        if second.as_bytes().first() == Some(&b'"') {
+            let (second_decoded, _) = unquote_c_style_diff_prefix(second)?;
+            let rel2 = skip_tree_prefix_bytes(&second_decoded, p_value)?;
+            if rel2 != rel_first {
+                return None;
+            }
+        } else {
+            let rel2 = skip_tree_prefix_bytes(second.as_bytes(), p_value)?;
+            if rel2.len() != rel_first.len() || rel2 != rel_first {
+                return None;
+            }
+        }
+        return bytes_to_path_string(rel_first).ok();
+    }
+
+    let name = skip_tree_prefix_bytes(rest_b, p_value)?;
+    let name_start = name.as_ptr() as usize - rest_b.as_ptr() as usize;
+
+    for offset in 0..name.len() {
+        if name[offset] != b'"' {
+            continue;
+        }
+        let second_slice = &rest_b[name_start + offset..];
+        let (decoded, _) = unquote_c_style_diff_prefix(std::str::from_utf8(second_slice).ok()?)?;
+        let np = skip_tree_prefix_bytes(&decoded, p_value)?;
+        let plen = np.len();
+        if plen < offset
+            && name.len() > plen
+            && &name[..plen] == np
+            && name[plen].is_ascii_whitespace()
+        {
+            return bytes_to_path_string(np).ok();
+        }
+        return None;
+    }
+
+    let line_len = rest.len().saturating_sub(name_start);
+    let mut len = 0usize;
+    while len < line_len {
+        match rest_b[name_start + len] {
+            b'\n' => return None,
+            b'\t' | b' ' => {
+                let after = name_start + len + 1;
+                if after > name_start + line_len {
+                    return None;
+                }
+                let second =
+                    skip_tree_prefix_bytes(&rest_b[after..name_start + line_len], p_value)?;
+                let names_match =
+                    name.len() >= len && second.len() >= len && name[..len] == second[..len];
+                let boundary_ok = second.get(len) == Some(&b'\n') || second.len() == len;
+                if names_match && boundary_ok {
+                    return bytes_to_path_string(&name[..len]).ok();
+                }
+            }
+            _ => {}
+        }
+        len += 1;
+    }
+    None
+}
+
 /// Git `name_terminate` for `---`/`+++` parsing (`TERM_TAB` only).
 fn diff_header_name_terminate(c: u8) -> bool {
     const TERM_SPACE: u8 = 1;
@@ -524,11 +1104,28 @@ fn header_line_file_path(line: &str, p_value: usize) -> String {
         .unwrap_or_else(|| line.split('\t').next().unwrap_or(line).to_string())
 }
 
+/// Path from `rename from` / `copy from` lines (Git `find_name` with `terminate == 0`).
+fn find_name_extended_header(rest: &str, p_extended: usize) -> Option<String> {
+    let b = rest.trim_end_matches(['\r', '\n']).as_bytes();
+    let end = b
+        .iter()
+        .position(|&c| c == b'\t' || c == b'\n' || c == b'\r' || c == b' ')
+        .unwrap_or(b.len());
+    let name = find_name_common_bounded(b, None, p_extended, end)?;
+    bytes_to_path_string(&name).ok()
+}
+
 /// Parse a unified diff into a list of `FilePatch` entries.
+///
+/// `strip` is Git's `p_value` (`-p` count, default 1).
 fn parse_patch(input: &str, strip: usize) -> Result<Vec<FilePatch>> {
     let lines: Vec<&str> = input.lines().collect();
     let mut patches = Vec::new();
     let mut i = 0;
+    let mut p_guess_for_traditional: Option<usize> = None;
+
+    let p_strip = strip;
+    let p_extended = strip.saturating_sub(1);
 
     while i < lines.len() {
         // Look for "diff --git" header or a bare ---/+++ pair.
@@ -555,8 +1152,11 @@ fn parse_patch(input: &str, strip: usize) -> Result<Vec<FilePatch>> {
                 ws_rule: 0,
             };
 
+            let header_line = lines[i];
+            let def_name = git_header_def_name(header_line, p_strip);
+
             // Parse "diff --git a/foo b/foo"
-            let rest = &lines[i]["diff --git ".len()..];
+            let rest = &header_line["diff --git ".len()..];
             if let Some((a, b)) = split_diff_git_paths(rest) {
                 fp.diff_old_path = Some(a.clone());
                 fp.diff_new_path = Some(b.clone());
@@ -584,16 +1184,24 @@ fn parse_patch(input: &str, strip: usize) -> Result<Vec<FilePatch>> {
                     fp.old_mode = Some(val.to_string());
                 } else if let Some(val) = line.strip_prefix("rename from ") {
                     fp.is_rename = true;
-                    fp.old_path = Some(val.to_string());
+                    if let Some(p) = find_name_extended_header(val, p_extended) {
+                        fp.old_path = Some(p);
+                    }
                 } else if let Some(val) = line.strip_prefix("rename to ") {
                     fp.is_rename = true;
-                    fp.new_path = Some(val.to_string());
+                    if let Some(p) = find_name_extended_header(val, p_extended) {
+                        fp.new_path = Some(p);
+                    }
                 } else if let Some(val) = line.strip_prefix("copy from ") {
                     fp.is_copy = true;
-                    fp.old_path = Some(val.to_string());
+                    if let Some(p) = find_name_extended_header(val, p_extended) {
+                        fp.old_path = Some(p);
+                    }
                 } else if let Some(val) = line.strip_prefix("copy to ") {
                     fp.is_copy = true;
-                    fp.new_path = Some(val.to_string());
+                    if let Some(p) = find_name_extended_header(val, p_extended) {
+                        fp.new_path = Some(p);
+                    }
                 } else if let Some(val) = line.strip_prefix("similarity index ") {
                     fp.similarity_index = val.trim_end_matches('%').parse().ok();
                 } else if let Some(val) = line.strip_prefix("dissimilarity index ") {
@@ -615,15 +1223,34 @@ fn parse_patch(input: &str, strip: usize) -> Result<Vec<FilePatch>> {
                 i += 1;
             }
 
+            if let Some(dn) = def_name {
+                if fp.old_path.is_none() {
+                    fp.old_path = Some(dn.clone());
+                }
+                if fp.new_path.is_none() {
+                    fp.new_path = Some(dn);
+                }
+            }
+
             // Parse ---/+++ headers if present
             if i < lines.len() && lines[i].starts_with("--- ") {
-                let old_p = &lines[i]["--- ".len()..];
-                fp.old_path = Some(header_line_file_path(old_p, strip));
+                let old_p = lines[i]["--- ".len()..].trim_end_matches(['\r', '\n']);
+                let old_b = old_p.as_bytes();
+                if is_dev_null_nameline(old_b) {
+                    fp.old_path = Some("/dev/null".to_string());
+                } else if let Some(p) = find_name_tab_terminated(old_b, p_strip) {
+                    fp.old_path = Some(bytes_to_path_string(&p)?);
+                }
                 fp.saw_old_header = true;
                 i += 1;
                 if i < lines.len() && lines[i].starts_with("+++ ") {
-                    let new_p = &lines[i]["+++ ".len()..];
-                    fp.new_path = Some(header_line_file_path(new_p, strip));
+                    let new_p = lines[i]["+++ ".len()..].trim_end_matches(['\r', '\n']);
+                    let new_b = new_p.as_bytes();
+                    if is_dev_null_nameline(new_b) {
+                        fp.new_path = Some("/dev/null".to_string());
+                    } else if let Some(p) = find_name_tab_terminated(new_b, p_strip) {
+                        fp.new_path = Some(bytes_to_path_string(&p)?);
+                    }
                     fp.saw_new_header = true;
                     i += 1;
                 }
@@ -642,45 +1269,15 @@ fn parse_patch(input: &str, strip: usize) -> Result<Vec<FilePatch>> {
             && i + 1 < lines.len()
             && lines[i + 1].starts_with("+++ ")
         {
-            // Bare unified diff without "diff --git" header
-            let mut fp = FilePatch {
-                diff_old_path: None,
-                diff_new_path: None,
-                old_path: None,
-                new_path: None,
-                saw_old_header: false,
-                saw_new_header: false,
-                old_mode: None,
-                new_mode: None,
-                is_new: false,
-                is_deleted: false,
-                is_rename: false,
-                is_copy: false,
-                similarity_index: None,
-                dissimilarity_index: None,
-                old_oid: None,
-                new_oid: None,
-                binary_patch: None,
-                hunks: Vec::new(),
-                ws_rule: 0,
-            };
-
-            let old_p = &lines[i]["--- ".len()..];
-            fp.old_path = Some(header_line_file_path(old_p, strip));
-            fp.saw_old_header = true;
-            i += 1;
-            let new_p = &lines[i]["+++ ".len()..];
-            fp.new_path = Some(header_line_file_path(new_p, strip));
-            fp.saw_new_header = true;
-            i += 1;
-
-            // Check for /dev/null
-            if fp.old_path.as_deref() == Some("/dev/null") {
-                fp.is_new = true;
-            }
-            if fp.new_path.as_deref() == Some("/dev/null") {
-                fp.is_deleted = true;
-            }
+            let old_line = lines[i].as_bytes();
+            let new_line = lines[i + 1].as_bytes();
+            let mut fp = parse_traditional_patch_pair(
+                old_line,
+                new_line,
+                strip,
+                &mut p_guess_for_traditional,
+            )?;
+            i += 2;
 
             // Parse hunks
             while i < lines.len() && lines[i].starts_with("@@ ") {
@@ -866,16 +1463,38 @@ fn inflate_binary_payload(compressed: &[u8]) -> Result<Vec<u8>> {
     Ok(out)
 }
 
-/// Split "a/path b/path" from `diff --git` line. Handles spaces in paths
-/// by scanning for ` b/` boundary. Falls back if that fails.
+/// Split the two path tokens from the remainder of a `diff --git` line (after `diff --git `).
 fn split_diff_git_paths(s: &str) -> Option<(String, String)> {
-    // Keep raw paths (with a/ b/ prefix) so -p<n> stripping works correctly.
+    let s = s.trim_end_matches(['\r', '\n']);
+
+    if s.as_bytes().first() == Some(&b'"') {
+        let (first, rest_raw) = unquote_c_style_diff_prefix(s)?;
+        let rest = rest_raw.trim_start_matches(|c: char| c.is_ascii_whitespace());
+        if rest.is_empty() {
+            return None;
+        }
+        if rest.as_bytes().first() == Some(&b'"') {
+            let (second, _) = unquote_c_style_diff_prefix(rest)?;
+            return Some((
+                String::from_utf8_lossy(&first).into_owned(),
+                String::from_utf8_lossy(&second).into_owned(),
+            ));
+        }
+        let second = rest;
+        if second.len() != first.len() || second.as_bytes() != first.as_slice() {
+            return None;
+        }
+        return Some((
+            String::from_utf8_lossy(&first).into_owned(),
+            second.to_string(),
+        ));
+    }
+
     if let Some(pos) = s.find(" b/") {
         let a = &s[..pos];
         let b = &s[pos + 1..];
         return Some((a.to_string(), b.to_string()));
     }
-    // Also handle /dev/null cases
     if s.starts_with("a/") {
         if let Some(pos) = s.find(" /dev/null") {
             let a = &s[..pos];
@@ -884,6 +1503,32 @@ fn split_diff_git_paths(s: &str) -> Option<(String, String)> {
     }
     if let Some(b) = s.strip_prefix("/dev/null ") {
         return Some(("/dev/null".to_string(), b.to_string()));
+    }
+
+    let name = s.as_bytes();
+    let line_len = name.len();
+    let mut len = 0usize;
+    while len < line_len {
+        match name[len] {
+            b'\n' => return None,
+            b'\t' | b' ' => {
+                if len + 1 > line_len {
+                    return None;
+                }
+                let second = &name[len + 1..line_len];
+                let names_match =
+                    name.len() >= len && second.len() >= len && name[..len] == second[..len];
+                let boundary_ok = second.get(len) == Some(&b'\n') || second.len() == len;
+                if names_match && boundary_ok {
+                    return Some((
+                        String::from_utf8_lossy(&name[..len]).into_owned(),
+                        String::from_utf8_lossy(second).into_owned(),
+                    ));
+                }
+            }
+            _ => {}
+        }
+        len += 1;
     }
     None
 }

--- a/logs/2026-04-09_t4135-apply-weird-filenames.md
+++ b/logs/2026-04-09_t4135-apply-weird-filenames.md
@@ -1,0 +1,18 @@
+# t4135-apply-weird-filenames
+
+## Goal
+
+Make harness file `t4135-apply-weird-filenames.sh` pass all tests that are expected to pass (19/20; one remains `test_expect_failure` for quoted traditional patch).
+
+## Changes (grit `apply` patch parsing)
+
+- Ported Git `apply.c` traditional header logic: `diff_timestamp_len`, `find_name_traditional`, `parse_traditional_patch` semantics (including `.orig` shortening via `def`, same `+++` path for both sides when no epoch marker).
+- `has_epoch_timestamp` + fixed `tz_with_colon_len` (7-byte ` ±HH:MM` suffix) for `funny-tz.diff` / `damaged-tz.diff`.
+- `git_header_name` / `split_diff_git_paths`: C-quoted `diff --git` paths, repeated unquoted names with spaces, end-of-line boundary when `lines()` strips `\n`.
+- `---`/`+++` for git diffs: treat `/dev/null` literally (do not run `find_name` with `p=1`).
+- Extended headers `rename from` / `copy from`: strip with `p_value - 1` like Git.
+
+## Verification
+
+- `./scripts/run-tests.sh t4135-apply-weird-filenames.sh` → 19/20 pass (expected).
+- `cargo fmt`, `cargo clippy -p grit-rs --fix --allow-dirty`, `cargo test -p grit-lib --lib`.

--- a/progress.md
+++ b/progress.md
@@ -1,20 +1,21 @@
 # Progress — Grit Test Coverage
 
-**Updated:** 2026-04-08
+**Updated:** 2026-04-09
 
 ## Counts (derived from plan.md)
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   231 |
-| In progress |     2 |
-| Remaining   |   535 |
+| Completed   |   247 |
+| In progress |     4 |
+| Remaining   |   517 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 231 completed (`[x]`), 2 in progress (`[~]`), 535 remaining (`[ ]`).
+Task lines in `PLAN.md`: 247 completed (`[x]`), 4 in progress (`[~]`), 517 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t4135-apply-weird-filenames` — 19/20 tests pass (all `test_expect_success`; one intentional `test_expect_failure` for quoted traditional patch); `apply` now parses Git/traditional diff filenames like Git (`diff_timestamp_len`, C-quoted `diff --git`, epoch timestamps with colon TZ, `/dev/null` headers, `rename from` strip)
 - `t12820-diff-no-index-symlink` — 41/41 tests pass (symlink add/modify/delete, `diff`/`diff --cached`/`diff-tree`, stat/numstat/name output, multi-symlink and file↔symlink replacements; harness dashboards refreshed)
 - `t7817-grep-sparse-checkout` — 8/8 tests pass (non-cone sparse: `path_in_sparse_checkout` parent walk + last-match-wins; `sparse-checkout init` preserves cone mode and seeds `/*` + `!/*/` when recreating file; `disable` keeps pattern file so re-init reapplies `!b`; submodule `reset --hard` + sparse reapply; `grep` worktree: skip-worktree when absent, CE_VALID vs skip-worktree, unmerged paths grep worktree once; `grep_cached` per-stage for `--cached`)
 - `t7417-submodule-path-url` — 5/5 tests pass (`.gitmodules` dash paths: `mv` updates path + index blob; `escape_value` quotes leading `-`; receive-side `transfer.fsckObjects` via repo-local config only; clone `--recurse-submodules` resolves relative URLs from `origin` repo root + quoted path parsing + `GIT_QUIET` quiet mode)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns `grit apply` patch parsing with Git’s `apply.c` for unusual `diff --git` and traditional unified diff headers: C-quoted paths, repeated unquoted names (including spaces), timestamp stripping (`.orig` shortening), optional `-p` guessing, epoch timestamps (including colon timezones), correct `/dev/null` handling on `---`/`+++`, and `rename from` / `copy from` path stripping.

## Tests

- `./scripts/run-tests.sh t4135-apply-weird-filenames.sh` → **19/20** (all `test_expect_success`; one intentional `test_expect_failure` for quoted traditional patch remains upstream)
- `cargo fmt`, `cargo clippy -p grit-rs --fix --allow-dirty`, `cargo test -p grit-lib --lib`

## Notes

- Dashboard CSV/HTML updated by the harness run.
- `PLAN.md` / `progress.md` updated; log in `logs/2026-04-09_t4135-apply-weird-filenames.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6cb28e5e-7fc8-4b02-96a4-6cf91fc5ee38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6cb28e5e-7fc8-4b02-96a4-6cf91fc5ee38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

