### PR TITLE
docs: t5519-push-alternates fully passing (8/8)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -591,7 +591,7 @@ commit → check it off → move on.
 - [ ] `t5543-atomic-push` ██████████░░░░░░░░░░ 7/13 (6 left) — pushing to a repository using the atomic push option
 - [ ] `t5503-tagfollow` ██████████░░░░░░░░░░ 6/12 (6 left) — test automatic tag following
 - [ ] `t5408-send-pack-stdin` ████████░░░░░░░░░░░░ 4/10 (6 left) — send-pack --stdin tests
-- [ ] `t5519-push-alternates` █████░░░░░░░░░░░░░░░ 2/8 (6 left) — push to a repository that borrows from elsewhere
+- [x] `t5519-push-alternates` ████████████████████ 8/8 (0 left) — push to a repository that borrows from elsewhere
 - [ ] `t5802-connect-helper` █████░░░░░░░░░░░░░░░ 2/8 (6 left) — ext::cmd remote 
 - [ ] `t5552-skipping-fetch-negotiator` ░░░░░░░░░░░░░░░░░░░░ 0/6 (6 left) — test skipping fetch negotiator
 - [ ] `t5400-send-pack` ███████████░░░░░░░░░ 10/17 (7 left) — See why rewinding head breaks send-pack

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -934,7 +934,7 @@ t5515-fetch-merge-logic	t5	yes	65	1	64	false	ok	0
 t5516-fetch-push	t5	yes	124	10	114	false	ok	0
 t5517-push-mirror	t5	yes	13	8	5	false	ok	0
 t5518-fetch-exit-status	t5	yes	3	3	0	true	ok	0
-t5519-push-alternates	t5	yes	8	2	6	false	ok	0
+t5519-push-alternates	t5	yes	8	8	0	true	ok	0
 t5520-pull	t5	yes	80	12	68	false	ok	0
 t5521-pull-options	t5	yes	22	6	16	false	ok	0
 t5522-pull-symlink	t5	yes	4	3	1	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,16 +141,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T04:19:53+00:00" class="gen-time" title="2026-04-09 04:19 UTC">2026-04-09 04:19 UTC</time> · <a href="https://github.com/schacon/grit/commit/15ebd04f51d1eb021991d9a9eeed2a0c748fe898" style="color:#58a6ff">15ebd04</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T04:22:42+00:00" class="gen-time" title="2026-04-09 04:22 UTC">2026-04-09 04:22 UTC</time> · <a href="https://github.com/schacon/grit/commit/52f50c013148bd3b0dcad07f186bcd368a71ae17" style="color:#58a6ff">52f50c0</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">75.1%</div>
+      <div class="summary-big-val pct-blue">75.2%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,964</div>
+      <div class="summary-big-val">29,970</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -159,12 +159,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:75.1%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:75.2%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>750 files fully passing</span>
+    <span>751 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">35/167 files · 17 skipped · 1,379/3,949 tests</span>
+        <span class="group-meta">36/167 files · 17 skipped · 1,385/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:34.9%"></div></div>
-        <span class="group-pct pct-red">34.9%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:35.1%"></div></div>
+        <span class="group-pct pct-red">35.1%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:19:53+00:00" class="gen-time" title="2026-04-09 04:19 UTC">2026-04-09 04:19 UTC</time> · <a href="https://github.com/schacon/grit/commit/15ebd04f51d1eb021991d9a9eeed2a0c748fe898" style="color:#58a6ff">15ebd04</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:22:42+00:00" class="gen-time" title="2026-04-09 04:22 UTC">2026-04-09 04:22 UTC</time> · <a href="https://github.com/schacon/grit/commit/52f50c013148bd3b0dcad07f186bcd368a71ae17" style="color:#58a6ff">52f50c0</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,964</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">75.1%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,970</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">75.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -9497,14 +9497,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="8" data-passed="2">
+<tr class="" data-group="t5" data-tests="8" data-passed="8" data-full-pass="1">
   <td class="mono">t5519-push-alternates</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">8</td>
-  <td class="right">2</td>
+  <td class="right">8</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:25.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="80" data-passed="12">

--- a/logs/2026-04-09_t5519-push-alternates.md
+++ b/logs/2026-04-09_t5519-push-alternates.md
@@ -1,0 +1,5 @@
+# t5519-push-alternates
+
+- Ran `./scripts/run-tests.sh t5519-push-alternates.sh`: **8/8** pass.
+- No Rust changes required; implementation already handles push with alternate ODB (objects reachable via `objects/info/alternates` not re-sent).
+- Refreshed `data/test-files.csv` and dashboards; marked task complete in `PLAN.md` / `progress.md`.

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   253 |
+| Completed   |   254 |
 | In progress |     4 |
-| Remaining   |   511 |
+| Remaining   |   510 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 253 completed (`[x]`), 4 in progress (`[~]`), 511 remaining (`[ ]`).
+Task lines in `PLAN.md`: 254 completed (`[x]`), 4 in progress (`[~]`), 510 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t5519-push-alternates` — 8/8 tests pass (push to repo with `objects/info/alternates`; objects already available via alternate not re-packed; harness CSV/dashboards refreshed)
 - `t4214-log-graph-octopus` — 17/17 tests pass (`git log --graph` skewed-left octopus, crossover, and colored graph lines; harness CSV/dashboards refreshed)
 - `t3060-ls-files-with-tree` — 8/8 tests pass (`ls-files --with-tree`: `Index::overlay_tree_on_index`, `-s/-u`/`--recurse-submodules` incompatibilities with `fatal:` + exit 128, cwd pathspec `sub/` matches `sub/file`; harness CSV refreshed)
 - `t12660-init-shared-perm` — 37/37 tests pass (default `grit init` applies Git-style group-shared chmod on `.git` tree: 775 dirs / 664 HEAD under umask 022; explicit `--shared` / `core.sharedRepository` writes config + `receive.denyNonFastforwards`; reinit without shared config leaves modes unchanged)

--- a/test-results.md
+++ b/test-results.md
@@ -1,5 +1,9 @@
 # Test Results
 
+**Updated:** 2026-04-09
+
+- `./scripts/run-tests.sh t5519-push-alternates.sh`: 8/8 passing (push with alternate ODB; no code changes; harness CSV/dashboards refreshed).
+
 **Updated:** 2026-04-08
 
 - `./scripts/run-tests.sh t3060-ls-files-with-tree.sh`: 8/8 passing (`ls-files --with-tree`: tree overlay on index, usage incompatibilities, conflict + missing-index cases; harness CSV/dashboards refreshed).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t5519-push-alternates` already passes all harness tests (8/8). This change records that in tracking artifacts.

## Changes

- Refresh `data/test-files.csv` and generated dashboards after `./scripts/run-tests.sh t5519-push-alternates.sh`.
- Mark `t5519-push-alternates` complete in `PLAN.md`; bump counts in `progress.md`.
- Note the run in `test-results.md` and add `logs/2026-04-09_t5519-push-alternates.md`.

## Verification

- `./scripts/run-tests.sh t5519-push-alternates.sh`: 8/8
- `cargo test -p grit-lib --lib`: 121/121

No Rust code changes were required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-554d71ee-72ec-4949-9f3e-581474d84db3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-554d71ee-72ec-4949-9f3e-581474d84db3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

