### PR TITLE
t3050-ls-files-unmerged: verify passing, refresh harness

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -548,7 +548,7 @@ t3014-ls-files-pathspec-magic	t3	yes	29	27	2	false	ok	0
 t3020-ls-files-error-unmatch	t3	yes	3	3	0	true	ok	0
 t3030-merge-recursive	t3	yes	26	25	1	false	ok	0
 t3040-subprojects-basic	t3	yes	11	10	1	false	ok	0
-t3050-ls-files-unmerged	t3	yes	23	22	1	false	ok	0
+t3050-ls-files-unmerged	t3	yes	23	23	0	true	ok	0
 t3050-subprojects-fetch	t3	yes	4	4	0	true	ok	0
 t3060-ls-files-with-tree	t3	yes	8	8	0	true	ok	0
 t3070-wildmatch	t3	yes	1901	1901	0	true	ok	3

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T04:04:55+00:00" class="gen-time" title="2026-04-09 04:04 UTC">2026-04-09 04:04 UTC</time> · <a href="https://github.com/schacon/grit/commit/8292821a559988c8235b541ac75070d7fe15b5c7" style="color:#58a6ff">8292821</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T04:13:38+00:00" class="gen-time" title="2026-04-09 04:13 UTC">2026-04-09 04:13 UTC</time> · <a href="https://github.com/schacon/grit/commit/a4c5a5e06115acce00c0b83b1f490e3b7db0948e" style="color:#58a6ff">a4c5a5e</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,928</div>
+      <div class="summary-big-val">29,929</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>748 files fully passing</span>
+    <span>749 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,11 +212,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">45/141 files · 2 skipped · 3,355/4,619 tests</span>
+        <span class="group-meta">46/141 files · 2 skipped · 3,356/4,619 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.6%"></div></div>
-        <span class="group-pct pct-blue">72.6%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.7%"></div></div>
+        <span class="group-pct pct-blue">72.7%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:04:55+00:00" class="gen-time" title="2026-04-09 04:04 UTC">2026-04-09 04:04 UTC</time> · <a href="https://github.com/schacon/grit/commit/8292821a559988c8235b541ac75070d7fe15b5c7" style="color:#58a6ff">8292821</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:13:38+00:00" class="gen-time" title="2026-04-09 04:13 UTC">2026-04-09 04:13 UTC</time> · <a href="https://github.com/schacon/grit/commit/a4c5a5e06115acce00c0b83b1f490e3b7db0948e" style="color:#58a6ff">a4c5a5e</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,928</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,929</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">75.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -5637,14 +5637,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="23" data-passed="22">
+<tr class="" data-group="t3" data-tests="23" data-passed="23" data-full-pass="1">
   <td class="mono">t3050-ls-files-unmerged</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">23</td>
-  <td class="right">22</td>
+  <td class="right">23</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:95.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="4" data-passed="4" data-full-pass="1">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`tests/t3050-ls-files-unmerged.sh` already passes fully (23/23) against current `grit` (`read-tree -m`, `ls-files -u`/`-s`, pathspec filtering, delete-vs-modify stages, `read-tree --reset`).

This change only refreshes harness artifacts after re-running `./scripts/run-tests.sh t3050-ls-files-unmerged.sh` (`data/test-files.csv`, dashboards).

## Verification

- `./scripts/run-tests.sh t3050-ls-files-unmerged.sh` → 23/23
- `cargo build --release -p grit-rs`
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a6e96ae-2aa5-4a5b-ba54-25836f092c7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a6e96ae-2aa5-4a5b-ba54-25836f092c7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

