### PR TITLE
fix: refs list + for-each-ref for t1461 (partial)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -92,7 +92,7 @@ t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
 t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
-t1006-cat-file	t1	yes	290	285	5	false	ok	1
+t1006-cat-file	t1	yes	290	285	5	false	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	32	8	false	ok	0
 t10070-cat-file-batch-format	t1	yes	33	33	0	true	ok	0
@@ -430,7 +430,7 @@ t1450-fsck-basic	t1	yes	31	31	0	true	ok	0
 t1450-fsck-flags	t1	yes	10	10	0	true	ok	0
 t1451-fsck-buffer	t1	yes	72	72	0	true	ok	0
 t1460-refs-migrate	t1	skip	22	0	0	false	ok	0
-t1461-refs-list	t1	yes	0	0	0	false	timeout	0
+t1461-refs-list	t1	yes	428	352	76	false	ok	0
 t1462-refs-exists	t1	yes	12	3	9	false	ok	0
 t1463-refs-optimize	t1	yes	0	0	0	false	ok	0
 t1500-rev-parse	t1	yes	81	70	11	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,30 +141,30 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T04:00:19+00:00" class="gen-time" title="2026-04-09 04:00 UTC">2026-04-09 04:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">74.2%</div>
+      <div class="summary-big-val pct-blue">74.3%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,565</div>
+      <div class="summary-big-val">29,925</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">39,864</div>
+      <div class="summary-big-val">40,292</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:74.2%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:74.3%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>713 files fully passing</span>
+    <span>716 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -190,11 +190,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">273/368 files · 8 skipped · 10,802/11,373 tests</span>
+        <span class="group-meta">273/368 files · 8 skipped · 11,154/11,801 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:95.0%"></div></div>
-        <span class="group-pct pct-green">95.0%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:94.5%"></div></div>
+        <span class="group-pct pct-green">94.5%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t2">
@@ -212,7 +212,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">41/141 files · 2 skipped · 3,333/4,611 tests</span>
+        <span class="group-meta">42/141 files · 2 skipped · 3,334/4,611 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.3%"></div></div>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">30/167 files · 17 skipped · 1,336/3,949 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,342/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:33.8%"></div></div>
-        <span class="group-pct pct-red">33.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.0%"></div></div>
+        <span class="group-pct pct-red">34.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -256,7 +256,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">42/126 files · 11 skipped · 1,793/2,944 tests</span>
+        <span class="group-meta">43/126 files · 11 skipped · 1,794/2,944 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-08T18:02:31+00:00" class="gen-time" title="2026-04-08 18:02 UTC">2026-04-08 18:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ec0895ff64b14e9fb32686f168df6cb5aaef181" style="color:#58a6ff">8ec0895</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:00:19+00:00" class="gen-time" title="2026-04-09 04:00 UTC">2026-04-09 04:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/b85df347d6910651be83fdd5cd41c7e5398a2f3e" style="color:#58a6ff">b85df34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">39,864</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,565</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">74.2%</div><div class="lbl">Pass rate</div></div>
+  <div class="card"><div class="n" id="sum-tests">40,292</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,925</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">74.3%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -1085,7 +1085,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">285</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.3%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t10060-hash-object-determinism</td>
@@ -4457,14 +4457,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="0" data-passed="0">
+<tr class="" data-group="t1" data-tests="428" data-passed="352">
   <td class="mono">t1461-refs-list</td>
   <td>t1</td>
   <td></td>
-  <td class="right">0</td>
-  <td class="right">0</td>
-  <td class="right">timeout</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="right">428</td>
+  <td class="right">352</td>
+  <td class="right">ok</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:82.2%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="12" data-passed="3">
@@ -5110,8 +5110,7 @@ tr.row-skip td { opacity: 0.65; }
 <tr class="" data-group="t2" data-tests="15" data-passed="5">
   <td class="mono">t2061-switch-orphan</td>
   <td>t2</td>
-  <td><span class="badge ok">full pass</span></td>
-  <td class="right">15</td>
+  <td></td>
   <td class="right">15</td>
   <td class="right">5</td>
   <td class="right">ok</td>
@@ -6218,14 +6217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="54" data-passed="38">
+<tr class="" data-group="t3" data-tests="52" data-passed="3">
   <td class="mono">t3420-rebase-autostash</td>
   <td>t3</td>
   <td></td>
-  <td class="right">54</td>
-  <td class="right">38</td>
+  <td class="right">52</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="63" data-passed="11">
@@ -12598,7 +12597,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="2" data-passed="2">
+<tr class="" data-group="t7" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t7524-commit-summary</td>
   <td>t7</td>
   <td><span class="badge ok">full pass</span></td>

--- a/grit-lib/src/lib.rs
+++ b/grit-lib/src/lib.rs
@@ -34,6 +34,7 @@ pub mod ignore;
 pub mod index;
 pub mod line_log;
 pub mod ls_remote;
+pub mod mailmap;
 pub mod merge_base;
 pub mod merge_diff;
 pub mod merge_file;

--- a/grit-lib/src/mailmap.rs
+++ b/grit-lib/src/mailmap.rs
@@ -1,0 +1,267 @@
+//! Parse `.mailmap` and resolve author/committer identities (Git-compatible).
+
+use crate::config::ConfigSet;
+use crate::error::Error as GustError;
+use crate::objects::ObjectKind;
+use crate::repo::Repository;
+use crate::rev_parse::resolve_revision;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+type Result<T> = std::result::Result<T, GustError>;
+
+/// One line from a `.mailmap` file after parsing.
+#[derive(Debug, Clone)]
+pub struct MailmapEntry {
+    /// Canonical name (`None` = keep original).
+    pub canonical_name: Option<String>,
+    /// Canonical email (`None` = keep original).
+    pub canonical_email: Option<String>,
+    /// Match on this name (`None` = any name with the email).
+    pub match_name: Option<String>,
+    /// Match on this email.
+    pub match_email: String,
+}
+
+struct EmailSpan {
+    value: String,
+    start: usize,
+    end: usize,
+}
+
+fn extract_emails(line: &str) -> Vec<EmailSpan> {
+    let mut emails = Vec::new();
+    let mut search_from = 0;
+
+    while let Some(start) = line[search_from..].find('<') {
+        let abs_start = search_from + start;
+        if let Some(end) = line[abs_start..].find('>') {
+            let abs_end = abs_start + end + 1;
+            let email = line[abs_start + 1..abs_end - 1].to_string();
+            emails.push(EmailSpan {
+                value: email,
+                start: abs_start,
+                end: abs_end,
+            });
+            search_from = abs_end;
+        } else {
+            break;
+        }
+    }
+
+    emails
+}
+
+fn parse_mailmap_line(line: &str) -> Option<MailmapEntry> {
+    let emails = extract_emails(line);
+
+    match emails.len() {
+        1 => {
+            let email = &emails[0];
+            let before = line[..email.start].trim();
+            let canonical_name = if before.is_empty() {
+                None
+            } else {
+                Some(before.to_string())
+            };
+            Some(MailmapEntry {
+                canonical_name,
+                canonical_email: Some(email.value.clone()),
+                match_name: None,
+                match_email: email.value.clone(),
+            })
+        }
+        2 => {
+            let canonical_email = &emails[0];
+            let match_email = &emails[1];
+
+            let before_first = line[..canonical_email.start].trim();
+            let between = line[canonical_email.end..match_email.start].trim();
+
+            let canonical_name = if before_first.is_empty() {
+                None
+            } else {
+                Some(before_first.to_string())
+            };
+
+            let match_name = if between.is_empty() {
+                None
+            } else {
+                Some(between.to_string())
+            };
+
+            Some(MailmapEntry {
+                canonical_name,
+                canonical_email: Some(canonical_email.value.clone()),
+                match_name,
+                match_email: match_email.value.clone(),
+            })
+        }
+        _ => None,
+    }
+}
+
+/// Parse a `.mailmap` file body into entries (comments and blanks skipped).
+#[must_use]
+pub fn parse_mailmap(content: &str) -> Vec<MailmapEntry> {
+    let mut entries = Vec::new();
+
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        if let Some(entry) = parse_mailmap_line(line) {
+            entries.push(entry);
+        }
+    }
+
+    entries
+}
+
+/// Parse a contact string `Name <email>` or `<email>`.
+#[must_use]
+pub fn parse_contact(contact: &str) -> (Option<String>, Option<String>) {
+    let contact = contact.trim();
+    if let Some(lt) = contact.find('<') {
+        if let Some(gt) = contact.find('>') {
+            let name = contact[..lt].trim();
+            let email = contact[lt + 1..gt].trim();
+            return (
+                if name.is_empty() {
+                    None
+                } else {
+                    Some(name.to_string())
+                },
+                if email.is_empty() {
+                    None
+                } else {
+                    Some(email.to_string())
+                },
+            );
+        }
+    }
+    if contact.contains('@') && !contact.chars().any(char::is_whitespace) {
+        return (None, Some(contact.to_string()));
+    }
+
+    (Some(contact.to_string()), None)
+}
+
+/// Map `(name, email)` through the mailmap; last matching rule wins (Git order).
+#[must_use]
+pub fn map_contact(
+    name: Option<&str>,
+    email: Option<&str>,
+    mailmap: &[MailmapEntry],
+) -> (String, String) {
+    let orig_name = name.unwrap_or("");
+    let orig_email = email.unwrap_or("");
+
+    for entry in mailmap.iter().rev() {
+        if !entry.match_email.eq_ignore_ascii_case(orig_email) {
+            continue;
+        }
+
+        if let Some(ref match_name) = entry.match_name {
+            if !match_name.eq_ignore_ascii_case(orig_name) {
+                continue;
+            }
+        }
+
+        let result_name = entry.canonical_name.as_deref().unwrap_or(orig_name);
+        let result_email = entry.canonical_email.as_deref().unwrap_or(orig_email);
+
+        return (result_name.to_string(), result_email.to_string());
+    }
+
+    (orig_name.to_string(), orig_email.to_string())
+}
+
+/// Format a contact for display (`check-mailmap` style).
+#[must_use]
+pub fn render_contact(name: &str, email: &str) -> String {
+    if email.is_empty() {
+        return name.to_string();
+    }
+    if name.is_empty() {
+        return format!("<{email}>");
+    }
+    format!("{name} <{email}>")
+}
+
+fn resolve_mailmap_path(base: &Path, value: &str) -> PathBuf {
+    let candidate = Path::new(value);
+    if candidate.is_absolute() {
+        candidate.to_path_buf()
+    } else {
+        base.join(candidate)
+    }
+}
+
+fn read_optional_mailmap_file(path: &Path) -> Result<String> {
+    if path.exists() {
+        fs::read_to_string(path)
+            .map_err(|e| GustError::PathError(format!("reading {}: {e}", path.display())))
+    } else {
+        Ok(String::new())
+    }
+}
+
+/// Read mailmap text from a blob revision (for `mailmap.blob` / CLI `--mailmap-blob`).
+pub fn read_mailmap_blob(repo: &Repository, spec: &str) -> Result<String> {
+    let oid = resolve_revision(repo, spec)
+        .map_err(|e| GustError::PathError(format!("resolving mailmap blob '{spec}': {e}")))?;
+    let obj = repo
+        .odb
+        .read(&oid)
+        .map_err(|e| GustError::PathError(format!("reading mailmap blob '{spec}': {e}")))?;
+    if obj.kind != ObjectKind::Blob {
+        return Err(GustError::PathError(format!(
+            "mailmap.blob '{spec}' does not resolve to a blob object"
+        )));
+    }
+    Ok(String::from_utf8_lossy(&obj.data).into_owned())
+}
+
+/// Load and concatenate all configured mailmap sources for a repository.
+pub fn load_mailmap_raw(repo: &Repository) -> Result<String> {
+    let mut mailmap_content = String::new();
+
+    if let Some(ref wt) = repo.work_tree {
+        mailmap_content.push_str(&read_optional_mailmap_file(&wt.join(".mailmap"))?);
+        if !mailmap_content.ends_with('\n') && !mailmap_content.is_empty() {
+            mailmap_content.push('\n');
+        }
+    }
+
+    let config = ConfigSet::load(Some(&repo.git_dir), true)?;
+    let base_dir = repo
+        .work_tree
+        .as_deref()
+        .unwrap_or(repo.git_dir.as_path())
+        .to_path_buf();
+
+    if let Some(file) = config.get("mailmap.file") {
+        mailmap_content.push_str(&read_optional_mailmap_file(&resolve_mailmap_path(
+            &base_dir, &file,
+        ))?);
+        if !mailmap_content.ends_with('\n') && !mailmap_content.is_empty() {
+            mailmap_content.push('\n');
+        }
+    }
+    if let Some(blob) = config.get("mailmap.blob") {
+        mailmap_content.push_str(&read_mailmap_blob(repo, &blob)?);
+        if !mailmap_content.ends_with('\n') && !mailmap_content.is_empty() {
+            mailmap_content.push('\n');
+        }
+    }
+
+    Ok(mailmap_content)
+}
+
+/// Parsed mailmap for the repository (default `.mailmap` + config).
+pub fn load_mailmap(repo: &Repository) -> Result<Vec<MailmapEntry>> {
+    Ok(parse_mailmap(&load_mailmap_raw(repo)?))
+}

--- a/grit/src/commands/check_mailmap.rs
+++ b/grit/src/commands/check_mailmap.rs
@@ -9,10 +9,10 @@
 
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
-use grit_lib::config::ConfigSet;
-use grit_lib::objects::ObjectKind;
+use grit_lib::mailmap::{
+    load_mailmap_raw, map_contact, parse_contact, parse_mailmap, read_mailmap_blob, render_contact,
+};
 use grit_lib::repo::Repository;
-use grit_lib::rev_parse::resolve_revision;
 use std::fs;
 use std::io::{self, BufRead, Write};
 use std::path::{Path, PathBuf};
@@ -40,200 +40,6 @@ pub struct Args {
     pub contacts: Vec<String>,
 }
 
