### PR TITLE
t11560: cherry-pick signoff/edit suite verified; track completion

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T03:46:24+00:00" class="gen-time" title="2026-04-09 03:46 UTC">2026-04-09 03:46 UTC</time> · <a href="https://github.com/schacon/grit/commit/138e296430d8ce477b1c3b702c9e03b3ba87035a" style="color:#58a6ff">138e296</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T03:48:34+00:00" class="gen-time" title="2026-04-09 03:48 UTC">2026-04-09 03:48 UTC</time> · <a href="https://github.com/schacon/grit/commit/737de55ea17fe8f489829a57f95fb3d5fb0ff345" style="color:#58a6ff">737de55</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,7 +100,7 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T03:46:24+00:00" class="gen-time" title="2026-04-09 03:46 UTC">2026-04-09 03:46 UTC</time> · <a href="https://github.com/schacon/grit/commit/138e296430d8ce477b1c3b702c9e03b3ba87035a" style="color:#58a6ff">138e296</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T03:48:34+00:00" class="gen-time" title="2026-04-09 03:48 UTC">2026-04-09 03:48 UTC</time> · <a href="https://github.com/schacon/grit/commit/737de55ea17fe8f489829a57f95fb3d5fb0ff345" style="color:#58a6ff">737de55</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>

--- a/logs/2026-04-09_t11560-cherry-pick-signoff-edit.md
+++ b/logs/2026-04-09_t11560-cherry-pick-signoff-edit.md
@@ -1,0 +1,15 @@
+# t11560-cherry-pick-signoff-edit
+
+**Date:** 2026-04-09
+
+## Outcome
+
+`./scripts/run-tests.sh t11560-cherry-pick-signoff-edit.sh` reports **32/32** passing on branch `cursor/t11560-cherry-pick-signoff-cf63` (no Rust changes required in this session; behavior already matches the suite).
+
+## Coverage
+
+The file exercises `grit cherry-pick` with `--signoff`/`-s`, `-n`/`--no-commit`, `-x`, message preservation, author/committer identity for signoff, abbreviated OIDs, sequential picks, and tree parity vs `git cherry-pick`.
+
+## Follow-up
+
+None for this file.

--- a/progress.md
+++ b/progress.md
@@ -15,6 +15,7 @@ Task lines in `PLAN.md`: 253 completed (`[x]`), 4 in progress (`[~]`), 511 remai
 
 ## Recently completed
 
+- `t11560-cherry-pick-signoff-edit` — 32/32 tests pass (`cherry-pick` with `--signoff`/`-s`, `-n`/`--no-commit`, `-x`, message/body preservation, signoff identity from config, sequential picks; verified clean harness run; `t1-plan.md` marked done)
 - `t4214-log-graph-octopus` — 17/17 tests pass (`git log --graph` skewed-left octopus, crossover, and colored graph lines; harness CSV/dashboards refreshed)
 - `t3060-ls-files-with-tree` — 8/8 tests pass (`ls-files --with-tree`: `Index::overlay_tree_on_index`, `-s/-u`/`--recurse-submodules` incompatibilities with `fatal:` + exit 128, cwd pathspec `sub/` matches `sub/file`; harness CSV refreshed)
 - `t12660-init-shared-perm` — 37/37 tests pass (default `grit init` applies Git-style group-shared chmod on `.git` tree: 775 dirs / 664 HEAD under umask 022; explicit `--shared` / `core.sharedRepository` writes config + `receive.denyNonFastforwards`; reinit without shared config leaves modes unchanged)

--- a/t1-plan.md
+++ b/t1-plan.md
@@ -78,7 +78,7 @@
 - [ ] t11520-mv-directory-structure.sh
 - [ ] t11530-switch-orphan-track.sh
 - [ ] t11540-restore-staged-worktree.sh
-- [ ] t11560-cherry-pick-signoff-edit.sh
+- [x] t11560-cherry-pick-signoff-edit.sh
 - [ ] t11580-show-ref-heads-tags.sh
 - [ ] t11590-update-ref-reflog.sh
 - [ ] t11600-symbolic-ref-bare-worktree.sh


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`tests/t11560-cherry-pick-signoff-edit.sh` already passes in full (**32/32**) against current `grit cherry-pick` (`--signoff`/`-s`, `-n`/`--no-commit`, `-x`, message handling, etc.). This branch records that verification and updates planning artifacts.

## Changes

- Mark `t11560-cherry-pick-signoff-edit.sh` complete in `t1-plan.md`
- Add session log under `logs/`
- Note in `progress.md` under recently completed
- Refresh harness-generated dashboard timestamps in `docs/index.html` / `docs/testfiles.html` from the confirming `./scripts/run-tests.sh` run

## Verification

```bash
./scripts/run-tests.sh t11560-cherry-pick-signoff-edit.sh
# ✓ 32/32
```

No Rust code changes were required for this test file on the current tree.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1b8ee3a-dd13-49c1-b167-2bf30a02fbe5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1b8ee3a-dd13-49c1-b167-2bf30a02fbe5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

