### PR TITLE
Record t3418-rebase-continue as fully passing (30/30)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -604,7 +604,7 @@ t3413-rebase-hook	t3	yes	15	12	3	false	ok	0
 t3415-rebase-autosquash	t3	yes	28	2	26	false	ok	0
 t3416-rebase-onto-threedots	t3	yes	18	12	6	false	ok	0
 t3417-rebase-whitespace-fix	t3	yes	4	0	4	false	ok	0
-t3418-rebase-continue	t3	yes	30	7	23	false	ok	0
+t3418-rebase-continue	t3	yes	30	30	0	true	ok	0
 t3419-rebase-patch-id	t3	yes	8	8	0	true	ok	0
 t3420-rebase-autostash	t3	yes	52	3	49	false	ok	0
 t3421-rebase-topology-linear	t3	yes	63	11	52	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,16 +141,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T03:46:24+00:00" class="gen-time" title="2026-04-09 03:46 UTC">2026-04-09 03:46 UTC</time> · <a href="https://github.com/schacon/grit/commit/138e296430d8ce477b1c3b702c9e03b3ba87035a" style="color:#58a6ff">138e296</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T03:49:15+00:00" class="gen-time" title="2026-04-09 03:49 UTC">2026-04-09 03:49 UTC</time> · <a href="https://github.com/schacon/grit/commit/737de55ea17fe8f489829a57f95fb3d5fb0ff345" style="color:#58a6ff">737de55</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">75.0%</div>
+      <div class="summary-big-val pct-blue">75.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,908</div>
+      <div class="summary-big-val">29,931</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -159,12 +159,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:75.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:75.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>744 files fully passing</span>
+    <span>745 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,11 +212,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">45/141 files · 2 skipped · 3,355/4,619 tests</span>
+        <span class="group-meta">46/141 files · 2 skipped · 3,378/4,619 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.6%"></div></div>
-        <span class="group-pct pct-blue">72.6%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:73.1%"></div></div>
+        <span class="group-pct pct-blue">73.1%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T03:46:24+00:00" class="gen-time" title="2026-04-09 03:46 UTC">2026-04-09 03:46 UTC</time> · <a href="https://github.com/schacon/grit/commit/138e296430d8ce477b1c3b702c9e03b3ba87035a" style="color:#58a6ff">138e296</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T03:49:15+00:00" class="gen-time" title="2026-04-09 03:49 UTC">2026-04-09 03:49 UTC</time> · <a href="https://github.com/schacon/grit/commit/737de55ea17fe8f489829a57f95fb3d5fb0ff345" style="color:#58a6ff">737de55</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,908</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">75.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,931</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">75.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -6197,14 +6197,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="30" data-passed="7">
+<tr class="" data-group="t3" data-tests="30" data-passed="30" data-full-pass="1">
   <td class="mono">t3418-rebase-continue</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">30</td>
-  <td class="right">7</td>
+  <td class="right">30</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:23.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="8" data-passed="8" data-full-pass="1">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`./scripts/run-tests.sh t3418-rebase-continue.sh` reports **30/30** passing. This updates `data/test-files.csv` and regenerated dashboards (`docs/index.html`, `docs/testfiles.html`) to mark the file as fully passing.

## Verification

```bash
cargo build --release -p grit-rs
./scripts/run-tests.sh t3418-rebase-continue.sh
```

## Notes

No Rust changes were required for this run; Grit already satisfies the test file. The commit only refreshes harness metrics.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb491993-626d-4c98-a69f-e84916d235da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb491993-626d-4c98-a69f-e84916d235da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

