### PR TITLE
chore: t12000 rev-list topo-order verified passing

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T03:46:24+00:00" class="gen-time" title="2026-04-09 03:46 UTC">2026-04-09 03:46 UTC</time> · <a href="https://github.com/schacon/grit/commit/138e296430d8ce477b1c3b702c9e03b3ba87035a" style="color:#58a6ff">138e296</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T03:48:21+00:00" class="gen-time" title="2026-04-09 03:48 UTC">2026-04-09 03:48 UTC</time> · <a href="https://github.com/schacon/grit/commit/737de55ea17fe8f489829a57f95fb3d5fb0ff345" style="color:#58a6ff">737de55</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,7 +100,7 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T03:46:24+00:00" class="gen-time" title="2026-04-09 03:46 UTC">2026-04-09 03:46 UTC</time> · <a href="https://github.com/schacon/grit/commit/138e296430d8ce477b1c3b702c9e03b3ba87035a" style="color:#58a6ff">138e296</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T03:48:21+00:00" class="gen-time" title="2026-04-09 03:48 UTC">2026-04-09 03:48 UTC</time> · <a href="https://github.com/schacon/grit/commit/737de55ea17fe8f489829a57f95fb3d5fb0ff345" style="color:#58a6ff">737de55</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>

--- a/logs/2026-04-09_t12000-rev-list-topo-order.md
+++ b/logs/2026-04-09_t12000-rev-list-topo-order.md
@@ -1,0 +1,15 @@
+# t12000-rev-list-topo-order
+
+**Date:** 2026-04-09
+
+## Goal
+
+Ensure `tests/t12000-rev-list-topo-order.sh` passes (34 tests): `rev-list` with `--topo-order`, `--reverse`, `--count`, `--max-count`, `--skip`, ranges, `--all`, `--first-parent`, `--date-order`, branch tips.
+
+## Result
+
+`./scripts/run-tests.sh t12000-rev-list-topo-order.sh` → **34/34** on branch `cursor/t12000-rev-list-topo-order-7ab3` at `737de55e`. No Rust changes required; behavior already matches Git for this subset.
+
+## Follow-up
+
+Upstream-scale `t6003-rev-list-topo-order` in `PLAN.md` remains partially passing (separate, larger test file).

--- a/progress.md
+++ b/progress.md
@@ -15,6 +15,7 @@ Task lines in `PLAN.md`: 253 completed (`[x]`), 4 in progress (`[~]`), 511 remai
 
 ## Recently completed
 
+- `t12000-rev-list-topo-order` — 34/34 tests pass (`grit rev-list`: `--topo-order`, `--reverse`, `--count`, `--max-count`, `--skip`, `..` / `^` ranges, `--all`, `--first-parent`, `--date-order`, branch tips; verified clean harness run; no code changes)
 - `t4214-log-graph-octopus` — 17/17 tests pass (`git log --graph` skewed-left octopus, crossover, and colored graph lines; harness CSV/dashboards refreshed)
 - `t3060-ls-files-with-tree` — 8/8 tests pass (`ls-files --with-tree`: `Index::overlay_tree_on_index`, `-s/-u`/`--recurse-submodules` incompatibilities with `fatal:` + exit 128, cwd pathspec `sub/` matches `sub/file`; harness CSV refreshed)
 - `t12660-init-shared-perm` — 37/37 tests pass (default `grit init` applies Git-style group-shared chmod on `.git` tree: 775 dirs / 664 HEAD under umask 022; explicit `--shared` / `core.sharedRepository` writes config + `receive.denyNonFastforwards`; reinit without shared config leaves modes unchanged)

--- a/t1-plan.md
+++ b/t1-plan.md
@@ -87,7 +87,7 @@
 - [ ] t11930-diff-cached-empty-tree.sh
 - [ ] t11940-diff-tree-merge-base.sh
 - [ ] t11970-status-ignored-tracked.sh
-- [ ] t12000-rev-list-topo-order.sh
+- [x] t12000-rev-list-topo-order.sh
 - [ ] t12040-config-unset-all.sh
 - [ ] t12050-config-edit-file.sh
 - [ ] t12070-branch-describe-sort.sh


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`tests/t12000-rev-list-topo-order.sh` already passes **34/34** on current Grit (`./scripts/run-tests.sh t12000-rev-list-topo-order.sh`). No Rust changes were required for this harness file.

## Changes

- Mark `t12000-rev-list-topo-order.sh` complete in `t1-plan.md`
- Add `logs/2026-04-09_t12000-rev-list-topo-order.md`
- Note the verification in `progress.md` (recently completed)
- Refresh generated dashboard HTML timestamps after the harness run

## Note

The larger upstream-style file `t6003-rev-list-topo-order` tracked in `PLAN.md` is separate and still has failing cases.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d12001c-d2dd-4dc2-a8f8-26dac57e2016"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d12001c-d2dd-4dc2-a8f8-26dac57e2016"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

