### PR TITLE
t6134-pathspec-in-submodule: verify passing + clean odb test imports

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T03:31:04+00:00" class="gen-time" title="2026-04-09 03:31 UTC">2026-04-09 03:31 UTC</time> · <a href="https://github.com/schacon/grit/commit/f5b1dc0a582f7813c460c20219311bcf4e096661" style="color:#58a6ff">f5b1dc0</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T03:32:45+00:00" class="gen-time" title="2026-04-09 03:32 UTC">2026-04-09 03:32 UTC</time> · <a href="https://github.com/schacon/grit/commit/62bfa61a32894059692ff66118bea2a7e580ac7c" style="color:#58a6ff">62bfa61</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,7 +100,7 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T03:31:04+00:00" class="gen-time" title="2026-04-09 03:31 UTC">2026-04-09 03:31 UTC</time> · <a href="https://github.com/schacon/grit/commit/f5b1dc0a582f7813c460c20219311bcf4e096661" style="color:#58a6ff">f5b1dc0</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T03:32:45+00:00" class="gen-time" title="2026-04-09 03:32 UTC">2026-04-09 03:32 UTC</time> · <a href="https://github.com/schacon/grit/commit/62bfa61a32894059692ff66118bea2a7e580ac7c" style="color:#58a6ff">62bfa61</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>

--- a/grit-lib/src/fast_export.rs
+++ b/grit-lib/src/fast_export.rs
@@ -17,8 +17,7 @@ use crate::rev_list::{rev_list, OrderingMode, RevListOptions};
 use crate::index::{MODE_GITLINK, MODE_TREE};
 
 /// Options for [`export_stream`].
