### PR TITLE
t6133-pathspec-rev-dwim: verify 6/6, refresh harness, fix odb test imports

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1080,7 +1080,7 @@ t6120-name-rev	t6	yes	41	41	0	true	ok	0
 t6130-pathspec-noglob	t6	yes	21	8	13	false	ok	0
 t6131-pathspec-icase	t6	yes	9	1	8	false	ok	0
 t6132-pathspec-exclude	t6	yes	31	0	31	false	ok	0
-t6133-pathspec-rev-dwim	t6	yes	6	5	1	false	ok	0
+t6133-pathspec-rev-dwim	t6	yes	6	6	0	true	ok	0
 t6133-pathspec-toplevel	t6	yes	33	27	6	false	ok	0
 t6134-pathspec-in-submodule	t6	yes	3	3	0	true	ok	0
 t6134-pathspec-wildcard	t6	yes	32	32	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T03:28:01+00:00" class="gen-time" title="2026-04-09 03:28 UTC">2026-04-09 03:28 UTC</time> · <a href="https://github.com/schacon/grit/commit/a9b893d29049194edc3ad16f95bdc607b8f1a5d6" style="color:#58a6ff">a9b893d</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T03:32:02+00:00" class="gen-time" title="2026-04-09 03:32 UTC">2026-04-09 03:32 UTC</time> · <a href="https://github.com/schacon/grit/commit/f5b1dc0a582f7813c460c20219311bcf4e096661" style="color:#58a6ff">f5b1dc0</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,908</div>
+      <div class="summary-big-val">29,909</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>744 files fully passing</span>
+    <span>745 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -245,7 +245,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t6</span>
         <span class="group-desc">Revision tree commands (e.g. merge-base)</span>
-        <span class="group-meta">46/105 files · 3 skipped · 1,202/2,135 tests</span>
+        <span class="group-meta">47/105 files · 3 skipped · 1,203/2,135 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-orange" style="width:56.3%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T03:28:01+00:00" class="gen-time" title="2026-04-09 03:28 UTC">2026-04-09 03:28 UTC</time> · <a href="https://github.com/schacon/grit/commit/a9b893d29049194edc3ad16f95bdc607b8f1a5d6" style="color:#58a6ff">a9b893d</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T03:32:02+00:00" class="gen-time" title="2026-04-09 03:32 UTC">2026-04-09 03:32 UTC</time> · <a href="https://github.com/schacon/grit/commit/f5b1dc0a582f7813c460c20219311bcf4e096661" style="color:#58a6ff">f5b1dc0</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,908</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,909</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">75.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -10957,14 +10957,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t6" data-tests="6" data-passed="5">
+<tr class="" data-group="t6" data-tests="6" data-passed="6" data-full-pass="1">
   <td class="mono">t6133-pathspec-rev-dwim</td>
   <td>t6</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">6</td>
-  <td class="right">5</td>
+  <td class="right">6</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:83.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t6" data-tests="33" data-passed="27">

--- a/grit-lib/src/fast_export.rs
+++ b/grit-lib/src/fast_export.rs
@@ -17,8 +17,7 @@ use crate::rev_list::{rev_list, OrderingMode, RevListOptions};
 use crate::index::{MODE_GITLINK, MODE_TREE};
 
 /// Options for [`export_stream`].
