### PR TITLE
fix: implement git-compatible stash -p (t3904)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -92,7 +92,7 @@ t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
 t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
-t1006-cat-file	t1	yes	290	285	5	false	ok	1
+t1006-cat-file	t1	yes	290	285	5	false	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	32	8	false	ok	0
 t10070-cat-file-batch-format	t1	yes	33	33	0	true	ok	0
@@ -664,7 +664,7 @@ t3901-i18n-patch	t3	yes	20	0	20	false	ok	0
 t3902-quoted	t3	yes	13	5	8	false	ok	0
 t3902-quoted-ls-tree	t3	yes	8	8	0	true	ok	0
 t3903-stash	t3	yes	0	0	0	false	timeout	0
-t3904-stash-patch	t3	yes	10	4	6	false	ok	0
+t3904-stash-patch	t3	yes	10	10	0	true	ok	0
 t3905-stash-include-untracked	t3	yes	34	13	21	false	ok	0
 t3906-stash-submodule	t3	yes	8	0	8	false	ok	0
 t3907-stash-show-config	t3	yes	10	1	9	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T03:31:50+00:00" class="gen-time" title="2026-04-09 03:31 UTC">2026-04-09 03:31 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,565</div>
+      <div class="summary-big-val">29,579</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>713 files fully passing</span>
+    <span>717 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,11 +212,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">41/141 files · 2 skipped · 3,333/4,611 tests</span>
+        <span class="group-meta">43/141 files · 2 skipped · 3,340/4,611 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.3%"></div></div>
-        <span class="group-pct pct-blue">72.3%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.4%"></div></div>
+        <span class="group-pct pct-blue">72.4%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,336/3,949 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,342/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.8%"></div></div>
-        <span class="group-pct pct-red">33.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.0%"></div></div>
+        <span class="group-pct pct-red">34.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -256,7 +256,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">42/126 files · 11 skipped · 1,793/2,944 tests</span>
+        <span class="group-meta">43/126 files · 11 skipped · 1,794/2,944 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T03:31:50+00:00" class="gen-time" title="2026-04-09 03:31 UTC">2026-04-09 03:31 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,864</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,565</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,579</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1085,7 +1085,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">285</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.3%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t10060-hash-object-determinism</td>
@@ -5110,8 +5110,7 @@ tr.row-skip td { opacity: 0.65; }
 <tr class="" data-group="t2" data-tests="15" data-passed="5">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td><span class="badge ok">full pass</span></td>
-  <td class="right">15</td>
+  <td></td>
   <td class="right">15</td>
   <td class="right">5</td>
   <td class="right">ok</td>
@@ -6218,14 +6217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="54" data-passed="38">
+<tr class="" data-group="t3" data-tests="52" data-passed="3">
   <td class="mono">t3420-rebase-autostash</td>
   <td>t3</td>
   <td></td>
-  <td class="right">54</td>
-  <td class="right">38</td>
+  <td class="right">52</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="63" data-passed="11">
@@ -6798,14 +6797,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="10" data-passed="4">
+<tr class="" data-group="t3" data-tests="10" data-passed="10" data-full-pass="1">
   <td class="mono">t3904-stash-patch</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">10</td>
-  <td class="right">4</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:40.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="34" data-passed="13">
@@ -12598,7 +12597,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="2" data-passed="2">
+<tr class="" data-group="t7" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t7524-commit-summary</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>

--- a/grit/src/commands/checkout.rs
+++ b/grit/src/commands/checkout.rs
@@ -2904,40 +2904,14 @@ pub(crate) fn checkout_patch(
     Ok(())
 }
 
