### PR TITLE
fix: enable t1409 packed-refs tests (REFFILES prereq)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -409,7 +409,7 @@ t1405-main-ref-store-reftable	t1	yes	29	29	0	true	ok	0
 t1406-submodule-ref-store	t1	yes	15	8	7	false	ok	0
 t1407-worktree-ref-store	t1	skip	4	1	3	false	ok	0
 t1408-packed-refs	t1	yes	3	3	0	true	ok	0
-t1409-avoid-packing-refs	t1	yes	0	0	0	false	ok	0
+t1409-avoid-packing-refs	t1	yes	11	11	0	true	ok	0
 t1410-reflog	t1	yes	0	0	0	false	timeout	1
 t1411-reflog-show	t1	yes	17	8	9	false	ok	0
 t1412-reflog-loop	t1	yes	3	0	3	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T03:51:57+00:00" class="gen-time" title="2026-04-09 03:51 UTC">2026-04-09 03:51 UTC</time> · <a href="https://github.com/schacon/grit/commit/061400b8b5d5c7a744af3cdddde16d93d42dbb7e" style="color:#58a6ff">061400b</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T03:55:49+00:00" class="gen-time" title="2026-04-09 03:55 UTC">2026-04-09 03:55 UTC</time> · <a href="https://github.com/schacon/grit/commit/a74e5296e694b0a86f42b55ca115b93ae8728f99" style="color:#58a6ff">a74e529</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,11 +150,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,909</div>
+      <div class="summary-big-val">29,920</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">39,873</div>
+      <div class="summary-big-val">39,884</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>745 files fully passing</span>
+    <span>746 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -190,7 +190,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">280/368 files · 8 skipped · 10,781/11,373 tests</span>
+        <span class="group-meta">281/368 files · 8 skipped · 10,792/11,384 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-green" style="width:94.8%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T03:51:57+00:00" class="gen-time" title="2026-04-09 03:51 UTC">2026-04-09 03:51 UTC</time> · <a href="https://github.com/schacon/grit/commit/061400b8b5d5c7a744af3cdddde16d93d42dbb7e" style="color:#58a6ff">061400b</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T03:55:49+00:00" class="gen-time" title="2026-04-09 03:55 UTC">2026-04-09 03:55 UTC</time> · <a href="https://github.com/schacon/grit/commit/a74e5296e694b0a86f42b55ca115b93ae8728f99" style="color:#58a6ff">a74e529</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,909</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n" id="sum-tests">39,884</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,920</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">75.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -4247,14 +4247,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="0" data-passed="0">
+<tr class="" data-group="t1" data-tests="11" data-passed="11" data-full-pass="1">
   <td class="mono">t1409-avoid-packing-refs</td>
   <td>t1</td>
-  <td></td>
-  <td class="right">0</td>
-  <td class="right">0</td>
+  <td><span class="badge ok">full pass</span></td>
+  <td class="right">11</td>
+  <td class="right">11</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="0" data-passed="0">

--- a/tests/test-lib.sh
+++ b/tests/test-lib.sh
@@ -898,6 +898,9 @@ test_set_prereq () {
 	eval "_prereq_$1=set"
 }
 
+# Grit implements the traditional loose-ref + packed-refs layout (not reftable).
+test_set_prereq REFFILES
+
 # Lazy prerequisites (git/t0000 nested-lazy): script runs in a temp dir under trash.
 lazily_testable_prereq=
 lazily_tested_prereq=


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t1409-avoid-packing-refs` was skipped in the Grit harness because `tests/test-lib.sh` never set the `REFFILES` prerequisite. The test file exits early when `test_have_prereq !REFFILES` is true (i.e. when `REFFILES` is **not** set).

Grit uses the traditional loose-ref + `packed-refs` layout, matching Git’s **files** ref backend, so the harness should advertise `REFFILES` like upstream `git/t/test-lib.sh` does when `GIT_DEFAULT_REF_FORMAT=files`.

## Changes

- After `test_set_prereq` is defined, call `test_set_prereq REFFILES`.
- Refreshed harness CSV/dashboard counts from `./scripts/run-tests.sh t1409-avoid-packing-refs.sh` (11/11 passing).

## Verification

- `./scripts/run-tests.sh t1409-avoid-packing-refs.sh` → 11/11
- `cargo test -p grit-lib --lib` → pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c9e55ad-04c9-4598-a9ce-251b0d046461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c9e55ad-04c9-4598-a9ce-251b0d046461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

