### PR TITLE
fix: cherry-pick empty / redundant commits (t3505)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -636,7 +636,7 @@ t3501-revert-cherry-pick	t3	yes	21	5	16	false	ok	0
 t3502-cherry-pick-merge	t3	yes	12	12	0	true	ok	0
 t3503-cherry-pick-root	t3	yes	6	3	3	false	ok	0
 t3504-cherry-pick-rerere	t3	yes	9	3	6	false	ok	0
-t3505-cherry-pick-empty	t3	yes	0	0	0	false	timeout	0
+t3505-cherry-pick-empty	t3	yes	17	17	0	true	ok	0
 t3506-cherry-pick-ff	t3	yes	11	11	0	true	ok	0
 t3507-cherry-pick-conflict	t3	yes	44	13	31	false	ok	0
 t3508-cherry-pick-many-commits	t3	yes	14	5	9	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T04:04:55+00:00" class="gen-time" title="2026-04-09 04:04 UTC">2026-04-09 04:04 UTC</time> · <a href="https://github.com/schacon/grit/commit/8292821a559988c8235b541ac75070d7fe15b5c7" style="color:#58a6ff">8292821</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T04:19:25+00:00" class="gen-time" title="2026-04-09 04:19 UTC">2026-04-09 04:19 UTC</time> · <a href="https://github.com/schacon/grit/commit/a4c5a5e06115acce00c0b83b1f490e3b7db0948e" style="color:#58a6ff">a4c5a5e</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,11 +150,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,928</div>
+      <div class="summary-big-val">29,945</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">39,873</div>
+      <div class="summary-big-val">39,890</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>748 files fully passing</span>
+    <span>749 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,11 +212,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">45/141 files · 2 skipped · 3,355/4,619 tests</span>
+        <span class="group-meta">46/141 files · 2 skipped · 3,372/4,636 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.6%"></div></div>
-        <span class="group-pct pct-blue">72.6%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.7%"></div></div>
+        <span class="group-pct pct-blue">72.7%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:04:55+00:00" class="gen-time" title="2026-04-09 04:04 UTC">2026-04-09 04:04 UTC</time> · <a href="https://github.com/schacon/grit/commit/8292821a559988c8235b541ac75070d7fe15b5c7" style="color:#58a6ff">8292821</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:19:25+00:00" class="gen-time" title="2026-04-09 04:19 UTC">2026-04-09 04:19 UTC</time> · <a href="https://github.com/schacon/grit/commit/a4c5a5e06115acce00c0b83b1f490e3b7db0948e" style="color:#58a6ff">a4c5a5e</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,928</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n" id="sum-tests">39,890</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,945</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">75.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -6517,14 +6517,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:33.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="0" data-passed="0">
+<tr class="" data-group="t3" data-tests="17" data-passed="17" data-full-pass="1">
   <td class="mono">t3505-cherry-pick-empty</td>
   <td>t3</td>
-  <td></td>
-  <td class="right">0</td>
-  <td class="right">0</td>
-  <td class="right">timeout</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td><span class="badge ok">full pass</span></td>
+  <td class="right">17</td>
+  <td class="right">17</td>
+  <td class="right">ok</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="11" data-passed="11" data-full-pass="1">

--- a/grit/src/commands/cherry_pick.rs
+++ b/grit/src/commands/cherry_pick.rs
@@ -75,6 +75,74 @@ fn cherry_pick_rev_author() -> Option<String> {
     CHERRY_PICK_REV_OPTS.get().and_then(|(_, a)| a.clone())
 }
 
