### PR TITLE
fix: stream unpack-objects for large pack clones (t5608)

### DIFF
--- a/grit-lib/src/unpack_objects.rs
+++ b/grit-lib/src/unpack_objects.rs
@@ -4,9 +4,14 @@
 //! writes each object as a loose file in the object database.  Delta objects
 //! (both `OFS_DELTA` and `REF_DELTA`) are resolved against already-unpacked
 //! objects or objects already present in the ODB.
+//!
+//! Large blobs are written to the ODB and dropped from the in-memory maps so
+//! cloning multi-gigabyte repositories does not require holding the full pack
+//! in RAM (streaming read + bounded retention).
 
+use std::borrow::Cow;
 use std::collections::HashMap;
-use std::io::Read;
+use std::io::{self, Read};
 
 use flate2::read::ZlibDecoder;
 use sha1::{Digest, Sha1};
@@ -54,13 +59,15 @@ struct PendingDelta {
 /// - [`Error::Io`] — I/O failure reading from `reader`.
 /// - [`Error::Zlib`] — decompression failure.
 pub fn unpack_objects(reader: &mut dyn Read, odb: &Odb, opts: &UnpackOptions) -> Result<usize> {
-    let mut raw = Vec::new();
-    reader.read_to_end(&mut raw).map_err(Error::Io)?;
+    /// Blobs larger than this stay on disk only (after write) so huge packs do
+    /// not retain every blob in RAM. Smaller objects are kept for delta bases
+    /// and `--strict` graph walks without extra ODB reads.
+    const MAX_RETAIN_BYTES: usize = 1024 * 1024;
 
-    let mut rd = PackReader::new(raw);
+    let mut rd = StreamingPackReader::new(reader);
 
     // Validate magic and version.
-    let sig = rd.read_exact(4)?;
+    let sig = rd.read_exact_n(4)?;
     if sig != b"PACK" {
         return Err(Error::CorruptObject(
             "not a pack stream: invalid signature".to_owned(),
@@ -74,18 +81,16 @@ pub fn unpack_objects(reader: &mut dyn Read, odb: &Odb, opts: &UnpackOptions) ->
     }
     let nr_objects = rd.read_u32_be()? as usize;
 
-    // Maps used for delta resolution.
-    // pack-stream offset → (kind, decompressed-data) for objects resolved in
-    // this pass (needed to service OFS_DELTA back-references).
-    let mut by_offset: HashMap<usize, (ObjectKind, Vec<u8>)> = HashMap::new();
-    // ObjectId → (kind, data) for in-pack objects (REF_DELTA resolution).
-    let mut by_oid: HashMap<ObjectId, (ObjectKind, Vec<u8>)> = HashMap::new();
+    // pack-stream offset → resolved object (see [`PackedObjectEntry`]).
+    let mut by_offset: HashMap<usize, PackedObjectEntry> = HashMap::new();
+    // ObjectId → in-pack object for REF_DELTA resolution and strict checks.
+    let mut by_oid: HashMap<ObjectId, PackedObjectEntry> = HashMap::new();
 
     let mut pending: Vec<PendingDelta> = Vec::new();
     let mut count = 0usize;
 
     for _ in 0..nr_objects {
-        let obj_offset = rd.pos;
+        let obj_offset = rd.stream_pos();
         let (type_code, size) = rd.read_type_size()?;
 
         match type_code {
@@ -93,8 +98,9 @@ pub fn unpack_objects(reader: &mut dyn Read, odb: &Odb, opts: &UnpackOptions) ->
                 let kind = type_code_to_kind(type_code)?;
                 let data = rd.decompress(size)?;
                 let oid = write_or_hash(kind, &data, odb, opts.dry_run)?;
-                by_offset.insert(obj_offset, (kind, data.clone()));
-                by_oid.insert(oid, (kind, data));
+                let entry = packed_entry_after_write(kind, data, oid, odb, opts, MAX_RETAIN_BYTES);
+                by_offset.insert(obj_offset, entry.clone());
+                by_oid.insert(oid, entry);
                 count += 1;
             }
             6 => {
@@ -113,8 +119,8 @@ pub fn unpack_objects(reader: &mut dyn Read, odb: &Odb, opts: &UnpackOptions) ->
             }
             7 => {
                 // REF_DELTA: base identified by its SHA-1.
-                let base_bytes = rd.read_exact(20)?;
-                let base_oid = ObjectId::from_bytes(base_bytes)?;
+                let base_bytes = rd.read_exact_n(20)?;
+                let base_oid = ObjectId::from_bytes(&base_bytes)?;
                 let delta_data = rd.decompress(size)?;
                 pending.push(PendingDelta {
                     offset: obj_offset,
@@ -131,18 +137,13 @@ pub fn unpack_objects(reader: &mut dyn Read, odb: &Odb, opts: &UnpackOptions) ->
         }
     }
 
-    // Verify the pack trailing checksum: SHA-1 over all bytes consumed so far.
-    let consumed = rd.pos;
-    {
-        let mut hasher = Sha1::new();
-        hasher.update(&rd.data[..consumed]);
-        let digest = hasher.finalize();
-        let trailing = rd.read_exact(20)?;
-        if digest.as_slice() != trailing {
-            return Err(Error::CorruptObject(
-                "pack trailing checksum mismatch".to_owned(),
-            ));
-        }
+    // Trailing pack checksum (SHA-1 of all preceding bytes); not included in the hash.
+    let digest = rd.finalize_hasher();
+    let trailing = rd.read_trailer_20()?;
+    if digest.as_slice() != trailing {
+        return Err(Error::CorruptObject(
+            "pack trailing checksum mismatch".to_owned(),
+        ));
     }
 
     // Resolve pending deltas iteratively.  Each pass resolves all deltas whose
@@ -156,28 +157,43 @@ pub fn unpack_objects(reader: &mut dyn Read, odb: &Odb, opts: &UnpackOptions) ->
         let mut still_pending: Vec<PendingDelta> = Vec::new();
 
         for delta in remaining {
-            let base = if let Some(base_off) = delta.base_offset {
-                by_offset.get(&base_off).cloned()
-            } else if let Some(ref base_id) = delta.base_oid {
-                if let Some(entry) = by_oid.get(base_id) {
-                    Some(entry.clone())
-                } else if !opts.dry_run {
-                    odb.read(base_id).ok().map(|obj| (obj.kind, obj.data))
+            let base_res: Option<Result<(ObjectKind, Cow<'_, [u8]>)>> =
+                if let Some(base_off) = delta.base_offset {
+                    by_offset
+                        .get(&base_off)
+                        .map(|e| entry_object_bytes(e, odb).map(|d| (e.kind(), d)))
+                } else if let Some(ref base_id) = delta.base_oid {
+                    if let Some(e) = by_oid.get(base_id) {
+                        Some(entry_object_bytes(e, odb).map(|d| (e.kind(), d)))
+                    } else if !opts.dry_run {
+                        odb.read(base_id)
+                            .ok()
+                            .map(|obj| Ok((obj.kind, Cow::Owned(obj.data))))
+                    } else {
+                        None
+                    }
                 } else {
                     None
-                }
-            } else {
-                None
-            };
+                };
 
-            if let Some((base_kind, base_data)) = base {
-                let result = apply_delta(&base_data, &delta.delta_data)?;
-                let oid = write_or_hash(base_kind, &result, odb, opts.dry_run)?;
-                by_offset.insert(delta.offset, (base_kind, result.clone()));
-                by_oid.insert(oid, (base_kind, result));
-                count += 1;
-            } else {
-                still_pending.push(delta);
+            match base_res {
+                Some(Ok((base_kind, base_data))) => {
+                    let result = apply_delta(base_data.as_ref(), &delta.delta_data)?;
+                    let oid = write_or_hash(base_kind, &result, odb, opts.dry_run)?;
+                    let new_entry = packed_entry_after_write(
+                        base_kind,
+                        result,
+                        oid,
+                        odb,
+                        opts,
+                        MAX_RETAIN_BYTES,
+                    );
+                    by_offset.insert(delta.offset, new_entry.clone());
+                    by_oid.insert(oid, new_entry);
+                    count += 1;
+                }
+                Some(Err(e)) => return Err(e),
+                None => still_pending.push(delta),
             }
         }
 
@@ -191,10 +207,107 @@ pub fn unpack_objects(reader: &mut dyn Read, odb: &Odb, opts: &UnpackOptions) ->
     }
 
     if opts.strict {
-        strict_verify_packed_references(Some(odb), &by_oid)?;
+        strict_verify_packed_references_map(Some(odb), &by_oid)?;
     }
 
     Ok(count)
+}
+
+/// Resolved non-delta object: either full bytes in memory or a large blob on disk.
+#[derive(Debug, Clone)]
+enum PackedObjectEntry {
+    InMemory { kind: ObjectKind, data: Vec<u8> },
+    BlobOnDisk { oid: ObjectId },
+}
+
+impl PackedObjectEntry {
+    fn kind(&self) -> ObjectKind {
+        match self {
+            PackedObjectEntry::InMemory { kind, .. } => *kind,
+            PackedObjectEntry::BlobOnDisk { .. } => ObjectKind::Blob,
+        }
+    }
+}
+
+fn packed_entry_after_write(
+    kind: ObjectKind,
+    data: Vec<u8>,
+    oid: ObjectId,
+    _odb: &Odb,
+    opts: &UnpackOptions,
+    max_retain: usize,
+) -> PackedObjectEntry {
+    if !opts.dry_run && kind == ObjectKind::Blob && data.len() > max_retain {
+        PackedObjectEntry::BlobOnDisk { oid }
+    } else {
+        PackedObjectEntry::InMemory { kind, data }
+    }
+}
+
+fn entry_object_bytes<'a>(entry: &'a PackedObjectEntry, odb: &Odb) -> Result<Cow<'a, [u8]>> {
+    match entry {
+        PackedObjectEntry::InMemory { data, .. } => Ok(Cow::Borrowed(data.as_slice())),
+        PackedObjectEntry::BlobOnDisk { oid } => Ok(Cow::Owned(odb.read(oid)?.data)),
+    }
+}
+
+fn strict_verify_packed_references_map(
+    odb: Option<&Odb>,
+    pack: &HashMap<ObjectId, PackedObjectEntry>,
+) -> Result<()> {
+    for entry in pack.values() {
+        match entry {
+            PackedObjectEntry::BlobOnDisk { .. } => {}
+            PackedObjectEntry::InMemory { kind, data } => match kind {
+                ObjectKind::Tree => {
+                    for e in parse_tree(data)? {
+                        if !strict_ref_resolves_map(&e.oid, pack, odb) {
+                            return Err(Error::CorruptObject(format!(
+                                "strict: missing object {} referenced by tree",
+                                e.oid.to_hex()
+                            )));
+                        }
+                    }
+                }
+                ObjectKind::Commit => {
+                    let c = parse_commit(data)?;
+                    if !strict_ref_resolves_map(&c.tree, pack, odb) {
+                        return Err(Error::CorruptObject(format!(
+                            "strict: missing tree {} referenced by commit",
+                            c.tree.to_hex()
+                        )));
+                    }
+                    for p in &c.parents {
+                        if !strict_ref_resolves_map(p, pack, odb) {
+                            return Err(Error::CorruptObject(format!(
+                                "strict: missing parent {} referenced by commit",
+                                p.to_hex()
+                            )));
+                        }
+                    }
+                }
+                ObjectKind::Tag => {
+                    let t = parse_tag(data)?;
+                    if !strict_ref_resolves_map(&t.object, pack, odb) {
+                        return Err(Error::CorruptObject(format!(
+                            "strict: missing object {} referenced by tag",
+                            t.object.to_hex()
+                        )));
+                    }
+                }
+                ObjectKind::Blob => {}
+            },
+        }
+    }
+    Ok(())
+}
+
+fn strict_ref_resolves_map(
+    oid: &ObjectId,
+    pack: &HashMap<ObjectId, PackedObjectEntry>,
+    odb: Option<&Odb>,
+) -> bool {
+    pack.contains_key(oid) || odb.is_some_and(|o| o.exists(oid))
 }
 
 fn strict_ref_resolves(
@@ -281,55 +394,105 @@ fn type_code_to_kind(code: u8) -> Result<ObjectKind> {
     }
 }
 
-/// Low-level cursor over a buffered pack byte stream.
-struct PackReader {
-    data: Vec<u8>,
-    pos: usize,
+fn io_to_corrupt_eof(e: io::Error, stream_pos: usize, context: &str) -> Error {
+    if e.kind() == io::ErrorKind::UnexpectedEof {
+        Error::CorruptObject(format!(
+            "pack stream truncated ({context}) at offset {stream_pos}"
+        ))
+    } else {
+        Error::Io(e)
+    }
 }
 
-impl PackReader {
-    fn new(data: Vec<u8>) -> Self {
-        Self { data, pos: 0 }
+/// Streaming cursor over a pack file: hashes body bytes incrementally (no full-buffer read).
+///
+/// Raw pack bytes are either consumed as object headers (via [`Self::read_byte`]) or as zlib
+/// payloads.  Zlib decoders may read ahead; overflow bytes stay in [`Self::pending`] so the next
+/// object header or zlib stream starts at the correct offset.
+struct StreamingPackReader<'a> {
+    inner: &'a mut dyn Read,
+    pack_hasher: Sha1,
+    stream_pos: usize,
+    /// Compressed (or other) bytes already read from `inner` and hashed but not yet consumed by
+    /// the current parsing step.
+    pending: Vec<u8>,
+}
+
+impl<'a> StreamingPackReader<'a> {
+    fn new(inner: &'a mut dyn Read) -> Self {
+        Self {
+            inner,
+            pack_hasher: Sha1::new(),
+            stream_pos: 0,
+            pending: Vec::new(),
+        }
     }
 
-    /// Read exactly `n` bytes and advance the cursor, returning a slice into
-    /// the internal buffer.
-    fn read_exact(&mut self, n: usize) -> Result<&[u8]> {
-        if self.pos + n > self.data.len() {
+    fn stream_pos(&self) -> usize {
+        self.stream_pos
+    }
+
+    /// Read pack-body bytes (hashed). Used for headers and non-zlib payload reads only.
+    fn read_from_source(&mut self, buf: &mut [u8]) -> Result<usize> {
+        let n = if !self.pending.is_empty() {
+            let take = buf.len().min(self.pending.len());
+            buf[..take].copy_from_slice(&self.pending[..take]);
+            self.pending.drain(..take);
+            take
+        } else {
+            self.inner.read(buf).map_err(Error::Io)?
+        };
+        if n > 0 {
+            self.pack_hasher.update(&buf[..n]);
+            self.stream_pos += n;
+        }
+        Ok(n)
+    }
+
+    fn read_byte(&mut self) -> Result<u8> {
+        let mut b = [0u8; 1];
+        let n = self.read_from_source(&mut b)?;
+        if n == 0 {
             return Err(Error::CorruptObject(format!(
-                "pack stream truncated: need {n} bytes at offset {}",
-                self.pos
+                "pack stream truncated (read byte) at offset {}",
+                self.stream_pos
             )));
         }
-        let slice = &self.data[self.pos..self.pos + n];
-        self.pos += n;
-        Ok(slice)
+        Ok(b[0])
     }
 
-    /// Read a single byte and advance the cursor.
-    fn read_byte(&mut self) -> Result<u8> {
-        if self.pos >= self.data.len() {
-            return Err(Error::CorruptObject(
-                "unexpected end of pack stream".to_owned(),
-            ));
+    fn read_exact_n(&mut self, n: usize) -> Result<Vec<u8>> {
+        let mut v = vec![0u8; n];
+        let mut got = 0usize;
+        while got < n {
+            let m = self.read_from_source(&mut v[got..n])?;
+            if m == 0 {
+                return Err(Error::CorruptObject(format!(
+                    "pack stream truncated (read exact) at offset {}",
+                    self.stream_pos
+                )));
+            }
+            got += m;
         }
-        let b = self.data[self.pos];
-        self.pos += 1;
-        Ok(b)
+        Ok(v)
     }
 
-    /// Read a big-endian `u32`.
     fn read_u32_be(&mut self) -> Result<u32> {
-        let bytes = self.read_exact(4)?;
-        Ok(u32::from_be_bytes(bytes.try_into().map_err(|_| {
-            Error::CorruptObject("u32 read failed".to_owned())
-        })?))
+        let mut b = [0u8; 4];
+        let mut got = 0usize;
+        while got < 4 {
+            let m = self.read_from_source(&mut b[got..4])?;
+            if m == 0 {
+                return Err(Error::CorruptObject(format!(
+                    "pack stream truncated (read u32) at offset {}",
+                    self.stream_pos
+                )));
+            }
+            got += m;
+        }
+        Ok(u32::from_be_bytes(b))
     }
 
-    /// Read the packed-object type + size header (variable-length big-endian
-    /// encoding with the type in bits 4-6 of the first byte).
-    ///
-    /// Returns `(type_code, uncompressed_size)`.
     fn read_type_size(&mut self) -> Result<(u8, usize)> {
         let c = self.read_byte()?;
         let type_code = (c >> 4) & 0x7;
@@ -344,10 +507,6 @@ impl PackReader {
         Ok((type_code, size))
     }
 
-    /// Read an `OFS_DELTA` negative-offset value.
-    ///
-    /// The encoding uses a big-endian variable-length integer with a +1 bias
-    /// on each continuation byte, yielding values ≥ 1.
     fn read_ofs_neg_offset(&mut self) -> Result<usize> {
         let mut c = self.read_byte()?;
         let mut value = (c & 0x7f) as usize;
@@ -358,26 +517,72 @@ impl PackReader {
         Ok(value)
     }
 
-    /// Decompress zlib-compressed data starting at the current cursor position.
+    /// Pull zlib-compressed bytes until one object inflates to `expected_size` bytes.
     ///
-    /// Advances the cursor by exactly the number of compressed bytes consumed.
-    /// Returns an error if the decompressed length differs from `expected_size`.
+    /// Bytes read from `inner` into `pending` are not hashed until we know how many belong to the
+    /// zlib stream (`total_in()`). Lookahead past the zlib end (including the 20-byte pack
+    /// trailer) must never be fed to the pack checksum.
     fn decompress(&mut self, expected_size: usize) -> Result<Vec<u8>> {
-        let slice = &self.data[self.pos..];
-        let mut decoder = ZlibDecoder::new(slice);
-        let mut out = Vec::with_capacity(expected_size);
-        decoder
-            .read_to_end(&mut out)
-            .map_err(|e| Error::Zlib(e.to_string()))?;
-        if out.len() != expected_size {
-            return Err(Error::CorruptObject(format!(
-                "decompressed {} bytes but expected {}",
-                out.len(),
-                expected_size
-            )));
+        const CHUNK: usize = 64 * 1024;
+        let mut scratch = [0u8; CHUNK];
+        let mut out = vec![0u8; expected_size];
+        loop {
+            let mut cursor = std::io::Cursor::new(self.pending.as_slice());
+            let mut z = ZlibDecoder::new(&mut cursor);
+            match z.read_exact(&mut out) {
+                Ok(()) => {
+                    let consumed = z.total_in() as usize;
+                    if consumed > self.pending.len() {
+                        return Err(Error::CorruptObject(
+                            "zlib total_in exceeds pending buffer".to_owned(),
+                        ));
+                    }
+                    self.pack_hasher.update(&self.pending[..consumed]);
+                    self.stream_pos += consumed;
+                    self.pending.drain(..consumed);
+                    return Ok(out);
+                }
+                Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => {
+                    let n = self.inner.read(&mut scratch).map_err(Error::Io)?;
+                    if n == 0 {
+                        return Err(Error::CorruptObject(format!(
+                            "pack stream truncated (zlib) at offset {}",
+                            self.stream_pos
+                        )));
+                    }
+                    self.pending.extend_from_slice(&scratch[..n]);
+                }
+                Err(e) => return Err(Error::Zlib(e.to_string())),
+            }
         }
-        self.pos += decoder.total_in() as usize;
-        Ok(out)
+    }
+
+    /// SHA-1 over all pack bytes read so far (objects only; trailer not yet read).
+    fn finalize_hasher(
+        &self,
+    ) -> sha1::digest::generic_array::GenericArray<u8, sha1::digest::consts::U20> {
+        self.pack_hasher.clone().finalize()
+    }
+
+    /// Trailing pack checksum; not included in [`Self::finalize_hasher`].
+    fn read_trailer_20(&mut self) -> Result<[u8; 20]> {
+        let mut b = [0u8; 20];
+        if self.pending.len() >= 20 {
+            b.copy_from_slice(&self.pending[..20]);
+            self.pending.drain(..20);
+            self.stream_pos += 20;
+            return Ok(b);
+        }
+        let tail = self.pending.len();
+        if tail > 0 {
+            b[..tail].copy_from_slice(&self.pending[..]);
+            self.pending.clear();
+        }
+        self.inner
+            .read_exact(&mut b[tail..])
+            .map_err(|e| io_to_corrupt_eof(e, self.stream_pos, "trailer"))?;
+        self.stream_pos += 20;
+        Ok(b)
     }
 }
 

--- a/logs/2026-04-09-t5608-clone-2gb-unpack-streaming.md
+++ b/logs/2026-04-09-t5608-clone-2gb-unpack-streaming.md
@@ -1,0 +1,22 @@
+# t5608-clone-2gb — streaming unpack-objects
+
+## Problem
+
+`file://` clones use upload-pack and `unpack_objects`, which previously called
+`read_to_end` on the entire pack into a `Vec` and kept every resolved object in
+`HashMap` values. A >2GB pack could exhaust memory (OOM) during t5608.
+
+## Change
+
+- `grit-lib/src/unpack_objects.rs`: stream-parse the pack with incremental SHA-1
+  (only zlib-compressed bytes counted via `total_in()`, lookahead/trailer not
+  hashed incorrectly).
+- After writing blobs larger than 1 MiB, drop body from in-memory maps
+  (`BlobOnDisk`); delta bases still load from ODB when needed.
+- `--strict` verification skips blob bodies (unchanged semantics for refs).
+
+## Validation
+
+- `cargo test -p grit-lib --lib` (all pass).
+- Harness `t5608-clone-2gb.sh` with `GIT_TEST_CLONE_2GB=false` skips (0 tests);
+  full run requires `GIT_TEST_CLONE_2GB=true` and large disk/RAM.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t5608-clone-2gb` builds a repo over 2GB and clones via `file://` (protocol v1 upload-pack). Our client buffered the entire received pack with `read_to_end` and kept every unpacked object in memory, which could OOM before the test finished.

## Changes

- **`grit-lib/src/unpack_objects.rs`**: Stream-parse the pack while incrementally updating the pack SHA-1. Only bytes consumed by zlib (`total_in`) are hashed; read-ahead past zlib streams (including overlap with the 20-byte trailer) is handled without corrupting the checksum.
- After writing **blobs larger than 1 MiB**, drop the body from in-memory resolution maps (`BlobOnDisk`); delta bases are re-read from the ODB when needed. Small objects stay in memory for cheap `OFS_DELTA` / `REF_DELTA` resolution.

## Testing

- `cargo test -p grit-lib --lib` — all pass.
- Full `t5608-clone-2gb` requires `GIT_TEST_CLONE_2GB=true` and substantial disk/time; not run in CI here.

## Log

See `logs/2026-04-09-t5608-clone-2gb-unpack-streaming.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52299a3e-c167-4711-93a3-791f2d657eca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52299a3e-c167-4711-93a3-791f2d657eca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

