### PR TITLE
chore: verify t9040-hash-object-types; rustfmt gitmodules

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T04:24:01+00:00" class="gen-time" title="2026-04-09 04:24 UTC">2026-04-09 04:24 UTC</time> · <a href="https://github.com/schacon/grit/commit/f505bcdb0fb1ebd69fb85f5fa146ab32f9c3cc6b" style="color:#58a6ff">f505bcd</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T04:31:44+00:00" class="gen-time" title="2026-04-09 04:31 UTC">2026-04-09 04:31 UTC</time> · <a href="https://github.com/schacon/grit/commit/d21876f3291bc23b90aede54cde535a564fb9b20" style="color:#58a6ff">d21876f</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,7 +100,7 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:24:01+00:00" class="gen-time" title="2026-04-09 04:24 UTC">2026-04-09 04:24 UTC</time> · <a href="https://github.com/schacon/grit/commit/f505bcdb0fb1ebd69fb85f5fa146ab32f9c3cc6b" style="color:#58a6ff">f505bcd</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:31:44+00:00" class="gen-time" title="2026-04-09 04:31 UTC">2026-04-09 04:31 UTC</time> · <a href="https://github.com/schacon/grit/commit/d21876f3291bc23b90aede54cde535a564fb9b20" style="color:#58a6ff">d21876f</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>

--- a/grit-lib/src/gitmodules.rs
+++ b/grit-lib/src/gitmodules.rs
@@ -235,10 +235,13 @@ fn check_submodule_name(name: &str) -> bool {
     }
     let b = name.as_bytes();
     // Git `check_submodule_name`: `goto in_component` before the loop — first component.
-    if b.len() >= 2 && b[0] == b'.' && b[1] == b'.'
-        && (b.len() == 2 || b[2] == b'/' || b[2] == b'\\') {
-            return false;
-        }
+    if b.len() >= 2
+        && b[0] == b'.'
+        && b[1] == b'.'
+        && (b.len() == 2 || b[2] == b'/' || b[2] == b'\\')
+    {
+        return false;
+    }
     let mut i = 0usize;
     while i < b.len() {
         let c = b[i];

--- a/logs/2026-04-09-t9040-hash-object-types.md
+++ b/logs/2026-04-09-t9040-hash-object-types.md
@@ -1,0 +1,7 @@
+# t9040-hash-object-types
+
+- Verified `./scripts/run-tests.sh t9040-hash-object-types.sh`: **28/28** pass (current `grit hash-object` implementation).
+- Ran `cargo fmt`; `grit-lib/src/gitmodules.rs` needed rustfmt so `cargo fmt --check` passes.
+- Committed harness dashboard refresh (`docs/index.html`, `docs/testfiles.html`) from the test run.
+
+No functional change to `hash-object` was required for this file.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t9040-hash-object-types` already passes **28/28** against current `grit hash-object` (`./scripts/run-tests.sh t9040-hash-object-types.sh`).

This branch:

- Applies **rustfmt** to `grit-lib/src/gitmodules.rs` so `cargo fmt --check` succeeds (unrelated to t9040 but required for a clean fmt gate).
- Refreshes harness **dashboard HTML** from the test run.
- Adds a short **work log** under `logs/`.

No behavioral changes to `hash-object` were needed for t9040.

## Validation

- `cargo build --release -p grit-rs`
- `./scripts/run-tests.sh t9040-hash-object-types.sh` (28/28)
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3e31023-07a9-436f-9b25-9902dfde84af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3e31023-07a9-436f-9b25-9902dfde84af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

