### PR TITLE
Refresh t8340-restore-staged harness results (27/27)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1326,7 +1326,7 @@ t8300-rev-list-objects	t8	yes	34	34	0	true	ok	0
 t8310-for-each-ref-format-deep	t8	yes	32	32	0	true	ok	0
 t8320-config-global-local	t8	yes	34	34	0	true	ok	0
 t8330-switch-track	t8	yes	30	10	20	false	ok	0
-t8340-restore-staged	t8	yes	27	16	11	false	ok	0
+t8340-restore-staged	t8	yes	27	27	0	true	ok	0
 t8350-checkout-index-force	t8	yes	30	30	0	true	ok	0
 t8360-read-tree-twoway	t8	yes	25	20	5	false	ok	0
 t8370-mktree-roundtrip	t8	yes	26	26	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T03:22:16+00:00" class="gen-time" title="2026-04-09 03:22 UTC">2026-04-09 03:22 UTC</time> · <a href="https://github.com/schacon/grit/commit/2b7a76f2875aab51d7a94ea3559ae67fc03b2a4d" style="color:#58a6ff">2b7a76f</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T03:26:57+00:00" class="gen-time" title="2026-04-09 03:26 UTC">2026-04-09 03:26 UTC</time> · <a href="https://github.com/schacon/grit/commit/934ec6cfa3933483ca2fa833491dad7fe3129e4f" style="color:#58a6ff">934ec6c</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,897</div>
+      <div class="summary-big-val">29,908</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>743 files fully passing</span>
+    <span>744 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -267,11 +267,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t8</span>
         <span class="group-desc">Porcelainish commands concerning forensics</span>
-        <span class="group-meta">80/105 files · 0 skipped · 2,861/3,116 tests</span>
+        <span class="group-meta">81/105 files · 0 skipped · 2,872/3,116 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:91.8%"></div></div>
-        <span class="group-pct pct-green">91.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:92.2%"></div></div>
+        <span class="group-pct pct-green">92.2%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t9">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T03:22:16+00:00" class="gen-time" title="2026-04-09 03:22 UTC">2026-04-09 03:22 UTC</time> · <a href="https://github.com/schacon/grit/commit/2b7a76f2875aab51d7a94ea3559ae67fc03b2a4d" style="color:#58a6ff">2b7a76f</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T03:26:57+00:00" class="gen-time" title="2026-04-09 03:26 UTC">2026-04-09 03:26 UTC</time> · <a href="https://github.com/schacon/grit/commit/934ec6cfa3933483ca2fa833491dad7fe3129e4f" style="color:#58a6ff">934ec6c</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,897</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,908</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">75.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -13417,14 +13417,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:33.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t8" data-tests="27" data-passed="16">
+<tr class="" data-group="t8" data-tests="27" data-passed="27" data-full-pass="1">
   <td class="mono">t8340-restore-staged</td>
   <td>t8</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">27</td>
-  <td class="right">16</td>
+  <td class="right">27</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:59.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t8" data-tests="30" data-passed="30" data-full-pass="1">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`tests/t8340-restore-staged.sh` already passes fully against the current `grit` binary. The tracked harness metadata was stale (16/27).

## Changes

- Updated `data/test-files.csv` for `t8340-restore-staged` to **27 passed / 0 failed**, `fully_passing=true`.
- Regenerated `docs/index.html` and `docs/testfiles.html` via `./scripts/run-tests.sh t8340-restore-staged.sh`.

## Verification

```bash
./scripts/run-tests.sh t8340-restore-staged.sh
# ✓ t8340-restore-staged (27/27)
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4c4b466-2225-42f1-80cc-1c940d61abc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4c4b466-2225-42f1-80cc-1c940d61abc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

