### PR TITLE
docs: t7507-commit-verbose fully passing (45/45)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -879,7 +879,7 @@ commit → check it off → move on.
 - [ ] `t7528-signed-commit-ssh` ████░░░░░░░░░░░░░░░░ 6/29 (23 left) — ssh signed commit tests
 - [ ] `t7700-repack` █████████░░░░░░░░░░░ 22/47 (25 left) — git repack works correctly
 - [ ] `t7061-wtstatus-ignore` ░░░░░░░░░░░░░░░░░░░░ 0/25 (25 left) — git-status ignored files
-- [ ] `t7507-commit-verbose` ████████░░░░░░░░░░░░ 19/45 (26 left) — verbose commit template
+- [x] `t7507-commit-verbose` — verbose commit template (45/45)
 - [x] `t7064-wtstatus-pv2` — git status --porcelain=v2 (28/28)
 
 - [ ] `t7450-bad-git-dotfiles` ████████░░░░░░░░░░░░ 22/50 (28 left) — check broken or malicious patterns in .git* files

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1228,7 +1228,7 @@ t7504-commit-msg-hook	t7	yes	29	22	7	false	ok	1
 t7505-prepare-commit-msg	t7	yes	30	30	0	true	ok	0
 t7505-prepare-commit-msg-hook	t7	yes	23	7	16	false	ok	0
 t7506-status-submodule	t7	yes	40	6	34	false	ok	0
-t7507-commit-verbose	t7	yes	45	19	26	false	ok	0
+t7507-commit-verbose	t7	yes	45	45	0	true	ok	0
 t7508-status	t7	yes	126	39	87	false	ok	0
 t7509-commit-authorship	t7	yes	12	4	8	false	ok	0
 t7510-signed-commit	t7	skip	28	0	0	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,16 +141,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T03:51:57+00:00" class="gen-time" title="2026-04-09 03:51 UTC">2026-04-09 03:51 UTC</time> · <a href="https://github.com/schacon/grit/commit/061400b8b5d5c7a744af3cdddde16d93d42dbb7e" style="color:#58a6ff">061400b</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T03:55:56+00:00" class="gen-time" title="2026-04-09 03:55 UTC">2026-04-09 03:55 UTC</time> · <a href="https://github.com/schacon/grit/commit/a74e5296e694b0a86f42b55ca115b93ae8728f99" style="color:#58a6ff">a74e529</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">75.0%</div>
+      <div class="summary-big-val pct-blue">75.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,909</div>
+      <div class="summary-big-val">29,935</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -159,12 +159,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:75.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:75.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>745 files fully passing</span>
+    <span>746 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -256,11 +256,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 1,935/2,944 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 1,961/2,944 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:65.7%"></div></div>
-        <span class="group-pct pct-blue">65.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:66.6%"></div></div>
+        <span class="group-pct pct-blue">66.6%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T03:51:57+00:00" class="gen-time" title="2026-04-09 03:51 UTC">2026-04-09 03:51 UTC</time> · <a href="https://github.com/schacon/grit/commit/061400b8b5d5c7a744af3cdddde16d93d42dbb7e" style="color:#58a6ff">061400b</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T03:55:56+00:00" class="gen-time" title="2026-04-09 03:55 UTC">2026-04-09 03:55 UTC</time> · <a href="https://github.com/schacon/grit/commit/a74e5296e694b0a86f42b55ca115b93ae8728f99" style="color:#58a6ff">a74e529</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,909</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">75.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,935</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">75.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -12437,14 +12437,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:15.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="45" data-passed="19">
+<tr class="" data-group="t7" data-tests="45" data-passed="45" data-full-pass="1">
   <td class="mono">t7507-commit-verbose</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">45</td>
-  <td class="right">19</td>
+  <td class="right">45</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:42.2%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="126" data-passed="39">

--- a/logs/2026-04-09_t7507-commit-verbose.md
+++ b/logs/2026-04-09_t7507-commit-verbose.md
@@ -1,0 +1,12 @@
+# t7507-commit-verbose
+
+**Date:** 2026-04-09
+
+## Outcome
+
+`./scripts/run-tests.sh t7507-commit-verbose.sh` reports **45/45** passing on branch `cursor/t7507-commit-verbose-test-74e1`. No Rust changes were required in this session; the implementation already satisfied the suite.
+
+## Actions
+
+- Ran harness; refreshed `data/test-files.csv` and dashboards.
+- Marked task complete in `PLAN.md` and updated `progress.md` counts.

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   253 |
+| Completed   |   254 |
 | In progress |     4 |
-| Remaining   |   511 |
+| Remaining   |   510 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 253 completed (`[x]`), 4 in progress (`[~]`), 511 remaining (`[ ]`).
+Task lines in `PLAN.md`: 254 completed (`[x]`), 4 in progress (`[~]`), 510 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t7507-commit-verbose` — 45/45 tests pass (`commit -v` / `--no-verbose`, `commit.verbose` levels, stripping verbose template from edited message, `core.commentChar` including multi-byte; harness CSV/dashboards refreshed)
 - `t4214-log-graph-octopus` — 17/17 tests pass (`git log --graph` skewed-left octopus, crossover, and colored graph lines; harness CSV/dashboards refreshed)
 - `t3060-ls-files-with-tree` — 8/8 tests pass (`ls-files --with-tree`: `Index::overlay_tree_on_index`, `-s/-u`/`--recurse-submodules` incompatibilities with `fatal:` + exit 128, cwd pathspec `sub/` matches `sub/file`; harness CSV refreshed)
 - `t12660-init-shared-perm` — 37/37 tests pass (default `grit init` applies Git-style group-shared chmod on `.git` tree: 775 dirs / 664 HEAD under umask 022; explicit `--shared` / `core.sharedRepository` writes config + `receive.denyNonFastforwards`; reinit without shared config leaves modes unchanged)

--- a/test-results.md
+++ b/test-results.md
@@ -1,5 +1,9 @@
 # Test Results
 
+**Updated:** 2026-04-09
+
+- `./scripts/run-tests.sh t7507-commit-verbose.sh`: 45/45 passing (verbose commit template, `commit.verbose`, comment char stripping; harness CSV/dashboards refreshed; no code changes in this pass).
+
 **Updated:** 2026-04-08
 
 - `./scripts/run-tests.sh t3060-ls-files-with-tree.sh`: 8/8 passing (`ls-files --with-tree`: tree overlay on index, usage incompatibilities, conflict + missing-index cases; harness CSV/dashboards refreshed).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Verified `t7507-commit-verbose` against the harness: **45/45** tests pass. No Rust changes were required; current `commit -v` / `commit.verbose` / template-stripping behavior already matches expectations.

## Changes

- Refreshed `data/test-files.csv` and generated dashboards (`docs/index.html`, `docs/testfiles.html`) via `./scripts/run-tests.sh t7507-commit-verbose.sh`.
- Marked the task complete in `PLAN.md` and adjusted counts in `progress.md`.
- Added a short entry to `test-results.md` and `logs/2026-04-09_t7507-commit-verbose.md`.

## Validation

- `./scripts/run-tests.sh t7507-commit-verbose.sh`: 45/45
- `cargo test -p grit-lib --lib`: 121/121
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2b06efd-bb1e-4380-bfe7-b7eae042f34b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2b06efd-bb1e-4380-bfe7-b7eae042f34b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

