### PR TITLE
fix: send-pack --stdin, mirror+refspec validation, duplicate dest refs (t5408)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -590,7 +590,7 @@ commit → check it off → move on.
 - [ ] `t5534-push-signed` ██████████░░░░░░░░░░ 7/13 (6 left) — signed push
 - [ ] `t5543-atomic-push` ██████████░░░░░░░░░░ 7/13 (6 left) — pushing to a repository using the atomic push option
 - [ ] `t5503-tagfollow` ██████████░░░░░░░░░░ 6/12 (6 left) — test automatic tag following
-- [ ] `t5408-send-pack-stdin` ████████░░░░░░░░░░░░ 4/10 (6 left) — send-pack --stdin tests
+- [x] `t5408-send-pack-stdin` ████████████████████ 10/10 — send-pack --stdin tests
 - [ ] `t5519-push-alternates` █████░░░░░░░░░░░░░░░ 2/8 (6 left) — push to a repository that borrows from elsewhere
 - [ ] `t5802-connect-helper` █████░░░░░░░░░░░░░░░ 2/8 (6 left) — ext::cmd remote 
 - [ ] `t5552-skipping-fetch-negotiator` ░░░░░░░░░░░░░░░░░░░░ 0/6 (6 left) — test skipping fetch negotiator

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -912,7 +912,7 @@ t5404-tracking-branches	t5	yes	7	3	4	false	ok	0
 t5405-send-pack-rewind	t5	yes	3	3	0	true	ok	0
 t5406-remote-rejects	t5	yes	3	2	1	false	ok	0
 t5407-post-rewrite-hook	t5	yes	17	3	14	false	ok	0
-t5408-send-pack-stdin	t5	yes	10	4	6	false	ok	0
+t5408-send-pack-stdin	t5	yes	10	10	0	true	ok	0
 t5409-colorize-remote-messages	t5	yes	11	11	0	true	ok	0
 t5410-receive-pack	t5	yes	5	1	4	false	ok	0
 t5411-proc-receive-hook	t5	skip	2	0	0	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T04:24:01+00:00" class="gen-time" title="2026-04-09 04:24 UTC">2026-04-09 04:24 UTC</time> · <a href="https://github.com/schacon/grit/commit/f505bcdb0fb1ebd69fb85f5fa146ab32f9c3cc6b" style="color:#58a6ff">f505bcd</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T04:35:31+00:00" class="gen-time" title="2026-04-09 04:35 UTC">2026-04-09 04:35 UTC</time> · <a href="https://github.com/schacon/grit/commit/d21876f3291bc23b90aede54cde535a564fb9b20" style="color:#58a6ff">d21876f</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,974</div>
+      <div class="summary-big-val">29,980</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>751 files fully passing</span>
+    <span>752 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">36/167 files · 17 skipped · 1,389/3,949 tests</span>
+        <span class="group-meta">37/167 files · 17 skipped · 1,395/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:35.2%"></div></div>
-        <span class="group-pct pct-red">35.2%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:35.3%"></div></div>
+        <span class="group-pct pct-red">35.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:24:01+00:00" class="gen-time" title="2026-04-09 04:24 UTC">2026-04-09 04:24 UTC</time> · <a href="https://github.com/schacon/grit/commit/f505bcdb0fb1ebd69fb85f5fa146ab32f9c3cc6b" style="color:#58a6ff">f505bcd</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:35:31+00:00" class="gen-time" title="2026-04-09 04:35 UTC">2026-04-09 04:35 UTC</time> · <a href="https://github.com/schacon/grit/commit/d21876f3291bc23b90aede54cde535a564fb9b20" style="color:#58a6ff">d21876f</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,974</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">29,980</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">75.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -9277,14 +9277,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:17.6%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="10" data-passed="4">
+<tr class="" data-group="t5" data-tests="10" data-passed="10" data-full-pass="1">
   <td class="mono">t5408-send-pack-stdin</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">10</td>
-  <td class="right">4</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:40.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="11" data-passed="11" data-full-pass="1">

--- a/grit/src/commands/send_pack.rs
+++ b/grit/src/commands/send_pack.rs
@@ -3,14 +3,24 @@
 //! Low-level plumbing command that sends pack data to a remote repository
 //! and updates remote refs.  Only **local** transports are supported.
 
+use crate::explicit_exit::ExplicitExit;
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::merge_base::is_ancestor;
 use grit_lib::objects::ObjectId;
 use grit_lib::refs;
 use grit_lib::repo::Repository;
+use std::collections::HashSet;
 use std::fs;
+use std::io::{self, BufRead};
 use std::path::{Path, PathBuf};
+
+/// Upstream `git send-pack` usage synopsis (exit 129 when options are incompatible).
+const SEND_PACK_USAGE: &str = "usage: git send-pack [--mirror] [--dry-run] [--force]\n\
+              [--receive-pack=<git-receive-pack>]\n\
+              [--verbose] [--thin] [--atomic]\n\
+              [--[no-]signed | --signed=(true|false|if-asked)]\n\
+              [<host>:]<directory> (--all | <ref>...)";
 
 /// Arguments for `grit send-pack`.
 #[derive(Debug, ClapArgs)]