-#[derive(Debug, Clone)]
-#[derive(Default)]
+#[derive(Debug, Clone, Default)]
 pub struct FastExportOptions {
     /// Export all heads under `refs/heads/` (and reachable history).
     pub all: bool,
@@ -29,7 +28,6 @@ pub struct FastExportOptions {
     /// Emit `feature done` / trailing `done` (matches `git fast-import` when the feature is negotiated).
     pub use_done_feature: bool,
 }
-
 
 struct AnonState<'a> {
     seeds: &'a HashMap<String, String>,

--- a/grit-lib/src/gitmodules.rs
+++ b/grit-lib/src/gitmodules.rs
@@ -235,11 +235,10 @@ fn check_submodule_name(name: &str) -> bool {
     }
     let b = name.as_bytes();
     // Git `check_submodule_name`: `goto in_component` before the loop — first component.
-    if b.len() >= 2 && b[0] == b'.' && b[1] == b'.' {
-        if b.len() == 2 || b[2] == b'/' || b[2] == b'\\' {
+    if b.len() >= 2 && b[0] == b'.' && b[1] == b'.'
+        && (b.len() == 2 || b[2] == b'/' || b[2] == b'\\') {
             return false;
         }
-    }
     let mut i = 0usize;
     while i < b.len() {
         let c = b[i];

--- a/grit-lib/src/merge_diff.rs
+++ b/grit-lib/src/merge_diff.rs
@@ -132,7 +132,7 @@ pub fn convert_blob_to_worktree_for_path(
     };
     let file_attrs = crate::crlf::get_file_attrs(&rules, path, &config);
     crate::crlf::convert_to_worktree(blob, path, &conv, &file_attrs, oid_hex, None)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+        .map_err(|e| std::io::Error::other(e))
 }
 
 /// Prepare blob bytes for diff: optional textconv when `use_textconv` and `diff=<driver>`.

--- a/grit-lib/src/odb.rs
+++ b/grit-lib/src/odb.rs
@@ -37,7 +37,7 @@ use crate::pack;
 /// (`t1006-cat-file` zlib-dictionary test).
 fn read_zlib_loose_payload(mut file: fs::File) -> Result<Vec<u8>> {
     let mut hdr = [0u8; 2];
-    file.read_exact(&mut hdr).map_err(|e| Error::Io(e.into()))?;
+    file.read_exact(&mut hdr).map_err(|e| Error::Io(e))?;
     let cmf_flg = u16::from(hdr[0]) << 8 | u16::from(hdr[1]);
     let looks_like_zlib_header = cmf_flg != 0 && cmf_flg % 31 == 0;
     let preset_dictionary = looks_like_zlib_header && (hdr[1] & 0x20) != 0;
@@ -176,7 +176,7 @@ impl Odb {
     /// - [`Error::CorruptObject`] — header is malformed.
     /// - [`Error::LooseHashMismatch`] — payload OID does not match `expected_oid`.
     pub fn read_loose_verify_oid(path: &Path, expected_oid: &ObjectId) -> Result<Object> {
-        let file = fs::File::open(path).map_err(|e| Error::Io(e))?;
+        let file = fs::File::open(path).map_err(Error::Io)?;
         let raw = read_zlib_loose_payload(file)?;
         let obj = parse_object_bytes(&raw)?;
         let computed = hash_object_from_parsed(&obj);
@@ -541,8 +541,6 @@ mod tests {
     #![allow(clippy::expect_used, clippy::unwrap_used)]
 
     use super::*;
-    use flate2::read::ZlibDecoder;
-    use std::io::Read;
     use tempfile::TempDir;
 
     #[test]

--- a/grit-lib/src/reftable.rs
+++ b/grit-lib/src/reftable.rs
@@ -1887,7 +1887,7 @@ mod tests {
             .add_ref(RefRecord {
                 name: "refs/heads/main".to_owned(),
                 update_index: 1,
-                value: RefValue::Val1(oid.clone()),
+                value: RefValue::Val1(oid),
             })
             .unwrap();
         let data = writer.finish().unwrap();
@@ -1911,21 +1911,21 @@ mod tests {
             .add_ref(RefRecord {
                 name: "refs/heads/a".to_owned(),
                 update_index: 1,
-                value: RefValue::Val1(oid1.clone()),
+                value: RefValue::Val1(oid1),
             })
             .unwrap();
         writer
             .add_ref(RefRecord {
                 name: "refs/heads/b".to_owned(),
                 update_index: 1,
-                value: RefValue::Val1(oid2.clone()),
+                value: RefValue::Val1(oid2),
             })
             .unwrap();
         writer
             .add_ref(RefRecord {
                 name: "refs/tags/v1.0".to_owned(),
                 update_index: 1,
-                value: RefValue::Val2(oid3.clone(), oid1.clone()),
+                value: RefValue::Val2(oid3, oid1),
             })
             .unwrap();
         let data = writer.finish().unwrap();
@@ -1972,8 +1972,8 @@ mod tests {
             .add_log(LogRecord {
                 refname: "refs/heads/main".to_owned(),
                 update_index: 1,
-                old_id: old_oid.clone(),
-                new_id: new_oid.clone(),
+                old_id: old_oid,
+                new_id: new_oid,
                 name: "Test User".to_owned(),
                 email: "test@example.com".to_owned(),
                 time_seconds: 1700000000,
@@ -2009,7 +2009,7 @@ mod tests {
             .add_ref(RefRecord {
                 name: "refs/heads/main".to_owned(),
                 update_index: 1,
-                value: RefValue::Val1(oid.clone()),
+                value: RefValue::Val1(oid),
             })
             .unwrap();
         let data = writer.finish().unwrap();

--- a/grit-lib/src/rerere.rs
+++ b/grit-lib/src/rerere.rs
@@ -236,9 +236,9 @@ fn handle_conflict(
             put_marker(&mut out, '>', marker_size);
             if let Some(h) = ctx {
                 h.update(one.as_bytes());
-                h.update(&[0]);
+                h.update([0]);
                 h.update(two.as_bytes());
-                h.update(&[0]);
+                h.update([0]);
             }
             return Ok(out);
         } else {
@@ -838,7 +838,7 @@ pub fn rerere_post_commit(repo: &Repository) -> Result<()> {
 /// `git rerere clear` — drop unresolved preimages tracked in `MERGE_RR`, remove `MERGE_RR`.
 pub fn rerere_clear(git_dir: &Path) -> Result<()> {
     let merge_rr = read_merge_rr(git_dir)?;
-    for (_path, ent) in &merge_rr {
+    for ent in merge_rr.values() {
         let Some(id) = &ent.id else {
             continue;
         };

--- a/grit-lib/src/simple_ipc.rs
+++ b/grit-lib/src/simple_ipc.rs
@@ -127,7 +127,7 @@ fn read_one_packet<R: Read>(r: &mut R, buf: &mut Vec<u8>) -> io::Result<Option<(
 fn read_packetized_to_end<R: Read>(r: &mut R) -> io::Result<Vec<u8>> {
     let mut out = Vec::new();
     loop {
-        if read_one_packet(r, &mut out)? == None {
+        if read_one_packet(r, &mut out)?.is_none() {
             break;
         }
     }

--- a/grit-lib/src/unpack_objects.rs
+++ b/grit-lib/src/unpack_objects.rs
@@ -517,7 +517,7 @@ mod tests {
             // Encode type+size header.
             let mut header = Vec::new();
             let mut size = data.len();
-            let first = ((type_code & 0x7) << 4) as u8 | (size & 0x0f) as u8;
+            let first = ((type_code & 0x7) << 4) | (size & 0x0f) as u8;
             size >>= 4;
             if size > 0 {
                 header.push(first | 0x80);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Confirmed `./scripts/run-tests.sh t6134-pathspec-in-submodule.sh` passes **3/3** (submodule pathspec fatal message and unpopulated `git -C sub add .` behavior).
- Removed unused imports in `grit-lib` `odb` unit tests so `cargo clippy -p grit-lib --tests` stays warning-free.
- Refreshed harness dashboards from the test run (`docs/index.html`, `docs/testfiles.html`).
- Follow-up: minor **clippy-driven cleanups** in several `grit-lib` modules (`FastExportOptions` derive merge, `io::Error::other`, test code clones, `rerere` loop, etc.).

## Validation

- `cargo build --release -p grit-rs`
- `./scripts/run-tests.sh t6134-pathspec-in-submodule.sh`
- `cargo fmt`, `cargo clippy -p grit-lib --tests --fix --allow-dirty`
- `cargo test -p grit-lib --lib`
- `cargo check -p grit-lib` (after clippy cleanups commit)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65426b0e-11b0-430a-b024-324949264d92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65426b0e-11b0-430a-b024-324949264d92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

