### PR TITLE
test: t4070-diff-pairs harness refresh (7/7)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -752,7 +752,7 @@ t4068-diff-symmetric	t4	yes	20	20	0	true	ok	0
 t4068-diff-symmetric-merge-base	t4	yes	36	1	35	false	ok	0
 t4069-diff-summary	t4	yes	34	34	0	true	ok	0
 t4069-remerge-diff	t4	yes	16	8	8	false	ok	0
-t4070-diff-pairs	t4	yes	7	3	4	false	ok	0
+t4070-diff-pairs	t4	yes	7	7	0	true	ok	0
 t4070-diff-submodule	t4	yes	31	31	0	true	ok	0
 t4071-diff-empty-tree	t4	yes	32	29	3	false	ok	0
 t4071-diff-minimal	t4	yes	1	1	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T04:04:55+00:00" class="gen-time" title="2026-04-09 04:04 UTC">2026-04-09 04:04 UTC</time> · <a href="https://github.com/schacon/grit/commit/8292821a559988c8235b541ac75070d7fe15b5c7" style="color:#58a6ff">8292821</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T04:13:26+00:00" class="gen-time" title="2026-04-09 04:13 UTC">2026-04-09 04:13 UTC</time> · <a href="https://github.com/schacon/grit/commit/a4c5a5e06115acce00c0b83b1f490e3b7db0948e" style="color:#58a6ff">a4c5a5e</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,928</div>
+      <div class="summary-big-val">29,932</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>748 files fully passing</span>
+    <span>749 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -223,11 +223,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">68/178 files · 2 skipped · 2,055/3,542 tests</span>
+        <span class="group-meta">69/178 files · 2 skipped · 2,059/3,542 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:58.0%"></div></div>
-        <span class="group-pct pct-orange">58.0%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:58.1%"></div></div>
+        <span class="group-pct pct-orange">58.1%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:04:55+00:00" class="gen-time" title="2026-04-09 04:04 UTC">2026-04-09 04:04 UTC</time> · <a href="https://github.com/schacon/grit/commit/8292821a559988c8235b541ac75070d7fe15b5c7" style="color:#58a6ff">8292821</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:13:26+00:00" class="gen-time" title="2026-04-09 04:13 UTC">2026-04-09 04:13 UTC</time> · <a href="https://github.com/schacon/grit/commit/a4c5a5e06115acce00c0b83b1f490e3b7db0948e" style="color:#58a6ff">a4c5a5e</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,928</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,932</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">75.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -7677,14 +7677,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="7" data-passed="3">
+<tr class="" data-group="t4" data-tests="7" data-passed="7" data-full-pass="1">
   <td class="mono">t4070-diff-pairs</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">7</td>
-  <td class="right">3</td>
+  <td class="right">7</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:42.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="31" data-passed="31" data-full-pass="1">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t4070-diff-pairs` already passes all seven upstream-style tests against the current `grit diff-pairs` implementation. The branch only refreshes harness metadata after `./scripts/run-tests.sh t4070-diff-pairs.sh`.

## Changes

- Update `data/test-files.csv` row for `t4070-diff-pairs`: `7/7` passing, `fully_passing=true`
- Regenerate `docs/index.html` and `docs/testfiles.html`

## Verification

```bash
cargo build --release -p grit-rs
./scripts/run-tests.sh t4070-diff-pairs.sh
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-201b005e-0da4-4ae0-a394-6147595ffd6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-201b005e-0da4-4ae0-a394-6147595ffd6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

