### PR TITLE
chore: t5321-pack-large-objects fully passing

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -560,7 +560,7 @@ commit → check it off → move on.
 - [x] `t5405-send-pack-rewind` ████████████████████ 3/3 (0 left) — forced push to replace commit we do not have
 - [ ] `t5524-pull-msg` ██████░░░░░░░░░░░░░░ 1/3 (2 left) — git pull message generation
 - [ ] `t5542-push-http-shallow` ██████░░░░░░░░░░░░░░ 1/3 (2 left) — push from/to a shallow clone over http
-- [ ] `t5321-pack-large-objects` ░░░░░░░░░░░░░░░░░░░░ 0/2 (2 left) — git pack-object with 
+- [x] `t5321-pack-large-objects` ████████████████████ 2/2 (0 left) — git pack-object with large delta metadata (`GIT_TEST_OE_DELTA_SIZE` path exercised by `pack-objects` REF_DELTA reuse)
 - [ ] `t5557-http-get` ░░░░░░░░░░░░░░░░░░░░ 0/2 (2 left) — test downloading a file by URL
 - [ ] `t5565-push-multiple` ░░░░░░░░░░░░░░░░░░░░ 0/2 (2 left) — push to group
 - [ ] `t5619-clone-local-ambiguous-transport` ░░░░░░░░░░░░░░░░░░░░ 0/2 (2 left) — test local clone with ambiguous transport

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -888,7 +888,7 @@ t5318-commit-graph	t5	skip	85	0	0	false	ok	0
 t5318-pack-objects-revs-exclude	t5	yes	9	6	3	false	ok	0
 t5319-multi-pack-index	t5	yes	0	0	0	false	timeout	0
 t5320-delta-islands	t5	yes	15	15	0	true	ok	0
-t5321-pack-large-objects	t5	yes	2	0	2	false	ok	0
+t5321-pack-large-objects	t5	yes	2	2	0	true	ok	0
 t5322-pack-objects-sparse	t5	yes	11	5	6	false	ok	0
 t5323-pack-redundant	t5	yes	18	2	16	false	ok	0
 t5324-split-commit-graph	t5	yes	42	9	33	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T04:34:09+00:00" class="gen-time" title="2026-04-09 04:34 UTC">2026-04-09 04:34 UTC</time> · <a href="https://github.com/schacon/grit/commit/cea43079fcce95ccd79fb6a0ac457f56eee9bd2d" style="color:#58a6ff">cea4307</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T04:36:59+00:00" class="gen-time" title="2026-04-09 04:36 UTC">2026-04-09 04:36 UTC</time> · <a href="https://github.com/schacon/grit/commit/f9b26c2e1c8b0dc945edcc9a9588dae0d6ee58e2" style="color:#58a6ff">f9b26c2</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">29,998</div>
+      <div class="summary-big-val">30,000</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>753 files fully passing</span>
+    <span>754 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -234,7 +234,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">36/167 files · 17 skipped · 1,389/3,949 tests</span>
+        <span class="group-meta">37/167 files · 17 skipped · 1,391/3,949 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-red" style="width:35.2%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:34:09+00:00" class="gen-time" title="2026-04-09 04:34 UTC">2026-04-09 04:34 UTC</time> · <a href="https://github.com/schacon/grit/commit/cea43079fcce95ccd79fb6a0ac457f56eee9bd2d" style="color:#58a6ff">cea4307</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:36:59+00:00" class="gen-time" title="2026-04-09 04:36 UTC">2026-04-09 04:36 UTC</time> · <a href="https://github.com/schacon/grit/commit/f9b26c2e1c8b0dc945edcc9a9588dae0d6ee58e2" style="color:#58a6ff">f9b26c2</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">29,998</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,000</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">75.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -9037,14 +9037,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="2" data-passed="0">
+<tr class="" data-group="t5" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t5321-pack-large-objects</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">2</td>
-  <td class="right">0</td>
+  <td class="right">2</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="11" data-passed="5">

