### PR TITLE
fix: t4055 diff.context in log and Git-compatible config errors

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -735,7 +735,7 @@ t4051-diff-function-name	t4	yes	27	7	20	false	ok	0
 t4052-stat-output	t4	yes	89	89	0	true	ok	0
 t4053-diff-no-index	t4	skip	41	0	0	false	ok	0
 t4054-diff-bogus-tree	t4	yes	14	14	0	true	ok	0
-t4055-diff-context	t4	yes	10	7	3	false	ok	0
+t4055-diff-context	t4	yes	10	10	0	true	ok	0
 t4056-diff-order	t4	yes	23	10	13	false	ok	0
 t4057-diff-combined-paths	t4	yes	4	0	4	false	ok	0
 t4058-diff-duplicates	t4	yes	14	7	7	false	ok	2

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T04:04:55+00:00" class="gen-time" title="2026-04-09 04:04 UTC">2026-04-09 04:04 UTC</time> · <a href="https://github.com/schacon/grit/commit/8292821a559988c8235b541ac75070d7fe15b5c7" style="color:#58a6ff">8292821</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T04:31:42+00:00" class="gen-time" title="2026-04-09 04:31 UTC">2026-04-09 04:31 UTC</time> · <a href="https://github.com/schacon/grit/commit/a4c5a5e06115acce00c0b83b1f490e3b7db0948e" style="color:#58a6ff">a4c5a5e</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,928</div>
+      <div class="summary-big-val">29,931</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>748 files fully passing</span>
+    <span>749 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -223,11 +223,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">68/178 files · 2 skipped · 2,055/3,542 tests</span>
+        <span class="group-meta">69/178 files · 2 skipped · 2,058/3,542 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:58.0%"></div></div>
-        <span class="group-pct pct-orange">58.0%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:58.1%"></div></div>
+        <span class="group-pct pct-orange">58.1%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:04:55+00:00" class="gen-time" title="2026-04-09 04:04 UTC">2026-04-09 04:04 UTC</time> · <a href="https://github.com/schacon/grit/commit/8292821a559988c8235b541ac75070d7fe15b5c7" style="color:#58a6ff">8292821</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:31:42+00:00" class="gen-time" title="2026-04-09 04:31 UTC">2026-04-09 04:31 UTC</time> · <a href="https://github.com/schacon/grit/commit/a4c5a5e06115acce00c0b83b1f490e3b7db0948e" style="color:#58a6ff">a4c5a5e</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,928</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,931</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">75.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -7507,14 +7507,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="10" data-passed="7">
+<tr class="" data-group="t4" data-tests="10" data-passed="10" data-full-pass="1">
   <td class="mono">t4055-diff-context</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">10</td>
-  <td class="right">7</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="23" data-passed="10">

--- a/grit-lib/src/config.rs
+++ b/grit-lib/src/config.rs
@@ -1396,6 +1396,16 @@ impl ConfigSet {
             .map(|e| e.value.clone().unwrap_or_else(|| "true".to_owned()))
     }
 
