### PR TITLE
fix: test-tool lazy-init-name-hash for t3008

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -537,7 +537,7 @@ t3004-ls-files-basic	t3	yes	6	6	0	true	ok	0
 t3005-ls-files-relative	t3	yes	4	1	3	false	ok	0
 t3006-ls-files-long	t3	yes	3	3	0	true	ok	0
 t3007-ls-files-recurse-submodules	t3	yes	24	1	23	false	ok	0
-t3008-ls-files-lazy-init-name-hash	t3	yes	1	0	1	false	ok	0
+t3008-ls-files-lazy-init-name-hash	t3	yes	1	1	0	true	ok	0
 t3009-ls-files-others-nonsubmodule	t3	yes	2	2	0	true	ok	0
 t3010-ls-files-killed-modified	t3	yes	6	3	3	false	ok	0
 t3011-common-prefixes-and-directory-traversal	t3	yes	20	16	4	false	ok	1

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T03:51:57+00:00" class="gen-time" title="2026-04-09 03:51 UTC">2026-04-09 03:51 UTC</time> · <a href="https://github.com/schacon/grit/commit/061400b8b5d5c7a744af3cdddde16d93d42dbb7e" style="color:#58a6ff">061400b</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T04:18:06+00:00" class="gen-time" title="2026-04-09 04:18 UTC">2026-04-09 04:18 UTC</time> · <a href="https://github.com/schacon/grit/commit/a74e5296e694b0a86f42b55ca115b93ae8728f99" style="color:#58a6ff">a74e529</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,909</div>
+      <div class="summary-big-val">29,910</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>745 files fully passing</span>
+    <span>746 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,11 +212,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">45/141 files · 2 skipped · 3,355/4,619 tests</span>
+        <span class="group-meta">46/141 files · 2 skipped · 3,356/4,619 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.6%"></div></div>
-        <span class="group-pct pct-blue">72.6%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.7%"></div></div>
+        <span class="group-pct pct-blue">72.7%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T03:51:57+00:00" class="gen-time" title="2026-04-09 03:51 UTC">2026-04-09 03:51 UTC</time> · <a href="https://github.com/schacon/grit/commit/061400b8b5d5c7a744af3cdddde16d93d42dbb7e" style="color:#58a6ff">061400b</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:18:06+00:00" class="gen-time" title="2026-04-09 04:18 UTC">2026-04-09 04:18 UTC</time> · <a href="https://github.com/schacon/grit/commit/a74e5296e694b0a86f42b55ca115b93ae8728f99" style="color:#58a6ff">a74e529</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,909</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,910</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">75.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -5527,14 +5527,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:4.2%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="1" data-passed="0">
+<tr class="" data-group="t3" data-tests="1" data-passed="1" data-full-pass="1">
   <td class="mono">t3008-ls-files-lazy-init-name-hash</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">1</td>
-  <td class="right">0</td>
+  <td class="right">1</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="2" data-passed="2" data-full-pass="1">

