### PR TITLE
test: t1700-split-index harness refresh (29/29 passing)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -453,7 +453,7 @@ t1515-rev-parse-outside-repo	t1	yes	4	4	0	true	ok	0
 t1517-outside-repo	t1	yes	0	0	0	false	timeout	0
 t1600-index	t1	yes	7	7	0	true	ok	0
 t1601-index-bogus	t1	yes	4	4	0	true	ok	0
-t1700-split-index	t1	yes	29	3	26	false	ok	0
+t1700-split-index	t1	yes	29	29	0	true	ok	0
 t1701-racy-split-index	t1	yes	31	1	30	false	ok	0
 t1800-hook	t1	yes	0	0	0	false	timeout	0
 t1800-ls-remote	t1	yes	24	22	2	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,16 +141,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T03:13:47+00:00" class="gen-time" title="2026-04-09 03:13 UTC">2026-04-09 03:13 UTC</time> · <a href="https://github.com/schacon/grit/commit/1dadfd2c33c1c4812878f02237deff3c44bdf86b" style="color:#58a6ff">1dadfd2</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T03:17:33+00:00" class="gen-time" title="2026-04-09 03:17 UTC">2026-04-09 03:17 UTC</time> · <a href="https://github.com/schacon/grit/commit/a2ebecb3809e77f3b1ad9dd2a15e1d9e2ee0259c" style="color:#58a6ff">a2ebecb</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">74.9%</div>
+      <div class="summary-big-val pct-blue">75.0%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,876</div>
+      <div class="summary-big-val">29,902</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -159,12 +159,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:74.9%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:75.0%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>741 files fully passing</span>
+    <span>742 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -190,11 +190,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">279/368 files · 8 skipped · 10,780/11,373 tests</span>
+        <span class="group-meta">280/368 files · 8 skipped · 10,806/11,373 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:94.8%"></div></div>
-        <span class="group-pct pct-green">94.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:95.0%"></div></div>
+        <span class="group-pct pct-green">95.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t2">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T03:13:47+00:00" class="gen-time" title="2026-04-09 03:13 UTC">2026-04-09 03:13 UTC</time> · <a href="https://github.com/schacon/grit/commit/1dadfd2c33c1c4812878f02237deff3c44bdf86b" style="color:#58a6ff">1dadfd2</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T03:17:33+00:00" class="gen-time" title="2026-04-09 03:17 UTC">2026-04-09 03:17 UTC</time> · <a href="https://github.com/schacon/grit/commit/a2ebecb3809e77f3b1ad9dd2a15e1d9e2ee0259c" style="color:#58a6ff">a2ebecb</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,876</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">74.9%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,902</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">75.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -4687,14 +4687,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="29" data-passed="3">
+<tr class="" data-group="t1" data-tests="29" data-passed="29" data-full-pass="1">
   <td class="mono">t1700-split-index</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">29</td>
-  <td class="right">3</td>
+  <td class="right">29</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:10.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="31" data-passed="1">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t1700-split-index.sh` already passes fully against current `grit`; the harness metadata was stale (3 passed / 26 failed).

## Changes

- Ran `./scripts/run-tests.sh t1700-split-index.sh` to refresh `data/test-files.csv` and dashboards (`docs/index.html`, `docs/testfiles.html`).
- `t1700-split-index` is now recorded as **29/29** passing.

## Verification

```bash
cargo build --release -p grit-rs
./scripts/run-tests.sh t1700-split-index.sh
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd44df8a-e87c-4474-bbe7-22e39419ace7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd44df8a-e87c-4474-bbe7-22e39419ace7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

