### PR TITLE
docs: t7505-prepare-commit-msg-hook fully passing (23/23)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -865,7 +865,7 @@ commit → check it off → move on.
 - [ ] `t7425-submodule-gitdir-path-extension` █████░░░░░░░░░░░░░░░ 6/23 (17 left) — submodulePathConfig extension works as expected
 - [ ] `t7422-submodule-output` █░░░░░░░░░░░░░░░░░░░ 1/18 (17 left) — submodule --cached, --quiet etc. output
 - [ ] `t7301-clean-interactive` ████░░░░░░░░░░░░░░░░ 5/23 (18 left) — git clean -i basic tests
-- [ ] `t7505-prepare-commit-msg-hook` ████░░░░░░░░░░░░░░░░ 5/23 (18 left) — prepare-commit-msg hook
+- [x] `t7505-prepare-commit-msg-hook` — prepare-commit-msg hook (23/23)
 - [ ] `t7411-submodule-config` ██░░░░░░░░░░░░░░░░░░ 2/20 (18 left) — Test submodules config cache infrastructure
 
 - [ ] `t7519-status-fsmonitor` ████████░░░░░░░░░░░░ 14/33 (19 left) — git status with file system watcher

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1226,7 +1226,7 @@ t7503-pre-commit-and-diff-whitespace	t7	yes	0	0	0	false	timeout	0
 t7503-pre-commit-and-pre-merge-commit-hooks	t7	yes	22	6	16	false	ok	0
 t7504-commit-msg-hook	t7	yes	29	22	7	false	ok	1
 t7505-prepare-commit-msg	t7	yes	30	30	0	true	ok	0
-t7505-prepare-commit-msg-hook	t7	yes	23	7	16	false	ok	0
+t7505-prepare-commit-msg-hook	t7	yes	23	23	0	true	ok	0
 t7506-status-submodule	t7	yes	40	6	34	false	ok	0
 t7507-commit-verbose	t7	yes	45	19	26	false	ok	0
 t7508-status	t7	yes	126	39	87	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T03:22:16+00:00" class="gen-time" title="2026-04-09 03:22 UTC">2026-04-09 03:22 UTC</time> · <a href="https://github.com/schacon/grit/commit/2b7a76f2875aab51d7a94ea3559ae67fc03b2a4d" style="color:#58a6ff">2b7a76f</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T03:24:34+00:00" class="gen-time" title="2026-04-09 03:24 UTC">2026-04-09 03:24 UTC</time> · <a href="https://github.com/schacon/grit/commit/934ec6cfa3933483ca2fa833491dad7fe3129e4f" style="color:#58a6ff">934ec6c</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,897</div>
+      <div class="summary-big-val">29,913</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>743 files fully passing</span>
+    <span>744 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -256,11 +256,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 1,935/2,944 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 1,951/2,944 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:65.7%"></div></div>
-        <span class="group-pct pct-blue">65.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:66.3%"></div></div>
+        <span class="group-pct pct-blue">66.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T03:22:16+00:00" class="gen-time" title="2026-04-09 03:22 UTC">2026-04-09 03:22 UTC</time> · <a href="https://github.com/schacon/grit/commit/2b7a76f2875aab51d7a94ea3559ae67fc03b2a4d" style="color:#58a6ff">2b7a76f</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T03:24:34+00:00" class="gen-time" title="2026-04-09 03:24 UTC">2026-04-09 03:24 UTC</time> · <a href="https://github.com/schacon/grit/commit/934ec6cfa3933483ca2fa833491dad7fe3129e4f" style="color:#58a6ff">934ec6c</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,897</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,913</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">75.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -12417,14 +12417,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="23" data-passed="7">
+<tr class="" data-group="t7" data-tests="23" data-passed="23" data-full-pass="1">
   <td class="mono">t7505-prepare-commit-msg-hook</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">23</td>
-  <td class="right">7</td>
+  <td class="right">23</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:30.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="40" data-passed="6">