+/// Whether the picked commit's tree matches its first parent's tree (or the empty tree for roots).
+fn is_original_commit_empty(repo: &Repository, commit: &CommitData) -> Result<bool> {
+    let parent_tree_oid = if commit.parents.is_empty() {
+        repo.odb.write(ObjectKind::Tree, &[])?
+    } else {
+        let parent_obj = repo.odb.read(&commit.parents[0])?;
+        parse_commit(&parent_obj.data)?.tree
+    };
+    Ok(parent_tree_oid == commit.tree)
+}
+
+/// Resolves how to handle a cherry-pick whose merged tree equals `HEAD` (index unchanged vs HEAD).
+fn resolve_empty_pick_resolution(
+    originally_empty: bool,
+    args: &Args,
+) -> Result<EmptyPickResolution> {
+    let drop_redundant = matches!(args.empty.as_deref(), Some("drop"));
+    let keep_redundant =
+        args.keep_redundant_commits || matches!(args.empty.as_deref(), Some("keep"));
+    let allow_initial_empty = args.allow_empty || args.keep_redundant_commits;
+
+    if originally_empty {
+        return Ok(if allow_initial_empty {
+            EmptyPickResolution::Proceed
+        } else {
+            EmptyPickResolution::Stop
+        });
+    }
+    if keep_redundant {
+        return Ok(EmptyPickResolution::Proceed);
+    }
+    if drop_redundant {
+        return Ok(EmptyPickResolution::Drop);
+    }
+    Ok(EmptyPickResolution::Stop)
+}
+
+fn verify_pick_flags_not_with_operation(args: &Args, operation: &str) {
+    let mut incompatible: Option<&'static str> = None;
+    if args.no_commit {
+        incompatible = Some("--no-commit");
+    } else if args.signoff {
+        incompatible = Some("--signoff");
+    } else if args.mainline.is_some() {
+        incompatible = Some("-m");
+    } else if args.strategy.is_some() {
+        incompatible = Some("--strategy");
+    } else if !args.strategy_option.is_empty() {
+        incompatible = Some("--strategy-option");
+    } else if args.append_source {
+        incompatible = Some("-x");
+    } else if args.ff {
+        incompatible = Some("--ff");
+    } else if args.keep_redundant_commits {
+        incompatible = Some("--keep-redundant-commits");
+    } else if args.empty.is_some() {
+        incompatible = Some("--empty");
+    } else if args.allow_empty {
+        incompatible = Some("--allow-empty");
+    } else if args.edit {
+        incompatible = Some("--edit");
+    }
+    if let Some(flag) = incompatible {
+        eprintln!("fatal: cherry-pick: {flag} cannot be used with {operation}");
+        std::process::exit(128);
+    }
+}
+
 use super::sequencer::{
     rollback_is_safe, sequencer_is_pick_sequence, sequencer_is_revert_sequence,
     strip_first_sequencer_todo_line, write_abort_safety_file,
@@ -93,6 +161,17 @@ struct WhitespaceStrategyOptions {
     ignore_space_change: bool,
     ignore_space_at_eol: bool,
     ignore_cr_at_eol: bool,
+}
+
+/// How to handle a cherry-pick whose resulting tree matches `HEAD`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum EmptyPickResolution {
+    /// Create the commit (empty or redundant).
+    Proceed,
+    /// Skip without error (patch already upstream).
+    Drop,
+    /// Stop with `CHERRY_PICK_HEAD` set (user may `--skip` or `--allow-empty`).
+    Stop,
 }
 
 /// Arguments for `grit cherry-pick`.
@@ -143,6 +222,14 @@ pub struct Args {
     #[arg(long = "allow-empty")]
     pub allow_empty: bool,
 
+    /// Allow recording commits whose message is empty (matches `git cherry-pick`).
+    #[arg(long = "allow-empty-message")]
+    pub allow_empty_message: bool,
+
+    /// Keep commits that become empty after replaying onto the current branch (deprecated alias for `--empty=keep`).
+    #[arg(long = "keep-redundant-commits")]
+    pub keep_redundant_commits: bool,
+
     /// Merge strategy to use (e.g. recursive, ort, resolve).
     #[arg(long = "strategy")]
     pub strategy: Option<String>,
@@ -169,20 +256,28 @@ pub fn run(args: Args) -> Result<()> {
             std::process::exit(129);
         }
     }
+
     if args.abort {
+        verify_pick_flags_not_with_operation(&args, "--abort");
         return abort_cherry_pick_or_revert();
+    }
+    if args.quit {
+        verify_pick_flags_not_with_operation(&args, "--quit");
+        return do_quit();
     }
     if args.skip {
         return do_skip(args);
-    }
-    if args.quit {
-        return do_quit();
     }
     if args.r#continue {
         return do_continue(args);
     }
     if args.commits.is_empty() {
         bail!("nothing to cherry-pick; specify at least one commit");
+    }
+
+    let mut args = args;
+    if args.keep_redundant_commits || matches!(args.empty.as_deref(), Some("keep")) {
+        args.allow_empty = true;
     }
     do_cherry_pick(args)
 }
@@ -625,15 +720,23 @@ fn cherry_pick_one_commit(repo: &Repository, commit_oid: ObjectId, args: &Args) 
 
     let has_conflicts = merge_result.index.entries.iter().any(|e| e.stage() != 0);
 