@@ -19,6 +29,14 @@ pub struct Args {
     /// Path to the remote repository (bare or non-bare).
     #[arg(value_name = "REMOTE")]
     pub remote: String,
+
+    /// Read additional refspec lines from stdin (after command-line refspecs).
+    #[arg(long = "stdin")]
+    pub stdin: bool,
+
+    /// Mirror all refs (incompatible with explicit refspecs; not implemented for local transport).
+    #[arg(long = "mirror")]
+    pub mirror: bool,
 
     /// Refspec(s) to push (e.g. "main:main", "refs/heads/main:refs/heads/main").
     /// Format: <src>:<dst> or just <ref> (implies same name on both sides).
@@ -52,14 +70,43 @@ pub fn run(args: Args) -> Result<()> {
         )
     })?;
 
-    // Build list of ref updates from refspecs
-    let mut updates = Vec::new();
+    let mut refspecs = args.refs.clone();
+    if args.stdin {
+        let stdin = io::stdin();
+        for line in stdin.lock().lines() {
+            let line = line.context("reading refspecs from stdin")?;
+            let line = line.trim_end_matches(['\r', '\n']);
+            if line.is_empty() {
+                continue;
+            }
+            refspecs.push(line.to_owned());
+        }
+    }
 
-    if args.refs.is_empty() {
+    if !refspecs.is_empty() && args.mirror {
+        return Err(anyhow::Error::new(ExplicitExit {
+            code: 129,
+            message: SEND_PACK_USAGE.to_string(),
+        }));
+    }
+
+    if refspecs.is_empty() {
         bail!("no refs specified; nothing to push");
     }
 
-    for spec in &args.refs {
+    let mut seen_remote: HashSet<String> = HashSet::new();
+    for spec in &refspecs {
+        let (_, dst) = parse_refspec(spec);
+        let remote_ref = normalize_ref(&dst);
+        if !seen_remote.insert(remote_ref.clone()) {
+            bail!("multiple updates for ref '{remote_ref}' not allowed");
+        }
+    }
+
+    // Build list of ref updates from refspecs
+    let mut updates = Vec::new();
+
+    for spec in &refspecs {
         let (src, dst) = parse_refspec(spec);
         let local_ref = normalize_ref(&src);
         let remote_ref = normalize_ref(&dst);

--- a/logs/2026-04-09_t5408-send-pack-stdin.md
+++ b/logs/2026-04-09_t5408-send-pack-stdin.md
@@ -1,0 +1,14 @@
+# t5408-send-pack-stdin
+
+## Goal
+
+Make `tests/t5408-send-pack-stdin.sh` pass under the harness (grit as `git`).
+
+## Changes
+
+- `grit/src/commands/send_pack.rs`: added `--stdin` (append refspec lines from stdin after argv), `--mirror` (reject when any refspecs are present with exit 129 and Git’s `send-pack` usage text), and pre-flight duplicate detection on normalized destination refs (`multiple updates for ref '…' not allowed`).
+
+## Verification
+
+- `cargo build --release -p grit-rs`
+- `./scripts/run-tests.sh t5408-send-pack-stdin.sh` → 10/10

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   254 |
+| Completed   |   255 |
 | In progress |     4 |
-| Remaining   |   510 |
+| Remaining   |   509 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 254 completed (`[x]`), 4 in progress (`[~]`), 510 remaining (`[ ]`).
+Task lines in `PLAN.md`: 255 completed (`[x]`), 4 in progress (`[~]`), 509 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t5408-send-pack-stdin` — 10/10 tests pass (`send-pack`: `--stdin` refspec lines after argv, duplicate destination ref rejected with Git’s message, `--mirror` with refspecs exits 129 with upstream usage synopsis)
 - `t5320-delta-islands` — 15/15 tests pass (`repack` delta islands: `pack.island` / `pack.islandcore`, superset-island delta rules, verify-pack ordering; harness CSV/dashboards refreshed)
 - `t4214-log-graph-octopus` — 17/17 tests pass (`git log --graph` skewed-left octopus, crossover, and colored graph lines; harness CSV/dashboards refreshed)
 - `t3060-ls-files-with-tree` — 8/8 tests pass (`ls-files --with-tree`: `Index::overlay_tree_on_index`, `-s/-u`/`--recurse-submodules` incompatibilities with `fatal:` + exit 128, cwd pathspec `sub/` matches `sub/file`; harness CSV refreshed)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements missing `git send-pack` behaviors needed for `t5408-send-pack-stdin`:

- **`--stdin`**: reads additional refspec lines from stdin (after argv refspecs), skipping empty lines.
- **`--mirror` with refspecs**: rejects with the same usage synopsis as upstream Git and exit code **129** (`ExplicitExit`).
- **Duplicate destination refs**: rejects before opening the remote with Git’s message: `multiple updates for ref '…' not allowed`.

## Test plan

- `cargo build --release -p grit-rs`
- `./scripts/run-tests.sh t5408-send-pack-stdin.sh` → 10/10
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3f1e8fe-35f7-4c02-865d-22edeaf6cdfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3f1e8fe-35f7-4c02-865d-22edeaf6cdfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