--- a/grit-lib/src/index_name_hash_lazy.rs
+++ b/grit-lib/src/index_name_hash_lazy.rs
@@ -1,0 +1,464 @@
+//! Lazy, optionally multi-threaded index name/dir hash initialization compatible with Git's
+//! `name-hash.c` (used by `test-tool lazy-init-name-hash` and regression test t3008).
+//!
+//! This mirrors Git's `memihash` / `LAZY_THREAD_COST` thresholds and the recursive directory
+//! scan used when `core.ignorecase` is effectively enabled for the test helper.
+
+use std::collections::HashMap;
+use std::io::{self, Write};
+use std::sync::{Arc, Mutex};
+
+use crate::index::{Index, IndexEntry};
+
+const FNV32_BASE: u32 = 0x811c9dc5;
+const FNV32_PRIME: u32 = 0x0100_0193;
+/// Matches Git `name-hash.c` (`LAZY_THREAD_COST`).
+const LAZY_THREAD_COST: usize = 2000;
+/// Initial hash table size in Git's `hashmap.c` (`HASHMAP_INITIAL_SIZE`).
+const HASHMAP_INITIAL_SIZE: usize = 64;
+
+#[inline]
+fn fold_byte_case_insensitive(c: u8) -> u32 {
+    u32::from(c.to_ascii_lowercase())
+}
+
+/// Git `memihash`: case-insensitive FNV-1a over bytes.
+#[must_use]
+pub fn memihash(buf: &[u8]) -> u32 {
+    let mut hash = FNV32_BASE;
+    for &b in buf {
+        hash = (hash.wrapping_mul(FNV32_PRIME)) ^ fold_byte_case_insensitive(b);
+    }
+    hash
+}
+
+/// Git `memihash_cont`.
+#[must_use]
+pub fn memihash_cont(hash_seed: u32, buf: &[u8]) -> u32 {
+    let mut hash = hash_seed;
+    for &b in buf {
+        hash = (hash.wrapping_mul(FNV32_PRIME)) ^ fold_byte_case_insensitive(b);
+    }
+    hash
+}
+
+#[inline]
+fn hashmap_bucket(hash: u32) -> usize {
+    usize::try_from(hash).unwrap_or(0) & (HASHMAP_INITIAL_SIZE - 1)
+}
+
+struct DirNode {
+    hash: u32,
+    name: Vec<u8>,
+    /// Reference count (Git `dir_entry.nr`): incremented for child dirs and for indexed files.
+    nr: i32,
+}
+
+struct DirTable {
+    map: HashMap<Vec<u8>, usize>,
+    nodes: Vec<DirNode>,
+}
+
+impl DirTable {
+    fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+            nodes: Vec::new(),
+        }
+    }
+}
+
+struct LazyEntry {
+    dir: Option<usize>,
+    hash_name: u32,
+}
+
+fn dir_entry_name_matches_key(name: &[u8], key: &[u8]) -> bool {
+    name.len() == key.len() && name.eq_ignore_ascii_case(key)
+}
+
+fn find_dir_entry(table: &DirTable, name: &[u8], hash: u32) -> Option<usize> {
+    let idx = *table.map.get(name)?;
+    let n = &table.nodes[idx];
+    if n.hash == hash && dir_entry_name_matches_key(&n.name, name) {
+        Some(idx)
+    } else {
+        None
+    }
+}
+
+/// Like C `strncmp(ce_name, prefix, prefix.len())` on byte strings (no NUL termination).
+fn strncmp_prefix(ce_name: &[u8], prefix: &[u8]) -> std::cmp::Ordering {
+    for (i, &pb) in prefix.iter().enumerate() {
+        let cb = ce_name.get(i).copied().unwrap_or(0);
+        match cb.cmp(&pb) {
+            std::cmp::Ordering::Equal => {}
+            o => return o,
+        }
+    }
+    std::cmp::Ordering::Equal
+}
+
+fn hash_dir_entry_with_parent_and_prefix(
+    table: &mut DirTable,
+    parent: Option<usize>,
+    prefix: &[u8],
+) -> usize {
+    let hash = if let Some(pidx) = parent {
+        let pn = &table.nodes[pidx];
+        memihash_cont(pn.hash, &prefix[pn.name.len()..])
+    } else {
+        memihash(prefix)
+    };
+
+    if let Some(idx) = find_dir_entry(table, prefix, hash) {
+        return idx;
+    }
+
+    let idx = table.nodes.len();
+    table.nodes.push(DirNode {
+        hash,
+        name: prefix.to_vec(),
+        nr: 0,
+    });
+    table.map.insert(prefix.to_vec(), idx);
+
+    if let Some(pidx) = parent {
+        table.nodes[pidx].nr = table.nodes[pidx].nr.saturating_add(1);
+    }
+
+    idx
+}
+
+#[allow(clippy::too_many_arguments)]
+fn handle_range_dir(
+    entries: &[IndexEntry],
+    k_start: usize,
+    k_end: usize,
+    parent: Option<usize>,
+    prefix: &mut Vec<u8>,
+    lazy_entries: &mut [LazyEntry],
+    entry_base: usize,
+    table: &mut DirTable,
+) -> usize {
+    let input_prefix_len = prefix.len();
+    let dir_new = hash_dir_entry_with_parent_and_prefix(table, parent, prefix);
+    prefix.push(b'/');
+
+    let k = if k_start + 1 >= k_end {
+        k_end
+    } else if strncmp_prefix(&entries[k_start + 1].path, prefix.as_slice())
+        != std::cmp::Ordering::Equal
+    {
+        k_start + 1
+    } else if strncmp_prefix(&entries[k_end - 1].path, prefix.as_slice())
+        == std::cmp::Ordering::Equal
+    {
+        k_end
+    } else {
+        let mut begin = k_start;
+        let mut end = k_end;
+        while begin < end {
+            let mid = begin + ((end - begin) >> 1);
+            let cmp = strncmp_prefix(&entries[mid].path, prefix.as_slice());
+            match cmp {
+                std::cmp::Ordering::Equal => begin = mid + 1,
+                std::cmp::Ordering::Greater => end = mid,
+                std::cmp::Ordering::Less => panic!("cache entry out of order"),
+            }
+        }
+        begin
+    };
+
+    let mut processed = handle_range_1(
+        entries,
+        k_start,
+        k,
+        Some(dir_new),
+        prefix,
+        lazy_entries,
+        entry_base,
+        table,
+    );
+    if processed > 0 {
+        prefix.truncate(input_prefix_len);
+        return processed;
+    }
+
+    prefix.push(b'/');
+    processed = handle_range_1(
+        entries,
+        k,
+        k_end,
+        Some(dir_new),
+        prefix,
+        lazy_entries,
+        entry_base,
+        table,
+    );
+    prefix.truncate(input_prefix_len);
+    processed
+}
+
+#[allow(clippy::too_many_arguments)]
+fn handle_range_1(
+    entries: &[IndexEntry],
+    k_start: usize,
+    k_end: usize,
+    parent: Option<usize>,
+    prefix: &mut Vec<u8>,
+    lazy_entries: &mut [LazyEntry],
+    entry_base: usize,
+    table: &mut DirTable,
+) -> usize {
+    let input_prefix_len = prefix.len();
+    let mut k = k_start;
+
+    while k < k_end {
+        let ce_k = &entries[k];
+        if !prefix.is_empty() && !ce_k.path.starts_with(prefix.as_slice()) {
+            break;
+        }
+
+        let name = if prefix.is_empty() {
+            ce_k.path.as_slice()
+        } else {
+            &ce_k.path[prefix.len()..]
+        };
+
+        if let Some(slash_rel) = name.iter().position(|&b| b == b'/') {
+            let len = slash_rel;
+            prefix.extend_from_slice(&name[..len]);
+            let processed = handle_range_dir(
+                entries,
+                k,
+                k_end,
+                parent,
+                prefix,
+                lazy_entries,
+                entry_base,
+                table,
+            );
+            k += processed;
+            prefix.truncate(input_prefix_len);
+            continue;
+        }
+
+        let li = k - entry_base;
+        lazy_entries[li].dir = parent;
+        if let Some(pidx) = parent {
+            let pn = &table.nodes[pidx];
+            let suffix = &ce_k.path[pn.name.len()..];
+            lazy_entries[li].hash_name = memihash_cont(pn.hash, suffix);
+        } else {
+            lazy_entries[li].hash_name = memihash(&ce_k.path);
+        }
+
+        k += 1;
+    }
+
+    k - k_start
+}
+
+fn lazy_update_dir_ref_counts(table: &mut DirTable, lazy_entries: &[LazyEntry]) {
+    for le in lazy_entries {
+        if let Some(didx) = le.dir {
+            table.nodes[didx].nr = table.nodes[didx].nr.saturating_add(1);
+        }
+    }
+}
+
+fn lookup_lazy_params(try_threaded: bool, cache_nr: usize) -> usize {
+    if !try_threaded {
+        return 0;
+    }
+
+    let nr_cpus = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+    if nr_cpus < 2 {
+        return 0;
+    }
+    if cache_nr < 2 * LAZY_THREAD_COST {
+        return 0;
+    }
+
+    let mut nr_cpus = nr_cpus;
+    if cache_nr < nr_cpus * LAZY_THREAD_COST {
+        nr_cpus = cache_nr / LAZY_THREAD_COST;
+    }
+    nr_cpus
+}
+
+fn sequential_lazy_build(index: &Index) -> (DirTable, Vec<LazyEntry>) {
+    let cache_nr = index.entries.len();
+    let mut lazy_entries: Vec<LazyEntry> = (0..cache_nr)
+        .map(|_| LazyEntry {
+            dir: None,
+            hash_name: 0,
+        })
+        .collect();
+    let mut table = DirTable::new();
+    let mut prefix = Vec::new();
+    handle_range_1(
+        &index.entries,
+        0,
+        cache_nr,
+        None,
+        &mut prefix,
+        &mut lazy_entries,
+        0,
+        &mut table,
+    );
+    lazy_update_dir_ref_counts(&mut table, &lazy_entries);
+    (table, lazy_entries)
+}
+
+fn threaded_lazy_build(
+    index: &Index,
+    nr_dir_threads: usize,
+) -> Result<(DirTable, Vec<LazyEntry>), String> {
+    let cache_nr = index.entries.len();
+    let mut lazy_entries: Vec<LazyEntry> = (0..cache_nr)
+        .map(|_| LazyEntry {
+            dir: None,
+            hash_name: 0,
+        })
+        .collect();
+
+    let shared = Arc::new(Mutex::new(DirTable::new()));
+    let nr_each = cache_nr.div_ceil(nr_dir_threads);
+
+    std::thread::scope(|s| {
+        let mut handles = Vec::new();
+        let mut k_start: usize = 0;
+        for _ in 0..nr_dir_threads {
+            let mut k_end = k_start.saturating_add(nr_each);
+            if k_end > cache_nr {
+                k_end = cache_nr;
+            }
+            let shared = Arc::clone(&shared);
+            let slice = &index.entries;
+            let range_start = k_start;
+            let range_end = k_end;
+            let seg_len = range_end - range_start;
+            handles.push(s.spawn(move || {
+                let mut prefix = Vec::new();
+                let mut seg: Vec<LazyEntry> = (0..seg_len)
+                    .map(|_| LazyEntry {
+                        dir: None,
+                        hash_name: 0,
+                    })
+                    .collect();
+                let mut table = match shared.lock() {
+                    Ok(g) => g,
+                    Err(e) => e.into_inner(),
+                };
+                handle_range_1(
+                    slice,
+                    range_start,
+                    range_end,
+                    None,
+                    &mut prefix,
+                    &mut seg,
+                    range_start,
+                    &mut table,
+                );
+                (range_start, seg)
+            }));
+            k_start = k_end;
+            if k_start >= cache_nr {
+                break;
+            }
+        }
+        for h in handles {
+            match h.join() {
+                Ok((rs, seg)) => {
+                    for (j, le) in seg.into_iter().enumerate() {
+                        lazy_entries[rs + j] = le;
+                    }
+                }
+                Err(e) => std::panic::resume_unwind(e),
+            }
+        }
+    });
+
+    let mutex = Arc::try_unwrap(shared).map_err(|_| "lazy name-hash: arc still shared")?;
+    let mut table = mutex.into_inner().unwrap_or_else(|e| e.into_inner());
+    lazy_update_dir_ref_counts(&mut table, &lazy_entries);
+
+    Ok((table, lazy_entries))
+}
+
+fn single_threaded_hash_pass(index: &Index) {
+    let mut name_buckets = vec![Vec::new(); HASHMAP_INITIAL_SIZE];
+    for (i, e) in index.entries.iter().enumerate() {
+        if e.is_sparse_directory_placeholder() {
+            continue;
+        }
+        let h = memihash(&e.path);
+        name_buckets[hashmap_bucket(h)].push(i);
+    }
+    let _ = name_buckets;
+}
+
+/// Print `dir` / `name` lines like Git `test-lazy-init-name-hash.c` `dump_run`.
+///
+/// When `multi` is true but threading is disabled by Git's thresholds, returns
+/// `Err` so callers can match Git's `die("non-threaded code path used")`.
+///
+/// # Errors
+///
+/// Returns an error on IO failure or when `multi` was requested without threads.
+pub fn dump_lazy_init_name_hash(index: &Index, multi: bool) -> Result<(), String> {
+    let cache_nr = index.entries.len();
+    let nr_threads = lookup_lazy_params(multi, cache_nr);
+    if multi && nr_threads == 0 {
+        return Err("non-threaded code path used".to_owned());
+    }
+    let (table, lazy_entries) = if nr_threads == 0 {
+        sequential_lazy_build(index)
+    } else {
+        threaded_lazy_build(index, nr_threads)?
+    };
+
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
+    for dir in &table.nodes {
+        let path = String::from_utf8_lossy(&dir.name);
+        writeln!(out, "dir {:08x} {:7} {}", dir.hash, dir.nr, path).map_err(|e| e.to_string())?;
+    }
+    for (k, e) in index.entries.iter().enumerate() {
+        if e.is_sparse_directory_placeholder() {
+            continue;
+        }
+        let path = String::from_utf8_lossy(&e.path);
+        writeln!(out, "name {:08x} {}", lazy_entries[k].hash_name, path)
+            .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+/// Run Git-compatible lazy name-hash initialization on `index`.
+///
+/// When `try_threaded` is true and entry count / CPU count meet Git's thresholds, uses a
+/// multi-threaded directory scan (return value is the thread count). Otherwise uses the
+/// single-threaded path and returns `0`.
+///
+/// Sparse-directory placeholder entries are skipped for the name table, matching Git's
+/// `S_ISSPARSEDIR` handling.
+///
+/// # Errors
+///
+/// Returns an error if the threaded builder cannot recover the shared directory table
+/// (should not happen after worker threads have joined).
+pub fn test_lazy_init_name_hash(index: &Index, try_threaded: bool) -> Result<usize, String> {
+    let cache_nr = index.entries.len();
+    let nr_threads = lookup_lazy_params(try_threaded, cache_nr);
+    if nr_threads == 0 {
+        single_threaded_hash_pass(index);
+    } else {
+        threaded_lazy_build(index, nr_threads)?;
+    }
+    Ok(nr_threads)
+}

--- a/grit-lib/src/lib.rs
+++ b/grit-lib/src/lib.rs
@@ -34,6 +34,7 @@ pub mod gitmodules;
 pub mod hooks;
 pub mod ignore;
 pub mod index;
+pub mod index_name_hash_lazy;
 pub mod interpret_trailers;
 pub mod line_log;
 pub mod ls_remote;

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -970,6 +970,295 @@ fn test_tool_usage() -> Result<()> {
     bail!("test-tool: unknown or invalid subcommand usage")
 }
 
+/// `test-tool online-cpus` — print the number of processors Git would consider "online"
+/// (matches `git/t/helper/test-online-cpus.c` using `std::thread::available_parallelism`).
+fn run_test_tool_online_cpus(rest: &[String]) -> Result<()> {
+    let _ = preprocess_test_tool_args(rest)?;
+    let n = std::thread::available_parallelism()
+        .map(|p| p.get())
+        .unwrap_or(1);
+    println!("{n}");
+    Ok(())
+}
+
+/// `test-tool lazy-init-name-hash` — exercise case-folding name/dir hash init (t3008, perf tests).
+fn run_test_tool_lazy_init_name_hash(rest: &[String]) -> Result<()> {
+    use anyhow::Context;
+    use std::io::Write;
+
+    let args = preprocess_test_tool_args(rest)?;
+    if args.first().map(String::as_str) != Some("lazy-init-name-hash") {
+        bail!("internal error: lazy-init-name-hash dispatcher");
+    }
+
+    let repo = grit_lib::repo::Repository::discover(None).context("not a git repository")?;
+    let index = repo.load_index().context("loading index")?;
+
+    let mut single = false;
+    let mut multi = false;
+    let mut count: usize = 1;
+    let mut dump = false;
+    let mut perf = false;
+    let mut analyze: Option<i32> = None;
+    let mut analyze_step: Option<i32> = None;
+
+    let mut i = 1usize;
+    while i < args.len() {
+        match args[i].as_str() {
+            "-s" | "--single" => {
+                single = true;
+                i += 1;
+            }
+            "-m" | "--multi" => {
+                multi = true;
+                i += 1;
+            }
+            "-c" | "--count" => {
+                let v = args.get(i + 1).ok_or_else(|| {
+                    anyhow::anyhow!("test-tool lazy-init-name-hash: --count needs a value")
+                })?;
+                count = v
+                    .parse()
+                    .with_context(|| format!("invalid --count '{v}'"))?;
+                i += 2;
+            }
+            "-d" | "--dump" => {
+                dump = true;
+                i += 1;
+            }
+            "-p" | "--perf" => {
+                perf = true;
+                i += 1;
+            }
+            "-a" | "--analyze" => {
+                let v = args.get(i + 1).ok_or_else(|| {
+                    anyhow::anyhow!("test-tool lazy-init-name-hash: --analyze needs a value")
+                })?;
+                let a: i32 = v
+                    .parse()
+                    .with_context(|| format!("invalid --analyze '{v}'"))?;
+                analyze = Some(a);
+                i += 2;
+            }
+            "--step" => {
+                let v = args.get(i + 1).ok_or_else(|| {
+                    anyhow::anyhow!("test-tool lazy-init-name-hash: --step needs a value")
+                })?;
+                let s: i32 = v.parse().with_context(|| format!("invalid --step '{v}'"))?;
+                analyze_step = Some(s);
+                i += 2;
+            }
+            other => bail!("test-tool lazy-init-name-hash: unknown argument '{other}'"),
+        }
+    }
+
+    if dump {
+        if perf || analyze.is_some() {
+            bail!("test-tool lazy-init-name-hash: cannot combine dump, perf, or analyze");
+        }
+        if count > 1 {
+            bail!("test-tool lazy-init-name-hash: count not valid with dump");
+        }
+        if single && multi {
+            bail!("test-tool lazy-init-name-hash: cannot use both single and multi with dump");
+        }
+        if !single && !multi {
+            bail!("test-tool lazy-init-name-hash: dump requires either single or multi");
+        }
+        grit_lib::index_name_hash_lazy::dump_lazy_init_name_hash(&index, multi)
+            .map_err(|s| anyhow::anyhow!(s))?;
+        return Ok(());
+    }
+
+    if perf {
+        if analyze.is_some() {
+            bail!("test-tool lazy-init-name-hash: cannot combine dump, perf, or analyze");
+        }
+        if single || multi {
+            bail!("test-tool lazy-init-name-hash: cannot use single or multi with perf");
+        }
+        let avg_single = time_runs_lazy_name_hash(&index, false, count)?;
+        let avg_multi = time_runs_lazy_name_hash(&index, true, count)?;
+        if avg_multi > avg_single {
+            bail!("test-tool lazy-init-name-hash: multi is slower");
+        }
+        return Ok(());
+    }
+
+    if let Some(a) = analyze {
+        if a < 500 {
+            bail!("test-tool lazy-init-name-hash: analyze must be at least 500");
+        }
+        let step = analyze_step.unwrap_or(a);
+        if single || multi {
+            bail!("test-tool lazy-init-name-hash: cannot use single or multi with analyze");
+        }
+        analyze_runs_lazy_name_hash(&index, a, step, count)?;
+        return Ok(());
+    }
+
+    if !single && !multi {
+        bail!("test-tool lazy-init-name-hash: require either -s or -m or both");
+    }
+
+    if single {
+        time_runs_lazy_name_hash(&index, false, count)?;
+    }
+    if multi {
+        time_runs_lazy_name_hash(&index, true, count)?;
+    }
+    let _ = std::io::stdout().flush();
+    Ok(())
+}
+
+fn time_runs_lazy_name_hash(
+    index: &grit_lib::index::Index,
+    try_threaded: bool,
+    count: usize,
+) -> Result<u64> {
+    use std::io::Write;
+    let mut sum_ns: u64 = 0;
+    let mut last_nr_threads = 0usize;
+    for _ in 0..count {
+        let t0 = std::time::Instant::now();
+        let nr = grit_lib::index_name_hash_lazy::test_lazy_init_name_hash(index, try_threaded)
+            .map_err(|e| anyhow::anyhow!(e))?;
+        let t1 = std::time::Instant::now();
+        let dt = t1.duration_since(t0);
+        sum_ns += dt.as_nanos() as u64;
+        last_nr_threads = nr;
+
+        if try_threaded && nr == 0 {
+            bail!("test-tool lazy-init-name-hash: non-threaded code path used");
+        }
+
+        let read_ns = 0u64;
+        let work_ns = dt.as_nanos() as u64;
+        let nr_entries = index.entries.len();
+        if nr > 0 {
+            println!(
+                "{} {} {} multi {}",
+                (read_ns as f64) / 1e9,
+                (work_ns as f64) / 1e9,
+                nr_entries,
+                nr
+            );
+        } else {
+            println!(
+                "{} {} {} single",
+                (read_ns as f64) / 1e9,
+                (work_ns as f64) / 1e9,
+                nr_entries
+            );
+        }
+        let _ = std::io::stdout().flush();
+    }
+    if count > 1 {
+        let avg = sum_ns / count as u64;
+        println!(
+            "avg {} {}",
+            (avg as f64) / 1e9,
+            if try_threaded && last_nr_threads > 0 {
+                "multi"
+            } else {
+                "single"
+            }
+        );
+    }
+    Ok(sum_ns / count as u64)
+}
+
+fn analyze_runs_lazy_name_hash(
+    index: &grit_lib::index::Index,
+    analyze_start: i32,
+    step: i32,
+    count: usize,
+) -> Result<()> {
+    use std::io::Write;
+
+    let cache_nr_limit = index.entries.len();
+    let mut nr = analyze_start as usize;
+    let analyze_step = step as usize;
+
+    loop {
+        if nr > cache_nr_limit {
+            nr = cache_nr_limit;
+        }
+
+        let mut sum_single: u128 = 0;
+        let mut sum_multi: u128 = 0;
+        let mut nr_threads_used = 0usize;
+
+        for _ in 0..count {
+            let truncated = truncate_index_for_analyze(index, nr);
+
+            let t1s = std::time::Instant::now();
+            grit_lib::index_name_hash_lazy::test_lazy_init_name_hash(&truncated, false)
+                .map_err(|e| anyhow::anyhow!(e))?;
+            let t2s = std::time::Instant::now();
+            sum_single += t2s.duration_since(t1s).as_nanos();
+
+            let t1m = std::time::Instant::now();
+            nr_threads_used =
+                grit_lib::index_name_hash_lazy::test_lazy_init_name_hash(&truncated, true)
+                    .map_err(|e| anyhow::anyhow!(e))?;
+            let t2m = std::time::Instant::now();
+            sum_multi += t2m.duration_since(t1m).as_nanos();
+
+            if nr_threads_used == 0 {
+                println!(
+                    "    [size {:8}] [single {}]   non-threaded code path used",
+                    nr,
+                    (t2s.duration_since(t1s).as_nanos() as f64) / 1e9
+                );
+            } else {
+                let ds = t2s.duration_since(t1s).as_nanos() as i128;
+                let dm = t2m.duration_since(t1m).as_nanos() as i128;
+                println!(
+                    "    [size {:8}] [single {}] {} [multi {} {}]",
+                    nr,
+                    (ds as f64) / 1e9,
+                    if ds < dm { '<' } else { '>' },
+                    (dm as f64) / 1e9,
+                    nr_threads_used
+                );
+            }
+            let _ = std::io::stdout().flush();
+        }
+
+        if count > 1 {
+            let avg_single = sum_single / count as u128;
+            let avg_multi = sum_multi / count as u128;
+            if nr_threads_used == 0 {
+                println!("avg [size {:8}] [single {}]", nr, (avg_single as f64) / 1e9);
+            } else {
+                println!(
+                    "avg [size {:8}] [single {}] {} [multi {} {}]",
+                    nr,
+                    (avg_single as f64) / 1e9,
+                    if avg_single < avg_multi { '<' } else { '>' },
+                    (avg_multi as f64) / 1e9,
+                    nr_threads_used
+                );
+            }
+            let _ = std::io::stdout().flush();
+        }
+
+        if nr >= cache_nr_limit {
+            return Ok(());
+        }
+        nr = nr.saturating_add(analyze_step);
+    }
+}
+
+fn truncate_index_for_analyze(index: &grit_lib::index::Index, n: usize) -> grit_lib::index::Index {
+    let mut out = index.clone();
+    if n < out.entries.len() {
+        out.entries.truncate(n);
+    }
+    out
+}
+
 fn preprocess_test_tool_args(rest: &[String]) -> Result<Vec<String>> {
     let mut i = 0usize;
     let mut change_dir: Option<std::path::PathBuf> = None;
@@ -3436,6 +3725,8 @@ pub(crate) fn dispatch(subcmd: &str, rest: &[String], opts: &GlobalOpts) -> Resu
                 "userdiff" => run_test_tool_userdiff(rest),
                 "find-pack" => run_test_tool_find_pack(rest),
                 "ref-store" => run_test_tool_ref_store(rest),
+                "online-cpus" => run_test_tool_online_cpus(rest),
+                "lazy-init-name-hash" => run_test_tool_lazy_init_name_hash(rest),
                 "rot13-filter" => commands::test_tool_rot13_filter::run(&rest[1..]),
                 "path-utils" => run_test_tool_path_utils(&rest[1..]),
                 "submodule" => run_test_tool_submodule(&rest[1..]),

--- a/logs/2026-04-09_t3008-lazy-init-name-hash-test-tool.md
+++ b/logs/2026-04-09_t3008-lazy-init-name-hash-test-tool.md
@@ -1,0 +1,5 @@
+## 2026-04-09 — t3008 lazy-init name hash / test-tool
+
+- Added `grit-lib::index_name_hash_lazy` implementing Git-compatible `memihash`, sequential and multi-threaded directory/name hash build (mirrors `name-hash.c` thresholds: `LAZY_THREAD_COST`, `online_cpus`-style parallelism).
+- Wired `grit test-tool online-cpus` and `test-tool lazy-init-name-hash` in `grit/src/main.rs` (dump/perf/analyze modes aligned with `git/t/helper/test-lazy-init-name-hash.c`).
+- `./scripts/run-tests.sh t3008-ls-files-lazy-init-name-hash.sh` → 1/1; `scripts/run-upstream-tests.sh t3008` → 1/1.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements `test-tool online-cpus` and `test-tool lazy-init-name-hash` so `t3008-ls-files-lazy-init-name-hash` runs against a fresh `target/release/grit` binary (upstream harness was failing with unknown subcommands).

## Changes

- **`grit-lib`**: new `index_name_hash_lazy` module — Git-compatible `memihash`, sequential and parallel directory/name hash construction using the same `LAZY_THREAD_COST` / CPU thresholds as Git's `name-hash.c`.
- **`grit`**: dispatch `online-cpus` and `lazy-init-name-hash` with modes matching `git/t/helper/test-lazy-init-name-hash.c` (single/multi, dump, perf, analyze).
- Refreshed harness CSV/dashboards from `./scripts/run-tests.sh t3008-ls-files-lazy-init-name-hash.sh`.

## Verification

- `./scripts/run-tests.sh t3008-ls-files-lazy-init-name-hash.sh` — 1/1
- `bash scripts/run-upstream-tests.sh t3008` — 1/1
- `cargo test -p grit-lib --lib` — pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21bc8856-df22-4847-813c-fe4d616ad41e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21bc8856-df22-4847-813c-fe4d616ad41e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