-    // Check for empty cherry-pick (tree unchanged from HEAD)
-    if !has_conflicts && !args.allow_empty {
+    // Index matches HEAD: either drop, record an empty commit, or stop (Git's `allow_empty()`).
+    if !has_conflicts {
         let new_tree_oid = write_tree_from_index(&repo.odb, &merge_result.index, "")?;
         if new_tree_oid == head_tree_oid {
-            let empty_action = args.empty.as_deref().unwrap_or("stop");
-            match empty_action {
-                "drop" => return Ok(()),
-                "keep" => { /* fall through to commit */ }
-                _ /* "stop" */ => {
+            let originally_empty = is_original_commit_empty(repo, &commit)?;
+            match resolve_empty_pick_resolution(originally_empty, args)? {
+                EmptyPickResolution::Drop => {
+                    let subject = commit.message.lines().next().unwrap_or("");
+                    eprintln!(
+                        "dropping {} {} -- patch contents already upstream",
+                        commit_oid.to_hex(),
+                        subject
+                    );
+                    return Ok(());
+                }
+                EmptyPickResolution::Proceed => { /* commit below */ }
+                EmptyPickResolution::Stop => {
                     let mut msg = commit.message.clone();
                     if args.append_source {
                         let trailer =
@@ -753,6 +856,7 @@ fn do_continue(mut args: Args) -> Result<()> {
 
     merge_sequencer_opts(git_dir, &mut args);
     let args = &args;
+    verify_pick_flags_not_with_operation(args, "--continue");
 
     let has_cherry_pick_head = git_dir.join("CHERRY_PICK_HEAD").exists();
     let sequencer_todo = git_dir.join("sequencer").join("todo");
@@ -952,6 +1056,7 @@ fn do_skip(mut args: Args) -> Result<()> {
 
     merge_sequencer_opts(git_dir, &mut args);
     let args = &args;
+    verify_pick_flags_not_with_operation(args, "--skip");
 
     if git_dir.join("REVERT_HEAD").exists() {
         eprintln!("error: no cherry-pick in progress");
@@ -1050,6 +1155,15 @@ fn write_sequencer_opts(git_dir: &Path, args: &Args) -> Result<()> {
     if args.edit {
         opts.push_str("\tedit = true\n");
     }
+    if args.allow_empty {
+        opts.push_str("\tallow-empty = true\n");
+    }
+    if args.allow_empty_message {
+        opts.push_str("\tallow-empty-message = true\n");
+    }
+    if args.keep_redundant_commits {
+        opts.push_str("\tkeep-redundant-commits = true\n");
+    }
     if let Some(ref empty) = args.empty {
         opts.push_str(&format!("\tempty = {empty}\n"));
     }
@@ -1105,6 +1219,12 @@ fn merge_sequencer_opts(git_dir: &Path, args: &mut Args) {
                 "record-origin" if val == "true" => args.append_source = true,
                 "no_commit" if val == "true" => args.no_commit = true,
                 "edit" if val == "true" => args.edit = true,
+                "allow-empty" if val == "true" => args.allow_empty = true,
+                "allow-empty-message" if val == "true" => args.allow_empty_message = true,
+                "keep-redundant-commits" if val == "true" => {
+                    args.keep_redundant_commits = true;
+                    args.allow_empty = true;
+                }
                 "mainline" => {
                     if let Ok(m) = val.parse::<usize>() {
                         args.mainline = Some(m);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible handling of empty and redundant cherry-picks so `t3505-cherry-pick-empty.sh` passes (17/17).

## Changes

- **Originally empty vs became empty**: Matches Git's `allow_empty()` — `--allow-empty` / `--keep-redundant-commits` only affect commits that were already empty on the source branch; redundant (no-op) picks use `--empty=drop|keep` or default stop.
- **`--empty=drop`**: Skips the commit and prints the "dropping … patch contents already upstream" message.
- **CLI / sequencer**: Added `--allow-empty-message` (parsed and stored in `sequencer/opts`); `--keep-redundant-commits` implies `allow-empty` like upstream.
- **Operation modes**: Rejects incompatible pick flags with `--continue`, `--skip`, `--abort`, and `--quit` with `fatal: cherry-pick: … cannot be used with …` (exit 128).

## Validation

- `./scripts/run-tests.sh t3505-cherry-pick-empty.sh` → 17/17
- `cargo check -p grit-rs`
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19e6d23-fbe1-475a-b6b2-5997810ee4f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19e6d23-fbe1-475a-b6b2-5997810ee4f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