--- a/grit-lib/src/wildmatch.rs
+++ b/grit-lib/src/wildmatch.rs
@@ -1,10 +1,10 @@
-/// Git-compatible wildmatch pattern matching.
-///
-/// Implements shell-style pattern matching for `?`, `\`, `[]`, and `*`
-/// characters, with special handling of `**` for directory matching.
-///
-/// Based on the algorithm by Rich Salz (1986), modified by Wayne Davison
-/// for special `/` handling and `**` glob support.
+//! Git-compatible wildmatch pattern matching.
+//!
+//! Implements shell-style pattern matching for `?`, `\`, `[]`, and `*`
+//! characters, with special handling of `**` for directory matching.
+//!
+//! Based on the algorithm by Rich Salz (1986), modified by Wayne Davison
+//! for special `/` handling and `**` glob support.
 
 pub const WM_CASEFOLD: u32 = 1;
 pub const WM_PATHNAME: u32 = 2;

--- a/logs/2026-04-09_t5321-pack-large-objects.md
+++ b/logs/2026-04-09_t5321-pack-large-objects.md
@@ -1,0 +1,19 @@
+# t5321-pack-large-objects
+
+**Date:** 2026-04-09
+
+## Outcome
+
+- `./scripts/run-tests.sh t5321-pack-large-objects.sh`: **2/2** passing (no Rust changes required for pack-objects behavior).
+- Refreshed `data/test-files.csv` and dashboards from the harness run.
+- Updated `PLAN.md` / `progress.md` / `test-results.md` to record full pass.
+
+## Notes
+
+- `GIT_TEST_OE_DELTA_SIZE` in upstream Git only widens the object-entry slot for *storing* delta sizes in `pack-objects`; grit does not mirror that packed metadata layout, but the test only requires a successful repack with REF_DELTA between the two similar blobs.
+- Fixed `grit-lib/src/wildmatch.rs`: top-level `///` block was attached to `WM_*` constants and tripped `clippy::empty_line_after_doc_comments` under `-D warnings`; switched to inner module docs (`//!`).
+
+## Validation
+
+- `cargo build --release -p grit-rs`
+- `cargo test -p grit-lib --lib` (121 tests)

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   255 |
+| Completed   |   256 |
 | In progress |     4 |
-| Remaining   |   509 |
+| Remaining   |   508 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 255 completed (`[x]`), 4 in progress (`[~]`), 509 remaining (`[ ]`).
+Task lines in `PLAN.md`: 256 completed (`[x]`), 4 in progress (`[~]`), 508 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t5321-pack-large-objects` — 2/2 tests pass (`index-pack` ingests test pack; `GIT_TEST_OE_DELTA_SIZE=2 git pack-objects` repacks blobs with REF_DELTA; harness CSV/dashboards refreshed)
 - `t4120-apply-popt` — 12/12 tests pass (`git apply -p`: strip path components, malformed `-p` errors, traditional quoted paths, `--stat` with oversized strip, mode-only and rename patches with `--index`; harness CSV/dashboards refreshed)
 - `t5320-delta-islands` — 15/15 tests pass (`repack` delta islands: `pack.island` / `pack.islandcore`, superset-island delta rules, verify-pack ordering; harness CSV/dashboards refreshed)
 - `t4214-log-graph-octopus` — 17/17 tests pass (`git log --graph` skewed-left octopus, crossover, and colored graph lines; harness CSV/dashboards refreshed)

--- a/test-results.md
+++ b/test-results.md
@@ -2,6 +2,8 @@
 
 **Updated:** 2026-04-09
 
+- `./scripts/run-tests.sh t5321-pack-large-objects.sh`: 2/2 passing (`index-pack --stdin` on fixture pack; `GIT_TEST_OE_DELTA_SIZE=2 git pack-objects` repack; harness CSV/dashboards refreshed).
+- `cargo test -p grit-lib --lib`: 121/121 passing.
 - `./scripts/run-tests.sh t4120-apply-popt.sh`: 12/12 passing (`git apply -p` strip count, invalid `-p` diagnostics, quoted traditional diff paths, `--stat` oversized strip, mode-only and rename with `--index`; harness CSV/dashboards refreshed).
 
 **Updated:** 2026-04-08


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t5321-pack-large-objects` already passes the harness (2/2). This change records that in planning/docs, refreshes the test CSV and dashboards from `./scripts/run-tests.sh`, and fixes a `wildmatch` module doc comment so it is a proper inner doc (`//!`) instead of attaching to the following `pub const` items (avoids `clippy::empty_line_after_doc_comments` when running with `-D warnings`).

## Test plan

- `./scripts/run-tests.sh t5321-pack-large-objects.sh`
- `cargo test -p grit-lib --lib`
- `cargo build --release -p grit-rs`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21dda943-f263-4d99-985f-31bc716d6e8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21dda943-f263-4d99-985f-31bc716d6e8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