-#[derive(Debug, Clone)]
-#[derive(Default)]
+#[derive(Debug, Clone, Default)]
 pub struct FastExportOptions {
     /// Export all heads under `refs/heads/` (and reachable history).
     pub all: bool,
@@ -29,7 +28,6 @@ pub struct FastExportOptions {
     /// Emit `feature done` / trailing `done` (matches `git fast-import` when the feature is negotiated).
     pub use_done_feature: bool,
 }
-
 
 struct AnonState<'a> {
     seeds: &'a HashMap<String, String>,

--- a/grit-lib/src/gitmodules.rs
+++ b/grit-lib/src/gitmodules.rs
@@ -235,10 +235,12 @@ fn check_submodule_name(name: &str) -> bool {
     }
     let b = name.as_bytes();
     // Git `check_submodule_name`: `goto in_component` before the loop — first component.
-    if b.len() >= 2 && b[0] == b'.' && b[1] == b'.' {
-        if b.len() == 2 || b[2] == b'/' || b[2] == b'\\' {
-            return false;
-        }
+    if b.len() >= 2
+        && b[0] == b'.'
+        && b[1] == b'.'
+        && (b.len() == 2 || b[2] == b'/' || b[2] == b'\\')
+    {
+        return false;
     }
     let mut i = 0usize;
     while i < b.len() {

--- a/grit-lib/src/merge_diff.rs
+++ b/grit-lib/src/merge_diff.rs
@@ -132,7 +132,7 @@ pub fn convert_blob_to_worktree_for_path(
     };
     let file_attrs = crate::crlf::get_file_attrs(&rules, path, &config);
     crate::crlf::convert_to_worktree(blob, path, &conv, &file_attrs, oid_hex, None)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+        .map_err(|e| std::io::Error::other(e))
 }
 
 /// Prepare blob bytes for diff: optional textconv when `use_textconv` and `diff=<driver>`.

--- a/grit-lib/src/odb.rs
+++ b/grit-lib/src/odb.rs
@@ -37,7 +37,7 @@ use crate::pack;
 /// (`t1006-cat-file` zlib-dictionary test).
 fn read_zlib_loose_payload(mut file: fs::File) -> Result<Vec<u8>> {
     let mut hdr = [0u8; 2];
-    file.read_exact(&mut hdr).map_err(|e| Error::Io(e.into()))?;
+    file.read_exact(&mut hdr).map_err(|e| Error::Io(e))?;
     let cmf_flg = u16::from(hdr[0]) << 8 | u16::from(hdr[1]);
     let looks_like_zlib_header = cmf_flg != 0 && cmf_flg % 31 == 0;
     let preset_dictionary = looks_like_zlib_header && (hdr[1] & 0x20) != 0;
@@ -176,7 +176,7 @@ impl Odb {
     /// - [`Error::CorruptObject`] — header is malformed.
     /// - [`Error::LooseHashMismatch`] — payload OID does not match `expected_oid`.
     pub fn read_loose_verify_oid(path: &Path, expected_oid: &ObjectId) -> Result<Object> {
-        let file = fs::File::open(path).map_err(|e| Error::Io(e))?;
+        let file = fs::File::open(path).map_err(Error::Io)?;
         let raw = read_zlib_loose_payload(file)?;
         let obj = parse_object_bytes(&raw)?;
         let computed = hash_object_from_parsed(&obj);
@@ -541,8 +541,6 @@ mod tests {
     #![allow(clippy::expect_used, clippy::unwrap_used)]
 
     use super::*;
-    use flate2::read::ZlibDecoder;
-    use std::io::Read;
     use tempfile::TempDir;
 
     #[test]

--- a/grit-lib/src/rerere.rs
+++ b/grit-lib/src/rerere.rs
@@ -236,9 +236,9 @@ fn handle_conflict(
             put_marker(&mut out, '>', marker_size);
             if let Some(h) = ctx {
                 h.update(one.as_bytes());
-                h.update(&[0]);
+                h.update([0]);
                 h.update(two.as_bytes());
-                h.update(&[0]);
+                h.update([0]);
             }
             return Ok(out);
         } else {
@@ -838,7 +838,7 @@ pub fn rerere_post_commit(repo: &Repository) -> Result<()> {
 /// `git rerere clear` — drop unresolved preimages tracked in `MERGE_RR`, remove `MERGE_RR`.
 pub fn rerere_clear(git_dir: &Path) -> Result<()> {
     let merge_rr = read_merge_rr(git_dir)?;
-    for (_path, ent) in &merge_rr {
+    for ent in merge_rr.values() {
         let Some(id) = &ent.id else {
             continue;
         };

--- a/grit-lib/src/simple_ipc.rs
+++ b/grit-lib/src/simple_ipc.rs
@@ -127,7 +127,7 @@ fn read_one_packet<R: Read>(r: &mut R, buf: &mut Vec<u8>) -> io::Result<Option<(
 fn read_packetized_to_end<R: Read>(r: &mut R) -> io::Result<Vec<u8>> {
     let mut out = Vec::new();
     loop {
-        if read_one_packet(r, &mut out)? == None {
+        if read_one_packet(r, &mut out)?.is_none() {
             break;
         }
     }

--- a/grit/src/commands/cherry_pick.rs
+++ b/grit/src/commands/cherry_pick.rs
@@ -455,7 +455,7 @@ fn walk_first_parent_filtered(
     while let Some(c) = current {
         let obj = repo.odb.read(&c)?;
         let commit = parse_commit(&obj.data)?;
-        let author_ok = author_sub.map_or(true, |sub| commit.author.contains(sub));
+        let author_ok = author_sub.is_none_or(|sub| commit.author.contains(sub));
         if author_ok {
             matches.push(c);
             if let Some(limit) = max_count {
@@ -931,12 +931,12 @@ pub(crate) fn abort_cherry_pick_or_revert() -> Result<()> {
 
 fn reset_to_head_tree(repo: &Repository, git_dir: &Path) -> Result<()> {
     let head = resolve_head(git_dir)?;
-    let old_index = load_index(&repo)?;
+    let old_index = load_index(repo)?;
     let mut new_index = Index::new();
     if let Some(head_oid) = head.oid() {
         let obj = repo.odb.read(head_oid)?;
         let commit = parse_commit(&obj.data)?;
-        new_index.entries = tree_to_index_entries(&repo, &commit.tree, "")?;
+        new_index.entries = tree_to_index_entries(repo, &commit.tree, "")?;
     }
     new_index.sort();
     repo.write_index(&mut new_index)?;

--- a/grit/src/commands/clean.rs
+++ b/grit/src/commands/clean.rs
@@ -152,11 +152,12 @@ pub fn run(args: Args) -> Result<()> {
     let stdout = io::stdout();
     let mut out = stdout.lock();
 
-    if args.interactive && !args.dry_run {
-        if !run_interactive_clean(&mut out, &args, &cwd, &work_tree, &to_remove)? {
-            out.flush()?;
-            return Ok(());
-        }
+    if args.interactive
+        && !args.dry_run
+        && !run_interactive_clean(&mut out, &args, &cwd, &work_tree, &to_remove)?
+    {
+        out.flush()?;
+        return Ok(());
     }
 
     for (path, is_dir) in &to_remove {
@@ -359,7 +360,7 @@ fn collect_untracked(
 
         let rel = path
             .strip_prefix(work_tree)
-            .map(|p| path_to_slash(p))
+            .map(path_to_slash)
             .unwrap_or_else(|_| name.clone());
 
         if args.ignored_too
@@ -425,13 +426,13 @@ fn collect_untracked(
             if args.force < 2 {
                 if let Some(index_ref) = index {
                     if submodule_containing_path(&rel, index_ref).is_some()
-                        && !pathspec_enters_any(&pathspecs, cwd_prefix, &rel)
+                        && !pathspec_enters_any(pathspecs, cwd_prefix, &rel)
                     {
                         continue;
                     }
                 }
                 if is_nested_git_metadata(&path)
-                    && !pathspec_enters_any(&pathspecs, cwd_prefix, &rel)
+                    && !pathspec_enters_any(pathspecs, cwd_prefix, &rel)
                 {
                     continue;
                 }
@@ -621,7 +622,7 @@ fn collect_untracked(
                 rel.clone()
             };
 
-            if is_tracked(tracked, index, &work_tree, &rel_for_track) {
+            if is_tracked(tracked, index, work_tree, &rel_for_track) {
                 continue;
             }
 
@@ -833,10 +834,7 @@ fn pathdiff(cwd: &Path, work_tree: &Path) -> Option<String> {
     if cwd_canon == wt_canon {
         return None;
     }
-    cwd_canon
-        .strip_prefix(&wt_canon)
-        .ok()
-        .map(|p| path_to_slash(p))
+    cwd_canon.strip_prefix(&wt_canon).ok().map(path_to_slash)
 }
 
 fn path_for_clean_display(cwd: &Path, work_tree: &Path, repo_rel: &str) -> String {
@@ -1071,7 +1069,7 @@ fn dir_has_any_ignored(
 
         let rel = path
             .strip_prefix(work_tree)
-            .map(|p| path_to_slash(p))
+            .map(path_to_slash)
             .unwrap_or(name);
 
         let is_dir = path.is_dir();
@@ -1117,7 +1115,7 @@ fn dir_all_ignored(
         saw_entry = true;
         let rel = path
             .strip_prefix(work_tree)
-            .map(|p| path_to_slash(p))
+            .map(path_to_slash)
             .unwrap_or(name);
 
         let is_dir = path.is_dir();

--- a/grit/src/commands/sequencer.rs
+++ b/grit/src/commands/sequencer.rs
@@ -48,9 +48,8 @@ pub fn sequencer_is_revert_sequence(git_dir: &Path) -> bool {
 pub fn write_abort_safety_file(git_dir: &Path) -> std::io::Result<()> {
     let seq_dir = git_dir.join("sequencer");
     fs::create_dir_all(&seq_dir)?;
-    let head = resolve_head(git_dir).map_err(|e| {
-        std::io::Error::new(std::io::ErrorKind::Other, format!("resolve HEAD: {e}"))
-    })?;
+    let head =
+        resolve_head(git_dir).map_err(|e| std::io::Error::other(format!("resolve HEAD: {e}")))?;
     let line = match head.oid() {
         Some(oid) => format!("{}\n", oid.to_hex()),
         None => "\n".to_string(),

--- a/logs/2026-04-09_t6133-pathspec-rev-dwim.md
+++ b/logs/2026-04-09_t6133-pathspec-rev-dwim.md
@@ -1,0 +1,5 @@
+## t6133-pathspec-rev-dwim (2026-04-09)
+
+- Ran `./scripts/run-tests.sh t6133-pathspec-rev-dwim.sh` → **6/6** passing on current branch.
+- `data/test-files.csv` previously showed 5/6; refreshed to 6/6 after harness run.
+- Removed unused `ZlibDecoder` / `Read` imports in `grit-lib` `odb` unit test module (clean `cargo test -p grit-lib --lib`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Confirmed `t6133-pathspec-rev-dwim` passes **6/6** via `./scripts/run-tests.sh t6133-pathspec-rev-dwim.sh`.
- Updated harness artifacts (`data/test-files.csv`, dashboards) to reflect full pass.
- Removed unused imports in `grit-lib` `odb` unit tests so `cargo test -p grit-lib --lib` stays warning-free.
- Follow-up: small **clippy/idiom cleanups** across `grit` and `grit-lib` (derive merge, `io::Error::other`, `is_none_or`, `values()` iteration, etc.) — no behavior change intended.

## Testing

- `./scripts/run-tests.sh t6133-pathspec-rev-dwim.sh`
- `cargo test -p grit-lib --lib`
- `cargo check -p grit-rs -p grit-lib`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61625d61-eb96-4f9f-b0fd-e4ebd9a7ef5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61625d61-eb96-4f9f-b0fd-e4ebd9a7ef5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