+    /// Last (highest-priority) [`ConfigEntry`] for a key, including origin metadata.
+    ///
+    /// Bare boolean keys are returned with [`ConfigEntry::value`] set to `None` (same as `get`,
+    /// which maps them to `"true"` for string lookups).
+    #[must_use]
+    pub fn get_last_entry(&self, key: &str) -> Option<ConfigEntry> {
+        let canon = canonical_key(key).ok()?;
+        self.entries.iter().rev().find(|e| e.key == canon).cloned()
+    }
+
     /// Get all values for a key (multi-valued; in load order).
     #[must_use]
     pub fn get_all(&self, key: &str) -> Vec<String> {
@@ -1760,6 +1770,119 @@ pub fn parse_i64(s: &str) -> std::result::Result<i64, String> {
         .map_err(|_| format!("invalid integer: '{s}'"))?;
     base.checked_mul(multiplier)
         .ok_or_else(|| format!("integer overflow: '{s}'"))
+}
+
+/// Why [`parse_git_config_int_strict`] failed (mirrors Git `errno` after `git_parse_signed`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GitConfigIntStrictError {
+    /// `EINVAL` — trailing junk, unknown unit suffix, or not a number.
+    InvalidUnit,
+    /// `ERANGE` — value does not fit in `i64` after scaling.
+    OutOfRange,
+}
+
+/// Parse a signed decimal integer with optional `k`/`m`/`g` multiplier suffix, requiring the
+/// entire input (trimmed) to be consumed — same constraints as Git's `git_parse_signed` used by
+/// `git_config_int` (so `no` and `1foo` are rejected, unlike [`parse_i64`]).
+pub fn parse_git_config_int_strict(raw: &str) -> std::result::Result<i64, GitConfigIntStrictError> {
+    let s = raw.trim();
+    if s.is_empty() {
+        return Err(GitConfigIntStrictError::InvalidUnit);
+    }
+
+    let bytes = s.as_bytes();
+    let mut idx = 0usize;
+    if matches!(bytes.first(), Some(b'+') | Some(b'-')) {
+        idx = 1;
+    }
+    if idx >= bytes.len() {
+        return Err(GitConfigIntStrictError::InvalidUnit);
+    }
+    let digit_start = idx;
+    while idx < bytes.len() && bytes[idx].is_ascii_digit() {
+        idx += 1;
+    }
+    if idx == digit_start {
+        return Err(GitConfigIntStrictError::InvalidUnit);
+    }
+
+    let num_part =
+        std::str::from_utf8(&bytes[..idx]).map_err(|_| GitConfigIntStrictError::InvalidUnit)?;
+    let suffix =
+        std::str::from_utf8(&bytes[idx..]).map_err(|_| GitConfigIntStrictError::InvalidUnit)?;
+    let mult: i64 = match suffix {
+        "" => 1,
+        "k" | "K" => 1024,
+        "m" | "M" => 1024 * 1024,
+        "g" | "G" => 1024_i64
+            .checked_mul(1024)
+            .and_then(|x| x.checked_mul(1024))
+            .ok_or(GitConfigIntStrictError::OutOfRange)?,
+        _ => return Err(GitConfigIntStrictError::InvalidUnit),
+    };
+
+    let val: i64 = num_part
+        .parse()
+        .map_err(|_| GitConfigIntStrictError::InvalidUnit)?;
+    val.checked_mul(mult)
+        .ok_or(GitConfigIntStrictError::OutOfRange)
+}
+
+const DIFF_CONTEXT_KEY: &str = "diff.context";
+
+fn format_bad_numeric_diff_context(
+    value: &str,
+    err: GitConfigIntStrictError,
+    entry: &ConfigEntry,
+) -> String {
+    let detail = match err {
+        GitConfigIntStrictError::InvalidUnit => "invalid unit",
+        GitConfigIntStrictError::OutOfRange => "out of range",
+    };
+    if entry.scope == ConfigScope::Command || entry.file.is_none() {
+        return format!(
+            "fatal: bad numeric config value '{value}' for '{DIFF_CONTEXT_KEY}': {detail}"
+        );
+    }
+    let path = entry
+        .file
+        .as_deref()
+        .map(config_error_path_display)
+        .unwrap_or_default();
+    format!("fatal: bad numeric config value '{value}' for '{DIFF_CONTEXT_KEY}' in file {path}: {detail}")
+}
+
+fn format_bad_diff_context_variable(entry: &ConfigEntry) -> String {
+    if entry.scope == ConfigScope::Command || entry.file.is_none() {
+        return format!("fatal: unable to parse '{DIFF_CONTEXT_KEY}' from command-line config");
+    }
+    let path = entry
+        .file
+        .as_deref()
+        .map(config_error_path_display)
+        .unwrap_or_default();
+    format!(
+        "fatal: bad config variable '{DIFF_CONTEXT_KEY}' in file '{path}' at line {}",
+        entry.line
+    )
+}
+
+/// Read `diff.context` from a loaded [`ConfigSet`] with Git-compatible validation.
+///
+/// Returns `Ok(None)` when the key is unset. When set, the value must be a non-negative integer
+/// acceptable to Git's diff machinery (same rules as `git diff` / `git log -p`).
+pub fn resolve_diff_context_lines(cfg: &ConfigSet) -> std::result::Result<Option<usize>, String> {
+    let Some(entry) = cfg.get_last_entry(DIFF_CONTEXT_KEY) else {
+        return Ok(None);
+    };
+    let value_src = entry.value.as_deref().unwrap_or("").trim();
+    match parse_git_config_int_strict(value_src) {
+        Ok(n) if n < 0 => Err(format_bad_diff_context_variable(&entry)),
+        Ok(n) => Ok(Some(usize::try_from(n).map_err(|_| {
+            format_bad_numeric_diff_context(value_src, GitConfigIntStrictError::OutOfRange, &entry)
+        })?)),
+        Err(e) => Err(format_bad_numeric_diff_context(value_src, e, &entry)),
+    }
 }
 
 /// Parse a Git color value and return the ANSI escape sequence.

