### PR TITLE
t8950-show-ref-patterns: confirm full pass, refresh harness

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1381,7 +1381,7 @@ t8880-mv-subdirectory	t8	yes	24	24	0	true	ok	0
 t8920-rev-parse-flags	t8	yes	31	31	0	true	ok	0
 t8930-rev-list-first-parent	t8	yes	32	32	0	true	ok	0
 t8940-for-each-ref-points-at	t8	yes	29	29	0	true	ok	0
-t8950-show-ref-patterns	t8	yes	29	27	2	false	ok	0
+t8950-show-ref-patterns	t8	yes	29	29	0	true	ok	0
 t8960-update-ref-stdin-nul	t8	yes	31	31	0	true	ok	0
 t8970-symbolic-ref-chains	t8	yes	30	30	0	true	ok	0
 t8980-config-get-regexp	t8	yes	27	27	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T03:55:50+00:00" class="gen-time" title="2026-04-09 03:55 UTC">2026-04-09 03:55 UTC</time> · <a href="https://github.com/schacon/grit/commit/fa2bf3c699c133a9a8579e19dc10560d8d9caea9" style="color:#58a6ff">fa2bf3c</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T03:58:39+00:00" class="gen-time" title="2026-04-09 03:58 UTC">2026-04-09 03:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/e3673bffc0490e6b09b18a7cb6b76419ebb49844" style="color:#58a6ff">e3673bf</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,925</div>
+      <div class="summary-big-val">29,927</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>746 files fully passing</span>
+    <span>747 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -267,7 +267,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t8</span>
         <span class="group-desc">Porcelainish commands concerning forensics</span>
-        <span class="group-meta">81/105 files · 0 skipped · 2,872/3,116 tests</span>
+        <span class="group-meta">82/105 files · 0 skipped · 2,874/3,116 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-green" style="width:92.2%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T03:55:50+00:00" class="gen-time" title="2026-04-09 03:55 UTC">2026-04-09 03:55 UTC</time> · <a href="https://github.com/schacon/grit/commit/fa2bf3c699c133a9a8579e19dc10560d8d9caea9" style="color:#58a6ff">fa2bf3c</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T03:58:39+00:00" class="gen-time" title="2026-04-09 03:58 UTC">2026-04-09 03:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/e3673bffc0490e6b09b18a7cb6b76419ebb49844" style="color:#58a6ff">e3673bf</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,925</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,927</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">75.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -13967,14 +13967,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t8" data-tests="29" data-passed="27">
+<tr class="" data-group="t8" data-tests="29" data-passed="29" data-full-pass="1">
   <td class="mono">t8950-show-ref-patterns</td>
   <td>t8</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">29</td>
-  <td class="right">27</td>
+  <td class="right">29</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:93.1%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t8" data-tests="31" data-passed="31" data-full-pass="1">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t8950-show-ref-patterns.sh` already passes all 29 tests against current `grit show-ref` (patterns, `--verify`, `--exists`, `--hash`/`-s`, `--head`, `--dereference`, `--abbrev`, `--quiet`).

This change refresishes harness metadata after a clean run:

- `data/test-files.csv`: `t8950-show-ref-patterns` → 29/29, `fully_passing=true`
- Regenerated `docs/index.html` and `docs/testfiles.html`

## Verification

```bash
cargo build --release -p grit-rs
./scripts/run-tests.sh t8950-show-ref-patterns.sh
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8367e8f-5352-4f97-8741-5b028a96b170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8367e8f-5352-4f97-8741-5b028a96b170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

