### PR TITLE
test: t4120-apply-popt fully passing (12/12)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -469,7 +469,7 @@ commit → check it off → move on.
 - [ ] `t4058-diff-duplicates` ████████░░░░░░░░░░░░ 7/16 (9 left) — test tree diff when trees have duplicate entries
 - [ ] `t4008-diff-break-rewrite` ███████░░░░░░░░░░░░░ 5/14 (9 left) — Break and then rename
 
-- [ ] `t4120-apply-popt` █████░░░░░░░░░░░░░░░ 3/12 (9 left) — git apply -p handling.
+- [x] `t4120-apply-popt` ████████████████████ 12/12 (0 left) — git apply -p handling.
 - [ ] `t4067-diff-partial-clone` ░░░░░░░░░░░░░░░░░░░░ 0/9 (9 left) — behavior of diff when reading objects in a partial clone
 - [ ] `t4208-log-magic-pathspec` ██████████░░░░░░░░░░ 11/21 (10 left) — magic pathspec tests using git-log
 - [ ] `t4212-log-corrupt` ████░░░░░░░░░░░░░░░░ 3/13 (10 left) — git log with invalid commit headers

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -789,7 +789,7 @@ t4116-apply-reverse	t4	yes	7	6	1	false	ok	0
 t4117-apply-reject	t4	yes	8	2	6	false	ok	0
 t4118-apply-empty-context	t4	yes	3	3	0	true	ok	0
 t4119-apply-config	t4	yes	11	2	9	false	ok	0
-t4120-apply-popt	t4	yes	12	4	8	false	ok	0
+t4120-apply-popt	t4	yes	12	12	0	true	ok	0
 t4121-apply-diffs	t4	yes	2	2	0	true	ok	0
 t4122-apply-symlink-inside	t4	yes	7	3	4	false	ok	0
 t4123-apply-shrink	t4	yes	2	2	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T04:30:11+00:00" class="gen-time" title="2026-04-09 04:30 UTC">2026-04-09 04:30 UTC</time> · <a href="https://github.com/schacon/grit/commit/f2297125d07b68ac5a0ae0e65055d329882a5149" style="color:#58a6ff">f229712</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T04:32:01+00:00" class="gen-time" title="2026-04-09 04:32 UTC">2026-04-09 04:32 UTC</time> · <a href="https://github.com/schacon/grit/commit/cbee119ba6b26098bd5f91480b0b9b2f6525194a" style="color:#58a6ff">cbee119</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,990</div>
+      <div class="summary-big-val">29,998</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>752 files fully passing</span>
+    <span>753 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -223,11 +223,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">69/178 files · 2 skipped · 2,059/3,542 tests</span>
+        <span class="group-meta">70/178 files · 2 skipped · 2,067/3,542 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:58.1%"></div></div>
-        <span class="group-pct pct-orange">58.1%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:58.4%"></div></div>
+        <span class="group-pct pct-orange">58.4%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:30:11+00:00" class="gen-time" title="2026-04-09 04:30 UTC">2026-04-09 04:30 UTC</time> · <a href="https://github.com/schacon/grit/commit/f2297125d07b68ac5a0ae0e65055d329882a5149" style="color:#58a6ff">f229712</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:32:01+00:00" class="gen-time" title="2026-04-09 04:32 UTC">2026-04-09 04:32 UTC</time> · <a href="https://github.com/schacon/grit/commit/cbee119ba6b26098bd5f91480b0b9b2f6525194a" style="color:#58a6ff">cbee119</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,990</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,998</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">75.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -8047,14 +8047,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:18.2%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="12" data-passed="4">
+<tr class="" data-group="t4" data-tests="12" data-passed="12" data-full-pass="1">
   <td class="mono">t4120-apply-popt</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">12</td>
-  <td class="right">4</td>
+  <td class="right">12</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:33.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="2" data-passed="2" data-full-pass="1">

--- a/logs/2026-04-09_t4120-apply-popt.md
+++ b/logs/2026-04-09_t4120-apply-popt.md
@@ -1,0 +1,12 @@
+# t4120-apply-popt
+
+**Date:** 2026-04-09
+
+## Outcome
+
+`./scripts/run-tests.sh t4120-apply-popt.sh` reports **12/12** passing. No Rust changes were required on this branch; the implementation already satisfied the suite.
+
+## Actions
+
+- Refreshed `data/test-files.csv` and dashboards via `run-tests.sh`.
+- Marked `t4120-apply-popt` complete in `PLAN.md` and updated `progress.md` counts.

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   254 |
+| Completed   |   255 |
 | In progress |     4 |
-| Remaining   |   510 |
+| Remaining   |   509 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 254 completed (`[x]`), 4 in progress (`[~]`), 510 remaining (`[ ]`).
+Task lines in `PLAN.md`: 255 completed (`[x]`), 4 in progress (`[~]`), 509 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t4120-apply-popt` — 12/12 tests pass (`git apply -p`: strip path components, malformed `-p` errors, traditional quoted paths, `--stat` with oversized strip, mode-only and rename patches with `--index`; harness CSV/dashboards refreshed)
 - `t5320-delta-islands` — 15/15 tests pass (`repack` delta islands: `pack.island` / `pack.islandcore`, superset-island delta rules, verify-pack ordering; harness CSV/dashboards refreshed)
 - `t4214-log-graph-octopus` — 17/17 tests pass (`git log --graph` skewed-left octopus, crossover, and colored graph lines; harness CSV/dashboards refreshed)
 - `t3060-ls-files-with-tree` — 8/8 tests pass (`ls-files --with-tree`: `Index::overlay_tree_on_index`, `-s/-u`/`--recurse-submodules` incompatibilities with `fatal:` + exit 128, cwd pathspec `sub/` matches `sub/file`; harness CSV refreshed)

--- a/test-results.md
+++ b/test-results.md
@@ -1,5 +1,9 @@
 # Test Results
 
+**Updated:** 2026-04-09
+
+- `./scripts/run-tests.sh t4120-apply-popt.sh`: 12/12 passing (`git apply -p` strip count, invalid `-p` diagnostics, quoted traditional diff paths, `--stat` oversized strip, mode-only and rename with `--index`; harness CSV/dashboards refreshed).
+
 **Updated:** 2026-04-08
 
 - `./scripts/run-tests.sh t3060-ls-files-with-tree.sh`: 8/8 passing (`ls-files --with-tree`: tree overlay on index, usage incompatibilities, conflict + missing-index cases; harness CSV/dashboards refreshed).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t4120-apply-popt` now reports **12/12** in the harness (`./scripts/run-tests.sh t4120-apply-popt.sh`). No Rust changes were required; this updates tracked harness metadata and planning docs.

## Changes

- Refreshed `data/test-files.csv` and dashboards (`docs/index.html`, `docs/testfiles.html`).
- Marked `t4120-apply-popt` complete in `PLAN.md` and adjusted counts in `progress.md`.
- Added `logs/2026-04-09_t4120-apply-popt.md` and a line in `test-results.md`.

## Validation

- `cargo test -p grit-lib --lib`: 121/121 passing.
- `./scripts/run-tests.sh t4120-apply-popt.sh`: 12/12 passing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1771707c-d294-49b8-933f-9c70ab2abf29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1771707c-d294-49b8-933f-9c70ab2abf29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

