### PR TITLE
test: t5537-fetch-shallow fully passing (harness refresh)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -954,7 +954,7 @@ t5533-push-cas	t5	yes	23	11	12	false	ok	0
 t5534-push-signed	t5	skip	13	0	0	false	ok	0
 t5535-fetch-push-symref	t5	yes	3	3	0	true	ok	0
 t5536-fetch-conflicts	t5	yes	7	7	0	true	ok	0
-t5537-fetch-shallow	t5	yes	16	3	13	false	ok	0
+t5537-fetch-shallow	t5	yes	16	16	0	true	ok	0
 t5538-push-shallow	t5	yes	8	2	6	false	ok	0
 t5539-fetch-http-shallow	t5	yes	8	1	7	false	ok	0
 t5540-fetch-push-edge-cases	t5	yes	12	11	1	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T03:46:24+00:00" class="gen-time" title="2026-04-09 03:46 UTC">2026-04-09 03:46 UTC</time> · <a href="https://github.com/schacon/grit/commit/138e296430d8ce477b1c3b702c9e03b3ba87035a" style="color:#58a6ff">138e296</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T03:49:33+00:00" class="gen-time" title="2026-04-09 03:49 UTC">2026-04-09 03:49 UTC</time> · <a href="https://github.com/schacon/grit/commit/737de55ea17fe8f489829a57f95fb3d5fb0ff345" style="color:#58a6ff">737de55</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,908</div>
+      <div class="summary-big-val">29,921</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>744 files fully passing</span>
+    <span>745 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">34/167 files · 17 skipped · 1,378/3,949 tests</span>
+        <span class="group-meta">35/167 files · 17 skipped · 1,391/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.9%"></div></div>
-        <span class="group-pct pct-red">34.9%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:35.2%"></div></div>
+        <span class="group-pct pct-red">35.2%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T03:46:24+00:00" class="gen-time" title="2026-04-09 03:46 UTC">2026-04-09 03:46 UTC</time> · <a href="https://github.com/schacon/grit/commit/138e296430d8ce477b1c3b702c9e03b3ba87035a" style="color:#58a6ff">138e296</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T03:49:33+00:00" class="gen-time" title="2026-04-09 03:49 UTC">2026-04-09 03:49 UTC</time> · <a href="https://github.com/schacon/grit/commit/737de55ea17fe8f489829a57f95fb3d5fb0ff345" style="color:#58a6ff">737de55</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,908</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,921</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">75.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -9697,14 +9697,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="16" data-passed="3">
+<tr class="" data-group="t5" data-tests="16" data-passed="16" data-full-pass="1">
   <td class="mono">t5537-fetch-shallow</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">16</td>
-  <td class="right">3</td>
+  <td class="right">16</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:18.8%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="8" data-passed="2">

--- a/logs/2026-04-09-t5537-fetch-shallow.md
+++ b/logs/2026-04-09-t5537-fetch-shallow.md
@@ -1,0 +1,5 @@
+# t5537-fetch-shallow
+
+- Ran `./scripts/run-tests.sh t5537-fetch-shallow.sh` after `cargo build --release -p grit-rs`.
+- Result: 16/16 pass with current `grit`; no Rust changes required.
+- Updated `data/test-files.csv` and generated dashboards to reflect full pass.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Verified `tests/t5537-fetch-shallow.sh` against current `grit`: **16/16 tests pass**. No Rust changes were required.

## Changes

- Refreshed `data/test-files.csv` row for `t5537-fetch-shallow` (was 3/16 in CSV; actual run is full pass).
- Regenerated `docs/index.html` and `docs/testfiles.html` via the harness.
- Added `logs/2026-04-09-t5537-fetch-shallow.md` with run notes.

## Validation

```bash
cargo build --release -p grit-rs
./scripts/run-tests.sh t5537-fetch-shallow.sh
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c32897c-c411-4b58-b50b-435838578658"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c32897c-c411-4b58-b50b-435838578658"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