--- a/grit-lib/src/odb.rs
+++ b/grit-lib/src/odb.rs
@@ -541,8 +541,6 @@ mod tests {
     #![allow(clippy::expect_used, clippy::unwrap_used)]
 
     use super::*;
-    use flate2::read::ZlibDecoder;
-    use std::io::Read;
     use tempfile::TempDir;
 
     #[test]

--- a/logs/2026-04-09_t7505-prepare-commit-msg-hook.md
+++ b/logs/2026-04-09_t7505-prepare-commit-msg-hook.md
@@ -1,0 +1,14 @@
+# t7505-prepare-commit-msg-hook
+
+**Date:** 2026-04-09
+
+## Outcome
+
+`./scripts/run-tests.sh t7505-prepare-commit-msg-hook.sh` reports **23/23** passing on current `grit`; no Rust changes were required for this file.
+
+## Changes
+
+- Refreshed harness artifacts: `data/test-files.csv`, `docs/index.html`, `docs/testfiles.html`.
+- Marked task complete in `PLAN.md`; updated `progress.md` counts and recently completed list.
+- Removed unused test-module imports in `grit-lib/src/odb.rs` (cleans `cargo test -p grit-lib --lib` warnings).
+- Appended run summary to `test-results.md`.

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   253 |
+| Completed   |   254 |
 | In progress |     4 |
-| Remaining   |   511 |
+| Remaining   |   510 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 253 completed (`[x]`), 4 in progress (`[~]`), 511 remaining (`[ ]`).
+Task lines in `PLAN.md`: 254 completed (`[x]`), 4 in progress (`[~]`), 510 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t7505-prepare-commit-msg-hook` — 23/23 tests pass (prepare-commit-msg hook: `-m`/`-F`/`-t`/`-C`/`-c`, merge and cherry-pick, interactive rebase flow, failing hook behavior; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t4214-log-graph-octopus` — 17/17 tests pass (`git log --graph` skewed-left octopus, crossover, and colored graph lines; harness CSV/dashboards refreshed)
 - `t3060-ls-files-with-tree` — 8/8 tests pass (`ls-files --with-tree`: `Index::overlay_tree_on_index`, `-s/-u`/`--recurse-submodules` incompatibilities with `fatal:` + exit 128, cwd pathspec `sub/` matches `sub/file`; harness CSV refreshed)
 - `t12660-init-shared-perm` — 37/37 tests pass (default `grit init` applies Git-style group-shared chmod on `.git` tree: 775 dirs / 664 HEAD under umask 022; explicit `--shared` / `core.sharedRepository` writes config + `receive.denyNonFastforwards`; reinit without shared config leaves modes unchanged)

--- a/test-results.md
+++ b/test-results.md
@@ -1,5 +1,10 @@
 # Test Results
 
+**Updated:** 2026-04-09
+
+- `./scripts/run-tests.sh t7505-prepare-commit-msg-hook.sh`: 23/23 passing (prepare-commit-msg hook coverage; harness CSV/dashboards refreshed).
+- `cargo test -p grit-lib --lib`: 121/121 passing.
+
 **Updated:** 2026-04-08
 
 - `./scripts/run-tests.sh t3060-ls-files-with-tree.sh`: 8/8 passing (`ls-files --with-tree`: tree overlay on index, usage incompatibilities, conflict + missing-index cases; harness CSV/dashboards refreshed).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`./scripts/run-tests.sh t7505-prepare-commit-msg-hook.sh` passes **23/23** on current `grit`. No behavioral changes were required for this test file.

## Changes

- Refreshed harness metadata and dashboards (`data/test-files.csv`, `docs/index.html`, `docs/testfiles.html`) after the clean run.
- Marked `t7505-prepare-commit-msg-hook` complete in `PLAN.md` and updated `progress.md` counts.
- Removed unused imports in `grit-lib` `odb` test module (eliminates test-build warnings).
- Logged work in `logs/2026-04-09_t7505-prepare-commit-msg-hook.md` and appended `test-results.md`.

## Validation

- `cargo build --release -p grit-rs`
- `./scripts/run-tests.sh t7505-prepare-commit-msg-hook.sh` → 23/23
- `cargo test -p grit-lib --lib` → 121/121
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47848c52-a8e8-4244-a9b1-065b96da310d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47848c52-a8e8-4244-a9b1-065b96da310d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

