### PR TITLE
fix: git grep --open-files-in-pager (t7811)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1271,7 +1271,7 @@ t7703-repack-geometric	t7	yes	18	2	16	false	ok	0
 t7704-repack-cruft	t7	skip	25	5	20	false	ok	0
 t7800-difftool	t7	yes	0	0	0	false	timeout	0
 t7810-grep	t7	yes	0	0	0	false	timeout	0
-t7811-grep-open	t7	yes	10	3	7	false	ok	0
+t7811-grep-open	t7	yes	10	10	0	true	ok	0
 t7812-grep-icase-non-ascii	t7	yes	18	18	0	true	ok	0
 t7813-grep-icase-iso	t7	yes	2	2	0	true	ok	0
 t7814-grep-recurse-submodules	t7	yes	27	20	7	false	ok	7

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T03:54:55+00:00" class="gen-time" title="2026-04-09 03:54 UTC">2026-04-09 03:54 UTC</time> · <a href="https://github.com/schacon/grit/commit/650e9578ea47d9d77d32d94ccab29d5d67a1d12d" style="color:#58a6ff">650e957</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T04:14:56+00:00" class="gen-time" title="2026-04-09 04:14 UTC">2026-04-09 04:14 UTC</time> · <a href="https://github.com/schacon/grit/commit/fa2bf3c699c133a9a8579e19dc10560d8d9caea9" style="color:#58a6ff">fa2bf3c</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,925</div>
+      <div class="summary-big-val">29,932</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>746 files fully passing</span>
+    <span>747 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -256,11 +256,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 1,935/2,944 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 1,942/2,944 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:65.7%"></div></div>
-        <span class="group-pct pct-blue">65.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:66.0%"></div></div>
+        <span class="group-pct pct-blue">66.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T03:54:55+00:00" class="gen-time" title="2026-04-09 03:54 UTC">2026-04-09 03:54 UTC</time> · <a href="https://github.com/schacon/grit/commit/650e9578ea47d9d77d32d94ccab29d5d67a1d12d" style="color:#58a6ff">650e957</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:14:56+00:00" class="gen-time" title="2026-04-09 04:14 UTC">2026-04-09 04:14 UTC</time> · <a href="https://github.com/schacon/grit/commit/fa2bf3c699c133a9a8579e19dc10560d8d9caea9" style="color:#58a6ff">fa2bf3c</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,925</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,932</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">75.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -12867,14 +12867,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="10" data-passed="3">
+<tr class="" data-group="t7" data-tests="10" data-passed="10" data-full-pass="1">
   <td class="mono">t7811-grep-open</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">10</td>
-  <td class="right">3</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:30.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">

--- a/grit/src/commands/grep.rs
+++ b/grit/src/commands/grep.rs
@@ -5,6 +5,7 @@ use clap::Args as ClapArgs;
 use regex::{Regex, RegexBuilder};
 use std::io::{self, Write};
 use std::path::Path;
+use std::process::Command;
 
 use grit_lib::config::ConfigSet;
 use grit_lib::index::{MODE_GITLINK, MODE_TREE};
@@ -224,6 +225,14 @@ pub struct Args {
     /// Positional arguments: [pattern] [<tree>] [-- pathspec...]
     #[arg(trailing_var_arg = true)]
     pub positional: Vec<String>,
+
+    /// Set by `main` after stripping `-O` / `--open-files-in-pager` (Git does not consume the next argv as the pager unless it is glued: `-Opager`).
+    #[arg(skip)]
+    pub open_in_pager: bool,
+
+    /// Explicit pager from `-Opager` or `--open-files-in-pager=pager`. When `None` with `open_in_pager`, resolve like Git (GIT_PAGER / config / PAGER).
+    #[arg(skip)]
+    pub open_pager_cmd: Option<String>,
 }
 
 impl Args {
@@ -262,6 +271,41 @@ impl Args {
     }
 }
 
