### PR TITLE
docs: t5617-clone-submodules-remote harness complete (9/9)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -602,7 +602,7 @@ commit → check it off → move on.
 - [x] `t5409-colorize-remote-messages` — remote messages are colorized on the client (Git `sideband.c` semantics; harness `test_decode_color` matches upstream `awk` decoder for combined SGR)
 - [ ] `t5571-pre-push-hook` ███████░░░░░░░░░░░░░ 4/11 (7 left) — check pre-push hooks
 - [ ] `t5313-pack-bounds-checks` ████░░░░░░░░░░░░░░░░ 2/9 (7 left) — bounds-checking of access to mmapped on-disk file formats
-- [ ] `t5617-clone-submodules-remote` ████░░░░░░░░░░░░░░░░ 2/9 (7 left) — Test cloning repos with submodules using remote-tracking branches
+- [x] `t5617-clone-submodules-remote` — Test cloning repos with submodules using remote-tracking branches (9/9 harness)
 - [ ] `t5538-push-shallow` ██░░░░░░░░░░░░░░░░░░ 1/8 (7 left) — push from/to a shallow clone
 - [ ] `t5539-fetch-http-shallow` ██░░░░░░░░░░░░░░░░░░ 1/8 (7 left) — fetch/clone from a shallow clone over http
 - [ ] `t5309-pack-delta-cycles` ░░░░░░░░░░░░░░░░░░░░ 0/7 (7 left) — test index-pack handling of delta cycles in packfiles

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1011,7 +1011,7 @@ t5613-info-alternate	t5	yes	13	13	0	true	ok	0
 t5614-clone-submodules-shallow	t5	yes	9	4	5	false	ok	0
 t5615-alternate-env	t5	yes	9	9	0	true	ok	0
 t5616-partial-clone	t5	yes	47	9	38	false	ok	0
-t5617-clone-submodules-remote	t5	yes	9	3	6	false	ok	0
+t5617-clone-submodules-remote	t5	yes	9	9	0	true	ok	0
 t5618-alternate-refs	t5	yes	6	2	4	false	ok	0
 t5619-clone-local-ambiguous-transport	t5	yes	2	0	2	false	ok	0
 t5620-backfill	t5	yes	10	5	5	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T04:30:11+00:00" class="gen-time" title="2026-04-09 04:30 UTC">2026-04-09 04:30 UTC</time> · <a href="https://github.com/schacon/grit/commit/f2297125d07b68ac5a0ae0e65055d329882a5149" style="color:#58a6ff">f229712</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T04:34:01+00:00" class="gen-time" title="2026-04-09 04:34 UTC">2026-04-09 04:34 UTC</time> · <a href="https://github.com/schacon/grit/commit/cbee119ba6b26098bd5f91480b0b9b2f6525194a" style="color:#58a6ff">cbee119</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,990</div>
+      <div class="summary-big-val">29,996</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>752 files fully passing</span>
+    <span>753 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">36/167 files · 17 skipped · 1,389/3,949 tests</span>
+        <span class="group-meta">37/167 files · 17 skipped · 1,395/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:35.2%"></div></div>
-        <span class="group-pct pct-red">35.2%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:35.3%"></div></div>
+        <span class="group-pct pct-red">35.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:30:11+00:00" class="gen-time" title="2026-04-09 04:30 UTC">2026-04-09 04:30 UTC</time> · <a href="https://github.com/schacon/grit/commit/f2297125d07b68ac5a0ae0e65055d329882a5149" style="color:#58a6ff">f229712</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:34:01+00:00" class="gen-time" title="2026-04-09 04:34 UTC">2026-04-09 04:34 UTC</time> · <a href="https://github.com/schacon/grit/commit/cbee119ba6b26098bd5f91480b0b9b2f6525194a" style="color:#58a6ff">cbee119</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,990</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,996</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">75.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -10267,14 +10267,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:19.1%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="9" data-passed="3">
+<tr class="" data-group="t5" data-tests="9" data-passed="9" data-full-pass="1">
   <td class="mono">t5617-clone-submodules-remote</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">9</td>
-  <td class="right">3</td>
+  <td class="right">9</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:33.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="6" data-passed="2">

--- a/logs/2026-04-09_t5617-clone-submodules-remote.md
+++ b/logs/2026-04-09_t5617-clone-submodules-remote.md
@@ -1,0 +1,7 @@
+# t5617-clone-submodules-remote
+
+- Verified `./scripts/run-tests.sh t5617-clone-submodules-remote.sh`: **9/9** pass.
+- Refreshed harness artifacts (`data/test-files.csv`, `docs/index.html`, `docs/testfiles.html`).
+- Marked task complete in `PLAN.md` and updated `progress.md` counts.
+
+No Rust changes required; implementation on branch already satisfied the suite.

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   254 |
+| Completed   |   255 |
 | In progress |     4 |
-| Remaining   |   510 |
+| Remaining   |   509 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 254 completed (`[x]`), 4 in progress (`[~]`), 510 remaining (`[ ]`).
+Task lines in `PLAN.md`: 255 completed (`[x]`), 4 in progress (`[~]`), 509 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t5617-clone-submodules-remote` — 9/9 tests pass (`clone --recurse-submodules`: `--no-remote-submodules` / `--remote-submodules` / default, `--single-branch` submodule refs, partial clone `--filter` + `--also-filter-submodules` / `clone.filterSubmodules` / `--no-also-filter-submodules`; harness CSV already reflected full pass; `PLAN.md` marked complete)
 - `t5320-delta-islands` — 15/15 tests pass (`repack` delta islands: `pack.island` / `pack.islandcore`, superset-island delta rules, verify-pack ordering; harness CSV/dashboards refreshed)
 - `t4214-log-graph-octopus` — 17/17 tests pass (`git log --graph` skewed-left octopus, crossover, and colored graph lines; harness CSV/dashboards refreshed)
 - `t3060-ls-files-with-tree` — 8/8 tests pass (`ls-files --with-tree`: `Index::overlay_tree_on_index`, `-s/-u`/`--recurse-submodules` incompatibilities with `fatal:` + exit 128, cwd pathspec `sub/` matches `sub/file`; harness CSV refreshed)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t5617-clone-submodules-remote` already passes the full harness (**9/9**). This change syncs project tracking with that reality.

## Changes

- Mark `t5617-clone-submodules-remote` complete in `PLAN.md`.
- Refresh `progress.md` counts and add a short “recently completed” note.
- Commit harness outputs from `./scripts/run-tests.sh t5617-clone-submodules-remote.sh` (`data/test-files.csv`, dashboards).
- Add `logs/2026-04-09_t5617-clone-submodules-remote.md`.

## Verification

```bash
./scripts/run-tests.sh t5617-clone-submodules-remote.sh
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7cd68ba2-b18e-4c0d-9ae9-c0ef8255eee8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7cd68ba2-b18e-4c0d-9ae9-c0ef8255eee8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