-/// Apply accepted hunks by reconstructing the file content.
-///
-/// For each accepted hunk, we revert the worktree lines back to the source
-/// version. Unaccepted hunks keep the worktree version.
-fn apply_accepted_hunks(
-    _repo: &Repository,
-    work_tree: &std::path::Path,
-    path: &str,
+/// Blend `source` and `worktree` line-by-line using a Myers line diff: each contiguous group of
+/// non-equal ops is one hunk; accepted hunks take the source side, rejected hunks the worktree
+/// side. Matches Git add--interactive / stash patch semantics.
+pub(crate) fn blend_line_diff_by_hunks(
     source_data: &[u8],
     worktree_data: &[u8],
     accepted: &[bool],
-) -> Result<()> {
-    if !accepted.iter().any(|&a| a) {
-        return Ok(()); // Nothing accepted
-    }
-
-    let abs_path = work_tree.join(path);
-
-    // If all hunks are accepted, just write the source content
-    if accepted.iter().all(|&a| a) {
-        if source_data.is_empty() {
-            let _ = std::fs::remove_file(&abs_path);
-        } else {
-            if let Some(parent) = abs_path.parent() {
-                std::fs::create_dir_all(parent)?;
-            }
-            std::fs::write(&abs_path, source_data)?;
-        }
-        return Ok(());
-    }
-
-    // Partial acceptance: reconstruct file using diff ops.
-    // Each non-Equal op is a "hunk". We map each contiguous group of
-    // non-Equal ops to the same hunk index.
+) -> String {
     let source_str = String::from_utf8_lossy(source_data);
     let worktree_str = String::from_utf8_lossy(worktree_data);
     let source_lines: Vec<&str> = source_str.lines().collect();
@@ -2945,7 +2919,6 @@ fn apply_accepted_hunks(
 
     let text_diff = similar::TextDiff::from_lines(source_str.as_ref(), worktree_str.as_ref());
 
-    // Map ops to hunk indices: consecutive non-Equal ops share a hunk index.
     let ops: Vec<_> = text_diff.ops().to_vec();
     let mut hunk_indices: Vec<usize> = Vec::new();
     let mut current_hunk: usize = 0;
@@ -2953,7 +2926,7 @@ fn apply_accepted_hunks(
     for op in &ops {
         match op {
             similar::DiffOp::Equal { .. } => {
-                hunk_indices.push(usize::MAX); // sentinel for equal
+                hunk_indices.push(usize::MAX);
                 if prev_was_change {
                     current_hunk += 1;
                     prev_was_change = false;
@@ -2982,25 +2955,21 @@ fn apply_accepted_hunks(
                 old_index, old_len, ..
             } => {
                 if is_accepted {
-                    // Restore source lines
                     for j in 0..*old_len {
                         output.push_str(source_lines[old_index + j]);
                         output.push('\n');
                     }
                 }
-                // Rejected: lines stay deleted
             }
             similar::DiffOp::Insert {
                 new_index, new_len, ..
             } => {
                 if !is_accepted {
-                    // Keep worktree additions
                     for j in 0..*new_len {
                         output.push_str(worktree_lines[new_index + j]);
                         output.push('\n');
                     }
                 }
-                // Accepted: revert additions (don't include them)
             }
             similar::DiffOp::Replace {
                 old_index,
@@ -3009,13 +2978,11 @@ fn apply_accepted_hunks(
                 new_len,
             } => {
                 if is_accepted {
-                    // Restore source lines
                     for j in 0..*old_len {
                         output.push_str(source_lines[old_index + j]);
                         output.push('\n');
                     }
                 } else {
-                    // Keep worktree lines
                     for j in 0..*new_len {
                         output.push_str(worktree_lines[new_index + j]);
                         output.push('\n');
@@ -3025,6 +2992,122 @@ fn apply_accepted_hunks(
         }
     }
 
+    output
+}
+
+/// Like [`blend_line_diff_by_hunks`], but each entry of `ranges` is an inclusive-exclusive span of
+/// op indices for one interactive sub-hunk; `accepted[d]` applies to all change ops in `ranges[d]`.
+pub(crate) fn blend_line_diff_by_hunk_ranges(
+    source_data: &[u8],
+    worktree_data: &[u8],
+    ranges: &[(usize, usize)],
+    accepted: &[bool],
+) -> String {
+    let source_str = String::from_utf8_lossy(source_data);
+    let worktree_str = String::from_utf8_lossy(worktree_data);
+    let source_lines: Vec<&str> = source_str.lines().collect();
+    let worktree_lines: Vec<&str> = worktree_str.lines().collect();
+
+    let text_diff = similar::TextDiff::from_lines(source_str.as_ref(), worktree_str.as_ref());
+    let ops: Vec<_> = text_diff.ops().to_vec();
+
+    fn op_display_hunk(op_i: usize, ranges: &[(usize, usize)]) -> Option<usize> {
+        for (d, &(s, e)) in ranges.iter().enumerate() {
+            if op_i >= s && op_i < e {
+                return Some(d);
+            }
+        }
+        None
+    }
+
+    let mut output = String::new();
+    for (i, op) in ops.iter().enumerate() {
+        match op {
+            similar::DiffOp::Equal { old_index, len, .. } => {
+                for j in 0..*len {
+                    output.push_str(source_lines[old_index + j]);
+                    output.push('\n');
+                }
+            }
+            similar::DiffOp::Delete {
+                old_index, old_len, ..
+            } => {
+                let disp = op_display_hunk(i, ranges).unwrap_or(0);
+                let is_accepted = disp < accepted.len() && accepted[disp];
+                if is_accepted {
+                    for j in 0..*old_len {
+                        output.push_str(source_lines[old_index + j]);
+                        output.push('\n');
+                    }
+                }
+            }
+            similar::DiffOp::Insert {
+                new_index, new_len, ..
+            } => {
+                let disp = op_display_hunk(i, ranges).unwrap_or(0);
+                let is_accepted = disp < accepted.len() && accepted[disp];
+                if !is_accepted {
+                    for j in 0..*new_len {
+                        output.push_str(worktree_lines[new_index + j]);
+                        output.push('\n');
+                    }
+                }
+            }
+            similar::DiffOp::Replace {
+                old_index,
+                old_len,
+                new_index,
+                new_len,
+            } => {
+                let disp = op_display_hunk(i, ranges).unwrap_or(0);
+                let is_accepted = disp < accepted.len() && accepted[disp];
+                if is_accepted {
+                    for j in 0..*old_len {
+                        output.push_str(source_lines[old_index + j]);
+                        output.push('\n');
+                    }
+                } else {
+                    for j in 0..*new_len {
+                        output.push_str(worktree_lines[new_index + j]);
+                        output.push('\n');
+                    }
+                }
+            }
+        }
+    }
+
+    output
+}
+
+/// Apply per-hunk revert decisions: for each accepted hunk, use `source_data`; otherwise keep
+/// `worktree_data`. Used by `checkout -p` and `stash -p` (same semantics as Git's add--interactive).
+pub(crate) fn apply_accepted_hunks(
+    _repo: &Repository,
+    work_tree: &std::path::Path,
+    path: &str,
+    source_data: &[u8],
+    worktree_data: &[u8],
+    accepted: &[bool],
+) -> Result<()> {
+    if !accepted.iter().any(|&a| a) {
+        return Ok(());
+    }
+
+    let abs_path = work_tree.join(path);
+
+    if accepted.iter().all(|&a| a) {
+        if source_data.is_empty() {
+            let _ = std::fs::remove_file(&abs_path);
+        } else {
+            if let Some(parent) = abs_path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::write(&abs_path, source_data)?;
+        }
+        return Ok(());
+    }
+
+    let output = blend_line_diff_by_hunks(source_data, worktree_data, accepted);
     if let Some(parent) = abs_path.parent() {
         std::fs::create_dir_all(parent)?;
     }

--- a/grit/src/commands/stash.rs
+++ b/grit/src/commands/stash.rs
@@ -12,12 +12,13 @@
 
 use anyhow::{bail, Context, Result};
 use clap::{Args as ClapArgs, Subcommand};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
+use std::io::{self, BufRead, Write as IoWrite};
 use std::path::Path;
 
 use grit_lib::config::ConfigSet;
-use grit_lib::diff::{diff_index_to_tree, diff_index_to_worktree};
+use grit_lib::diff::{diff_index_to_tree, diff_index_to_worktree, unified_diff};
 use grit_lib::error::Error;
 use grit_lib::index::{
     entry_from_stat, Index, IndexEntry, MODE_EXECUTABLE, MODE_GITLINK, MODE_REGULAR, MODE_SYMLINK,
@@ -123,6 +124,9 @@ pub enum StashCommand {
         /// Keep staged changes in the index.
         #[arg(short = 'k', long = "keep-index")]
         keep_index: bool,
+        /// Revert keep-index (default behavior for patch is keep-index).
+        #[arg(long = "no-keep-index")]
+        no_keep_index: bool,
         /// Also stash untracked files.
         #[arg(short = 'u', long = "include-untracked")]
         include_untracked: bool,
@@ -314,6 +318,7 @@ pub fn run(args: Args) -> Result<()> {
         Some(StashCommand::Save {
             message,
             keep_index,
+            no_keep_index,
             include_untracked,
             patch,
             quiet,
@@ -328,13 +333,14 @@ pub fn run(args: Args) -> Result<()> {
                 }
             });
             let ki = keep_index || args.keep_index;
+            let nki = no_keep_index || args.no_keep_index;
             let iu = include_untracked || args.include_untracked;
             let q = quiet || args.quiet;
             let p = patch || args.patch;
             do_push(PushOpts {
                 message: msg,
                 keep_index: ki,
-                no_keep_index: false,
+                no_keep_index: nki,
                 include_untracked: iu,
                 staged: false,
                 patch: p,
@@ -690,10 +696,15 @@ fn do_push(opts: PushOpts) -> Result<()> {
     };
 
     if opts.patch {
-        if has_pathspec {
-            return super::checkout::checkout_patch(&repo, None, &opts.pathspec);
-        }
-        return super::checkout::checkout_patch(&repo, None, &[]);
+        return do_stash_patch_push(
+            &repo,
+            &work_tree,
+            &head,
+            *head_oid,
+            &index,
+            opts,
+            has_pathspec,
+        );
     }
 
     if has_pathspec {
@@ -764,6 +775,518 @@ fn do_push(opts: PushOpts) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// `git stash push -p` / `stash save -p`: interactive selection against **HEAD** (like Git's
+/// `diff-index HEAD`), then build the stash commit and reverse-apply the stashed patch to the
+/// worktree (and optionally reset the index).
+fn do_stash_patch_push(
+    repo: &Repository,
+    work_tree: &Path,
+    head: &HeadState,
+    head_oid: ObjectId,
+    index: &Index,
+    opts: PushOpts,
+    has_pathspec: bool,
+) -> Result<()> {
+    use similar::{Algorithm, TextDiff};
+
+    let head_obj = repo.odb.read(&head_oid)?;
+    let head_commit = parse_commit(&head_obj.data)?;
+    let head_tree_entries = flatten_tree_full(&repo.odb, &head_commit.tree, "")?;
+    let head_flat_map: BTreeMap<String, &FlatTreeEntry> = head_tree_entries
+        .iter()
+        .map(|e| (e.path.clone(), e))
+        .collect();
+
+    let staged = diff_index_to_tree(&repo.odb, index, Some(&head_commit.tree))?;
+    let unstaged = diff_index_to_worktree(&repo.odb, index, work_tree)?;
+
+    let mut candidate_paths: BTreeSet<String> = BTreeSet::new();
+    for e in &staged {
+        if let Some(p) = e.new_path.as_ref().or(e.old_path.as_ref()) {
+            if has_pathspec && !matches_pathspec(p, &opts.pathspec) {
+                continue;
+            }
+            candidate_paths.insert(p.clone());
+        }
+    }
+    for e in &unstaged {
+        if let Some(p) = e.new_path.as_ref().or(e.old_path.as_ref()) {
+            if has_pathspec && !matches_pathspec(p, &opts.pathspec) {
+                continue;
+            }
+            candidate_paths.insert(p.clone());
+        }
+    }
+
+    let mut shadow_by_path: BTreeMap<String, Vec<u8>> = BTreeMap::new();
+    let mut work_by_path: BTreeMap<String, Vec<u8>> = BTreeMap::new();
+
+    for path in &candidate_paths {
+        let head_content: Vec<u8> = if let Some(te) = head_flat_map.get(path) {
+            if te.mode == MODE_SYMLINK {
+                continue;
+            }
+            let b = repo.odb.read(&te.oid)?;
+            if b.kind != ObjectKind::Blob {
+                continue;
+            }
+            b.data.clone()
+        } else {
+            Vec::new()
+        };
+        let abs = work_tree.join(path);
+        let work_content = if abs.exists() {
+            fs::read(&abs).with_context(|| format!("reading {path}"))?
+        } else {
+            Vec::new()
+        };
+        if work_content == head_content {
+            continue;
+        }
+        shadow_by_path.insert(path.clone(), head_content);
+        work_by_path.insert(path.clone(), work_content);
+    }
+
+    if shadow_by_path.is_empty() {
+        if !opts.quiet {
+            eprintln!("No local changes to save");
+        }
+        return Ok(());
+    }
+
+    let stdin = io::stdin();
+    let mut reader = stdin.lock();
+    let mut out = io::stdout();
+
+    let paths: Vec<String> = shadow_by_path.keys().cloned().collect();
+    // Per-path worktree content after stashing (what remains on disk).
+    let mut post_wt: BTreeMap<String, Vec<u8>> = BTreeMap::new();
+    // Per-path blob stored in the stash commit's tree for that path.
+    let mut stash_tree_blob: BTreeMap<String, Vec<u8>> = BTreeMap::new();
+    let mut any_hunk_marked_stash = false;
+
+    for path in paths {
+        let Some(head_content) = shadow_by_path.get(&path).cloned() else {
+            continue;
+        };
+        let Some(mut cur_work) = work_by_path.get(&path).cloned() else {
+            continue;
+        };
+
+        'file_pass: loop {
+            let head_str = String::from_utf8_lossy(&head_content);
+            let work_str = String::from_utf8_lossy(&cur_work);
+            let text_diff = TextDiff::configure()
+                .algorithm(Algorithm::Myers)
+                .diff_lines(head_str.as_ref(), work_str.as_ref());
+            let ops: Vec<_> = text_diff.ops().to_vec();
+
+            let has_change = ops
+                .iter()
+                .any(|o| !matches!(o, similar::DiffOp::Equal { .. }));
+            if !has_change {
+                post_wt.insert(path.clone(), cur_work.clone());
+                stash_tree_blob.insert(path.clone(), head_content.clone());
+                break 'file_pass;
+            }
+
+            let n_ops = ops.len();
+            let mut hunk_ranges: Vec<(usize, usize)> = vec![(0, n_ops)];
+
+            let mut accepted = vec![false; hunk_ranges.len()];
+            let mut hunk_cursor = 0usize;
+
+            'hunk_loop: loop {
+                let n_hunks = hunk_ranges.len();
+                if hunk_cursor >= n_hunks {
+                    break;
+                }
+
+                let display_idx = hunk_cursor + 1;
+                let (s, e) = hunk_ranges[hunk_cursor];
+                let hunk_only = partial_unified_for_op_range(
+                    path.as_str(),
+                    &head_content,
+                    &cur_work,
+                    &ops[s..e],
+                    3,
+                );
+
+                writeln!(out, "diff --git a/{path} b/{path}").ok();
+                write!(out, "--- a/{path}\n+++ b/{path}\n").ok();
+                write!(out, "{hunk_only}").ok();
+                write!(
+                    out,
+                    "({display_idx}/{n_hunks}) Stash this hunk [y,n,q,a,d,s,e,?]? "
+                )
+                .ok();
+                out.flush().ok();
+
+                let mut line = String::new();
+                if reader.read_line(&mut line).unwrap_or(0) == 0 {
+                    // Match Git: EOF while prompting aborts the stash (tests pipe exact answers).
+                    std::process::exit(1);
+                }
+                let answer = line.trim();
+                match answer {
+                    "y" | "Y" => {
+                        accepted[hunk_cursor] = true;
+                        any_hunk_marked_stash = true;
+                        hunk_cursor += 1;
+                    }
+                    "n" | "N" => {
+                        hunk_cursor += 1;
+                    }
+                    "a" | "A" => {
+                        any_hunk_marked_stash = true;
+                        for j in hunk_cursor..n_hunks {
+                            accepted[j] = true;
+                        }
+                        break 'hunk_loop;
+                    }
+                    "d" | "D" => {
+                        break 'hunk_loop;
+                    }
+                    "q" | "Q" => {
+                        std::process::exit(1);
+                    }
+                    "s" | "S" => {
+                        if !split_hunk_at_first_gap(&mut hunk_ranges, hunk_cursor, &ops) {
+                            continue 'hunk_loop;
+                        }
+                        let n = hunk_ranges.len();
+                        accepted.resize(n, false);
+                        if hunk_cursor >= n {
+                            hunk_cursor = n.saturating_sub(1);
+                        }
+                    }
+                    "e" | "E" => {
+                        if let Ok(edited) = edit_bytes_tempfile(&cur_work) {
+                            cur_work = edited;
+                            continue 'file_pass;
+                        }
+                    }
+                    "?" => {
+                        writeln!(
+                            out,
+                            "y - stash this hunk\n\
+                             n - do not stash this hunk\n\
+                             q - quit; do not stash this hunk or any of the remaining ones\n\
+                             a - stash this hunk and all later hunks in the file\n\
+                             d - do not stash this hunk or any of the later hunks in the file\n\
+                             s - split the current hunk into smaller hunks\n\
+                             e - manually edit the current file and re-diff\n"
+                        )
+                        .ok();
+                        out.flush().ok();
+                    }
+                    _ => {}
+                }
+            }
+
+            let post = super::checkout::blend_line_diff_by_hunk_ranges(
+                &head_content,
+                &cur_work,
+                &hunk_ranges,
+                &accepted,
+            );
+            let stash_accepted: Vec<bool> = accepted.iter().map(|a| !*a).collect();
+            let stash_content = super::checkout::blend_line_diff_by_hunk_ranges(
+                &head_content,
+                &cur_work,
+                &hunk_ranges,
+                &stash_accepted,
+            );
+            post_wt.insert(path.clone(), post.into_bytes());
+            stash_tree_blob.insert(path, stash_content.into_bytes());
+            break 'file_pass;
+        }
+    }
+
+    if !any_hunk_marked_stash {
+        if !opts.quiet {
+            eprintln!("No changes selected");
+        }
+        std::process::exit(1);
+    }
+
+    let mut wt_index = build_index_from_tree(&repo.odb, &head_tree_entries)?;
+    for (path, content) in &stash_tree_blob {
+        let path_bytes = path.as_bytes();
+        if content.is_empty() {
+            wt_index.remove(path_bytes);
+            continue;
+        }
+        let blob_oid = repo.odb.write(ObjectKind::Blob, content)?;
+        let abs = work_tree.join(path);
+        let mode = if abs.exists() {
+            let meta = fs::metadata(&abs)?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                if meta.permissions().mode() & 0o111 != 0 {
+                    MODE_EXECUTABLE
+                } else {
+                    MODE_REGULAR
+                }
+            }
+            #[cfg(not(unix))]
+            {
+                let _ = meta;
+                MODE_REGULAR
+            }
+        } else {
+            MODE_REGULAR
+        };
+        wt_index.add_or_replace(IndexEntry {
+            ctime_sec: 0,
+            ctime_nsec: 0,
+            mtime_sec: 0,
+            mtime_nsec: 0,
+            dev: 0,
+            ino: 0,
+            mode,
+            uid: 0,
+            gid: 0,
+            size: content.len() as u32,
+            oid: blob_oid,
+            flags: 0,
+            flags_extended: None,
+            path: path_bytes.to_vec(),
+        });
+    }
+
+    let now = OffsetDateTime::now_utc();
+    let identity = resolve_identity(repo, now)?;
+    let index_tree_oid = write_tree_from_index(&repo.odb, index, "")?;
+    let index_commit_data = CommitData {
+        tree: index_tree_oid,
+        parents: vec![head_oid],
+        author: identity.clone(),
+        committer: identity.clone(),
+        encoding: None,
+        message: format!("index on {}\n", branch_description(head)),
+        raw_message: None,
+    };
+    let index_commit_oid = repo
+        .odb
+        .write(ObjectKind::Commit, &serialize_commit(&index_commit_data))?;
+    let wt_tree_oid = write_tree_from_index(&repo.odb, &wt_index, "")?;
+    let stash_msg = stash_save_msg(head, opts.message.as_deref());
+    let stash_commit = CommitData {
+        tree: wt_tree_oid,
+        parents: vec![head_oid, index_commit_oid],
+        author: identity.clone(),
+        committer: identity.clone(),
+        encoding: None,
+        message: stash_msg.clone(),
+        raw_message: None,
+    };
+    let stash_oid = repo
+        .odb
+        .write(ObjectKind::Commit, &serialize_commit(&stash_commit))?;
+
+    for (path, bytes) in &post_wt {
+        let abs = work_tree.join(path);
+        if bytes.is_empty() {
+            let _ = fs::remove_file(&abs);
+            if let Some(parent) = abs.parent() {
+                remove_empty_dirs(parent, work_tree);
+            }
+        } else {
+            if let Some(parent) = abs.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::write(&abs, bytes)?;
+        }
+    }
+
+    let effective_keep_index = !opts.no_keep_index;
+    if effective_keep_index {
+        // With `--keep-index`, Git only reverses the stashed patch on the worktree (`apply -R`);
+        // it does **not** run `checkout` from the index (that would overwrite unstaged results).
+    } else {
+        let mut new_index = index.clone();
+        for path in post_wt.keys() {
+            let path_bytes = path.as_bytes();
+            if let Some(te) = head_flat_map.get(path) {
+                let blob = repo.odb.read(&te.oid)?;
+                if let Some(ie) = new_index.get_mut(path_bytes, 0) {
+                    ie.oid = te.oid;
+                    ie.mode = te.mode;
+                } else {
+                    new_index.add_or_replace(IndexEntry {
+                        ctime_sec: 0,
+                        ctime_nsec: 0,
+                        mtime_sec: 0,
+                        mtime_nsec: 0,
+                        dev: 0,
+                        ino: 0,
+                        mode: te.mode,
+                        uid: 0,
+                        gid: 0,
+                        size: blob.data.len() as u32,
+                        oid: te.oid,
+                        flags: 0,
+                        flags_extended: None,
+                        path: path_bytes.to_vec(),
+                    });
+                }
+            } else {
+                new_index.remove(path_bytes);
+            }
+        }
+        repo.write_index(&mut new_index)?;
+    }
+
+    update_stash_ref(
+        repo,
+        &stash_oid,
+        &stash_reflog_msg(head, opts.message.as_deref()),
+    )?;
+
+    if !opts.quiet {
+        // Match Git: this line goes to stdout so `git stash -p 2>error` stays stderr-clean
+        // (t3904).
+        println!(
+            "Saved working directory and index state {}",
+            stash_msg.trim_end_matches('\n')
+        );
+    }
+
+    Ok(())
+}
+
+/// Build unified hunk text (`@@` …) for a slice of Myers line-diff ops (HEAD vs current worktree).
+fn partial_unified_for_op_range(
+    path: &str,
+    head_bytes: &[u8],
+    work_bytes: &[u8],
+    op_slice: &[similar::DiffOp],
+    context: usize,
+) -> String {
+    let head_str = String::from_utf8_lossy(head_bytes);
+    let work_str = String::from_utf8_lossy(work_bytes);
+    let head_lines: Vec<&str> = head_str.lines().collect();
+    let work_lines: Vec<&str> = work_str.lines().collect();
+
+    let mut old_partial = String::new();
+    let mut new_partial = String::new();
+    for op in op_slice {
+        match *op {
+            similar::DiffOp::Equal { old_index, len, .. } => {
+                for j in 0..len {
+                    let line = head_lines[old_index + j];
+                    old_partial.push_str(line);
+                    old_partial.push('\n');
+                    new_partial.push_str(line);
+                    new_partial.push('\n');
+                }
+            }
+            similar::DiffOp::Delete {
+                old_index, old_len, ..
+            } => {
+                for j in 0..old_len {
+                    old_partial.push_str(head_lines[old_index + j]);
+                    old_partial.push('\n');
+                }
+            }
+            similar::DiffOp::Insert {
+                new_index, new_len, ..
+            } => {
+                for j in 0..new_len {
+                    new_partial.push_str(work_lines[new_index + j]);
+                    new_partial.push('\n');
+                }
+            }
+            similar::DiffOp::Replace {
+                old_index,
+                old_len,
+                new_index,
+                new_len,
+            } => {
+                for j in 0..old_len {
+                    old_partial.push_str(head_lines[old_index + j]);
+                    old_partial.push('\n');
+                }
+                for j in 0..new_len {
+                    new_partial.push_str(work_lines[new_index + j]);
+                    new_partial.push('\n');
+                }
+            }
+        }
+    }
+
+    let full = unified_diff(&old_partial, &new_partial, path, path, context);
+    let mut tail: String = full
+        .lines()
+        .skip_while(|l| !l.starts_with("@@ "))
+        .collect::<Vec<_>>()
+        .join("\n");
+    tail.push('\n');
+    tail
+}
+
+/// Split after the first change block, at the following line-equality (`Equal`) ops, when more
+/// changes exist after that context (same idea as Git `add -p` / stash `s`).
+fn split_hunk_at_first_gap(
+    ranges: &mut Vec<(usize, usize)>,
+    hunk_cursor: usize,
+    ops: &[similar::DiffOp],
+) -> bool {
+    if hunk_cursor >= ranges.len() {
+        return false;
+    }
+    let (start, end) = ranges[hunk_cursor];
+    let is_eq = |i: usize| matches!(ops.get(i), Some(similar::DiffOp::Equal { .. }));
+
+    let mut i = start;
+    while i < end && is_eq(i) {
+        i += 1;
+    }
+    if i >= end {
+        return false;
+    }
+    while i < end && !is_eq(i) {
+        i += 1;
+    }
+    if i >= end {
+        return false;
+    }
+    let eq_start = i;
+    while i < end && is_eq(i) {
+        i += 1;
+    }
+    if i >= end {
+        return false;
+    }
+
+    ranges[hunk_cursor] = (start, eq_start);
+    ranges.insert(hunk_cursor + 1, (eq_start, end));
+    true
+}
+
+fn edit_bytes_tempfile(content: &[u8]) -> Result<Vec<u8>> {
+    let mut f = tempfile::NamedTempFile::new().context("temp file for stash -p edit")?;
+    f.as_file_mut().write_all(content)?;
+    f.flush()?;
+    let path = f.path().to_owned();
+    let editor = std::env::var("VISUAL")
+        .or_else(|_| std::env::var("EDITOR"))
+        .unwrap_or_else(|_| "vi".to_string());
+    let status = std::process::Command::new("sh")
+        .arg("-c")
+        .arg(format!("{} \"$1\"", editor))
+        .arg("sh")
+        .arg(&path)
+        .status()
+        .context("running editor")?;
+    if !status.success() {
+        bail!("editor failed");
+    }
+    fs::read(&path).context("reading edited file")
 }
 
 /// Push with pathspec: only stash specific files.

--- a/logs/2026-04-09-t3904-stash-patch.md
+++ b/logs/2026-04-09-t3904-stash-patch.md
@@ -1,0 +1,18 @@
+# t3904-stash-patch
+
+## Summary
+
+Implemented Git-compatible `stash -p` / `stash push -p`: diff worktree vs **HEAD** (not index), interactive hunk selection with split (`s`), complementary blend for stash tree vs post-stash worktree, `--keep-index` / `--no-keep-index`, pathspec filtering, and stdout for "Saved working directory..." so `2>error` stays clean (t3904.8).
+
+## Key fixes
+
+- Replaced mistaken `checkout_patch` (index vs worktree) with `do_stash_patch_push`.
+- Stash tree blobs = worktree minus selected hunks; remaining worktree = HEAD plus rejected hunks (inverse of stash selection).
+- Removed wrong `reset_worktree_to_index` after patch stash with `--keep-index` (Git only uses `apply -R` semantics on worktree).
+- `stash save` gained `--no-keep-index` for clap parity with `stash push`.
+- Refactored `apply_accepted_hunks` to use shared `blend_line_diff_by_hunks` / `blend_line_diff_by_hunk_ranges` in checkout.
+
+## Validation
+
+- `./scripts/run-tests.sh t3904-stash-patch.sh` — 10/10
+- `cargo test -p grit-lib --lib`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **`git stash -p` / `stash push -p`** to match upstream behavior covered by `t3904-stash-patch.sh`.

## What changed

- **Correct diff basis:** interactive patch mode now diffs the **worktree vs `HEAD`** (not index vs worktree), including pathspec filtering.
- **Stash tree vs remaining worktree:** for each hunk marked to stash, the stash commit records the **worktree version** of that hunk; the post-stash worktree keeps the **HEAD** side for those hunks (complementary blend). This matches Git’s `add -p` stash semantics without relying on `apply -R` subprocesses.
- **`--keep-index` / `--no-keep-index`:** after patch stash, the worktree is updated from the blend; the index is reset toward `HEAD` only when `--no-keep-index` is in effect. Removed an incorrect `reset_worktree_to_index` that broke keep-index cases.
- **Split hunks (`s`):** fixed split logic and dynamic hunk counts after split; sub-hunk display uses a partial unified diff built from the relevant op slice.
- **`stash save`:** added **`--no-keep-index`** and merged it with global args so `stash save --no-keep-index -p` works.
- **Stdout vs stderr:** patch-mode **“Saved working directory and index state …”** is printed to **stdout** so tests that redirect stderr stay clean (`t3904.8`).
- **Refactor:** `checkout` now exposes `blend_line_diff_by_hunks` / `blend_line_diff_by_hunk_ranges`; `apply_accepted_hunks` delegates to the shared blend.

## Tests

- `./scripts/run-tests.sh t3904-stash-patch.sh` → **10/10**
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7eefc645-a3ce-4a77-89cf-2706ac7608e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7eefc645-a3ce-4a77-89cf-2706ac7608e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