--- a/grit/src/commands/diff.rs
+++ b/grit/src/commands/diff.rs
@@ -526,6 +526,16 @@ pub fn run(mut args: Args) -> Result<()> {
 
     let repo = Repository::discover(None).context("not a git repository")?;
 
+    let patch_context = if let Some(u) = args.unified {
+        u
+    } else {
+        let cfg = grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true)
+            .context("loading git config")?;
+        grit_lib::config::resolve_diff_context_lines(&cfg)
+            .map_err(|m| anyhow::anyhow!(m))?
+            .unwrap_or(3)
+    };
+
     let emit_unified_patch = diff_emit_unified_patch_from_argv(&raw_args);
 
     // Resolve diff prefixes from config and command-line options
@@ -537,7 +547,15 @@ pub fn run(mut args: Args) -> Result<()> {
         && !args.cached
         && split_treeish_colon(&revs[0]).is_some()
     {
-        return run_diff_blob_vs_file(&repo, &args, &revs[0], &paths[0], &src_prefix, &dst_prefix);
+        return run_diff_blob_vs_file(
+            &repo,
+            &args,
+            &revs[0],
+            &paths[0],
+            &src_prefix,
+            &dst_prefix,
+            patch_context,
+        );
     }
 
     // Expand A...B (symmetric diff) → merge-base(A,B)..B
@@ -1203,16 +1221,7 @@ pub fn run(mut args: Args) -> Result<()> {
     let quiet_suppresses_stdout = args.quiet && !format_besides_unified_patch;
 
     if !quiet_suppresses_stdout {
-        let config_context = if args.unified.is_none() {
-            // Read diff.context from config
-            grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true)
-                .ok()
-                .and_then(|cfg| cfg.get("diff.context"))
-                .and_then(|s| s.parse::<usize>().ok())
-        } else {
-            None
-        };
-        let context_lines = args.unified.or(config_context).unwrap_or(3);
+        let context_lines = patch_context;
         if args.shortstat {
             write_shortstat(
                 &mut out,
@@ -1321,6 +1330,7 @@ fn run_diff_blob_vs_file(
     file_path: &str,
     src_prefix: &str,
     dst_prefix: &str,
+    patch_context: usize,
 ) -> Result<()> {
     let wt = repo
         .work_tree
@@ -1340,15 +1350,7 @@ fn run_diff_blob_vs_file(
     let disk_bytes = fs::read(&abs).unwrap_or_default();
     let disk_text = String::from_utf8_lossy(&disk_bytes);
 
-    let context_lines = if let Some(u) = args.unified {
-        u
-    } else {
-        grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true)
-            .ok()
-            .and_then(|cfg| cfg.get("diff.context"))
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(3)
-    };
+    let context_lines = patch_context;
 
     let has_diff = blob_text != disk_text;
     if !has_diff {

--- a/grit/src/commands/log.rs
+++ b/grit/src/commands/log.rs
@@ -490,7 +490,7 @@ fn log_resolve_stdout_color(args: &Args, git_dir: &Path) -> bool {
     c
 }
 
-fn run_line_log(repo: &Repository, args: Args) -> Result<()> {
+fn run_line_log(repo: &Repository, args: Args, _patch_context: usize) -> Result<()> {
     if !args.pathspecs.is_empty() {
         anyhow::bail!("-L<range>:<file> cannot be used with pathspec");
     }
@@ -865,7 +865,7 @@ fn resolve_decoration_display(args: &Args, format_requires_decorations: bool) ->
     (show, full)
 }
 
-fn run_graph_log(repo: &Repository, args: &Args) -> Result<()> {
+fn run_graph_log(repo: &Repository, args: &Args, patch_context: usize) -> Result<()> {
     let mut implied_pathspecs: Vec<String> = Vec::new();
     let mut revision_specs = Vec::new();
     for rev in &args.revisions {
@@ -1116,6 +1116,7 @@ fn run_graph_log(repo: &Repository, args: &Args) -> Result<()> {
                 args,
                 &combined_pathspecs,
                 graph_stat_prefix.as_deref(),
+                patch_context,
             )?;
         }
     }
@@ -2112,15 +2113,23 @@ pub fn run(mut args: Args) -> Result<()> {
     }
 
     let repo = Repository::discover(None).context("not a git repository")?;
+    let patch_context = if let Some(u) = args.unified {
+        u
+    } else {
+        let cfg = ConfigSet::load(Some(&repo.git_dir), true).context("loading git config")?;
+        grit_lib::config::resolve_diff_context_lines(&cfg)
+            .map_err(|m| anyhow::anyhow!(m))?
+            .unwrap_or(3)
+    };
     if !args.line_range.is_empty() {
-        return run_line_log(&repo, args);
+        return run_line_log(&repo, args, patch_context);
     }
     if args
         .revisions
         .iter()
         .any(|r| r != "--" && is_symmetric_diff(r))
     {
-        return run_symmetric_log(&repo, &args);
+        return run_symmetric_log(&repo, &args, patch_context);
     }
     validate_pathspec_scope(&repo, &args.pathspecs)?;
     let mut implied_pathspecs: Vec<String> = Vec::new();
@@ -2158,16 +2167,16 @@ pub fn run(mut args: Args) -> Result<()> {
 
     // Handle -g / --walk-reflogs mode
     if args.walk_reflogs {
-        return run_reflog_walk(&repo, &args);
+        return run_reflog_walk(&repo, &args, patch_context);
     }
 
     // Handle --no-walk: show given commits without walking parents
     if args.no_walk.is_some() {
-        return run_no_walk(&repo, &args);
+        return run_no_walk(&repo, &args, patch_context);
     }
 
     if args.graph {
-        return run_graph_log(&repo, &args);
+        return run_graph_log(&repo, &args, patch_context);
     }
 
     // Determine starting points and excluded commits.
@@ -2392,6 +2401,7 @@ pub fn run(mut args: Args) -> Result<()> {
                     &args,
                     effective_pathspecs,
                     None,
+                    patch_context,
                 )?;
             }
             if flush_each {
@@ -2555,6 +2565,7 @@ pub fn run(mut args: Args) -> Result<()> {
                     &args,
                     &combined_pathspecs,
                     None,
+                    patch_context,
                 )?;
             }
         }
@@ -2713,7 +2724,7 @@ fn normalize_path(path: &Path) -> PathBuf {
 }
 
 /// Run `--no-walk` mode: show the given commits without walking their parents.
-pub fn run_no_walk(repo: &Repository, args: &Args) -> Result<()> {
+pub fn run_no_walk(repo: &Repository, args: &Args, patch_context: usize) -> Result<()> {
     let mut oids = Vec::new();
     if args.revisions.is_empty() {
         let head = resolve_head(&repo.git_dir)?;
@@ -2804,7 +2815,15 @@ pub fn run_no_walk(repo: &Repository, args: &Args) -> Result<()> {
             None,
         )?;
         if show_diff {
-            write_commit_diff(&mut out, repo, commit_data, args, &args.pathspecs, None)?;
+            write_commit_diff(
+                &mut out,
+                repo,
+                commit_data,
+                args,
+                &args.pathspecs,
+                None,
+                patch_context,
+            )?;
         }
     }
 
@@ -2812,7 +2831,7 @@ pub fn run_no_walk(repo: &Repository, args: &Args) -> Result<()> {
 }
 
 /// Run the reflog walk mode (`log -g` / `log --walk-reflogs`).
-fn run_reflog_walk(repo: &Repository, args: &Args) -> Result<()> {
+fn run_reflog_walk(repo: &Repository, args: &Args, _patch_context: usize) -> Result<()> {
     // Determine which ref to walk
     let refname = if args.revisions.is_empty() {
         "HEAD".to_string()
@@ -3767,7 +3786,7 @@ fn commit_passes_post_walk_filters(
     Ok(true)
 }
 
-fn run_symmetric_log(repo: &Repository, args: &Args) -> Result<()> {
+fn run_symmetric_log(repo: &Repository, args: &Args, _patch_context: usize) -> Result<()> {
     let mut lhs: Option<String> = None;
     let mut rhs: Option<String> = None;
     for rev in &args.revisions {
@@ -5179,6 +5198,7 @@ fn write_commit_diff(
     args: &Args,
     pathspecs: &[String],
     graph_stat_prefix: Option<&str>,
+    patch_context: usize,
 ) -> Result<()> {
     let odb = &repo.odb;
 
@@ -5196,7 +5216,7 @@ fn write_commit_diff(
             pickaxe: None,
             find_object: find_oid,
             submodule_mode: None,
-            context_lines: args.unified.unwrap_or(3),
+            context_lines: patch_context,
         };
         return write_remerge_diff(out, repo, &info.tree, &info.parents, &opts);
     }
@@ -5291,7 +5311,7 @@ fn write_commit_diff(
             &entries
         };
         for entry in show_entries {
-            log_write_patch_entry(out, odb, entry, args)?;
+            log_write_patch_entry(out, odb, entry, args, patch_context)?;
         }
     }
 
@@ -5304,8 +5324,8 @@ fn log_write_patch_entry(
     odb: &Odb,
     entry: &DiffEntry,
     args: &Args,
+    context_lines: usize,
 ) -> Result<()> {
-    let context_lines = args.unified.unwrap_or(3);
     let old_path = entry
         .old_path
         .as_deref()

--- a/logs/2026-04-09_t4055-diff-context-upstream.md
+++ b/logs/2026-04-09_t4055-diff-context-upstream.md
@@ -1,0 +1,5 @@
+## t4055-diff-context (upstream parity)
+
+- **Issue:** `scripts/run-upstream-tests.sh t4055-diff-context` failed 3/10 while `./scripts/run-tests.sh` passed: `log -p` ignored `diff.context`; invalid `diff.context` values did not produce Git’s fatal messages.
+- **Fix:** Added Git-compatible strict int parsing and `resolve_diff_context_lines` in `grit-lib`; `log` now resolves `patch_context` once at startup (matching Git loading `git_diff_ui_config`) and threads it into patch output; `git diff` validates `diff.context` at command start for repo diffs.
+- **Verify:** `./scripts/run-tests.sh t4055-diff-context.sh` and `bash scripts/run-upstream-tests.sh t4055-diff-context` → 10/10.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Upstream `git/t/t4055-diff-context.sh` was failing 3 tests against grit while the ported `tests/` copy passed. This aligns behavior with real Git.

## Changes

- **`grit-lib`:** Strict Git-style integer parsing for config (whole string consumed; optional `k`/`m`/`g` suffix; rejects values like `no`). New `ConfigSet::get_last_entry` and `resolve_diff_context_lines` with fatal messages matching Git (`bad numeric config value` / `bad config variable` / command-line form).
- **`grit log`:** Resolve effective patch context once at startup (`-U` wins, else `diff.context`, else 3) and thread it through `write_commit_diff` / `log_write_patch_entry` so `log -p` honors config like Git.
- **`grit diff`:** Load and validate `diff.context` when opening the repo so invalid values fail even for non-patch output modes, matching Git.

## Verification

- `./scripts/run-tests.sh t4055-diff-context.sh` — 10/10
- `bash scripts/run-upstream-tests.sh t4055-diff-context` — 10/10
- `cargo test -p grit-lib --lib` — pass

Harness row for `t4055-diff-context` updated to full pass in `data/test-files.csv` and dashboards regenerated.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-848f588d-120f-4a04-82c0-754f789f5fc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-848f588d-120f-4a04-82c0-754f789f5fc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