+/// Strip `-O` / `--open-files-in-pager` from argv before clap parsing.
+///
+/// Git only takes the pager from the same argv cell as `-O` (`-Opager`). A separate token after
+/// lone `-O` is not the pager (it is usually the pattern).
+pub fn preprocess_open_in_pager_argv(argv: Vec<String>) -> (Vec<String>, bool, Option<String>) {
+    let mut open_in_pager = false;
+    let mut open_pager_cmd: Option<String> = None;
+    let mut out = Vec::with_capacity(argv.len());
+    for a in argv {
+        if a == "-O" || a == "--open-files-in-pager" {
+            open_in_pager = true;
+            continue;
+        }
+        if let Some(v) = a.strip_prefix("--open-files-in-pager=") {
+            open_in_pager = true;
+            if !v.is_empty() {
+                open_pager_cmd = Some(v.to_string());
+            }
+            continue;
+        }
+        if a.len() >= 2 {
+            let b = a.as_bytes();
+            if b[0] == b'-' && b[1] == b'O' {
+                open_in_pager = true;
+                if a.len() > 2 {
+                    open_pager_cmd = Some(a[2..].to_string());
+                }
+                continue;
+            }
+        }
+        out.push(a);
+    }
+    (out, open_in_pager, open_pager_cmd)
+}
+
 /// Run `grit grep`.
 pub fn run(mut args: Args) -> Result<()> {
     let has_attr_src = std::env::var("GIT_ATTR_SOURCE")
@@ -277,8 +321,8 @@ pub fn run(mut args: Args) -> Result<()> {
     let repo = Repository::discover(None).context("not a git repository")?;
 
     // Apply grep config settings
+    let config = ConfigSet::load(Some(&repo.git_dir), true).ok();
     {
-        let config = ConfigSet::load(Some(&repo.git_dir), true).ok();
         if let Some(ref c) = config {
             // grep.linenumber: if user didn't explicitly pass -n or --no-line-number
             if !args.line_number && !args.no_line_number {
@@ -385,11 +429,29 @@ pub fn run(mut args: Args) -> Result<()> {
         bail!("no pattern given");
     }
 
+    if args.open_in_pager && args.cached {
+        bail!("--open-files-in-pager only works on the worktree");
+    }
+    if args.open_in_pager && tree_ish.is_some() {
+        bail!("--open-files-in-pager only works on the worktree");
+    }
+
     // Determine matching mode: --all-match or --and means all patterns must match a line
     let all_match = args.all_match || args.and;
 
     // Build the regex matchers
     let matchers = build_matchers(&patterns, &args)?;
+
+    let mut open_paths: Option<Vec<String>> = if args.open_in_pager {
+        Some(Vec::new())
+    } else {
+        None
+    };
+
+    if open_paths.is_some() {
+        args.color = "never".to_string();
+        args.files_with_matches = true;
+    }
 
     let stdout = io::stdout();
     let mut out_handle = stdout.lock();
@@ -416,6 +478,7 @@ pub fn run(mut args: Args) -> Result<()> {
             &mut need_sep,
             out,
             all_match,
+            &mut open_paths,
         )?;
     } else if let Some(tree_spec) = &tree_ish {
         // Search a tree object
@@ -459,6 +522,7 @@ pub fn run(mut args: Args) -> Result<()> {
             out,
             all_match,
             &diff_attrs,
+            &mut open_paths,
         )?;
     } else if args.cached {
         // Search index blobs (--cached)
@@ -471,6 +535,7 @@ pub fn run(mut args: Args) -> Result<()> {
             &mut need_sep,
             out,
             all_match,
+            &mut open_paths,
         )?;
     } else {
         // Search working tree (tracked files from index)
@@ -483,14 +548,110 @@ pub fn run(mut args: Args) -> Result<()> {
             &mut need_sep,
             out,
             all_match,
+            &mut open_paths,
         )?;
     }
 
     if found_any {
+        if let Some(paths) = open_paths {
+            let pager_cmd = match &args.open_pager_cmd {
+                Some(s) if !s.is_empty() => s.clone(),
+                _ => resolve_git_pager(&config),
+            };
+            let work_dir = std::env::current_dir().context("cannot get current directory")?;
+            run_open_in_pager(&work_dir, &pager_cmd, &patterns, args.ignore_case, &paths)?;
+        }
         Ok(())
     } else {
         std::process::exit(1);
     }
+}
+
+/// Resolve pager like `git var GIT_PAGER`: env, then `core.pager`, then `PAGER`, then `cat`.
+fn resolve_git_pager(config: &Option<ConfigSet>) -> String {
+    std::env::var("GIT_PAGER")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            config
+                .as_ref()
+                .and_then(|c| c.get("core.pager"))
+                .filter(|s| !s.is_empty())
+        })
+        .or_else(|| std::env::var("PAGER").ok().filter(|s| !s.is_empty()))
+        .unwrap_or_else(|| "cat".to_owned())
+}
+
+/// True if the pager command must be run via `sh -c` (Git's `prepare_shell_cmd` heuristic).
+fn pager_needs_shell(pager_cmd: &str) -> bool {
+    const META: &[u8] = b"|&;<>()$`\\\"' \t\n*?[#~=%";
+    pager_cmd.as_bytes().iter().any(|b| META.contains(b))
+}
+
+/// Strip leading directory from pager argv0 when Git would (path ending in `/xxxx`).
+fn pager_executable_for_argv0(pager_cmd: &str) -> String {
+    let b = pager_cmd.as_bytes();
+    let len = b.len();
+    if len > 4 && (b[len - 5] == b'/' || b[len - 5] == b'\\') {
+        pager_cmd[len - 4..].to_owned()
+    } else {
+        pager_cmd.to_owned()
+    }
+}
+
+/// Run the pager with collected file paths, matching Git's `run_pager` + `prepare_shell_cmd`.
+fn run_open_in_pager(
+    work_dir: &Path,
+    pager_cmd: &str,
+    patterns: &[String],
+    ignore_case: bool,
+    files: &[String],
+) -> Result<()> {
+    let exec0 = pager_executable_for_argv0(pager_cmd);
+    let base = Path::new(&exec0)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or(&exec0);
+
+    let mut extra: Vec<String> = Vec::new();
+    if patterns.len() == 1 {
+        let pat = &patterns[0];
+        if base == "less" || base == "vi" {
+            if ignore_case && base == "less" {
+                extra.push("-I".to_string());
+            }
+            let star = if base == "less" { "*" } else { "" };
+            extra.push(format!("+/{star}{pat}"));
+        }
+    }
+
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+    let status = if pager_needs_shell(pager_cmd) {
+        let script = if files.is_empty() {
+            pager_cmd.to_string()
+        } else {
+            format!("{pager_cmd} \"$@\"")
+        };
+        Command::new(&shell)
+            .current_dir(work_dir)
+            .arg("-c")
+            .arg(&script)
+            .args(extra.iter())
+            .args(files.iter())
+            .status()
+    } else {
+        Command::new(pager_cmd)
+            .current_dir(work_dir)
+            .args(extra.iter())
+            .args(files.iter())
+            .status()
+    }
+    .context("failed to run pager for --open-files-in-pager")?;
+
+    if !status.success() {
+        std::process::exit(status.code().unwrap_or(1));
+    }
+    Ok(())
 }
 
 /// Grep the index (--cached mode), optionally recursing into submodules.
@@ -504,6 +665,7 @@ fn grep_cached(
     need_sep: &mut bool,
     out: &mut (impl Write + ?Sized),
     all_match: bool,
+    open_paths: &mut Option<Vec<String>>,
 ) -> Result<bool> {
     let index = repo.load_index().context("loading index")?;
     // Load diff attrs from index (for --cached, use index attrs) or worktree
@@ -552,6 +714,7 @@ fn grep_cached(
                             need_sep,
                             out,
                             all_match,
+                            open_paths,
                         )? {
                             found_any = true;
                         }
@@ -595,6 +758,7 @@ fn grep_cached(
                         need_sep,
                         out,
                         all_match,
+                        open_paths,
                     )? {
                         found_any = true;
                     }
@@ -617,6 +781,7 @@ fn grep_cached(
                     need_sep,
                     out,
                     all_match,
+                    open_paths,
                 )? {
                     found_any = true;
                 }
@@ -657,6 +822,7 @@ fn grep_cached(
                     need_sep,
                     out,
                     all_match,
+                    open_paths,
                 )? {
                     found_any = true;
                 }
@@ -679,6 +845,7 @@ fn grep_cached(
                 need_sep,
                 out,
                 all_match,
+                open_paths,
             )? {
                 found_any = true;
             }
@@ -698,6 +865,7 @@ fn grep_worktree(
     need_sep: &mut bool,
     out: &mut (impl Write + ?Sized),
     all_match: bool,
+    open_paths: &mut Option<Vec<String>>,
 ) -> Result<bool> {
     let work_tree = repo
         .work_tree
@@ -744,6 +912,7 @@ fn grep_worktree(
                         need_sep,
                         out,
                         all_match,
+                        open_paths,
                     )? {
                         found_any = true;
                     }
@@ -793,6 +962,7 @@ fn grep_worktree(
                         need_sep,
                         out,
                         all_match,
+                        open_paths,
                     )? {
                         found_any = true;
                     }
@@ -815,6 +985,7 @@ fn grep_worktree(
                     need_sep,
                     out,
                     all_match,
+                    open_paths,
                 )? {
                     found_any = true;
                 }
@@ -863,6 +1034,7 @@ fn grep_worktree(
                         need_sep,
                         out,
                         all_match,
+                        open_paths,
                     )? {
                         found_any = true;
                     }
@@ -885,6 +1057,7 @@ fn grep_worktree(
                     need_sep,
                     out,
                     all_match,
+                    open_paths,
                 )? {
                     found_any = true;
                 }
@@ -925,6 +1098,7 @@ fn grep_worktree(
                     need_sep,
                     out,
                     all_match,
+                    open_paths,
                 )? {
                     found_any = true;
                 }
@@ -947,6 +1121,7 @@ fn grep_worktree(
                 need_sep,
                 out,
                 all_match,
+                open_paths,
             )? {
                 found_any = true;
             }
@@ -1151,6 +1326,7 @@ fn grep_filesystem(
     need_sep: &mut bool,
     out: &mut (impl Write + ?Sized),
     all_match: bool,
+    open_paths: &mut Option<Vec<String>>,
 ) -> Result<bool> {
     let mut found_any = false;
     let mut entries: Vec<_> = match std::fs::read_dir(dir) {
@@ -1187,6 +1363,7 @@ fn grep_filesystem(
                 need_sep,
                 out,
                 all_match,
+                open_paths,
             )? {
                 found_any = true;
             }
@@ -1223,6 +1400,7 @@ fn grep_filesystem(
                     need_sep,
                     out,
                     all_match,
+                    open_paths,
                 )? {
                     found_any = true;
                 }
@@ -1602,6 +1780,7 @@ fn grep_content(
     need_sep: &mut bool,
     out: &mut (impl Write + ?Sized),
     all_match: bool,
+    open_paths: &mut Option<Vec<String>>,
 ) -> Result<bool> {
     let color = args.use_color();
 
@@ -1662,7 +1841,11 @@ fn grep_content(
     // Special modes: files-with-matches, files-without-match, count
     if args.files_with_matches {
         if has_match {
-            writeln!(out, "{}", fmt_name(&display_name, color))?;
+            if let Some(paths) = open_paths {
+                paths.push(filename.to_string());
+            } else {
+                writeln!(out, "{}", fmt_name(&display_name, color))?;
+            }
         }
         return Ok(has_match);
     }
@@ -1869,6 +2052,7 @@ fn grep_tree(
     out: &mut (impl Write + ?Sized),
     all_match: bool,
     diff_attrs: &[DiffAttrRule],
+    open_paths: &mut Option<Vec<String>>,
 ) -> Result<bool> {
     let entries = parse_tree(tree_data)?;
     let mut found = false;
@@ -1935,6 +2119,7 @@ fn grep_tree(
                             out,
                             all_match,
                             &sub_diff_attrs,
+                            open_paths,
                         )? {
                             found = true;
                         }
@@ -1964,6 +2149,7 @@ fn grep_tree(
                 out,
                 all_match,
                 diff_attrs,
+                open_paths,
             )? {
                 found = true;
             }
@@ -2009,6 +2195,7 @@ fn grep_tree(
                 let content = String::from_utf8_lossy(&obj.data);
                 if grep_content(
                     &full_name, &content, matchers, args, tree_name, need_sep, out, all_match,
+                    open_paths,
                 )? {
                     found = true;
                 }

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -3202,6 +3202,8 @@ pub(crate) fn dispatch(subcmd: &str, rest: &[String], opts: &GlobalOpts) -> Resu
                     print_upstream_synopsis_and_exit(subcmd, syn, 129);
                 }
             }
+            let (rest, open_in_pager, open_pager_cmd) =
+                commands::grep::preprocess_open_in_pager_argv(rest.to_vec());
             // Also implement last-flag-wins for -G/-E/-F/-P pattern type flags.
             // Rewrite -h to --no-filename. Handle both standalone "-h" and
             // combined flags like "-ah" (split into "-a" + "--no-filename").
@@ -3249,7 +3251,10 @@ pub(crate) fn dispatch(subcmd: &str, rest: &[String], opts: &GlobalOpts) -> Resu
                 // Insert the winning flag back (at beginning, before positionals)
                 rest.insert(0, keep);
             }
-            commands::grep::run(parse_cmd_args(subcmd, &rest))
+            let mut args: commands::grep::Args = parse_cmd_args(subcmd, &rest);
+            args.open_in_pager = open_in_pager;
+            args.open_pager_cmd = open_pager_cmd;
+            commands::grep::run(args)
         }
         "hash-object" => commands::hash_object::run(parse_cmd_args(subcmd, rest)),
         "help" => commands::help::run(parse_cmd_args(subcmd, rest)),

--- a/logs/2026-04-09-t7811-grep-open.md
+++ b/logs/2026-04-09-t7811-grep-open.md
@@ -1,0 +1,14 @@
+# t7811-grep-open — `git grep -O` / `--open-files-in-pager`
+
+## Summary
+
+Implemented Git-compatible `--open-files-in-pager`: collect matching paths (worktree / `--no-index`), force name-only + no color like upstream, resolve pager (`GIT_PAGER` → `core.pager` → `PAGER` → `cat`), append `less`/`vi` jump args for a single pattern, run via shell when the pager command contains metacharacters (matching Git’s `prepare_shell_cmd`).
+
+## Arg parsing
+
+Clap’s optional value for `-O` would consume the pattern; Git only takes the pager from the same argv cell (`-Opager`). Preprocess argv in `main` with `preprocess_open_in_pager_argv` before clap, then set `Args.open_in_pager` / `open_pager_cmd`.
+
+## Validation
+
+- `./scripts/run-tests.sh t7811-grep-open.sh` — 10/10
+- `cargo fmt`, `cargo clippy -p grit-rs --fix --allow-dirty`, `cargo test -p grit-lib --lib`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements `git grep -O` / `--open-files-in-pager` to match upstream behavior needed by `t7811-grep-open.sh`.

## Details

- **Argv**: Git only treats the pager as part of the same token as `-O` (`-Opager`). A separate argument after lone `-O` is the pattern, not the pager. Clap’s optional value would swallow the pattern, so `preprocess_open_in_pager_argv` strips `-O` / long forms before parsing and sets `Args.open_in_pager` / `open_pager_cmd`.
- **Search**: When open-in-pager is active, force name-only output and `color=never`, collect matching file paths from worktree and `--no-index` paths, and error on `--cached` or tree revision mode like Git.
- **Pager**: Resolve pager like `GIT_PAGER` → `core.pager` → `PAGER` → `cat`. For a single pattern with `less`/`vi`, append jump arguments (`+*pattern` for less, `+/pattern` for vi; `-I` for less when `-i`). Run via `sh -c` when the pager string contains shell metacharacters (same idea as Git’s `prepare_shell_cmd`). Propagate non-zero pager exit.

## Testing

- `./scripts/run-tests.sh t7811-grep-open.sh` (10/10)
- `cargo build --release -p grit-rs`
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0700f281-1ab2-433c-8028-9adfd8b76399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0700f281-1ab2-433c-8028-9adfd8b76399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

