### PR TITLE
t4064-diff-oidfind: harness refresh (10/10 passing)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -744,7 +744,7 @@ t4060-diff-submodule-option-diff-format	t4	yes	51	29	22	false	ok	0
 t4061-diff-indent	t4	yes	33	5	28	false	ok	0
 t4062-diff-pickaxe	t4	yes	3	3	0	true	ok	0
 t4063-diff-blobs	t4	yes	18	3	15	false	ok	0
-t4064-diff-oidfind	t4	yes	10	6	4	false	ok	0
+t4064-diff-oidfind	t4	yes	10	10	0	true	ok	0
 t4065-diff-anchored	t4	yes	7	7	0	true	ok	0
 t4066-diff-emit-delay	t4	yes	2	2	0	true	ok	0
 t4067-diff-partial-clone	t4	yes	9	2	7	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T04:01:47+00:00" class="gen-time" title="2026-04-09 04:01 UTC">2026-04-09 04:01 UTC</time> · <a href="https://github.com/schacon/grit/commit/71860eb6b1b43ffe60f55b01a0f516172afbb86d" style="color:#58a6ff">71860eb</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T04:05:04+00:00" class="gen-time" title="2026-04-09 04:05 UTC">2026-04-09 04:05 UTC</time> · <a href="https://github.com/schacon/grit/commit/6101e34f3fcf3d20904dd831963eb3a2983b9057" style="color:#58a6ff">6101e34</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,927</div>
+      <div class="summary-big-val">29,931</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>747 files fully passing</span>
+    <span>748 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -223,11 +223,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">68/178 files · 2 skipped · 2,055/3,542 tests</span>
+        <span class="group-meta">69/178 files · 2 skipped · 2,059/3,542 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:58.0%"></div></div>
-        <span class="group-pct pct-orange">58.0%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:58.1%"></div></div>
+        <span class="group-pct pct-orange">58.1%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:01:47+00:00" class="gen-time" title="2026-04-09 04:01 UTC">2026-04-09 04:01 UTC</time> · <a href="https://github.com/schacon/grit/commit/71860eb6b1b43ffe60f55b01a0f516172afbb86d" style="color:#58a6ff">71860eb</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:05:04+00:00" class="gen-time" title="2026-04-09 04:05 UTC">2026-04-09 04:05 UTC</time> · <a href="https://github.com/schacon/grit/commit/6101e34f3fcf3d20904dd831963eb3a2983b9057" style="color:#58a6ff">6101e34</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,927</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,931</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">75.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -7597,14 +7597,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:16.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="10" data-passed="6">
+<tr class="" data-group="t4" data-tests="10" data-passed="10" data-full-pass="1">
   <td class="mono">t4064-diff-oidfind</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">10</td>
-  <td class="right">6</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:60.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="7" data-passed="7" data-full-pass="1">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t4064-diff-oidfind.sh` already passes all 10 tests against the current `grit` implementation. This change only refreshes harness metadata after `./scripts/run-tests.sh t4064-diff-oidfind.sh`.

## Verification

```bash
./scripts/run-tests.sh t4064-diff-oidfind.sh
```

Result: 10/10 passing.

## Files

- `data/test-files.csv` — updated counts/status for `t4064-diff-oidfind`
- `docs/index.html`, `docs/testfiles.html` — regenerated dashboards
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c71c0b8-12f4-4dc2-ba4a-43fbdf53b287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c71c0b8-12f4-4dc2-ba4a-43fbdf53b287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