-/// A single mailmap entry.
-#[derive(Debug, Clone)]
-struct MailmapEntry {
-    /// Canonical name (None = keep original).
-    canonical_name: Option<String>,
-    /// Canonical email (None = keep original).
-    canonical_email: Option<String>,
-    /// Match on this name (None = match any name with the email).
-    match_name: Option<String>,
-    /// Match on this email.
-    match_email: String,
-}
-
-/// Parse a .mailmap file into entries.
-fn parse_mailmap(content: &str) -> Vec<MailmapEntry> {
-    let mut entries = Vec::new();
-
-    for line in content.lines() {
-        let line = line.trim();
-        // Skip comments and empty lines.
-        if line.is_empty() || line.starts_with('#') {
-            continue;
-        }
-
-        if let Some(entry) = parse_mailmap_line(line) {
-            entries.push(entry);
-        }
-    }
-
-    entries
-}
-
-/// Parse a single .mailmap line.
-///
-/// Formats:
-///   <canonical-email>                          — map old email
-///   canonical-name <canonical-email>           — map old email, set name
-///   <canonical-email> <match-email>            — map email→email
-///   canonical-name <canonical-email> <match-email>  — map email, set name
-///   canonical-name <canonical-email> match-name <match-email>
-fn parse_mailmap_line(line: &str) -> Option<MailmapEntry> {
-    let emails = extract_emails(line);
-
-    match emails.len() {
-        1 => {
-            // One email: "Name <canonical-email>" or "<canonical-email>"
-            let email = &emails[0];
-            let before = line[..email.start].trim();
-            let canonical_name = if before.is_empty() {
-                None
-            } else {
-                Some(before.to_string())
-            };
-            Some(MailmapEntry {
-                canonical_name,
-                canonical_email: Some(email.value.clone()),
-                match_name: None,
-                match_email: email.value.clone(),
-            })
-        }
-        2 => {
-            // Two emails: various forms with canonical + match email.
-            let canonical_email = &emails[0];
-            let match_email = &emails[1];
-
-            let before_first = line[..canonical_email.start].trim();
-            let between = line[canonical_email.end..match_email.start].trim();
-
-            let canonical_name = if before_first.is_empty() {
-                None
-            } else {
-                Some(before_first.to_string())
-            };
-
-            let match_name = if between.is_empty() {
-                None
-            } else {
-                Some(between.to_string())
-            };
-
-            Some(MailmapEntry {
-                canonical_name,
-                canonical_email: Some(canonical_email.value.clone()),
-                match_name,
-                match_email: match_email.value.clone(),
-            })
-        }
-        _ => None,
-    }
-}
-
-/// Extracted email with position info.
-struct EmailSpan {
-    value: String,
-    start: usize,
-    end: usize,
-}
-
-/// Extract all <email> spans from a line.
-fn extract_emails(line: &str) -> Vec<EmailSpan> {
-    let mut emails = Vec::new();
-    let mut search_from = 0;
-
-    while let Some(start) = line[search_from..].find('<') {
-        let abs_start = search_from + start;
-        if let Some(end) = line[abs_start..].find('>') {
-            let abs_end = abs_start + end + 1;
-            let email = line[abs_start + 1..abs_end - 1].to_string();
-            emails.push(EmailSpan {
-                value: email,
-                start: abs_start,
-                end: abs_end,
-            });
-            search_from = abs_end;
-        } else {
-            break;
-        }
-    }
-
-    emails
-}
-
-/// Parse a contact string "Name <email>" or "<email>".
-fn parse_contact(contact: &str) -> (Option<String>, Option<String>) {
-    let contact = contact.trim();
-    if let Some(lt) = contact.find('<') {
-        if let Some(gt) = contact.find('>') {
-            let name = contact[..lt].trim();
-            let email = contact[lt + 1..gt].trim();
-            return (
-                if name.is_empty() {
-                    None
-                } else {
-                    Some(name.to_string())
-                },
-                if email.is_empty() {
-                    None
-                } else {
-                    Some(email.to_string())
-                },
-            );
-        }
-    }
-    // No angle brackets. If this looks like an email address, treat it as one.
-    if contact.contains('@') && !contact.chars().any(char::is_whitespace) {
-        return (None, Some(contact.to_string()));
-    }
-
-    // Otherwise treat as name only.
-    (Some(contact.to_string()), None)
-}
-
-/// Look up a contact in the mailmap and return the canonical form.
-fn map_contact(
-    name: Option<&str>,
-    email: Option<&str>,
-    mailmap: &[MailmapEntry],
-) -> (String, String) {
-    let orig_name = name.unwrap_or("");
-    let orig_email = email.unwrap_or("");
-
-    for entry in mailmap.iter().rev() {
-        // Check email match (case-insensitive).
-        if !entry.match_email.eq_ignore_ascii_case(orig_email) {
-            continue;
-        }
-
-        // Check name match if specified.
-        if let Some(ref match_name) = entry.match_name {
-            if !match_name.eq_ignore_ascii_case(orig_name) {
-                continue;
-            }
-        }
-
-        // Match found — apply canonical values.
-        let result_name = entry.canonical_name.as_deref().unwrap_or(orig_name);
-        let result_email = entry.canonical_email.as_deref().unwrap_or(orig_email);
-
-        return (result_name.to_string(), result_email.to_string());
-    }
-
-    (orig_name.to_string(), orig_email.to_string())
-}
-
-fn render_contact(name: &str, email: &str) -> String {
-    if email.is_empty() {
-        return name.to_string();
-    }
-    if name.is_empty() {
-        return format!("<{email}>");
-    }
-    format!("{name} <{email}>")
-}
-
 fn resolve_mailmap_path(base: &Path, value: &str) -> PathBuf {
     let candidate = Path::new(value);
     if candidate.is_absolute() {
@@ -251,56 +57,17 @@ fn read_optional_mailmap_file(path: &Path) -> Result<String> {
     }
 }
 
-fn read_mailmap_blob(repo: &Repository, spec: &str) -> Result<String> {
-    let oid =
-        resolve_revision(repo, spec).with_context(|| format!("resolving mailmap blob '{spec}'"))?;
-    let obj = repo
-        .odb
-        .read(&oid)
-        .with_context(|| format!("reading mailmap blob '{spec}'"))?;
-    if obj.kind != ObjectKind::Blob {
-        bail!("mailmap.blob '{}' does not resolve to a blob object", spec);
-    }
-    Ok(String::from_utf8_lossy(&obj.data).into_owned())
-}
-
 /// Run the `check-mailmap` command.
 pub fn run(args: Args) -> Result<()> {
     let repo = Repository::discover(None)?;
-    let mut mailmap_content = String::new();
+    let mut mailmap_content = load_mailmap_raw(&repo)?;
 
-    // 1) Default .mailmap in worktree root.
-    if let Some(ref wt) = repo.work_tree {
-        mailmap_content.push_str(&read_optional_mailmap_file(&wt.join(".mailmap"))?);
-        if !mailmap_content.ends_with('\n') && !mailmap_content.is_empty() {
-            mailmap_content.push('\n');
-        }
-    }
-
-    // 2) Configured mailmap.file / mailmap.blob.
-    let config = ConfigSet::load(Some(&repo.git_dir), true)?;
     let base_dir = repo
         .work_tree
         .as_deref()
         .unwrap_or(repo.git_dir.as_path())
         .to_path_buf();
 
-    if let Some(file) = config.get("mailmap.file") {
-        mailmap_content.push_str(&read_optional_mailmap_file(&resolve_mailmap_path(
-            &base_dir, &file,
-        ))?);
-        if !mailmap_content.ends_with('\n') && !mailmap_content.is_empty() {
-            mailmap_content.push('\n');
-        }
-    }
-    if let Some(blob) = config.get("mailmap.blob") {
-        mailmap_content.push_str(&read_mailmap_blob(&repo, &blob)?);
-        if !mailmap_content.ends_with('\n') && !mailmap_content.is_empty() {
-            mailmap_content.push('\n');
-        }
-    }
-
-    // 3) CLI overrides take precedence (append last).
     if let Some(ref file) = args.mailmap_file {
         mailmap_content.push_str(&read_optional_mailmap_file(&resolve_mailmap_path(
             &base_dir, file,

--- a/grit/src/commands/for_each_ref.rs
+++ b/grit/src/commands/for_each_ref.rs
@@ -3,7 +3,10 @@
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::error::Error as GustError;
-use grit_lib::merge_base::is_ancestor;
+use grit_lib::git_date::show::{date_mode_release, parse_date_format, show_date};
+use grit_lib::git_date::tm::atoi_bytes;
+use grit_lib::mailmap::{load_mailmap, map_contact, parse_contact, MailmapEntry};
+use grit_lib::merge_base::{ancestor_closure, is_ancestor};
 use grit_lib::objects::{parse_commit, parse_tag, ObjectId, ObjectKind};
 use grit_lib::refs::read_head;
 use grit_lib::repo::Repository;
@@ -22,23 +25,41 @@ pub struct Args {
     pub args: Vec<String>,
 }
 
+/// Which top-level command is driving ref listing (`for-each-ref` vs `refs list`).
+#[derive(Debug, Clone, Copy)]
+pub enum ForEachRefInvocation {
+    /// `git for-each-ref` (default).
+    ForEachRef,
+    /// `git refs list` — same options, different `usage:` line for tests and UX.
+    RefsList,
+}
+
 /// Run `grit for-each-ref`.
 pub fn run(args: Args) -> Result<()> {
+    run_with_invocation(args, ForEachRefInvocation::ForEachRef)
+}
+
+/// Run `git refs list` (alias): identical behavior to `for-each-ref` with `refs list` usage text.
+pub fn run_refs_list(args: Args) -> Result<()> {
+    run_with_invocation(args, ForEachRefInvocation::RefsList)
+}
+
+fn run_with_invocation(args: Args, inv: ForEachRefInvocation) -> Result<()> {
     if args.args.iter().any(|arg| arg == "-h" || arg == "--help") {
-        print_usage();
+        print_usage(inv);
         std::process::exit(129);
     }
 
     let repo = Repository::discover(None).context("not a git repository")?;
-    let opts = match parse_args(args.args) {
+    let opts = match parse_args(args.args, inv) {
         Ok(opts) => opts,
         Err(err) => {
-            eprintln!(
-                "usage: git for-each-ref [--count=<count>] [--sort=<key>] [--format=<format>] [--points-at=<object>] [--merged[=<object>]] [--no-merged[=<object>]] [--contains[=<object>]] [--no-contains[=<object>]] [--exclude=<pattern>] [--stdin] [<pattern>...]"
-            );
+            eprintln!("{}", full_usage_line(inv));
             return Err(err);
         }
     };
+
+    let mailmap = load_mailmap(&repo).unwrap_or_else(|_| Vec::new());
 
     let mut patterns = opts.patterns.clone();
     if opts.stdin {
@@ -60,6 +81,10 @@ pub fn run(args: Args) -> Result<()> {
     let format = opts
         .format
         .unwrap_or_else(|| "%(objectname) %(objecttype)\t%(refname)".to_owned());
+    if let Err(msg) = validate_format_quoting(&format, opts.quote_style) {
+        eprintln!("fatal: {msg}");
+        std::process::exit(128);
+    }
     let head_branch = read_head(&repo.git_dir).ok().flatten();
     let max = opts.count.unwrap_or(usize::MAX);
     let mut printed = 0usize;
@@ -67,7 +92,14 @@ pub fn run(args: Args) -> Result<()> {
         if printed >= max {
             break;
         }
-        match expand_format(&repo, &entry, &format, &head_branch) {
+        match expand_format(
+            &repo,
+            &entry,
+            &format,
+            &head_branch,
+            &mailmap,
+            opts.quote_style,
+        ) {
             Ok(line) => {
                 println!("{line}");
                 printed += 1;
@@ -99,12 +131,22 @@ enum SortField {
     RefName,
     ObjectName,
     ObjectType,
+    Raw,
+    RawSize,
 }
 
 #[derive(Debug, Clone, Copy)]
 struct SortKey {
     field: SortField,
     descending: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum QuoteStyle {
+    Shell,
+    Perl,
+    Python,
+    Tcl,
 }
 
 #[derive(Debug, Default)]
@@ -121,6 +163,7 @@ struct Options {
     no_contains: Option<Option<String>>,
     stdin: bool,
     ignore_case: bool,
+    quote_style: Option<QuoteStyle>,
 }
 
 #[derive(Debug)]
@@ -130,13 +173,25 @@ enum FormatError {
     Other(String),
 }
 
-fn print_usage() {
-    eprintln!(
-        "usage: git for-each-ref [--count=<count>] [--sort=<key>] [--format=<format>] [--points-at=<object>] [--merged[=<object>]] [--no-merged[=<object>]] [--contains[=<object>]] [--no-contains[=<object>]] [--exclude=<pattern>] [--stdin] [<pattern>...]"
-    );
+fn usage_command(inv: ForEachRefInvocation) -> &'static str {
+    match inv {
+        ForEachRefInvocation::ForEachRef => "git for-each-ref",
+        ForEachRefInvocation::RefsList => "git refs list",
+    }
 }
 
-fn parse_args(args: Vec<String>) -> Result<Options> {
+fn full_usage_line(inv: ForEachRefInvocation) -> String {
+    format!(
+        "usage: {} [--count=<count>] [--sort=<key>] [--format=<format>] [--points-at=<object>] [--merged[=<object>]] [--no-merged[=<object>]] [--contains[=<object>]] [--no-contains[=<object>]] [--exclude=<pattern>] [--stdin] [<pattern>...]",
+        usage_command(inv)
+    )
+}
+
+fn print_usage(inv: ForEachRefInvocation) {
+    eprintln!("{}", full_usage_line(inv));
+}
+
+fn parse_args(args: Vec<String>, inv: ForEachRefInvocation) -> Result<Options> {
     let mut opts = Options::default();
     let mut i = 0usize;
     while i < args.len() {
@@ -148,6 +203,26 @@ fn parse_args(args: Vec<String>) -> Result<Options> {
         }
         if arg == "--ignore-case" {
             opts.ignore_case = true;
+            i += 1;
+            continue;
+        }
+        if arg == "-s" || arg == "--shell" {
+            set_quote_style(&mut opts, QuoteStyle::Shell, inv)?;
+            i += 1;
+            continue;
+        }
+        if arg == "-p" || arg == "--perl" {
+            set_quote_style(&mut opts, QuoteStyle::Perl, inv)?;
+            i += 1;
+            continue;
+        }
+        if arg == "--python" {
+            set_quote_style(&mut opts, QuoteStyle::Python, inv)?;
+            i += 1;
+            continue;
+        }
+        if arg == "--tcl" {
+            set_quote_style(&mut opts, QuoteStyle::Tcl, inv)?;
             i += 1;
             continue;
         }
@@ -298,9 +373,7 @@ fn parse_args(args: Vec<String>) -> Result<Options> {
             continue;
         }
         if arg.starts_with('-') {
-            bail!(
-                "unsupported option: {arg}\nusage: git for-each-ref [--count=<count>] [--sort=<key>] [--format=<format>] [--points-at=<object>] [--merged[=<object>]] [--no-merged[=<object>]] [--contains[=<object>]] [--no-contains[=<object>]] [--exclude=<pattern>] [--stdin] [<pattern>...]"
-            );
+            bail!("unsupported option: {arg}\n{}", full_usage_line(inv));
         }
         opts.patterns.push(arg.clone());
         i += 1;
@@ -314,6 +387,18 @@ fn parse_args(args: Vec<String>) -> Result<Options> {
     }
 
     Ok(opts)
+}
+
+fn set_quote_style(opts: &mut Options, style: QuoteStyle, inv: ForEachRefInvocation) -> Result<()> {
+    if let Some(existing) = opts.quote_style {
+        if existing != style {
+            eprintln!("error: more than one quoting style?");
+            print_usage(inv);
+            std::process::exit(129);
+        }
+    }
+    opts.quote_style = Some(style);
+    Ok(())
 }
 
 fn parse_count(value: &str) -> Result<usize> {
@@ -336,6 +421,8 @@ fn parse_sort_key(raw: &str) -> Result<SortKey> {
         "refname" => SortField::RefName,
         "objectname" => SortField::ObjectName,
         "objecttype" => SortField::ObjectType,
+        "raw" => SortField::Raw,
+        "raw:size" => SortField::RawSize,
         _ => bail!("unsupported sort key: {raw}"),
     };
     Ok(SortKey { field, descending })
@@ -586,6 +673,28 @@ fn compare_on_key(
                     String::new()
                 }
             }
+            SortField::Raw => {
+                if let Some(oid) = entry.oid {
+                    repo.odb
+                        .read(&oid)
+                        .ok()
+                        .map(|obj| String::from_utf8_lossy(&obj.data).into_owned())
+                        .unwrap_or_default()
+                } else {
+                    String::new()
+                }
+            }
+            SortField::RawSize => {
+                if let Some(oid) = entry.oid {
+                    repo.odb
+                        .read(&oid)
+                        .ok()
+                        .map(|obj| obj.data.len().to_string())
+                        .unwrap_or_else(|| "0".to_owned())
+                } else {
+                    "0".to_owned()
+                }
+            }
         }
     };
     let mut left_val = value(left);
@@ -597,11 +706,133 @@ fn compare_on_key(
     left_val.cmp(&right_val)
 }
 
+fn validate_format_quoting(format: &str, quote: Option<QuoteStyle>) -> Result<(), String> {
+    let Some(q) = quote else {
+        return Ok(());
+    };
+    if matches!(q, QuoteStyle::Perl) {
+        return Ok(());
+    }
+    let mut rest = format;
+    while let Some(start) = rest.find('%') {
+        let after = &rest[start + 1..];
+        if after.starts_with('%') {
+            rest = &after[1..];
+            continue;
+        }
+        let Some(inner) = after.strip_prefix('(') else {
+            rest = after;
+            continue;
+        };
+        let Some(end) = inner.find(')') else {
+            return Ok(());
+        };
+        let atom = &inner[..end];
+        let body = atom.strip_prefix('*').unwrap_or(atom);
+        let (base, modifier) = body
+            .find(':')
+            .map(|p| (&body[..p], Some(&body[p + 1..])))
+            .unwrap_or((body, None));
+        if base == "raw" && modifier != Some("size") {
+            return Err("--format=raw cannot be used with --python, --shell, --tcl".to_owned());
+        }
+        rest = &inner[end + 1..];
+    }
+    Ok(())
+}
+
+fn quote_output(s: &str, style: Option<QuoteStyle>) -> String {
+    let Some(style) = style else {
+        return s.to_owned();
+    };
+    match style {
+        QuoteStyle::Shell => sq_quote_buf(s),
+        QuoteStyle::Perl => perl_quote_buf(s),
+        QuoteStyle::Python => python_quote_buf(s),
+        QuoteStyle::Tcl => tcl_quote_buf(s),
+    }
+}
+
+fn sq_quote_buf(src: &str) -> String {
+    let mut out = String::new();
+    out.push('\'');
+    let mut bytes = src.as_bytes();
+    while !bytes.is_empty() {
+        let len = bytes
+            .iter()
+            .take_while(|&&b| b != b'\'' && b != b'!')
+            .count();
+        out.push_str(std::str::from_utf8(&bytes[..len]).unwrap_or(""));
+        bytes = &bytes[len..];
+        while bytes.first() == Some(&b'\'') || bytes.first() == Some(&b'!') {
+            out.push_str("'\\");
+            out.push(char::from(bytes[0]));
+            out.push('\'');
+            bytes = &bytes[1..];
+        }
+    }
+    out.push('\'');
+    out
+}
+
+fn perl_quote_buf(src: &str) -> String {
+    let mut out = String::new();
+    out.push('\'');
+    for c in src.chars() {
+        if c == '\'' || c == '\\' {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out.push('\'');
+    out
+}
+
+fn python_quote_buf(src: &str) -> String {
+    let mut out = String::new();
+    out.push('\'');
+    for c in src.chars() {
+        if c == '\n' {
+            out.push_str("\\n");
+            continue;
+        }
+        if c == '\'' || c == '\\' {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out.push('\'');
+    out
+}
+
+fn tcl_quote_buf(src: &str) -> String {
+    let mut out = String::new();
+    out.push('"');
+    for c in src.chars() {
+        match c {
+            '[' | ']' | '{' | '}' | '$' | '\\' | '"' => {
+                out.push('\\');
+                out.push(c);
+            }
+            '\x0c' => out.push_str("\\f"),
+            '\r' => out.push_str("\\r"),
+            '\n' => out.push_str("\\n"),
+            '\t' => out.push_str("\\t"),
+            '\x0b' => out.push_str("\\v"),
+            _ => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
 fn expand_format(
     repo: &Repository,
     entry: &RefEntry,
     format: &str,
     head_branch: &Option<String>,
+    mailmap: &[MailmapEntry],
+    quote_style: Option<QuoteStyle>,
 ) -> Result<String, FormatError> {
     let mut out = String::new();
     let mut rest = format;
@@ -609,19 +840,18 @@ fn expand_format(
         out.push_str(&rest[..start]);
         let after = &rest[start + 1..];
         if after.starts_with('%') {
-            // %% -> literal %
-            out.push('%');
+            let lit = quote_output("%", quote_style);
+            out.push_str(&lit);
             rest = &after[1..];
         } else if let Some(inner) = after.strip_prefix('(') {
-            // %(atom) -> expand
             let Some(end) = inner.find(')') else {
                 return Err(FormatError::Other("unterminated format atom".to_owned()));
             };
             let atom = &inner[..end];
-            out.push_str(&atom_value(repo, entry, atom, head_branch)?);
+            let expanded = atom_value(repo, entry, atom, head_branch, mailmap)?;
+            out.push_str(&quote_output(&expanded, quote_style));
             rest = &inner[end + 1..];
         } else {
-            // bare % - output literally
             out.push('%');
             rest = after;
         }
@@ -635,11 +865,12 @@ fn atom_value(
     entry: &RefEntry,
     atom: &str,
     head_branch: &Option<String>,
+    mailmap: &[MailmapEntry],
 ) -> Result<String, FormatError> {
     // Handle deref atoms: %(* objectname), %(*objecttype), etc.
     // These dereference the pointed-to object (peel tags).
     if let Some(deref_atom) = atom.strip_prefix('*') {
-        return deref_atom_value(repo, entry, deref_atom, head_branch);
+        return deref_atom_value(repo, entry, deref_atom, head_branch, mailmap);
     }
 
     // Handle atoms with modifiers (e.g. "authordate:short")
@@ -657,6 +888,7 @@ fn atom_value(
             None => Ok(entry.name.clone()),
         },
         "objectname" => match modifier {
+            None => Ok(entry.object_name.clone()),
             Some("short") => {
                 if let Some(oid) = entry.oid {
                     Ok(abbreviate_oid(&oid, 7))
@@ -665,14 +897,25 @@ fn atom_value(
                 }
             }
             Some(m) if m.starts_with("short=") => {
-                let n: usize = m["short=".len()..].parse().unwrap_or(7);
+                let arg = &m["short=".len()..];
+                let n: u64 = arg.parse().map_err(|_| {
+                    FormatError::Fatal(format!("positive value expected '{arg}' in %(objectname)"))
+                })?;
+                if n == 0 {
+                    return Err(FormatError::Fatal(format!(
+                        "positive value expected '{arg}' in %(objectname)"
+                    )));
+                }
+                let n = n as usize;
                 if let Some(oid) = entry.oid {
                     Ok(abbreviate_oid(&oid, n.max(4)))
                 } else {
                     Ok(entry.object_name.clone())
                 }
             }
-            _ => Ok(entry.object_name.clone()),
+            Some(other) => Err(FormatError::Fatal(format!(
+                "unrecognized %(objectname) argument: {other}"
+            ))),
         },
         "objecttype" => {
             let object = read_object(repo, entry)?;
@@ -718,13 +961,15 @@ fn atom_value(
                     entry.name.clone(),
                 ));
             };
-            commit_field_for_oid(repo, entry, oid, |c| match modifier {
-                Some("short") => abbreviate_oid(&c.tree, 7),
-                Some(m) if m.starts_with("short=") => {
-                    let n: usize = m["short=".len()..].parse().unwrap_or(7);
-                    abbreviate_oid(&c.tree, n.max(4))
-                }
-                _ => c.tree.to_string(),
+            commit_field_for_oid(repo, entry, oid, |c| {
+                Ok(match modifier {
+                    Some("short") => abbreviate_oid(&c.tree, 7),
+                    Some(m) if m.starts_with("short=") => {
+                        let n: usize = m["short=".len()..].parse().unwrap_or(7);
+                        abbreviate_oid(&c.tree, n.max(4))
+                    }
+                    _ => c.tree.to_string(),
+                })
             })
         }
         "parent" => {
@@ -747,7 +992,7 @@ fn atom_value(
                         _ => p.to_string(),
                     })
                     .collect();
-                parents.join(" ")
+                Ok(parents.join(" "))
             })
         }
         "numparent" => {
@@ -757,7 +1002,7 @@ fn atom_value(
                     entry.name.clone(),
                 ));
             };
-            commit_field_for_oid(repo, entry, oid, |c| c.parents.len().to_string())
+            commit_field_for_oid(repo, entry, oid, |c| Ok(c.parents.len().to_string()))
         }
         "object" => {
             let object = read_object(repo, entry)?;
@@ -787,7 +1032,19 @@ fn atom_value(
         }
         "raw" => {
             let object = read_object(repo, entry)?;
-            Ok(String::from_utf8_lossy(&object.data).into_owned())
+            match modifier {
+                Some("size") => Ok(object.data.len().to_string()),
+                Some(other) => Err(FormatError::Fatal(format!(
+                    "unrecognized %(raw) argument: {other}"
+                ))),
+                None => {
+                    let mut s = String::from_utf8_lossy(&object.data).into_owned();
+                    if object.kind != ObjectKind::Commit {
+                        s.push('\n');
+                    }
+                    Ok(s)
+                }
+            }
         }
         "upstream" => resolve_upstream(repo, entry, modifier),
         "push" => resolve_push(repo, entry, modifier),
@@ -832,7 +1089,7 @@ fn atom_value(
                     entry.name.clone(),
                 ));
             };
-            commit_field_for_oid(repo, entry, oid, |c| c.author.clone())
+            commit_field_for_oid(repo, entry, oid, |c| Ok(c.author.clone()))
         }
         "authorname" => {
             let Some(oid) = entry.oid else {
@@ -841,7 +1098,18 @@ fn atom_value(
                     entry.name.clone(),
                 ));
             };
-            commit_field_for_oid(repo, entry, oid, |c| parse_identity_name(&c.author))
+            match modifier {
+                Some("mailmap") => commit_field_for_oid(repo, entry, oid, |c| {
+                    let (n, e) = parse_contact(&c.author);
+                    Ok(map_contact(n.as_deref(), e.as_deref(), mailmap).0)
+                }),
+                None => {
+                    commit_field_for_oid(repo, entry, oid, |c| Ok(parse_identity_name(&c.author)))
+                }
+                Some(other) => Err(FormatError::Fatal(format!(
+                    "unrecognized %(authorname) argument: {other}"
+                ))),
+            }
         }
         "authoremail" => {
             let Some(oid) = entry.oid else {
@@ -850,7 +1118,10 @@ fn atom_value(
                     entry.name.clone(),
                 ));
             };
-            commit_field_for_oid(repo, entry, oid, |c| format_email(&c.author, modifier))
+            let opts = parse_email_modifiers(modifier, "authoremail")?;
+            commit_field_for_oid(repo, entry, oid, |c| {
+                Ok(format_email_with_opts(&c.author, &opts, mailmap))
+            })
         }
         "authordate" => {
             let Some(oid) = entry.oid else {
@@ -860,7 +1131,7 @@ fn atom_value(
                 ));
             };
             commit_field_for_oid(repo, entry, oid, |c| {
-                format_identity_date(&c.author, modifier)
+                format_identity_date_git(&c.author, modifier)
             })
         }
         "committer" => {
@@ -870,7 +1141,7 @@ fn atom_value(
                     entry.name.clone(),
                 ));
             };
-            commit_field_for_oid(repo, entry, oid, |c| c.committer.clone())
+            commit_field_for_oid(repo, entry, oid, |c| Ok(c.committer.clone()))
         }
         "committername" => {
             let Some(oid) = entry.oid else {
@@ -879,7 +1150,18 @@ fn atom_value(
                     entry.name.clone(),
                 ));
             };
-            commit_field_for_oid(repo, entry, oid, |c| parse_identity_name(&c.committer))
+            match modifier {
+                Some("mailmap") => commit_field_for_oid(repo, entry, oid, |c| {
+                    let (n, e) = parse_contact(&c.committer);
+                    Ok(map_contact(n.as_deref(), e.as_deref(), mailmap).0)
+                }),
+                None => commit_field_for_oid(repo, entry, oid, |c| {
+                    Ok(parse_identity_name(&c.committer))
+                }),
+                Some(other) => Err(FormatError::Fatal(format!(
+                    "unrecognized %(committername) argument: {other}"
+                ))),
+            }
         }
         "committeremail" => {
             let Some(oid) = entry.oid else {
@@ -888,7 +1170,10 @@ fn atom_value(
                     entry.name.clone(),
                 ));
             };
-            commit_field_for_oid(repo, entry, oid, |c| format_email(&c.committer, modifier))
+            let opts = parse_email_modifiers(modifier, "committeremail")?;
+            commit_field_for_oid(repo, entry, oid, |c| {
+                Ok(format_email_with_opts(&c.committer, &opts, mailmap))
+            })
         }
         "committerdate" => {
             let Some(oid) = entry.oid else {
@@ -898,53 +1183,82 @@ fn atom_value(
                 ));
             };
             commit_field_for_oid(repo, entry, oid, |c| {
-                format_identity_date(&c.committer, modifier)
+                format_identity_date_git(&c.committer, modifier)
             })
         }
         "creatordate" => {
-            // creatordate: for tags use tagger date, for commits use committer date
             let object = read_object(repo, entry)?;
             match object.kind {
                 ObjectKind::Tag => {
                     let tag = parse_tag(&object.data).map_err(|_| {
                         FormatError::Other(format!("failed to parse tag for {}", entry.name))
                     })?;
-                    Ok(tag
-                        .tagger
-                        .as_ref()
-                        .map(|t| format_identity_date(t, modifier))
-                        .unwrap_or_default())
+                    match tag.tagger.as_ref() {
+                        Some(t) => format_identity_date_git(t, modifier),
+                        None => Ok(String::new()),
+                    }
                 }
                 ObjectKind::Commit => {
                     let commit = parse_commit(&object.data).map_err(|_| {
                         FormatError::Other(format!("failed to parse commit for {}", entry.name))
                     })?;
-                    Ok(format_identity_date(&commit.committer, modifier))
+                    format_identity_date_git(&commit.committer, modifier)
                 }
                 _ => Ok(String::new()),
             }
         }
-        "taggername" => tag_field_for_oid(repo, entry, |t| {
-            t.tagger
-                .as_ref()
-                .map(|s| parse_identity_name(s))
-                .unwrap_or_default()
-        }),
-        "taggeremail" => tag_field_for_oid(repo, entry, |t| {
-            t.tagger
-                .as_ref()
-                .map(|s| format_email(s, modifier))
-                .unwrap_or_default()
-        }),
+        "taggername" => {
+            let object = read_object(repo, entry)?;
+            if object.kind != ObjectKind::Tag {
+                return Ok(String::new());
+            }
+            let tag = parse_tag(&object.data).map_err(|_| {
+                FormatError::Other(format!("failed to parse tag for {}", entry.name))
+            })?;
+            let Some(ref raw) = tag.tagger else {
+                return Ok(String::new());
+            };
+            match modifier {
+                Some("mailmap") => {
+                    let (n, e) = parse_contact(raw);
+                    Ok(map_contact(n.as_deref(), e.as_deref(), mailmap).0)
+                }
+                None => Ok(parse_identity_name(raw)),
+                Some(other) => Err(FormatError::Fatal(format!(
+                    "unrecognized %(taggername) argument: {other}"
+                ))),
+            }
+        }
+        "taggeremail" => {
+            let object = read_object(repo, entry)?;
+            if object.kind != ObjectKind::Tag {
+                return Ok(String::new());
+            }
+            let tag = parse_tag(&object.data).map_err(|_| {
+                FormatError::Other(format!("failed to parse tag for {}", entry.name))
+            })?;
+            let Some(ref raw) = tag.tagger else {
+                return Ok(String::new());
+            };
+            let opts = parse_email_modifiers(modifier, "taggeremail")?;
+            Ok(format_email_with_opts(raw, &opts, mailmap))
+        }
         "tagger" => tag_field_for_oid(repo, entry, |t| {
             t.tagger.as_ref().cloned().unwrap_or_default()
         }),
-        "taggerdate" => tag_field_for_oid(repo, entry, |t| {
-            t.tagger
-                .as_ref()
-                .map(|s| format_identity_date(s, modifier))
-                .unwrap_or_default()
-        }),
+        "taggerdate" => {
+            let object = read_object(repo, entry)?;
+            if object.kind != ObjectKind::Tag {
+                return Ok(String::new());
+            }
+            let tag = parse_tag(&object.data).map_err(|_| {
+                FormatError::Other(format!("failed to parse tag for {}", entry.name))
+            })?;
+            match tag.tagger.as_ref() {
+                Some(t) => format_identity_date_git(t, modifier),
+                None => Ok(String::new()),
+            }
+        }
         "tag" => {
             let object = read_object(repo, entry)?;
             if object.kind == ObjectKind::Tag {
@@ -960,33 +1274,66 @@ fn atom_value(
         }
         "contents" => {
             let object = read_object(repo, entry)?;
-            let body = extract_commit_message(&object.data);
-            match modifier {
-                Some("subject") => Ok(body.lines().next().unwrap_or("").to_owned()),
-                Some("body") => {
-                    let mut lines = body.lines();
-                    lines.next(); // skip subject
-                    let rest: String = lines.collect::<Vec<_>>().join("\n");
-                    let rest = rest.trim_start_matches('\n');
-                    if rest.is_empty() {
-                        Ok(String::new())
-                    } else {
-                        Ok(format!("{rest}\n"))
+            match object.kind {
+                ObjectKind::Commit => {
+                    let body = extract_commit_message(&object.data);
+                    match modifier {
+                        Some("subject") => Ok(body.lines().next().unwrap_or("").to_owned()),
+                        Some("body") => {
+                            let mut lines = body.lines();
+                            lines.next();
+                            let rest: String = lines.collect::<Vec<_>>().join("\n");
+                            let rest = rest.trim_start_matches('\n');
+                            if rest.is_empty() {
+                                Ok(String::new())
+                            } else {
+                                Ok(format!("{rest}\n"))
+                            }
+                        }
+                        Some("signature") => {
+                            if let Some(sig_start) = body.find("-----BEGIN") {
+                                Ok(body[sig_start..].to_owned())
+                            } else {
+                                Ok(String::new())
+                            }
+                        }
+                        Some("size") => Ok(body.len().to_string()),
+                        Some("") | None => Ok(body),
+                        Some(m) => Err(FormatError::Other(format!(
+                            "unsupported contents modifier: {m}"
+                        ))),
                     }
                 }
-                Some("signature") => {
-                    // Extract PGP/GPG signature if present
-                    if let Some(sig_start) = body.find("-----BEGIN") {
-                        Ok(body[sig_start..].to_owned())
-                    } else {
-                        Ok(String::new())
+                ObjectKind::Tag => {
+                    let tag = parse_tag(&object.data).map_err(|_| {
+                        FormatError::Other(format!("failed to parse tag for {}", entry.name))
+                    })?;
+                    let body = &tag.message;
+                    match modifier {
+                        Some("subject") => Ok(tag_subject_paragraph(body)),
+                        Some("body") => {
+                            let b = tag_body_after_first_para(body);
+                            if b.is_empty() {
+                                Ok(String::new())
+                            } else {
+                                Ok(format!("{b}\n"))
+                            }
+                        }
+                        Some("signature") => {
+                            if let Some(sig_start) = body.find("-----BEGIN") {
+                                Ok(body[sig_start..].to_owned())
+                            } else {
+                                Ok(String::new())
+                            }
+                        }
+                        Some("size") => Ok(body.len().to_string()),
+                        Some("") | None => Ok(body.clone()),
+                        Some(m) => Err(FormatError::Other(format!(
+                            "unsupported contents modifier: {m}"
+                        ))),
                     }
                 }
-                Some("size") => Ok(body.len().to_string()),
-                Some("") | None => Ok(body),
-                Some(m) => Err(FormatError::Other(format!(
-                    "unsupported contents modifier: {m}"
-                ))),
+                _ => Ok(String::new()),
             }
         }
         "creator" => {
@@ -1043,6 +1390,7 @@ fn deref_atom_value(
     entry: &RefEntry,
     atom: &str,
     head_branch: &Option<String>,
+    mailmap: &[MailmapEntry],
 ) -> Result<String, FormatError> {
     use grit_lib::objects::ObjectKind;
     // Read the object to check if it's a tag
@@ -1070,7 +1418,25 @@ fn deref_atom_value(
         object_name: target_oid.to_string(),
     };
     // Evaluate the atom against the dereferenced entry
-    atom_value(repo, &deref_entry, atom, head_branch)
+    atom_value(repo, &deref_entry, atom, head_branch, mailmap)
+}
+
+/// Tag subject: first paragraph with inner newlines replaced by spaces (matches Git `ref-filter`).
+fn tag_subject_paragraph(message: &str) -> String {
+    let first_para = message.split("\n\n").next().unwrap_or("");
+    first_para
+        .lines()
+        .map(str::trim_end)
+        .filter(|l| !l.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Tag body: message after the first blank-line-separated paragraph.
+fn tag_body_after_first_para(message: &str) -> String {
+    let mut paras = message.splitn(2, "\n\n");
+    let _first = paras.next().unwrap_or("");
+    paras.next().unwrap_or("").to_owned()
 }
 
 fn subject_for_oid(
@@ -1093,7 +1459,7 @@ fn subject_for_oid(
             let tag = parse_tag(&object.data).map_err(|_| {
                 FormatError::Other(format!("failed to parse tag for {}", entry.name))
             })?;
-            Ok(tag.message.lines().next().unwrap_or("").to_owned())
+            Ok(tag_subject_paragraph(&tag.message))
         }
         _ => Ok(String::new()),
     }
@@ -1122,19 +1488,13 @@ fn body_for_oid(repo: &Repository, entry: &RefEntry, oid: ObjectId) -> Result<St
             let tag = parse_tag(&object.data).map_err(|_| {
                 FormatError::Other(format!("failed to parse tag for {}", entry.name))
             })?;
-            let mut lines = tag.message.splitn(2, '\n');
-            lines.next();
-            Ok(lines
-                .next()
-                .unwrap_or("")
-                .trim_start_matches('\n')
-                .to_owned())
+            Ok(tag_body_after_first_para(&tag.message))
         }
         _ => Ok(String::new()),
     }
 }
 
-fn commit_field_for_oid<F: Fn(&grit_lib::objects::CommitData) -> String>(
+fn commit_field_for_oid<F: Fn(&grit_lib::objects::CommitData) -> Result<String, FormatError>>(
     repo: &Repository,
     entry: &RefEntry,
     oid: ObjectId,
@@ -1149,7 +1509,7 @@ fn commit_field_for_oid<F: Fn(&grit_lib::objects::CommitData) -> String>(
             let commit = parse_commit(&object.data).map_err(|_| {
                 FormatError::Other(format!("failed to parse commit for {}", entry.name))
             })?;
-            Ok(extractor(&commit))
+            extractor(&commit)
         }
         ObjectKind::Tag => {
             // Non-deref atoms on tags return empty for commit-specific fields.
@@ -1194,48 +1554,88 @@ fn parse_identity_email(raw: &str) -> String {
     String::new()
 }
 
-/// Format an email from a raw identity string with optional modifiers.
-///
-/// Supported modifiers (comma-separated): `trim`, `localpart`, `mailmap`.
-/// `trim` removes the angle brackets, `localpart` keeps only the part
-/// before `@`. `mailmap` is accepted but currently a no-op.
-fn format_email(raw: &str, modifier: Option<&str>) -> String {
-    let email_with_brackets = parse_identity_email(raw);
-    if email_with_brackets.is_empty() {
-        return String::new();
+#[derive(Debug, Default, Clone)]
+struct EmailFormatOpts {
+    trim: bool,
+    localpart: bool,
+    mailmap: bool,
+}
+
+fn parse_email_modifiers(
+    modifier: Option<&str>,
+    atom_name: &str,
+) -> Result<EmailFormatOpts, FormatError> {
+    let mut opts = EmailFormatOpts::default();
+    let mut arg = modifier.unwrap_or("");
+    if arg.is_empty() {
+        return Ok(opts);
     }
-
-    let mods: Vec<&str> = modifier
-        .unwrap_or("")
-        .split(',')
-        .map(|s| s.trim())
-        .filter(|s| !s.is_empty())
-        .collect();
-
-    let do_trim = mods.contains(&"trim");
-    let do_localpart = mods.contains(&"localpart");
-
-    let email = if do_trim {
-        email_with_brackets
-            .trim_start_matches('<')
-            .trim_end_matches('>')
-            .to_owned()
-    } else {
-        email_with_brackets
-    };
-
-    if do_localpart {
-        // Strip brackets for localpart extraction — localpart always
-        // returns just the bare local part, never wrapped in angle brackets.
-        let bare = email.trim_start_matches('<').trim_end_matches('>');
-        return if let Some(at_pos) = bare.find('@') {
-            bare[..at_pos].to_owned()
+    loop {
+        let matched = if let Some(rest) = arg.strip_prefix("trim") {
+            arg = rest;
+            opts.trim = true;
+            true
+        } else if let Some(rest) = arg.strip_prefix("localpart") {
+            arg = rest;
+            opts.localpart = true;
+            true
+        } else if let Some(rest) = arg.strip_prefix("mailmap") {
+            arg = rest;
+            opts.mailmap = true;
+            true
         } else {
-            bare.to_owned()
+            false
         };
+        if !matched {
+            return Err(FormatError::Fatal(format!(
+                "unrecognized %({atom_name}) argument: {arg}"
+            )));
+        }
+        if arg.is_empty() {
+            break;
+        }
+        if let Some(rest) = arg.strip_prefix(',') {
+            arg = rest;
+        } else {
+            return Err(FormatError::Fatal(format!(
+                "unrecognized %({atom_name}) argument: {arg}"
+            )));
+        }
     }
+    Ok(opts)
+}
 
-    email
+fn copy_email_git(raw: &str, trim: bool, localpart: bool) -> String {
+    let Some(lt) = raw.find('<') else {
+        return String::new();
+    };
+    let mut start = lt;
+    if trim || localpart {
+        start = lt + 1;
+    }
+    let inner = &raw[start..];
+    let end = if localpart {
+        inner
+            .find('@')
+            .or_else(|| inner.find('>'))
+            .unwrap_or(inner.len())
+    } else if trim {
+        inner.find('>').unwrap_or(inner.len())
+    } else {
+        inner.find('>').map(|i| i + 1).unwrap_or(inner.len())
+    };
+    inner[..end].to_owned()
+}
+
+fn format_email_with_opts(raw: &str, opts: &EmailFormatOpts, mailmap: &[MailmapEntry]) -> String {
+    let line = if opts.mailmap {
+        let (name, email) = parse_contact(raw);
+        let (cn, ce) = map_contact(name.as_deref(), email.as_deref(), mailmap);
+        grit_lib::mailmap::render_contact(&cn, &ce)
+    } else {
+        raw.to_owned()
+    };
+    copy_email_git(&line, opts.trim, opts.localpart)
 }
 
 /// Parse the Unix timestamp and timezone from a raw Git identity string.
@@ -1253,148 +1653,22 @@ fn parse_identity_timestamp(raw: &str) -> Option<(i64, String)> {
     Some((epoch, tz))
 }
 
-/// Format a date from a raw identity string with an optional modifier.
-fn format_identity_date(raw: &str, modifier: Option<&str>) -> String {
-    let Some((epoch, tz)) = parse_identity_timestamp(raw) else {
-        return String::new();
+fn format_identity_date_git(raw: &str, modifier: Option<&str>) -> Result<String, FormatError> {
+    let Some((epoch_i64, tz_str)) = parse_identity_timestamp(raw) else {
+        return Ok(String::new());
     };
+    let epoch = u64::try_from(epoch_i64).unwrap_or(0);
+    let tz = atoi_bytes(tz_str.as_bytes());
 
-    // Parse tz offset into seconds
-    let tz_offset_secs = parse_tz_offset(&tz);
-    let adjusted = epoch + tz_offset_secs as i64;
-
-    match modifier {
-        Some("short") => format_epoch_short(adjusted),
-        Some("iso") | Some("iso8601") => format_epoch_iso(adjusted, &tz),
-        Some("iso-strict") | Some("iso8601-strict") => format_epoch_iso_strict(adjusted, &tz),
-        Some("unix") => epoch.to_string(),
-        Some("relative") => format_epoch_relative(epoch),
-        Some("raw") => format!("{epoch} {tz}"),
-        _ => format_epoch_default(adjusted, &tz),
-    }
-}
-
-fn parse_tz_offset(tz: &str) -> i32 {
-    if tz.len() < 5 {
-        return 0;
-    }
-    let sign = if tz.starts_with('-') { -1 } else { 1 };
-    let hours: i32 = tz[1..3].parse().unwrap_or(0);
-    let minutes: i32 = tz[3..5].parse().unwrap_or(0);
-    sign * (hours * 3600 + minutes * 60)
-}
-
-fn days_from_epoch(epoch_adjusted: i64) -> (i32, u32, u32) {
-    // Convert epoch seconds (already tz-adjusted) to Y-M-D
-    let days = (epoch_adjusted / 86400) as i32;
-    // Algorithm from http://howardhinnant.github.io/date_algorithms.html
-    let z = days + 719468;
-    let era = if z >= 0 { z } else { z - 146096 } / 146097;
-    let doe = (z - era * 146097) as u32;
-    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
-    let y = yoe as i32 + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let d = doy - (153 * mp + 2) / 5 + 1;
-    let m = if mp < 10 { mp + 3 } else { mp - 9 };
-    let y = if m <= 2 { y + 1 } else { y };
-    (y, m, d)
-}
-
-fn format_epoch_short(epoch_adjusted: i64) -> String {
-    let (y, m, d) = days_from_epoch(epoch_adjusted);
-    format!("{y:04}-{m:02}-{d:02}")
-}
-
-fn format_epoch_iso(epoch_adjusted: i64, tz: &str) -> String {
-    let (y, m, d) = days_from_epoch(epoch_adjusted);
-    let secs_in_day = epoch_adjusted.rem_euclid(86400);
-    let hh = secs_in_day / 3600;
-    let mm = (secs_in_day % 3600) / 60;
-    let ss = secs_in_day % 60;
-    format!("{y:04}-{m:02}-{d:02} {hh:02}:{mm:02}:{ss:02} {tz}")
-}
-
-fn format_epoch_iso_strict(epoch_adjusted: i64, tz: &str) -> String {
-    let (y, m, d) = days_from_epoch(epoch_adjusted);
-    let secs_in_day = epoch_adjusted.rem_euclid(86400);
-    let hh = secs_in_day / 3600;
-    let mm = (secs_in_day % 3600) / 60;
-    let ss = secs_in_day % 60;
-    let tz_display = if tz.len() >= 5 {
-        format!("{}:{}", &tz[..3], &tz[3..5])
-    } else {
-        tz.to_owned()
+    let format_spec = match modifier {
+        None | Some("") => "default",
+        Some(s) => s,
     };
-    format!("{y:04}-{m:02}-{d:02}T{hh:02}:{mm:02}:{ss:02}{tz_display}")
-}
-
-fn format_epoch_default(epoch_adjusted: i64, tz: &str) -> String {
-    // Git default: "Thu Jan  1 00:00:00 1970 +0000"
-    let (y, m, d) = days_from_epoch(epoch_adjusted);
-    let secs_in_day = epoch_adjusted.rem_euclid(86400);
-    let hh = secs_in_day / 3600;
-    let mm = (secs_in_day % 3600) / 60;
-    let ss = secs_in_day % 60;
-
-    let month_name = match m {
-        1 => "Jan",
-        2 => "Feb",
-        3 => "Mar",
-        4 => "Apr",
-        5 => "May",
-        6 => "Jun",
-        7 => "Jul",
-        8 => "Aug",
-        9 => "Sep",
-        10 => "Oct",
-        11 => "Nov",
-        12 => "Dec",
-        _ => "???",
-    };
-
-    // Compute day of week via Zeller-like
-    // epoch_adjusted / 86400 gives days since 1970-01-01 which was a Thursday
-    let day_index = ((epoch_adjusted / 86400) % 7 + 4 + 7) % 7; // 0=Sun
-    let day_name = match day_index {
-        0 => "Sun",
-        1 => "Mon",
-        2 => "Tue",
-        3 => "Wed",
-        4 => "Thu",
-        5 => "Fri",
-        6 => "Sat",
-        _ => "???",
-    };
-
-    format!("{day_name} {month_name} {d} {hh:02}:{mm:02}:{ss:02} {y:04} {tz}")
-}
-
-fn format_epoch_relative(epoch: i64) -> String {
-    // Very basic relative date
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs() as i64;
-    let diff = now - epoch;
-    if diff < 60 {
-        "just now".to_owned()
-    } else if diff < 3600 {
-        let m = diff / 60;
-        format!("{m} minute{} ago", if m == 1 { "" } else { "s" })
-    } else if diff < 86400 {
-        let h = diff / 3600;
-        format!("{h} hour{} ago", if h == 1 { "" } else { "s" })
-    } else if diff < 86400 * 30 {
-        let d = diff / 86400;
-        format!("{d} day{} ago", if d == 1 { "" } else { "s" })
-    } else if diff < 86400 * 365 {
-        let m = diff / (86400 * 30);
-        format!("{m} month{} ago", if m == 1 { "" } else { "s" })
-    } else {
-        let y = diff / (86400 * 365);
-        format!("{y} year{} ago", if y == 1 { "" } else { "s" })
-    }
+    let mut mode = parse_date_format(format_spec)
+        .map_err(|_| FormatError::Fatal(format!("unknown date format {format_spec}")))?;
+    let out = show_date(epoch, tz, &mut mode);
+    date_mode_release(&mut mode);
+    Ok(out)
 }
 
 /// Resolve upstream tracking info for a branch ref.
@@ -1763,31 +2037,13 @@ fn is_zero_oid(oid: &ObjectId) -> bool {
 /// Returns (ahead, behind) where ahead = commits reachable from `oid` but not `base`,
 /// and behind = commits reachable from `base` but not `oid`.
 fn compute_ahead_behind(repo: &Repository, oid: ObjectId, base: ObjectId) -> (usize, usize) {
-    use std::collections::{HashSet, VecDeque};
-
-    fn walk_ancestors(repo: &Repository, start: ObjectId) -> HashSet<ObjectId> {
-        let mut seen = HashSet::new();
-        let mut queue = VecDeque::new();
-        queue.push_back(start);
-        while let Some(oid) = queue.pop_front() {
-            if !seen.insert(oid) {
-                continue;
-            }
-            if let Ok(obj) = repo.odb.read(&oid) {
-                if let Ok(commit) = grit_lib::objects::parse_commit(&obj.data) {
-                    for parent in commit.parents {
-                        queue.push_back(parent);
-                    }
-                }
-            }
-        }
-        seen
-    }
-
-    let oid_ancestors = walk_ancestors(repo, oid);
-    let base_ancestors = walk_ancestors(repo, base);
-
-    let ahead = oid_ancestors.difference(&base_ancestors).count();
-    let behind = base_ancestors.difference(&oid_ancestors).count();
+    let Ok(al) = ancestor_closure(repo, oid) else {
+        return (0, 0);
+    };
+    let Ok(ar) = ancestor_closure(repo, base) else {
+        return (0, 0);
+    };
+    let ahead = al.difference(&ar).count();
+    let behind = ar.difference(&al).count();
     (ahead, behind)
 }

--- a/grit/src/commands/refs.rs
+++ b/grit/src/commands/refs.rs
@@ -3,7 +3,9 @@
 //! Provides subcommands for ref database operations:
 //! - `verify`  — verify the ref database integrity
 //! - `migrate` — migrate ref storage format (stub)
+//! - `list`    — alias for `for-each-ref` (same options and output)
 
+use crate::commands::for_each_ref;
 use anyhow::{Context, Result};
 use clap::{Args as ClapArgs, Subcommand};
 use std::fs;
@@ -31,8 +33,11 @@ pub enum RefsAction {
     },
     /// Optimize the ref database (pack loose refs).
     Optimize,
-    /// List all refs.
-    List,
+    /// List refs with filtering, sorting, and format atoms (`git for-each-ref` compatible).
+    List {
+        #[command(flatten)]
+        list_args: for_each_ref::Args,
+    },
 }
 
 /// Run `grit refs`.
@@ -43,7 +48,7 @@ pub fn run(args: Args) -> Result<()> {
         RefsAction::Verify => verify_refs(&repo),
         RefsAction::Migrate { ref_format } => migrate_refs(&repo, &ref_format),
         RefsAction::Optimize => optimize_refs(&repo),
-        RefsAction::List => list_refs(&repo),
+        RefsAction::List { list_args } => for_each_ref::run_refs_list(list_args),
     }
 }
 
@@ -373,14 +378,6 @@ fn verify_refs_dir(repo: &Repository, dir: &Path, bad_ref_name_level: &str) -> R
         }
     }
     Ok(errors)
-}
-
-fn list_refs(repo: &Repository) -> Result<()> {
-    let refs = grit_lib::refs::list_refs(&repo.git_dir, "refs/").context("failed to list refs")?;
-    for (name, oid) in refs {
-        println!("{oid} {name}");
-    }
-    Ok(())
 }
 
 fn optimize_refs(_repo: &Repository) -> Result<()> {

--- a/logs/2026-04-09_t1461-refs-list.md
+++ b/logs/2026-04-09_t1461-refs-list.md
@@ -1,0 +1,22 @@
+# t1461-refs-list / for-each-ref work (2026-04-09)
+
+## Done
+
+- Added `tests/for-each-ref-tests.sh` (copy from `git/t/`) so `t1461-refs-list.sh` and `t6300-for-each-ref.sh` can source it.
+- `grit refs list` now delegates to the same implementation as `for-each-ref` via `for_each_ref::run_refs_list`, with `usage: git refs list` when invoked that way.
+- Shared mailmap parsing in `grit-lib/src/mailmap.rs`; `check-mailmap` refactored to use it.
+- `for-each-ref` improvements toward upstream `for-each-ref-tests.sh`:
+  - Mailmap for author/committer/tagger name and email atoms; Git-style email modifier parsing.
+  - Date atoms via `grit_lib::git_date::show` (`parse_date_format` / `show_date`).
+  - `--shell`, `--perl`, `--python`, `--tcl` quoting; validation for `%(raw)` with shell/python/tcl.
+  - Stricter `%(objectname:short=…)` errors; `%(raw:size)`; sort keys `raw` and `raw:size`.
+  - `compute_ahead_behind` uses `ancestor_closure` (fixes `%(ahead-behind)` style counting).
+  - Tag multiline subject/body handling (paragraph rules) for `subject`, `body`, `contents:*`; trailing newline on `%(raw)` for non-commit objects.
+
+## Harness
+
+- `./scripts/run-tests.sh t1461-refs-list.sh` → **352/428** pass (was 0/0 when `for-each-ref-tests.sh` was missing).
+
+## Remaining for full t1461 pass
+
+Large subset of `for-each-ref-tests.sh` still unimplemented: `%(describe)`, `%(if)`/`%(then)`/`%(else)`/`%(end)`, `%(trailers)`, `%(symref)`, `%(color)`/`--color`, `--omit-empty`, `--no-sort`, extended `--sort` (e.g. `contents:size`, `creatordate:format:…`), `%(push)` push.default/simple, GPG/SSH signature atoms, etc.

--- a/tests/for-each-ref-tests.sh
+++ b/tests/for-each-ref-tests.sh
@@ -1,0 +1,2152 @@
+git_for_each_ref=${git_for_each_ref:-git for-each-ref}
+GNUPGHOME_NOT_USED=$GNUPGHOME
+. "$TEST_DIRECTORY"/lib-gpg.sh
+. "$TEST_DIRECTORY"/lib-terminal.sh
+
+# Mon Jul 3 23:18:43 2006 +0000
+datestamp=1151968723
+setdate_and_increment () {
+    GIT_COMMITTER_DATE="$datestamp +0200"
+    datestamp=$(expr "$datestamp" + 1)
+    GIT_AUTHOR_DATE="$datestamp +0200"
+    datestamp=$(expr "$datestamp" + 1)
+    export GIT_COMMITTER_DATE GIT_AUTHOR_DATE
+}
+
+test_object_file_size () {
+	oid=$(git rev-parse "$1")
+	path=".git/objects/$(test_oid_to_path $oid)"
+	test_file_size "$path"
+}
+
+test_expect_success setup '
+	# setup .mailmap
+	cat >.mailmap <<-EOF &&
+	A Thor <athor@example.com> A U Thor <author@example.com>
+	C Mitter <cmitter@example.com> C O Mitter <committer@example.com>
+	EOF
+
+	setdate_and_increment &&
+	echo "Using $datestamp" > one &&
+	git add one &&
+	git commit -m "Initial" &&
+	git branch -M main &&
+	setdate_and_increment &&
+	git tag -a -m "Tagging at $datestamp" testtag &&
+	git update-ref refs/remotes/origin/main main &&
+	git remote add origin nowhere &&
+	git config branch.main.remote origin &&
+	git config branch.main.merge refs/heads/main &&
+	git remote add myfork elsewhere &&
+	git config remote.pushdefault myfork &&
+	git config push.default current
+'
+
+test_atom () {
+	case "$1" in
+		head) ref=refs/heads/main ;;
+		 tag) ref=refs/tags/testtag ;;
+		 sym) ref=refs/heads/sym ;;
+		   *) ref=$1 ;;
+	esac
+	format=$2
+	test_do=test_expect_${4:-success}
+
+	printf '%s\n' "$3" >expected
+	$test_do $PREREQ "basic atom: $ref $format" '
+		${git_for_each_ref} --format="%($format)" "$ref" >actual &&
+		sanitize_pgp <actual >actual.clean &&
+		test_cmp expected actual.clean
+	'
+
+	# Automatically test "contents:size" atom after testing "contents"
+	if test "$format" = "contents"
+	then
+		# for commit leg, $3 is changed there
+		expect=$(printf '%s' "$3" | wc -c)
+		$test_do $PREREQ "basic atom: $ref contents:size" '
+			type=$(git cat-file -t "$ref") &&
+			case $type in
+			tag)
+				# We cannot use $3 as it expects sanitize_pgp to run
+				git cat-file tag $ref >out &&
+				expect=$(tail -n +6 out | wc -c) &&
+				rm -f out ;;
+			tree | blob)
+				expect="" ;;
+			commit)
+				: "use the calculated expect" ;;
+			*)
+				BUG "unknown object type" ;;
+			esac &&
+			# Leave $expect unquoted to lose possible leading whitespaces
+			echo $expect >expected &&
+			${git_for_each_ref} --format="%(contents:size)" "$ref" >actual &&
+			test_cmp expected actual
+		'
+	fi
+}
+
+hexlen=$(test_oid hexsz)
+
+test_atom head refname refs/heads/main
+test_atom head refname: refs/heads/main
+test_atom head refname:short main
+test_atom head refname:lstrip=1 heads/main
+test_atom head refname:lstrip=2 main
+test_atom head refname:lstrip=-1 main
+test_atom head refname:lstrip=-2 heads/main
+test_atom head refname:rstrip=1 refs/heads
+test_atom head refname:rstrip=2 refs
+test_atom head refname:rstrip=-1 refs
+test_atom head refname:rstrip=-2 refs/heads
+test_atom head refname:strip=1 heads/main
+test_atom head refname:strip=2 main
+test_atom head refname:strip=-1 main
+test_atom head refname:strip=-2 heads/main
+test_atom head upstream refs/remotes/origin/main
+test_atom head upstream:short origin/main
+test_atom head upstream:lstrip=2 origin/main
+test_atom head upstream:lstrip=-2 origin/main
+test_atom head upstream:rstrip=2 refs/remotes
+test_atom head upstream:rstrip=-2 refs/remotes
+test_atom head upstream:strip=2 origin/main
+test_atom head upstream:strip=-2 origin/main
+test_atom head push refs/remotes/myfork/main
+test_atom head push:short myfork/main
+test_atom head push:lstrip=1 remotes/myfork/main
+test_atom head push:lstrip=-1 main
+test_atom head push:rstrip=1 refs/remotes/myfork
+test_atom head push:rstrip=-1 refs
+test_atom head push:strip=1 remotes/myfork/main
+test_atom head push:strip=-1 main
+test_atom head objecttype commit
+test_atom head objectsize $((131 + hexlen))
+test_atom head objectsize:disk $(test_object_file_size refs/heads/main)
+test_atom head deltabase $ZERO_OID
+test_atom head objectname $(git rev-parse refs/heads/main)
+test_atom head objectname:short $(git rev-parse --short refs/heads/main)
+test_atom head objectname:short=1 $(git rev-parse --short=1 refs/heads/main)
+test_atom head objectname:short=10 $(git rev-parse --short=10 refs/heads/main)
+test_atom head tree $(git rev-parse refs/heads/main^{tree})
+test_atom head tree:short $(git rev-parse --short refs/heads/main^{tree})
+test_atom head tree:short=1 $(git rev-parse --short=1 refs/heads/main^{tree})
+test_atom head tree:short=10 $(git rev-parse --short=10 refs/heads/main^{tree})
+test_atom head parent ''
+test_atom head parent:short ''
+test_atom head parent:short=1 ''
+test_atom head parent:short=10 ''
+test_atom head numparent 0
+test_atom head object ''
+test_atom head type ''
+test_atom head raw "$(git cat-file commit refs/heads/main)
+"
+test_atom head '*objectname' ''
+test_atom head '*objecttype' ''
+test_atom head author 'A U Thor <author@example.com> 1151968724 +0200'
+test_atom head authorname 'A U Thor'
+test_atom head authorname:mailmap 'A Thor'
+test_atom head authoremail '<author@example.com>'
+test_atom head authoremail:trim 'author@example.com'
+test_atom head authoremail:localpart 'author'
+test_atom head authoremail:trim,localpart 'author'
+test_atom head authoremail:mailmap '<athor@example.com>'
+test_atom head authoremail:mailmap,trim 'athor@example.com'
+test_atom head authoremail:trim,mailmap 'athor@example.com'
+test_atom head authoremail:mailmap,localpart 'athor'
+test_atom head authoremail:localpart,mailmap 'athor'
+test_atom head authoremail:mailmap,trim,localpart,mailmap,trim 'athor'
+test_atom head authordate 'Tue Jul 4 01:18:44 2006 +0200'
+test_atom head committer 'C O Mitter <committer@example.com> 1151968723 +0200'
+test_atom head committername 'C O Mitter'
+test_atom head committername:mailmap 'C Mitter'
+test_atom head committeremail '<committer@example.com>'
+test_atom head committeremail:trim 'committer@example.com'
+test_atom head committeremail:localpart 'committer'
+test_atom head committeremail:localpart,trim 'committer'
+test_atom head committeremail:mailmap '<cmitter@example.com>'
+test_atom head committeremail:mailmap,trim 'cmitter@example.com'
+test_atom head committeremail:trim,mailmap 'cmitter@example.com'
+test_atom head committeremail:mailmap,localpart 'cmitter'
+test_atom head committeremail:localpart,mailmap 'cmitter'
+test_atom head committeremail:trim,mailmap,trim,trim,localpart 'cmitter'
+test_atom head committerdate 'Tue Jul 4 01:18:43 2006 +0200'
+test_atom head tag ''
+test_atom head tagger ''
+test_atom head taggername ''
+test_atom head taggeremail ''
+test_atom head taggeremail:trim ''
+test_atom head taggeremail:localpart ''
+test_atom head taggerdate ''
+test_atom head creator 'C O Mitter <committer@example.com> 1151968723 +0200'
+test_atom head creatordate 'Tue Jul 4 01:18:43 2006 +0200'
+test_atom head subject 'Initial'
+test_atom head subject:sanitize 'Initial'
+test_atom head contents:subject 'Initial'
+test_atom head body ''
+test_atom head contents:body ''
+test_atom head contents:signature ''
+test_atom head contents 'Initial
+'
+test_atom head HEAD '*'
+
+test_atom tag refname refs/tags/testtag
+test_atom tag refname:short testtag
+test_atom tag upstream ''
+test_atom tag push ''
+test_atom tag objecttype tag
+test_atom tag objectsize $((114 + hexlen))
+test_atom tag objectsize:disk $(test_object_file_size refs/tags/testtag)
+test_atom tag '*objectsize:disk' $(test_object_file_size refs/heads/main)
+test_atom tag deltabase $ZERO_OID
+test_atom tag '*deltabase' $ZERO_OID
+test_atom tag objectname $(git rev-parse refs/tags/testtag)
+test_atom tag objectname:short $(git rev-parse --short refs/tags/testtag)
+test_atom head objectname:short=1 $(git rev-parse --short=1 refs/heads/main)
+test_atom head objectname:short=10 $(git rev-parse --short=10 refs/heads/main)
+test_atom tag tree ''
+test_atom tag tree:short ''
+test_atom tag tree:short=1 ''
+test_atom tag tree:short=10 ''
+test_atom tag parent ''
+test_atom tag parent:short ''
+test_atom tag parent:short=1 ''
+test_atom tag parent:short=10 ''
+test_atom tag numparent ''
+test_atom tag object $(git rev-parse refs/tags/testtag^0)
+test_atom tag type 'commit'
+test_atom tag '*objectname' $(git rev-parse refs/tags/testtag^{})
+test_atom tag '*objecttype' 'commit'
+test_atom tag author ''
+test_atom tag authorname ''
+test_atom tag authorname:mailmap ''
+test_atom tag authoremail ''
+test_atom tag authoremail:trim ''
+test_atom tag authoremail:localpart ''
+test_atom tag authoremail:trim,localpart ''
+test_atom tag authoremail:mailmap ''
+test_atom tag authoremail:mailmap,trim ''
+test_atom tag authoremail:trim,mailmap ''
+test_atom tag authoremail:mailmap,localpart ''
+test_atom tag authoremail:localpart,mailmap ''
+test_atom tag authoremail:mailmap,trim,localpart,mailmap,trim ''
+test_atom tag authordate ''
+test_atom tag committer ''
+test_atom tag committername ''
+test_atom tag committername:mailmap ''
+test_atom tag committeremail ''
+test_atom tag committeremail:trim ''
+test_atom tag committeremail:localpart ''
+test_atom tag committeremail:localpart,trim ''
+test_atom tag committeremail:mailmap ''
+test_atom tag committeremail:mailmap,trim ''
+test_atom tag committeremail:trim,mailmap ''
+test_atom tag committeremail:mailmap,localpart ''
+test_atom tag committeremail:localpart,mailmap ''
+test_atom tag committeremail:trim,mailmap,trim,trim,localpart ''
+test_atom tag committerdate ''
+test_atom tag tag 'testtag'
+test_atom tag tagger 'C O Mitter <committer@example.com> 1151968725 +0200'
+test_atom tag taggername 'C O Mitter'
+test_atom tag taggername:mailmap 'C Mitter'
+test_atom tag taggeremail '<committer@example.com>'
+test_atom tag taggeremail:trim 'committer@example.com'
+test_atom tag taggeremail:localpart 'committer'
+test_atom tag taggeremail:trim,localpart 'committer'
+test_atom tag taggeremail:mailmap '<cmitter@example.com>'
+test_atom tag taggeremail:mailmap,trim 'cmitter@example.com'
+test_atom tag taggeremail:trim,mailmap 'cmitter@example.com'
+test_atom tag taggeremail:mailmap,localpart 'cmitter'
+test_atom tag taggeremail:localpart,mailmap 'cmitter'
+test_atom tag taggeremail:trim,mailmap,trim,localpart,localpart 'cmitter'
+test_atom tag taggerdate 'Tue Jul 4 01:18:45 2006 +0200'
+test_atom tag creator 'C O Mitter <committer@example.com> 1151968725 +0200'
+test_atom tag creatordate 'Tue Jul 4 01:18:45 2006 +0200'
+test_atom tag subject 'Tagging at 1151968727'
+test_atom tag subject:sanitize 'Tagging-at-1151968727'
+test_atom tag contents:subject 'Tagging at 1151968727'
+test_atom tag body ''
+test_atom tag contents:body ''
+test_atom tag contents:signature ''
+test_atom tag contents 'Tagging at 1151968727
+'
+test_atom tag HEAD ' '
+
+test_expect_success 'basic atom: refs/tags/testtag *raw' '
+	git cat-file commit refs/tags/testtag^{} >expected &&
+	${git_for_each_ref} --format="%(*raw)" refs/tags/testtag >actual &&
+	sanitize_pgp <expected >expected.clean &&
+	echo >>expected.clean &&
+	sanitize_pgp <actual >actual.clean &&
+	test_cmp expected.clean actual.clean
+'
+
+test_expect_success 'Check invalid atoms names are errors' '
+	test_must_fail ${git_for_each_ref} --format="%(INVALID)" refs/heads
+'
+
+test_expect_success 'Check format specifiers are ignored in naming date atoms' '
+	${git_for_each_ref} --format="%(authordate)" refs/heads &&
+	${git_for_each_ref} --format="%(authordate:default) %(authordate)" refs/heads &&
+	${git_for_each_ref} --format="%(authordate) %(authordate:default)" refs/heads &&
+	${git_for_each_ref} --format="%(authordate:default) %(authordate:default)" refs/heads
+'
+
+test_expect_success 'Check valid format specifiers for date fields' '
+	${git_for_each_ref} --format="%(authordate:default)" refs/heads &&
+	${git_for_each_ref} --format="%(authordate:relative)" refs/heads &&
+	${git_for_each_ref} --format="%(authordate:short)" refs/heads &&
+	${git_for_each_ref} --format="%(authordate:local)" refs/heads &&
+	${git_for_each_ref} --format="%(authordate:iso8601)" refs/heads &&
+	${git_for_each_ref} --format="%(authordate:rfc2822)" refs/heads
+'
+
+test_expect_success 'Check invalid format specifiers are errors' '
+	test_must_fail ${git_for_each_ref} --format="%(authordate:INVALID)" refs/heads
+'
+
+test_expect_success 'arguments to %(objectname:short=) must be positive integers' '
+	test_must_fail ${git_for_each_ref} --format="%(objectname:short=0)" &&
+	test_must_fail ${git_for_each_ref} --format="%(objectname:short=-1)" &&
+	test_must_fail ${git_for_each_ref} --format="%(objectname:short=foo)"
+'
+
+test_bad_atom () {
+	case "$1" in
+	head) ref=refs/heads/main ;;
+	 tag) ref=refs/tags/testtag ;;
+	 sym) ref=refs/heads/sym ;;
+	   *) ref=$1 ;;
+	esac
+	format=$2
+	test_do=test_expect_${4:-success}
+
+	printf '%s\n' "$3" >expect
+	$test_do $PREREQ "err basic atom: $ref $format" '
+		test_must_fail ${git_for_each_ref} \
+			--format="%($format)" "$ref" 2>error &&
+		test_cmp expect error
+	'
+}
+
+test_bad_atom head 'authoremail:foo' \
+	'fatal: unrecognized %(authoremail) argument: foo'
+
+test_bad_atom head 'authoremail:mailmap,trim,bar' \
+	'fatal: unrecognized %(authoremail) argument: bar'
+
+test_bad_atom head 'authoremail:trim,' \
+	'fatal: unrecognized %(authoremail) argument: '
+
+test_bad_atom head 'authoremail:mailmaptrim' \
+	'fatal: unrecognized %(authoremail) argument: trim'
+
+test_bad_atom head 'committeremail: ' \
+	'fatal: unrecognized %(committeremail) argument:  '
+
+test_bad_atom head 'committeremail: trim,foo' \
+	'fatal: unrecognized %(committeremail) argument:  trim,foo'
+
+test_bad_atom head 'committeremail:mailmap,localpart ' \
+	'fatal: unrecognized %(committeremail) argument:  '
+
+test_bad_atom head 'committeremail:trim_localpart' \
+	'fatal: unrecognized %(committeremail) argument: _localpart'
+
+test_bad_atom head 'committeremail:localpart,,,trim' \
+	'fatal: unrecognized %(committeremail) argument: ,,trim'
+
+test_bad_atom tag 'taggeremail:mailmap,trim, foo ' \
+	'fatal: unrecognized %(taggeremail) argument:  foo '
+
+test_bad_atom tag 'taggeremail:trim,localpart,' \
+	'fatal: unrecognized %(taggeremail) argument: '
+
+test_bad_atom tag 'taggeremail:mailmap;localpart trim' \
+	'fatal: unrecognized %(taggeremail) argument: ;localpart trim'
+
+test_bad_atom tag 'taggeremail:localpart trim' \
+	'fatal: unrecognized %(taggeremail) argument:  trim'
+
+test_bad_atom tag 'taggeremail:mailmap,mailmap,trim,qux,localpart,trim' \
+	'fatal: unrecognized %(taggeremail) argument: qux,localpart,trim'
+
+test_date () {
+	f=$1 &&
+	committer_date=$2 &&
+	author_date=$3 &&
+	tagger_date=$4 &&
+	cat >expected <<-EOF &&
+	'refs/heads/main' '$committer_date' '$author_date'
+	'refs/tags/testtag' '$tagger_date'
+	EOF
+	(
+		${git_for_each_ref} --shell \
+			--format="%(refname) %(committerdate${f:+:$f}) %(authordate${f:+:$f})" \
+			refs/heads &&
+		${git_for_each_ref} --shell \
+			--format="%(refname) %(taggerdate${f:+:$f})" \
+			refs/tags
+	) >actual &&
+	test_cmp expected actual
+}
+
+test_expect_success 'Check unformatted date fields output' '
+	test_date "" \
+		"Tue Jul 4 01:18:43 2006 +0200" \
+		"Tue Jul 4 01:18:44 2006 +0200" \
+		"Tue Jul 4 01:18:45 2006 +0200"
+'
+
+test_expect_success 'Check format "default" formatted date fields output' '
+	test_date default \
+		"Tue Jul 4 01:18:43 2006 +0200" \
+		"Tue Jul 4 01:18:44 2006 +0200" \
+		"Tue Jul 4 01:18:45 2006 +0200"
+'
+
+test_expect_success 'Check format "default-local" date fields output' '
+	test_date default-local "Mon Jul 3 23:18:43 2006" "Mon Jul 3 23:18:44 2006" "Mon Jul 3 23:18:45 2006"
+'
+
+# Don't know how to do relative check because I can't know when this script
+# is going to be run and can't fake the current time to git, and hence can't
+# provide expected output.  Instead, I'll just make sure that "relative"
+# doesn't exit in error
+test_expect_success 'Check format "relative" date fields output' '
+	f=relative &&
+	(${git_for_each_ref} --shell --format="%(refname) %(committerdate:$f) %(authordate:$f)" refs/heads &&
+	${git_for_each_ref} --shell --format="%(refname) %(taggerdate:$f)" refs/tags) >actual
+'
+
+# We just check that this is the same as "relative" for now.
+test_expect_success 'Check format "relative-local" date fields output' '
+	test_date relative-local \
+		"$(${git_for_each_ref} --format="%(committerdate:relative)" refs/heads)" \
+		"$(${git_for_each_ref} --format="%(authordate:relative)" refs/heads)" \
+		"$(${git_for_each_ref} --format="%(taggerdate:relative)" refs/tags)"
+'
+
+test_expect_success 'Check format "short" date fields output' '
+	test_date short 2006-07-04 2006-07-04 2006-07-04
+'
+
+test_expect_success 'Check format "short-local" date fields output' '
+	test_date short-local 2006-07-03 2006-07-03 2006-07-03
+'
+
+test_expect_success 'Check format "local" date fields output' '
+	test_date local \
+		"Mon Jul 3 23:18:43 2006" \
+		"Mon Jul 3 23:18:44 2006" \
+		"Mon Jul 3 23:18:45 2006"
+'
+
+test_expect_success 'Check format "iso8601" date fields output' '
+	test_date iso8601 \
+		"2006-07-04 01:18:43 +0200" \
+		"2006-07-04 01:18:44 +0200" \
+		"2006-07-04 01:18:45 +0200"
+'
+
+test_expect_success 'Check format "iso8601-local" date fields output' '
+	test_date iso8601-local "2006-07-03 23:18:43 +0000" "2006-07-03 23:18:44 +0000" "2006-07-03 23:18:45 +0000"
+'
+
+test_expect_success 'Check format "rfc2822" date fields output' '
+	test_date rfc2822 \
+		"Tue, 4 Jul 2006 01:18:43 +0200" \
+		"Tue, 4 Jul 2006 01:18:44 +0200" \
+		"Tue, 4 Jul 2006 01:18:45 +0200"
+'
+
+test_expect_success 'Check format "rfc2822-local" date fields output' '
+	test_date rfc2822-local "Mon, 3 Jul 2006 23:18:43 +0000" "Mon, 3 Jul 2006 23:18:44 +0000" "Mon, 3 Jul 2006 23:18:45 +0000"
+'
+
+test_expect_success 'Check format "raw" date fields output' '
+	test_date raw "1151968723 +0200" "1151968724 +0200" "1151968725 +0200"
+'
+
+test_expect_success 'Check format "raw-local" date fields output' '
+	test_date raw-local "1151968723 +0000" "1151968724 +0000" "1151968725 +0000"
+'
+
+test_expect_success 'Check format of strftime date fields' '
+	echo "my date is 2006-07-04" >expected &&
+	${git_for_each_ref} \
+	  --format="%(authordate:format:my date is %Y-%m-%d)" \
+	  refs/heads >actual &&
+	test_cmp expected actual
+'
+
+test_expect_success 'Check format of strftime-local date fields' '
+	echo "my date is 2006-07-03" >expected &&
+	${git_for_each_ref} \
+	  --format="%(authordate:format-local:my date is %Y-%m-%d)" \
+	  refs/heads >actual &&
+	test_cmp expected actual
+'
+
+test_expect_success 'exercise strftime with odd fields' '
+	echo >expected &&
+	${git_for_each_ref} --format="%(authordate:format:)" refs/heads >actual &&
+	test_cmp expected actual &&
+	long="long format -- $ZERO_OID$ZERO_OID$ZERO_OID$ZERO_OID$ZERO_OID$ZERO_OID$ZERO_OID" &&
+	echo $long >expected &&
+	${git_for_each_ref} --format="%(authordate:format:$long)" refs/heads >actual &&
+	test_cmp expected actual
+'
+
+cat >expected <<\EOF
+refs/heads/main
+refs/remotes/origin/main
+refs/tags/testtag
+EOF
+
+test_expect_success 'Verify ascending sort' '
+	${git_for_each_ref} --format="%(refname)" --sort=refname >actual &&
+	test_cmp expected actual
+'
+
+
+cat >expected <<\EOF
+refs/tags/testtag
+refs/remotes/origin/main
+refs/heads/main
+EOF
+
+test_expect_success 'Verify descending sort' '
+	${git_for_each_ref} --format="%(refname)" --sort=-refname >actual &&
+	test_cmp expected actual
+'
+
+test_expect_success 'Give help even with invalid sort atoms' '
+	test_expect_code 129 ${git_for_each_ref} --sort=bogus -h >actual 2>&1 &&
+	grep "^usage: ${git_for_each_ref}" actual
+'
+
+cat >expected <<\EOF
+refs/tags/testtag
+refs/tags/testtag-2
+EOF
+
+test_expect_success 'exercise patterns with prefixes' '
+	git tag testtag-2 &&
+	test_when_finished "git tag -d testtag-2" &&
+	${git_for_each_ref} --format="%(refname)" \
+		refs/tags/testtag refs/tags/testtag-2 >actual &&
+	test_cmp expected actual
+'
+
+cat >expected <<\EOF
+refs/tags/testtag
+refs/tags/testtag-2
+EOF
+
+test_expect_success 'exercise glob patterns with prefixes' '
+	git tag testtag-2 &&
+	test_when_finished "git tag -d testtag-2" &&
+	${git_for_each_ref} --format="%(refname)" \
+		refs/tags/testtag "refs/tags/testtag-*" >actual &&
+	test_cmp expected actual
+'
+
+cat >expected <<\EOF
+refs/tags/bar
+refs/tags/baz
+refs/tags/testtag
+EOF
+
+test_expect_success 'exercise patterns with prefix exclusions' '
+	for tag in foo/one foo/two foo/three bar baz
+	do
+		git tag "$tag" || return 1
+	done &&
+	test_when_finished "git tag -d foo/one foo/two foo/three bar baz" &&
+	${git_for_each_ref} --format="%(refname)" \
+		refs/tags/ --exclude=refs/tags/foo >actual &&
+	test_cmp expected actual
+'
+
+cat >expected <<\EOF
+refs/tags/bar
+refs/tags/baz
+refs/tags/foo/one
+refs/tags/testtag
+EOF
+
+test_expect_success 'exercise patterns with pattern exclusions' '
+	for tag in foo/one foo/two foo/three bar baz
+	do
+		git tag "$tag" || return 1
+	done &&
+	test_when_finished "git tag -d foo/one foo/two foo/three bar baz" &&
+	${git_for_each_ref} --format="%(refname)" \
+		refs/tags/ --exclude="refs/tags/foo/t*" >actual &&
+	test_cmp expected actual
+'
+
+cat >expected <<\EOF
+'refs/heads/main'
+'refs/remotes/origin/main'
+'refs/tags/testtag'
+EOF
+
+test_expect_success 'Quoting style: shell' '
+	${git_for_each_ref} --shell --format="%(refname)" >actual &&
+	test_cmp expected actual
+'
+
+test_expect_success 'Quoting style: perl' '
+	${git_for_each_ref} --perl --format="%(refname)" >actual &&
+	test_cmp expected actual
+'
+
+test_expect_success 'Quoting style: python' '
+	${git_for_each_ref} --python --format="%(refname)" >actual &&
+	test_cmp expected actual
+'
+
+cat >expected <<\EOF
+"refs/heads/main"
+"refs/remotes/origin/main"
+"refs/tags/testtag"
+EOF
+
+test_expect_success 'Quoting style: tcl' '
+	${git_for_each_ref} --tcl --format="%(refname)" >actual &&
+	test_cmp expected actual
+'
+
+for i in "--perl --shell" "-s --python" "--python --tcl" "--tcl --perl"; do
+	test_expect_success "more than one quoting style: $i" "
+		test_must_fail ${git_for_each_ref} $i 2>err &&
+		grep '^error: more than one quoting style' err
+	"
+done
+
+test_expect_success 'setup for upstream:track[short]' '
+	test_commit two
+'
+
+test_atom head upstream:track '[ahead 1]'
+test_atom head upstream:trackshort '>'
+test_atom head upstream:track,nobracket 'ahead 1'
+test_atom head upstream:nobracket,track 'ahead 1'
+
+test_expect_success 'setup for push:track[short]' '
+	test_commit third &&
+	git update-ref refs/remotes/myfork/main main &&
+	git reset main~1
+'
+
+test_atom head push:track '[behind 1]'
+test_atom head push:trackshort '<'
+
+test_expect_success 'Check that :track[short] cannot be used with other atoms' '
+	test_must_fail ${git_for_each_ref} --format="%(refname:track)" 2>/dev/null &&
+	test_must_fail ${git_for_each_ref} --format="%(refname:trackshort)" 2>/dev/null
+'
+
+test_expect_success 'Check that :track[short] works when upstream is invalid' '
+	cat >expected <<-\EOF &&
+	[gone]
+
+	EOF
+	test_when_finished "git config branch.main.merge refs/heads/main" &&
+	git config branch.main.merge refs/heads/does-not-exist &&
+	${git_for_each_ref} \
+		--format="%(upstream:track)$LF%(upstream:trackshort)" \
+		refs/heads >actual &&
+	test_cmp expected actual
+'
+
+test_expect_success 'Check for invalid refname format' '
+	test_must_fail ${git_for_each_ref} --format="%(refname:INVALID)"
+'
+
+test_expect_success 'set up color tests' '
+	cat >expected.color <<-EOF &&
+	$(git rev-parse --short refs/heads/main) <GREEN>main<RESET>
+	$(git rev-parse --short refs/remotes/myfork/main) <GREEN>myfork/main<RESET>
+	$(git rev-parse --short refs/remotes/origin/main) <GREEN>origin/main<RESET>
+	$(git rev-parse --short refs/tags/testtag) <GREEN>testtag<RESET>
+	$(git rev-parse --short refs/tags/third) <GREEN>third<RESET>
+	$(git rev-parse --short refs/tags/two) <GREEN>two<RESET>
+	EOF
+	sed "s/<[^>]*>//g" <expected.color >expected.bare &&
+	color_format="%(objectname:short) %(color:green)%(refname:short)"
+'
+
+test_expect_success TTY '%(color) shows color with a tty' '
+	test_terminal ${git_for_each_ref} --format="$color_format" >actual.raw &&
+	test_decode_color <actual.raw >actual &&
+	test_cmp expected.color actual
+'
+
+test_expect_success '%(color) does not show color without tty' '
+	TERM=vt100 ${git_for_each_ref} --format="$color_format" >actual &&
+	test_cmp expected.bare actual
+'
+
+test_expect_success '--color can override tty check' '
+	${git_for_each_ref} --color --format="$color_format" >actual.raw &&
+	test_decode_color <actual.raw >actual &&
+	test_cmp expected.color actual
+'
+
+test_expect_success 'color.ui=always does not override tty check' '
+	git -c color.ui=always ${git_for_each_ref#git} --format="$color_format" >actual &&
+	test_cmp expected.bare actual
+'
+
+test_expect_success 'setup for describe atom tests' '
+	git init -b master describe-repo &&
+	(
+		cd describe-repo &&
+
+		test_commit --no-tag one &&
+		git tag tagone &&
+
+		test_commit --no-tag two &&
+		git tag -a -m "tag two" tagtwo
+	)
+'
+
+test_expect_success 'describe atom vs git describe' '
+	(
+		cd describe-repo &&
+
+		${git_for_each_ref} --format="%(objectname)" \
+			refs/tags/ >obj &&
+		while read hash
+		do
+			if desc=$(git describe $hash)
+			then
+				: >expect-contains-good
+			else
+				: >expect-contains-bad
+			fi &&
+			echo "$hash $desc" || return 1
+		done <obj >expect &&
+		test_path_exists expect-contains-good &&
+		test_path_exists expect-contains-bad &&
+
+		${git_for_each_ref} --format="%(objectname) %(describe)" \
+			refs/tags/ >actual 2>err &&
+		test_cmp expect actual &&
+		test_must_be_empty err
+	)
+'
+
+test_expect_success 'describe:tags vs describe --tags' '
+	(
+		cd describe-repo &&
+		git describe --tags >expect &&
+		${git_for_each_ref} --format="%(describe:tags)" \
+				refs/heads/master >actual &&
+		test_cmp expect actual
+	)
+'
+
+test_expect_success 'describe:abbrev=... vs describe --abbrev=...' '
+	(
+		cd describe-repo &&
+
+		# Case 1: We have commits between HEAD and the most
+		#	  recent tag reachable from it
+		test_commit --no-tag file &&
+		git describe --abbrev=14 >expect &&
+		${git_for_each_ref} --format="%(describe:abbrev=14)" \
+			refs/heads/master >actual &&
+		test_cmp expect actual &&
+
+		# Make sure the hash used is at least 14 digits long
+		sed -e "s/^.*-g\([0-9a-f]*\)$/\1/" <actual >hexpart &&
+		test 15 -le $(wc -c <hexpart) &&
+
+		# Case 2: We have a tag at HEAD, describe directly gives
+		#	  the name of the tag
+		git tag -a -m tagged tagname &&
+		git describe --abbrev=14 >expect &&
+		${git_for_each_ref} --format="%(describe:abbrev=14)" \
+			refs/heads/master >actual &&
+		test_cmp expect actual &&
+		test tagname = $(cat actual)
+	)
+'
+
+test_expect_success 'describe:match=... vs describe --match ...' '
+	(
+		cd describe-repo &&
+		git tag -a -m "tag foo" tag-foo &&
+		git describe --match "*-foo" >expect &&
+		${git_for_each_ref} --format="%(describe:match="*-foo")" \
+			refs/heads/master >actual &&
+		test_cmp expect actual
+	)
+'
+
+test_expect_success 'describe:exclude:... vs describe --exclude ...' '
+	(
+		cd describe-repo &&
+		git tag -a -m "tag bar" tag-bar &&
+		git describe --exclude "*-bar" >expect &&
+		${git_for_each_ref} --format="%(describe:exclude="*-bar")" \
+			refs/heads/master >actual &&
+		test_cmp expect actual
+	)
+'
+
+test_expect_success 'deref with describe atom' '
+	(
+		cd describe-repo &&
+		cat >expect <<-\EOF &&
+
+		tagname
+		tagname
+		tagname
+
+		tagtwo
+		EOF
+		${git_for_each_ref} --format="%(*describe)" >actual &&
+		test_cmp expect actual
+	)
+'
+
+test_expect_success 'err on bad describe atom arg' '
+	(
+		cd describe-repo &&
+
+		# The bad arg is the only arg passed to describe atom
+		cat >expect <<-\EOF &&
+		fatal: unrecognized %(describe) argument: baz
+		EOF
+		test_must_fail ${git_for_each_ref} --format="%(describe:baz)" \
+			refs/heads/master 2>actual &&
+		test_cmp expect actual &&
+
+		# The bad arg is in the middle of the option string
+		# passed to the describe atom
+		cat >expect <<-\EOF &&
+		fatal: unrecognized %(describe) argument: qux=1,abbrev=14
+		EOF
+		test_must_fail ${git_for_each_ref} \
+			--format="%(describe:tags,qux=1,abbrev=14)" \
+			ref/heads/master 2>actual &&
+		test_cmp expect actual
+	)
+'
+
+cat >expected <<\EOF
+heads/main
+tags/main
+EOF
+
+test_expect_success 'Check ambiguous head and tag refs (strict)' '
+	git config --bool core.warnambiguousrefs true &&
+	git checkout -b newtag &&
+	echo "Using $datestamp" > one &&
+	git add one &&
+	git commit -m "Branch" &&
+	setdate_and_increment &&
+	git tag -m "Tagging at $datestamp" main &&
+	${git_for_each_ref} --format "%(refname:short)" refs/heads/main refs/tags/main >actual &&
+	test_cmp expected actual
+'
+
+cat >expected <<\EOF
+heads/main
+main
+EOF
+
+test_expect_success 'Check ambiguous head and tag refs (loose)' '
+	git config --bool core.warnambiguousrefs false &&
+	${git_for_each_ref} --format "%(refname:short)" refs/heads/main refs/tags/main >actual &&
+	test_cmp expected actual
+'
+
+cat >expected <<\EOF
+heads/ambiguous
+ambiguous
+EOF
+
+test_expect_success 'Check ambiguous head and tag refs II (loose)' '
+	git checkout main &&
+	git tag ambiguous testtag^0 &&
+	git branch ambiguous testtag^0 &&
+	${git_for_each_ref} --format "%(refname:short)" refs/heads/ambiguous refs/tags/ambiguous >actual &&
+	test_cmp expected actual
+'
+
+test_expect_success 'create tag without tagger' '
+	git tag -a -m "Broken tag" taggerless &&
+	git tag -f taggerless $(git cat-file tag taggerless |
+		sed -e "/^tagger /d" |
+		git hash-object --literally --stdin -w -t tag)
+'
+
+test_atom refs/tags/taggerless type 'commit'
+test_atom refs/tags/taggerless tag 'taggerless'
+test_atom refs/tags/taggerless tagger ''
+test_atom refs/tags/taggerless taggername ''
+test_atom refs/tags/taggerless taggeremail ''
+test_atom refs/tags/taggerless taggeremail:trim ''
+test_atom refs/tags/taggerless taggeremail:localpart ''
+test_atom refs/tags/taggerless taggerdate ''
+test_atom refs/tags/taggerless committer ''
+test_atom refs/tags/taggerless committername ''
+test_atom refs/tags/taggerless committeremail ''
+test_atom refs/tags/taggerless committeremail:trim ''
+test_atom refs/tags/taggerless committeremail:localpart ''
+test_atom refs/tags/taggerless committerdate ''
+test_atom refs/tags/taggerless subject 'Broken tag'
+
+test_expect_success 'an unusual tag with an incomplete line' '
+
+	git tag -m "bogo" bogo &&
+	bogo=$(git cat-file tag bogo) &&
+	bogo=$(printf "%s" "$bogo" | git mktag) &&
+	git tag -f bogo "$bogo" &&
+	${git_for_each_ref} --format "%(body)" refs/tags/bogo
+
+'
+
+test_expect_success 'create tag with subject and body content' '
+	cat >>msg <<-\EOF &&
+		the subject line
+
+		first body line
+		second body line
+	EOF
+	git tag -F msg subject-body
+'
+test_atom refs/tags/subject-body subject 'the subject line'
+test_atom refs/tags/subject-body subject:sanitize 'the-subject-line'
+test_atom refs/tags/subject-body body 'first body line
+second body line
+'
+test_atom refs/tags/subject-body contents 'the subject line
+
+first body line
+second body line
+'
+
+test_expect_success 'create tag with multiline subject' '
+	cat >msg <<-\EOF &&
+		first subject line
+		second subject line
+
+		first body line
+		second body line
+	EOF
+	git tag -F msg multiline
+'
+test_atom refs/tags/multiline subject 'first subject line second subject line'
+test_atom refs/tags/multiline subject:sanitize 'first-subject-line-second-subject-line'
+test_atom refs/tags/multiline contents:subject 'first subject line second subject line'
+test_atom refs/tags/multiline body 'first body line
+second body line
+'
+test_atom refs/tags/multiline contents:body 'first body line
+second body line
+'
+test_atom refs/tags/multiline contents:signature ''
+test_atom refs/tags/multiline contents 'first subject line
+second subject line
+
+first body line
+second body line
+'
+
+test_expect_success GPG 'create signed tags' '
+	git tag -s -m "" signed-empty &&
+	git tag -s -m "subject line" signed-short &&
+	cat >msg <<-\EOF &&
+	subject line
+
+	body contents
+	EOF
+	git tag -s -F msg signed-long
+'
+
+sig='-----BEGIN PGP SIGNATURE-----
+-----END PGP SIGNATURE-----
+'
+
+PREREQ=GPG
+test_atom refs/tags/signed-empty subject ''
+test_atom refs/tags/signed-empty subject:sanitize ''
+test_atom refs/tags/signed-empty contents:subject ''
+test_atom refs/tags/signed-empty body "$sig"
+test_atom refs/tags/signed-empty contents:body ''
+test_atom refs/tags/signed-empty contents:signature "$sig"
+test_atom refs/tags/signed-empty contents "$sig"
+
+test_expect_success GPG 'basic atom: refs/tags/signed-empty raw' '
+	git cat-file tag refs/tags/signed-empty >expected &&
+	${git_for_each_ref} --format="%(raw)" refs/tags/signed-empty >actual &&
+	sanitize_pgp <expected >expected.clean &&
+	echo >>expected.clean &&
+	sanitize_pgp <actual >actual.clean &&
+	test_cmp expected.clean actual.clean
+'
+
+test_atom refs/tags/signed-short subject 'subject line'
+test_atom refs/tags/signed-short subject:sanitize 'subject-line'
+test_atom refs/tags/signed-short contents:subject 'subject line'
+test_atom refs/tags/signed-short body "$sig"
+test_atom refs/tags/signed-short contents:body ''
+test_atom refs/tags/signed-short contents:signature "$sig"
+test_atom refs/tags/signed-short contents "subject line
+$sig"
+
+test_expect_success GPG 'basic atom: refs/tags/signed-short raw' '
+	git cat-file tag refs/tags/signed-short >expected &&
+	${git_for_each_ref} --format="%(raw)" refs/tags/signed-short >actual &&
+	sanitize_pgp <expected >expected.clean &&
+	echo >>expected.clean &&
+	sanitize_pgp <actual >actual.clean &&
+	test_cmp expected.clean actual.clean
+'
+
+test_atom refs/tags/signed-long subject 'subject line'
+test_atom refs/tags/signed-long subject:sanitize 'subject-line'
+test_atom refs/tags/signed-long contents:subject 'subject line'
+test_atom refs/tags/signed-long body "body contents
+$sig"
+test_atom refs/tags/signed-long contents:body 'body contents
+'
+test_atom refs/tags/signed-long contents:signature "$sig"
+test_atom refs/tags/signed-long contents "subject line
+
+body contents
+$sig"
+
+test_expect_success GPG 'basic atom: refs/tags/signed-long raw' '
+	git cat-file tag refs/tags/signed-long >expected &&
+	${git_for_each_ref} --format="%(raw)" refs/tags/signed-long >actual &&
+	sanitize_pgp <expected >expected.clean &&
+	echo >>expected.clean &&
+	sanitize_pgp <actual >actual.clean &&
+	test_cmp expected.clean actual.clean
+'
+
+test_expect_success 'set up refs pointing to tree and blob' '
+	git update-ref refs/mytrees/first refs/heads/main^{tree} &&
+	git update-ref refs/myblobs/first refs/heads/main:one
+'
+
+test_atom refs/mytrees/first subject ""
+test_atom refs/mytrees/first contents:subject ""
+test_atom refs/mytrees/first body ""
+test_atom refs/mytrees/first contents:body ""
+test_atom refs/mytrees/first contents:signature ""
+test_atom refs/mytrees/first contents ""
+
+test_expect_success 'basic atom: refs/mytrees/first raw' '
+	git cat-file tree refs/mytrees/first >expected &&
+	echo >>expected &&
+	${git_for_each_ref} --format="%(raw)" refs/mytrees/first >actual &&
+	test_cmp expected actual &&
+	git cat-file -s refs/mytrees/first >expected &&
+	${git_for_each_ref} --format="%(raw:size)" refs/mytrees/first >actual &&
+	test_cmp expected actual
+'
+
+test_atom refs/myblobs/first subject ""
+test_atom refs/myblobs/first contents:subject ""
+test_atom refs/myblobs/first body ""
+test_atom refs/myblobs/first contents:body ""
+test_atom refs/myblobs/first contents:signature ""
+test_atom refs/myblobs/first contents ""
+
+test_expect_success 'basic atom: refs/myblobs/first raw' '
+	git cat-file blob refs/myblobs/first >expected &&
+	echo >>expected &&
+	${git_for_each_ref} --format="%(raw)" refs/myblobs/first >actual &&
+	test_cmp expected actual &&
+	git cat-file -s refs/myblobs/first >expected &&
+	${git_for_each_ref} --format="%(raw:size)" refs/myblobs/first >actual &&
+	test_cmp expected actual
+'
+
+test_expect_success 'set up refs pointing to binary blob' '
+	printf "a\0b\0c" >blob1 &&
+	printf "a\0c\0b" >blob2 &&
+	printf "\0a\0b\0c" >blob3 &&
+	printf "abc" >blob4 &&
+	printf "\0 \0 \0 " >blob5 &&
+	printf "\0 \0a\0 " >blob6 &&
+	printf "  " >blob7 &&
+	>blob8 &&
+	obj=$(git hash-object -w blob1) &&
+	git update-ref refs/myblobs/blob1 "$obj" &&
+	obj=$(git hash-object -w blob2) &&
+	git update-ref refs/myblobs/blob2 "$obj" &&
+	obj=$(git hash-object -w blob3) &&
+	git update-ref refs/myblobs/blob3 "$obj" &&
+	obj=$(git hash-object -w blob4) &&
+	git update-ref refs/myblobs/blob4 "$obj" &&
+	obj=$(git hash-object -w blob5) &&
+	git update-ref refs/myblobs/blob5 "$obj" &&
+	obj=$(git hash-object -w blob6) &&
+	git update-ref refs/myblobs/blob6 "$obj" &&
+	obj=$(git hash-object -w blob7) &&
+	git update-ref refs/myblobs/blob7 "$obj" &&
+	obj=$(git hash-object -w blob8) &&
+	git update-ref refs/myblobs/blob8 "$obj"
+'
+
+test_expect_success 'Verify sorts with raw' '
+	cat >expected <<-EOF &&
+	refs/myblobs/blob8
+	refs/myblobs/blob5
+	refs/myblobs/blob6
+	refs/myblobs/blob3
+	refs/myblobs/blob7
+	refs/mytrees/first
+	refs/myblobs/first
+	refs/myblobs/blob1
+	refs/myblobs/blob2
+	refs/myblobs/blob4
+	refs/heads/main
+	EOF
+	${git_for_each_ref} --format="%(refname)" --sort=raw \
+		refs/heads/main refs/myblobs/ refs/mytrees/first >actual &&
+	test_cmp expected actual
+'
+
+test_expect_success 'Verify sorts with raw:size' '
+	cat >expected <<-EOF &&
+	refs/myblobs/blob8
+	refs/myblobs/blob7
+	refs/myblobs/blob4
+	refs/myblobs/blob1
+	refs/myblobs/blob2
+	refs/myblobs/blob3
+	refs/myblobs/blob5
+	refs/myblobs/blob6
+	refs/myblobs/first
+	refs/mytrees/first
+	refs/heads/main
+	EOF
+	${git_for_each_ref} --format="%(refname)" --sort=raw:size \
+		refs/heads/main refs/myblobs/ refs/mytrees/first >actual &&
+	test_cmp expected actual
+'
+
+test_expect_success 'validate raw atom with %(if:equals)' '
+	cat >expected <<-EOF &&
+	not equals
+	not equals
+	not equals
+	not equals
+	not equals
+	not equals
+	refs/myblobs/blob4
+	not equals
+	not equals
+	not equals
+	not equals
+	not equals
+	EOF
+	${git_for_each_ref} --format="%(if:equals=abc)%(raw)%(then)%(refname)%(else)not equals%(end)" \
+		refs/myblobs/ refs/heads/ >actual &&
+	test_cmp expected actual
+'
+
+test_expect_success 'validate raw atom with %(if:notequals)' '
+	cat >expected <<-EOF &&
+	refs/heads/ambiguous
+	refs/heads/main
+	refs/heads/newtag
+	refs/myblobs/blob1
+	refs/myblobs/blob2
+	refs/myblobs/blob3
+	equals
+	refs/myblobs/blob5
+	refs/myblobs/blob6
+	refs/myblobs/blob7
+	refs/myblobs/blob8
+	refs/myblobs/first
+	EOF
+	${git_for_each_ref} --format="%(if:notequals=abc)%(raw)%(then)%(refname)%(else)equals%(end)" \
+		refs/myblobs/ refs/heads/ >actual &&
+	test_cmp expected actual
+'
+
+test_expect_success 'empty raw refs with %(if)' '
+	cat >expected <<-EOF &&
+	refs/myblobs/blob1 not empty
+	refs/myblobs/blob2 not empty
+	refs/myblobs/blob3 not empty
+	refs/myblobs/blob4 not empty
+	refs/myblobs/blob5 not empty
+	refs/myblobs/blob6 not empty
+	refs/myblobs/blob7 empty
+	refs/myblobs/blob8 empty
+	refs/myblobs/first not empty
+	EOF
+	${git_for_each_ref} --format="%(refname) %(if)%(raw)%(then)not empty%(else)empty%(end)" \
+		refs/myblobs/ >actual &&
+	test_cmp expected actual
+'
+
+test_expect_success '%(raw) with --python must fail' '
+	test_must_fail ${git_for_each_ref} --format="%(raw)" --python
+'
+
+test_expect_success '%(raw) with --tcl must fail' '
+	test_must_fail ${git_for_each_ref} --format="%(raw)" --tcl
+'
+
+test_expect_success PERL_TEST_HELPERS '%(raw) with --perl' '
+	${git_for_each_ref} --format="\$name= %(raw);
+print \"\$name\"" refs/myblobs/blob1 --perl | perl >actual &&
+	cmp blob1 actual &&
+	${git_for_each_ref} --format="\$name= %(raw);
+print \"\$name\"" refs/myblobs/blob3 --perl | perl >actual &&
+	cmp blob3 actual &&
+	${git_for_each_ref} --format="\$name= %(raw);
+print \"\$name\"" refs/myblobs/blob8 --perl | perl >actual &&
+	cmp blob8 actual &&
+	${git_for_each_ref} --format="\$name= %(raw);
+print \"\$name\"" refs/myblobs/first --perl | perl >actual &&
+	cmp one actual &&
+	git cat-file tree refs/mytrees/first > expected &&
+	${git_for_each_ref} --format="\$name= %(raw);
+print \"\$name\"" refs/mytrees/first --perl | perl >actual &&
+	cmp expected actual
+'
+
+test_expect_success '%(raw) with --shell must fail' '
+	test_must_fail ${git_for_each_ref} --format="%(raw)" --shell
+'
+
+test_expect_success '%(raw) with --shell and --sort=raw must fail' '
+	test_must_fail ${git_for_each_ref} --format="%(raw)" --sort=raw --shell
+'
+
+test_expect_success '%(raw:size) with --shell' '
+	${git_for_each_ref} --format="%(raw:size)" | sed "s/^/$SQ/;s/$/$SQ/" >expect &&
+	${git_for_each_ref} --format="%(raw:size)" --shell >actual &&
+	test_cmp expect actual
+'
+
+test_expect_success "${git_for_each_ref} --format compare with cat-file --batch" '
+	git rev-parse refs/mytrees/first | git cat-file --batch >expected &&
+	${git_for_each_ref} --format="%(objectname) %(objecttype) %(objectsize)
+%(raw)" refs/mytrees/first >actual &&
+	test_cmp expected actual
+'
+
+test_expect_success 'verify sorts with contents:size' '
+	cat >expect <<-\EOF &&
+	refs/heads/main
+	refs/heads/newtag
+	refs/heads/ambiguous
+	EOF
+	${git_for_each_ref} --format="%(refname)" \
+		--sort=contents:size refs/heads/ >actual &&
+	test_cmp expect actual
+'
+
+test_expect_success 'set up multiple-sort tags' '
+	for when in 100000 200000
+	do
+		for email in user1 user2
+		do
+			for ref in ref1 ref2
+			do
+				GIT_COMMITTER_DATE="@$when +0000" \
+				GIT_COMMITTER_EMAIL="$email@example.com" \
+				git tag -m "tag $ref-$when-$email" \
+				multi-$ref-$when-$email || return 1
+			done
+		done
+	done
+'
+
+test_expect_success 'Verify sort with multiple keys' '
+	cat >expected <<-\EOF &&
+	100000 <user1@example.com> refs/tags/multi-ref2-100000-user1
+	100000 <user1@example.com> refs/tags/multi-ref1-100000-user1
+	100000 <user2@example.com> refs/tags/multi-ref2-100000-user2
+	100000 <user2@example.com> refs/tags/multi-ref1-100000-user2
+	200000 <user1@example.com> refs/tags/multi-ref2-200000-user1
+	200000 <user1@example.com> refs/tags/multi-ref1-200000-user1
+	200000 <user2@example.com> refs/tags/multi-ref2-200000-user2
+	200000 <user2@example.com> refs/tags/multi-ref1-200000-user2
+	EOF
+	${git_for_each_ref} \
+		--format="%(taggerdate:unix) %(taggeremail) %(refname)" \
+		--sort=-refname \
+		--sort=taggeremail \
+		--sort=taggerdate \
+		"refs/tags/multi-*" >actual &&
+	test_cmp expected actual
+'
+
+test_expect_success 'equivalent sorts fall back on refname' '
+	cat >expected <<-\EOF &&
+	100000 <user1@example.com> refs/tags/multi-ref1-100000-user1
+	100000 <user2@example.com> refs/tags/multi-ref1-100000-user2
+	100000 <user1@example.com> refs/tags/multi-ref2-100000-user1
+	100000 <user2@example.com> refs/tags/multi-ref2-100000-user2
+	200000 <user1@example.com> refs/tags/multi-ref1-200000-user1
+	200000 <user2@example.com> refs/tags/multi-ref1-200000-user2
+	200000 <user1@example.com> refs/tags/multi-ref2-200000-user1
+	200000 <user2@example.com> refs/tags/multi-ref2-200000-user2
+	EOF
+	${git_for_each_ref} \
+		--format="%(taggerdate:unix) %(taggeremail) %(refname)" \
+		--sort=taggerdate \
+		"refs/tags/multi-*" >actual &&
+	test_cmp expected actual
+'
+
+test_expect_success '--no-sort cancels the previous sort keys' '
+	cat >expected <<-\EOF &&
+	100000 <user1@example.com> refs/tags/multi-ref1-100000-user1
+	100000 <user2@example.com> refs/tags/multi-ref1-100000-user2
+	100000 <user1@example.com> refs/tags/multi-ref2-100000-user1
+	100000 <user2@example.com> refs/tags/multi-ref2-100000-user2
+	200000 <user1@example.com> refs/tags/multi-ref1-200000-user1
+	200000 <user2@example.com> refs/tags/multi-ref1-200000-user2
+	200000 <user1@example.com> refs/tags/multi-ref2-200000-user1
+	200000 <user2@example.com> refs/tags/multi-ref2-200000-user2
+	EOF
+	${git_for_each_ref} \
+		--format="%(taggerdate:unix) %(taggeremail) %(refname)" \
+		--sort=-refname \
+		--sort=taggeremail \
+		--no-sort \
+		--sort=taggerdate \
+		"refs/tags/multi-*" >actual &&
+	test_cmp expected actual
+'
+
+test_expect_success '--no-sort without subsequent --sort prints expected refs' '
+	cat >expected <<-\EOF &&
+	refs/tags/multi-ref1-100000-user1
+	refs/tags/multi-ref1-100000-user2
+	refs/tags/multi-ref1-200000-user1
+	refs/tags/multi-ref1-200000-user2
+	refs/tags/multi-ref2-100000-user1
+	refs/tags/multi-ref2-100000-user2
+	refs/tags/multi-ref2-200000-user1
+	refs/tags/multi-ref2-200000-user2
+	EOF
+
+	# Sort the results with `sort` for a consistent comparison against
+	# expected
+	${git_for_each_ref} \
+		--format="%(refname)" \
+		--no-sort \
+		"refs/tags/multi-*" | sort >actual &&
+	test_cmp expected actual
+'
+
+test_expect_success 'set up custom date sorting' '
+	# Dates:
+	# - Wed Feb 07 2024 21:34:20 +0000
+	# - Tue Dec 14 1999 00:05:22 +0000
+	# - Fri Jun 04 2021 11:26:51 +0000
+	# - Mon Jan 22 2007 16:44:01 GMT+0000
+	i=1 &&
+	for when in 1707341660 945129922 1622806011 1169484241
+	do
+		GIT_COMMITTER_DATE="@$when +0000" \
+		GIT_COMMITTER_EMAIL="user@example.com" \
+		git tag -m "tag $when" custom-dates-$i &&
+		i=$(($i+1)) || return 1
+	done
+'
+
+test_expect_success 'sort by date defaults to full timestamp' '
+	cat >expected <<-\EOF &&
+	945129922 refs/tags/custom-dates-2
+	1169484241 refs/tags/custom-dates-4
+	1622806011 refs/tags/custom-dates-3
+	1707341660 refs/tags/custom-dates-1
+	EOF
+
+	${git_for_each_ref} \
+		--format="%(creatordate:unix) %(refname)" \
+		--sort=creatordate \
+		"refs/tags/custom-dates-*" >actual &&
+	test_cmp expected actual
+'
+
+test_expect_success 'sort by custom date format' '
+	cat >expected <<-\EOF &&
+	00:05:22 refs/tags/custom-dates-2
+	11:26:51 refs/tags/custom-dates-3
+	16:44:01 refs/tags/custom-dates-4
+	21:34:20 refs/tags/custom-dates-1
+	EOF
+
+	${git_for_each_ref} \
+		--format="%(creatordate:format:%H:%M:%S) %(refname)" \
+		--sort="creatordate:format:%H:%M:%S" \
+		"refs/tags/custom-dates-*" >actual &&
+	test_cmp expected actual
+'
+
+test_expect_success 'do not dereference NULL upon %(HEAD) on unborn branch' '
+	test_when_finished "git checkout main" &&
+	${git_for_each_ref} --format="%(HEAD) %(refname:short)" refs/heads/ >actual &&
+	sed -e "s/^\* /  /" actual >expect &&
+	git checkout --orphan orphaned-branch &&
+	${git_for_each_ref} --format="%(HEAD) %(refname:short)" refs/heads/ >actual &&
+	test_cmp expect actual
+'
+
+cat >trailers <<EOF
+Reviewed-by: A U Thor <author@example.com>
+Signed-off-by: A U Thor <author@example.com>
+[ v2 updated patch description ]
+Acked-by: A U Thor
+  <author@example.com>
+EOF
+
+unfold () {
+	perl -0pe 's/\n\s+/ /g'
+}
+
+test_expect_success 'set up trailers for next test' '
+	echo "Some contents" > two &&
+	git add two &&
+	git commit -F - <<-EOF
+	trailers: this commit message has trailers
+
+	Some message contents
+
+	$(cat trailers)
+	EOF
+'
+
+test_trailer_option () {
+	if test "$#" -eq 3
+	then
+		prereq="$1"
+		shift
+	fi &&
+	title=$1 option=$2
+	cat >expect
+	test_expect_success $prereq "$title" '
+		${git_for_each_ref} --format="%($option)" refs/heads/main >actual &&
+		test_cmp expect actual &&
+		${git_for_each_ref} --format="%(contents:$option)" refs/heads/main >actual &&
+		test_cmp expect actual
+	'
+}
+
+test_trailer_option PERL_TEST_HELPERS '%(trailers:unfold) unfolds trailers' \
+	'trailers:unfold' <<-EOF
+	$(unfold <trailers)
+
+	EOF
+
+test_trailer_option '%(trailers:only) shows only "key: value" trailers' \
+	'trailers:only' <<-EOF
+	$(grep -v patch.description <trailers)
+
+	EOF
+
+test_trailer_option '%(trailers:only=no,only=true) shows only "key: value" trailers' \
+	'trailers:only=no,only=true' <<-EOF
+	$(grep -v patch.description <trailers)
+
+	EOF
+
+test_trailer_option '%(trailers:only=yes) shows only "key: value" trailers' \
+	'trailers:only=yes' <<-EOF
+	$(grep -v patch.description <trailers)
+
+	EOF
+
+test_trailer_option '%(trailers:only=no) shows all trailers' \
+	'trailers:only=no' <<-EOF
+	$(cat trailers)
+
+	EOF
+
+test_trailer_option PERL_TEST_HELPERS '%(trailers:only) and %(trailers:unfold) work together' \
+	'trailers:only,unfold' <<-EOF
+	$(grep -v patch.description <trailers | unfold)
+
+	EOF
+
+test_trailer_option PERL_TEST_HELPERS '%(trailers:unfold) and %(trailers:only) work together' \
+	'trailers:unfold,only' <<-EOF
+	$(grep -v patch.description <trailers | unfold)
+
+	EOF
+
+test_trailer_option '%(trailers:key=foo) shows that trailer' \
+	'trailers:key=Signed-off-by' <<-EOF
+	Signed-off-by: A U Thor <author@example.com>
+
+	EOF
+
+test_trailer_option '%(trailers:key=foo) is case insensitive' \
+	'trailers:key=SiGned-oFf-bY' <<-EOF
+	Signed-off-by: A U Thor <author@example.com>
+
+	EOF
+
+test_trailer_option '%(trailers:key=foo:) trailing colon also works' \
+	'trailers:key=Signed-off-by:' <<-EOF
+	Signed-off-by: A U Thor <author@example.com>
+
+	EOF
+
+test_trailer_option '%(trailers:key=foo) multiple keys' \
+	'trailers:key=Reviewed-by:,key=Signed-off-by' <<-EOF
+	Reviewed-by: A U Thor <author@example.com>
+	Signed-off-by: A U Thor <author@example.com>
+
+	EOF
+
+test_trailer_option '%(trailers:key=nonexistent) becomes empty' \
+	'trailers:key=Shined-off-by:' <<-EOF
+
+	EOF
+
+test_trailer_option '%(trailers:key=foo) handles multiple lines even if folded' \
+	'trailers:key=Acked-by' <<-EOF
+	$(grep -v patch.description <trailers | grep -v Signed-off-by | grep -v Reviewed-by)
+
+	EOF
+
+test_trailer_option '%(trailers:key=foo,unfold) properly unfolds' \
+	'trailers:key=Signed-Off-by,unfold' <<-EOF
+	$(unfold <trailers | grep Signed-off-by)
+
+	EOF
+
+test_trailer_option '%(trailers:key=foo,only=no) also includes nontrailer lines' \
+	'trailers:key=Signed-off-by,only=no' <<-EOF
+	Signed-off-by: A U Thor <author@example.com>
+	$(grep patch.description <trailers)
+
+	EOF
+
+test_trailer_option '%(trailers:key=foo,valueonly) shows only value' \
+	'trailers:key=Signed-off-by,valueonly' <<-EOF
+	A U Thor <author@example.com>
+
+	EOF
+
+test_trailer_option '%(trailers:separator) changes separator' \
+	'trailers:separator=%x2C,key=Reviewed-by,key=Signed-off-by:' <<-EOF
+	Reviewed-by: A U Thor <author@example.com>,Signed-off-by: A U Thor <author@example.com>
+	EOF
+
+test_trailer_option '%(trailers:key_value_separator) changes key-value separator' \
+	'trailers:key_value_separator=%x2C,key=Reviewed-by,key=Signed-off-by:' <<-EOF
+	Reviewed-by,A U Thor <author@example.com>
+	Signed-off-by,A U Thor <author@example.com>
+
+	EOF
+
+test_trailer_option '%(trailers:separator,key_value_separator) changes both separators' \
+	'trailers:separator=%x2C,key_value_separator=%x2C,key=Reviewed-by,key=Signed-off-by:' <<-EOF
+	Reviewed-by,A U Thor <author@example.com>,Signed-off-by,A U Thor <author@example.com>
+	EOF
+
+test_expect_success 'multiple %(trailers) use their own options' '
+	git tag -F - tag-with-trailers <<-\EOF &&
+	body
+
+	one: foo
+	one: bar
+	two: baz
+	two: qux
+	EOF
+	t1="%(trailers:key=one,key_value_separator=W,separator=X)" &&
+	t2="%(trailers:key=two,key_value_separator=Y,separator=Z)" &&
+	${git_for_each_ref} --format="$t1%0a$t2" refs/tags/tag-with-trailers >actual &&
+	cat >expect <<-\EOF &&
+	oneWfooXoneWbar
+	twoYbazZtwoYqux
+	EOF
+	test_cmp expect actual
+'
+
+test_failing_trailer_option () {
+	title=$1 option=$2
+	cat >expect
+	test_expect_success "$title" '
+		# error message cannot be checked under i18n
+		test_must_fail ${git_for_each_ref} --format="%($option)" refs/heads/main 2>actual &&
+		test_cmp expect actual &&
+		test_must_fail ${git_for_each_ref} --format="%(contents:$option)" refs/heads/main 2>actual &&
+		test_cmp expect actual
+	'
+}
+
+test_failing_trailer_option '%(trailers) rejects unknown trailers arguments' \
+	'trailers:unsupported' <<-\EOF
+	fatal: unknown %(trailers) argument: unsupported
+	EOF
+
+test_failing_trailer_option '%(trailers:key) without value is error' \
+	'trailers:key' <<-\EOF
+	fatal: expected %(trailers:key=<value>)
+	EOF
+
+test_expect_success 'if arguments, %(contents:trailers) shows error if colon is missing' '
+	cat >expect <<-EOF &&
+	fatal: unrecognized %(contents) argument: trailersonly
+	EOF
+	test_must_fail ${git_for_each_ref} --format="%(contents:trailersonly)" 2>actual &&
+	test_cmp expect actual
+'
+
+test_expect_success 'basic atom: head contents:trailers' '
+	${git_for_each_ref} --format="%(contents:trailers)" refs/heads/main >actual &&
+	sanitize_pgp <actual >actual.clean &&
+	# ${git_for_each_ref} ends with a blank line
+	cat >expect <<-EOF &&
+	$(cat trailers)
+
+	EOF
+	test_cmp expect actual.clean
+'
+
+test_expect_success 'basic atom: rest must fail' '
+	test_must_fail ${git_for_each_ref} --format="%(rest)" refs/heads/main
+'
+
+test_expect_success 'HEAD atom does not take arguments' '
+	test_must_fail ${git_for_each_ref} --format="%(HEAD:foo)" 2>err &&
+	echo "fatal: %(HEAD) does not take arguments" >expect &&
+	test_cmp expect err
+'
+
+test_expect_success 'subject atom rejects unknown arguments' '
+	test_must_fail ${git_for_each_ref} --format="%(subject:foo)" 2>err &&
+	echo "fatal: unrecognized %(subject) argument: foo" >expect &&
+	test_cmp expect err
+'
+
+test_expect_success 'refname atom rejects unknown arguments' '
+	test_must_fail ${git_for_each_ref} --format="%(refname:foo)" 2>err &&
+	echo "fatal: unrecognized %(refname) argument: foo" >expect &&
+	test_cmp expect err
+'
+
+test_expect_success 'trailer parsing not fooled by --- line' '
+	git commit --allow-empty -F - <<-\EOF &&
+	this is the subject
+
+	This is the body. The message has a "---" line which would confuse a
+	message+patch parser. But here we know we have only a commit message,
+	so we get it right.
+
+	trailer: wrong
+	---
+	This is more body.
+
+	trailer: right
+	EOF
+
+	{
+		echo "trailer: right" &&
+		echo
+	} >expect &&
+	${git_for_each_ref} --format="%(trailers)" refs/heads/main >actual &&
+	test_cmp expect actual
+'
+
+test_expect_success 'Add symbolic ref for the following tests' '
+	git symbolic-ref refs/heads/sym refs/heads/main
+'
+
+cat >expected <<EOF
+refs/heads/main
+EOF
+
+test_expect_success 'Verify usage of %(symref) atom' '
+	${git_for_each_ref} --format="%(symref)" refs/heads/sym >actual &&
+	test_cmp expected actual
+'
+
+cat >expected <<EOF
+heads/main
+EOF
+
+test_expect_success 'Verify usage of %(symref:short) atom' '
+	${git_for_each_ref} --format="%(symref:short)" refs/heads/sym >actual &&
+	test_cmp expected actual
+'
+
+cat >expected <<EOF
+main
+heads/main
+EOF
+
+test_expect_success 'Verify usage of %(symref:lstrip) atom' '
+	${git_for_each_ref} --format="%(symref:lstrip=2)" refs/heads/sym > actual &&
+	${git_for_each_ref} --format="%(symref:lstrip=-2)" refs/heads/sym >> actual &&
+	test_cmp expected actual &&
+
+	${git_for_each_ref} --format="%(symref:strip=2)" refs/heads/sym > actual &&
+	${git_for_each_ref} --format="%(symref:strip=-2)" refs/heads/sym >> actual &&
+	test_cmp expected actual
+'
+
+cat >expected <<EOF
+refs
+refs/heads
+EOF
+
+test_expect_success 'Verify usage of %(symref:rstrip) atom' '
+	${git_for_each_ref} --format="%(symref:rstrip=2)" refs/heads/sym > actual &&
+	${git_for_each_ref} --format="%(symref:rstrip=-2)" refs/heads/sym >> actual &&
+	test_cmp expected actual
+'
+
+test_expect_success ':remotename and :remoteref' '
+	git init remote-tests &&
+	(
+		cd remote-tests &&
+		test_commit initial &&
+		git branch -M main &&
+		git remote add from fifth.coffee:blub &&
+		git config branch.main.remote from &&
+		git config branch.main.merge refs/heads/stable &&
+		git remote add to southridge.audio:repo &&
+		git config remote.to.push "refs/heads/*:refs/heads/pushed/*" &&
+		git config branch.main.pushRemote to &&
+		for pair in "%(upstream)=refs/remotes/from/stable" \
+			"%(upstream:remotename)=from" \
+			"%(upstream:remoteref)=refs/heads/stable" \
+			"%(push)=refs/remotes/to/pushed/main" \
+			"%(push:remotename)=to" \
+			"%(push:remoteref)=refs/heads/pushed/main"
+		do
+			echo "${pair#*=}" >expect &&
+			${git_for_each_ref} --format="${pair%=*}" \
+				refs/heads/main >actual &&
+			test_cmp expect actual || exit 1
+		done &&
+		git branch push-simple &&
+		git config branch.push-simple.pushRemote from &&
+		actual="$(${git_for_each_ref} \
+			--format="%(push:remotename),%(push:remoteref)" \
+			refs/heads/push-simple)" &&
+		test from, = "$actual"
+	)
+'
+
+test_expect_success '%(push) with an invalid push-simple config' '
+	echo "refs/heads/main " >expect &&
+	git -c push.default=simple \
+	    -c remote.pushdefault=myfork \
+	    for-each-ref \
+	    --format="%(refname) %(push)" refs/heads/main >actual &&
+	test_cmp expect actual
+'
+
+test_expect_success "${git_for_each_ref} --ignore-case ignores case" '
+	${git_for_each_ref} --format="%(refname)" refs/heads/MAIN >actual &&
+	test_must_be_empty actual &&
+
+	echo refs/heads/main >expect &&
+	${git_for_each_ref} --format="%(refname)" --ignore-case \
+		refs/heads/MAIN >actual &&
+	test_cmp expect actual
+'
+
+test_expect_success "${git_for_each_ref} --omit-empty works" '
+	${git_for_each_ref} --format="%(refname)" >actual &&
+	test_line_count -gt 1 actual &&
+	${git_for_each_ref} --format="%(if:equals=refs/heads/main)%(refname)%(then)%(refname)%(end)" --omit-empty >actual &&
+	echo refs/heads/main >expect &&
+	test_cmp expect actual
+'
+
+test_expect_success "${git_for_each_ref} --ignore-case works on multiple sort keys" '
+	# name refs numerically to avoid case-insensitive filesystem conflicts
+	nr=0 &&
+	for email in a A b B
+	do
+		for subject in a A b B
+		do
+			GIT_COMMITTER_EMAIL="$email@example.com" \
+			git tag -m "tag $subject" icase-$(printf %02d $nr) &&
+			nr=$((nr+1))||
+			return 1
+		done
+	done &&
+	${git_for_each_ref} --ignore-case \
+		--format="%(taggeremail) %(subject) %(refname)" \
+		--sort=refname \
+		--sort=subject \
+		--sort=taggeremail \
+		refs/tags/icase-* >actual &&
+	cat >expect <<-\EOF &&
+	<a@example.com> tag a refs/tags/icase-00
+	<a@example.com> tag A refs/tags/icase-01
+	<A@example.com> tag a refs/tags/icase-04
+	<A@example.com> tag A refs/tags/icase-05
+	<a@example.com> tag b refs/tags/icase-02
+	<a@example.com> tag B refs/tags/icase-03
+	<A@example.com> tag b refs/tags/icase-06
+	<A@example.com> tag B refs/tags/icase-07
+	<b@example.com> tag a refs/tags/icase-08
+	<b@example.com> tag A refs/tags/icase-09
+	<B@example.com> tag a refs/tags/icase-12
+	<B@example.com> tag A refs/tags/icase-13
+	<b@example.com> tag b refs/tags/icase-10
+	<b@example.com> tag B refs/tags/icase-11
+	<B@example.com> tag b refs/tags/icase-14
+	<B@example.com> tag B refs/tags/icase-15
+	EOF
+	test_cmp expect actual
+'
+
+test_expect_success "${git_for_each_ref} reports broken tags" '
+	git tag -m "good tag" broken-tag-good HEAD &&
+	git cat-file tag broken-tag-good >good &&
+	sed s/commit/blob/ <good >bad &&
+	bad=$(git hash-object -w -t tag bad) &&
+	git update-ref refs/tags/broken-tag-bad $bad &&
+	test_must_fail ${git_for_each_ref} --format="%(*objectname)" \
+		refs/tags/broken-tag-* &&
+	test_must_fail ${git_for_each_ref} --format="%(*objectname)" \
+		refs/tags/broken-tag-bad
+'
+
+test_expect_success 'set up tag with signature and no blank lines' '
+	git tag -F - fake-sig-no-blanks <<-\EOF
+	this is the subject
+	-----BEGIN PGP SIGNATURE-----
+	not a real signature, but we just care about the
+	subject/body parsing. It is important here that
+	there are no blank lines in the signature.
+	-----END PGP SIGNATURE-----
+	EOF
+'
+
+test_atom refs/tags/fake-sig-no-blanks contents:subject 'this is the subject'
+test_atom refs/tags/fake-sig-no-blanks contents:body ''
+test_atom refs/tags/fake-sig-no-blanks contents:signature "$sig"
+
+test_expect_success 'set up tag with CRLF signature' '
+	append_cr <<-\EOF |
+	this is the subject
+	-----BEGIN PGP SIGNATURE-----
+
+	not a real signature, but we just care about
+	the subject/body parsing. It is important here
+	that there is a blank line separating this
+	from the signature header.
+	-----END PGP SIGNATURE-----
+	EOF
+	git tag -F - --cleanup=verbatim fake-sig-crlf
+'
+
+test_atom refs/tags/fake-sig-crlf contents:subject 'this is the subject'
+test_atom refs/tags/fake-sig-crlf contents:body ''
+
+# CRLF is retained in the signature, so we have to pass our expected value
+# through append_cr. But test_atom requires a shell string, which means command
+# substitution, and the shell will strip trailing newlines from the output of
+# the substitution. Hack around it by adding and then removing a dummy line.
+sig_crlf="$(printf "%s" "$sig" | append_cr; echo dummy)"
+sig_crlf=${sig_crlf%dummy}
+test_atom refs/tags/fake-sig-crlf contents:signature "$sig_crlf"
+
+test_expect_success 'set up tag with signature and trailers' '
+	git tag -F - fake-sig-trailer <<-\EOF
+	this is the subject
+
+	this is the body
+
+	My-Trailer: foo
+	-----BEGIN PGP SIGNATURE-----
+
+	not a real signature, but we just care about the
+	subject/body/trailer parsing.
+	-----END PGP SIGNATURE-----
+	EOF
+'
+
+# use "separator=" here to suppress the terminating newline
+test_atom refs/tags/fake-sig-trailer trailers:separator= 'My-Trailer: foo'
+
+test_expect_success "${git_for_each_ref} --stdin: empty" '
+	>in &&
+	${git_for_each_ref} --format="%(refname)" --stdin <in >actual &&
+	${git_for_each_ref} --format="%(refname)" >expect &&
+	test_cmp expect actual
+'
+
+test_expect_success "${git_for_each_ref} --stdin: fails if extra args" '
+	>in &&
+	test_must_fail ${git_for_each_ref} --format="%(refname)" \
+		--stdin refs/heads/extra <in 2>err &&
+	grep "unknown arguments supplied with --stdin" err
+'
+
+test_expect_success "${git_for_each_ref} --stdin: matches" '
+	cat >in <<-EOF &&
+	refs/tags/multi*
+	refs/heads/amb*
+	EOF
+
+	cat >expect <<-EOF &&
+	refs/heads/ambiguous
+	refs/tags/multi-ref1-100000-user1
+	refs/tags/multi-ref1-100000-user2
+	refs/tags/multi-ref1-200000-user1
+	refs/tags/multi-ref1-200000-user2
+	refs/tags/multi-ref2-100000-user1
+	refs/tags/multi-ref2-100000-user2
+	refs/tags/multi-ref2-200000-user1
+	refs/tags/multi-ref2-200000-user2
+	refs/tags/multiline
+	EOF
+
+	${git_for_each_ref} --format="%(refname)" --stdin <in >actual &&
+	test_cmp expect actual
+'
+
+test_expect_success "${git_for_each_ref} with non-existing refs" '
+	cat >in <<-EOF &&
+	refs/heads/this-ref-does-not-exist
+	refs/tags/bogus
+	EOF
+
+	${git_for_each_ref} --format="%(refname)" --stdin <in >actual &&
+	test_must_be_empty actual &&
+
+	xargs ${git_for_each_ref} --format="%(refname)" <in >actual &&
+	test_must_be_empty actual
+'
+
+test_expect_success "${git_for_each_ref} with nested tags" '
+	git tag -am "Normal tag" nested/base HEAD &&
+	git tag -am "Nested tag" nested/nest1 refs/tags/nested/base &&
+	git tag -am "Double nested tag" nested/nest2 refs/tags/nested/nest1 &&
+
+	head_oid="$(git rev-parse HEAD)" &&
+	base_tag_oid="$(git rev-parse refs/tags/nested/base)" &&
+	nest1_tag_oid="$(git rev-parse refs/tags/nested/nest1)" &&
+	nest2_tag_oid="$(git rev-parse refs/tags/nested/nest2)" &&
+
+	cat >expect <<-EOF &&
+	refs/tags/nested/base $base_tag_oid tag $head_oid commit
+	refs/tags/nested/nest1 $nest1_tag_oid tag $head_oid commit
+	refs/tags/nested/nest2 $nest2_tag_oid tag $head_oid commit
+	EOF
+
+	${git_for_each_ref} \
+		--format="%(refname) %(objectname) %(objecttype) %(*objectname) %(*objecttype)" \
+		refs/tags/nested/ >actual &&
+	test_cmp expect actual
+'
+
+test_expect_success 'is-base atom with non-commits' '
+	${git_for_each_ref} --format="%(is-base:HEAD) %(refname)" >out 2>err &&
+	grep "(HEAD) refs/heads/main" out &&
+
+	test_line_count = 2 err &&
+	grep "error: object .* is a commit, not a blob" err &&
+	grep "error: bad tag pointer to" err
+'
+
+GRADE_FORMAT="%(signature:grade)%0a%(signature:key)%0a%(signature:signer)%0a%(signature:fingerprint)%0a%(signature:primarykeyfingerprint)"
+TRUSTLEVEL_FORMAT="%(signature:trustlevel)%0a%(signature:key)%0a%(signature:signer)%0a%(signature:fingerprint)%0a%(signature:primarykeyfingerprint)"
+
+test_expect_success GPG 'setup for signature atom using gpg' '
+	git checkout -b signed &&
+
+	test_when_finished "test_unconfig commit.gpgSign" &&
+
+	echo "1" >file &&
+	git add file &&
+	test_tick &&
+	git commit -S -m "file: 1" &&
+	git tag first-signed &&
+
+	echo "2" >file &&
+	test_tick &&
+	git commit -a -m "file: 2" &&
+	git tag second-unsigned &&
+
+	git config commit.gpgSign 1 &&
+	echo "3" >file &&
+	test_tick &&
+	git commit -a --no-gpg-sign -m "file: 3" &&
+	git tag third-unsigned &&
+
+	test_tick &&
+	git rebase -f HEAD^^ && git tag second-signed HEAD^ &&
+	git tag third-signed &&
+
+	echo "4" >file &&
+	test_tick &&
+	git commit -a -SB7227189 -m "file: 4" &&
+	git tag fourth-signed &&
+
+	echo "5" >file &&
+	test_tick &&
+	git commit -a --no-gpg-sign -m "file: 5" &&
+	git tag fifth-unsigned &&
+
+	echo "6" >file &&
+	test_tick &&
+	git commit -a --no-gpg-sign -m "file: 6" &&
+
+	test_tick &&
+	git rebase -f HEAD^^ &&
+	git tag fifth-signed HEAD^ &&
+	git tag sixth-signed &&
+
+	echo "7" >file &&
+	test_tick &&
+	git commit -a --no-gpg-sign -m "file: 7" &&
+	git tag seventh-unsigned
+'
+
+test_expect_success GPGSSH 'setup for signature atom using ssh' '
+	test_when_finished "test_unconfig gpg.format user.signingkey" &&
+
+	test_config gpg.format ssh &&
+	test_config user.signingkey "${GPGSSH_KEY_PRIMARY}" &&
+	echo "8" >file &&
+	test_tick &&
+	git add file &&
+	git commit -S -m "file: 8" &&
+	git tag eighth-signed-ssh
+'
+
+test_expect_success GPG2 'bare signature atom' '
+	git verify-commit first-signed 2>expect &&
+	echo  >>expect &&
+	${git_for_each_ref} refs/tags/first-signed \
+		--format="%(signature)" >actual &&
+	test_cmp expect actual
+'
+
+test_expect_success GPG 'show good signature with custom format' '
+	git verify-commit first-signed &&
+	cat >expect <<-\EOF &&
+	G
+	13B6F51ECDDE430D
+	C O Mitter <committer@example.com>
+	73D758744BE721698EC54E8713B6F51ECDDE430D
+	73D758744BE721698EC54E8713B6F51ECDDE430D
+	EOF
+	${git_for_each_ref} refs/tags/first-signed \
+		--format="$GRADE_FORMAT" >actual &&
+	test_cmp expect actual
+'
+test_expect_success GPGSSH 'show good signature with custom format with ssh' '
+	test_config gpg.ssh.allowedSignersFile "${GPGSSH_ALLOWED_SIGNERS}" &&
+	FINGERPRINT=$(ssh-keygen -lf "${GPGSSH_KEY_PRIMARY}" | awk "{print \$2;}") &&
+	cat >expect.tmpl <<-\EOF &&
+	G
+	FINGERPRINT
+	principal with number 1
+	FINGERPRINT
+
+	EOF
+	sed "s|FINGERPRINT|$FINGERPRINT|g" expect.tmpl >expect &&
+	${git_for_each_ref} refs/tags/eighth-signed-ssh \
+		--format="$GRADE_FORMAT" >actual &&
+	test_cmp expect actual
+'
+
+test_expect_success GPG 'signature atom with grade option and bad signature' '
+	git cat-file commit third-signed >raw &&
+	sed -e "s/^file: 3/file: 3 forged/" raw >forged1 &&
+	FORGED1=$(git hash-object -w -t commit forged1) &&
+	git update-ref refs/tags/third-signed "$FORGED1" &&
+	test_must_fail git verify-commit "$FORGED1" &&
+
+	cat >expect <<-\EOF &&
+	B
+	13B6F51ECDDE430D
+	C O Mitter <committer@example.com>
+
+
+	EOF
+	${git_for_each_ref} refs/tags/third-signed \
+		--format="$GRADE_FORMAT" >actual &&
+	test_cmp expect actual
+'
+
+test_expect_success GPG 'show untrusted signature with custom format' '
+	cat >expect <<-\EOF &&
+	U
+	65A0EEA02E30CAD7
+	Eris Discordia <discord@example.net>
+	F8364A59E07FFE9F4D63005A65A0EEA02E30CAD7
+	D4BE22311AD3131E5EDA29A461092E85B7227189
+	EOF
+	${git_for_each_ref} refs/tags/fourth-signed \
+		--format="$GRADE_FORMAT" >actual &&
+	test_cmp expect actual
+'
+
+test_expect_success GPG 'show untrusted signature with undefined trust level' '
+	cat >expect <<-\EOF &&
+	undefined
+	65A0EEA02E30CAD7
+	Eris Discordia <discord@example.net>
+	F8364A59E07FFE9F4D63005A65A0EEA02E30CAD7
+	D4BE22311AD3131E5EDA29A461092E85B7227189
+	EOF
+	${git_for_each_ref} refs/tags/fourth-signed \
+		--format="$TRUSTLEVEL_FORMAT" >actual &&
+	test_cmp expect actual
+'
+
+test_expect_success GPG 'show untrusted signature with ultimate trust level' '
+	cat >expect <<-\EOF &&
+	ultimate
+	13B6F51ECDDE430D
+	C O Mitter <committer@example.com>
+	73D758744BE721698EC54E8713B6F51ECDDE430D
+	73D758744BE721698EC54E8713B6F51ECDDE430D
+	EOF
+	${git_for_each_ref} refs/tags/sixth-signed \
+		--format="$TRUSTLEVEL_FORMAT" >actual &&
+	test_cmp expect actual
+'
+
+test_expect_success GPG 'show unknown signature with custom format' '
+	cat >expect <<-\EOF &&
+	E
+	13B6F51ECDDE430D
+
+
+
+	EOF
+	GNUPGHOME="$GNUPGHOME_NOT_USED" ${git_for_each_ref} \
+		refs/tags/sixth-signed --format="$GRADE_FORMAT" >actual &&
+	test_cmp expect actual
+'
+
+test_expect_success GPG 'show lack of signature with custom format' '
+	cat >expect <<-\EOF &&
+	N
+
+
+
+
+	EOF
+	${git_for_each_ref} refs/tags/seventh-unsigned \
+		--format="$GRADE_FORMAT" >actual &&
+	test_cmp expect actual
+'
+
+test_done


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **`git refs list`** is wired to the same engine as **`for-each-ref`**, with the correct **`usage: git refs list`** line when invoked that way (required by `for-each-ref-tests.sh`).
- Added **`tests/for-each-ref-tests.sh`** (from upstream `git/t/`) so **`t1461-refs-list.sh`** and **`t6300-for-each-ref.sh`** can actually run.
- **`grit-lib::mailmap`**: shared `.mailmap` parsing/lookup; **`check-mailmap`** refactored to use it.
- **`for-each-ref`** gains a large chunk of Git-compatible behavior needed by the shared suite: mailmap on person atoms, **`git_date`** formatting for date atoms, **shell/perl/python/tcl** quoting, **`raw` / `raw:size`** sort keys, stricter **`objectname:short=`** errors, tag paragraph handling for subject/body/contents, trailing newline on **`%(raw)`** for non-commits, and **`ancestor_closure`**-based ahead/behind for **`%(ahead-behind)`**.

## Test status

`./scripts/run-tests.sh t1461-refs-list.sh` → **352 / 428** tests pass. The remaining failures are mostly unimplemented ref-filter atoms and options (`describe`, `if/then/else/end`, `trailers`, `symref`, color/`--color`, `--omit-empty`, `--no-sort`, more `--sort` keys, push.default nuances, GPG/SSH signature atoms, etc.).

## Notes

Full **t1461** is the entire upstream **`for-each-ref-tests.sh`** (428 cases); finishing it is a sizable **`ref-filter` parity** project beyond this increment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3278286-4ba0-44fd-abb8-1349009c04b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3278286-4ba0-44fd-abb8-1349009c04b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

