### PR TITLE
docs: t4216-log-bloom harness complete (167/167)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -533,7 +533,7 @@ commit → check it off → move on.
 - [ ] `t4124-apply-ws-rule` ███░░░░░░░░░░░░░░░░░ 13/85 (72 left) — core.whitespace rules and git apply
 - [ ] `t4202-log` █████████░░░░░░░░░░░ 69/149 (80 left) — git log
 - [ ] `t4013-diff-various` ██████░░░░░░░░░░░░░░ 78/230 (152 left) — Various diff formatting options
-- [ ] `t4216-log-bloom` █░░░░░░░░░░░░░░░░░░░ 12/167 (155 left) — git log for a path with Bloom filters
+- [x] `t4216-log-bloom` ████████████████████ 167/167 (0 left) — git log for a path with Bloom filters
 - [ ] `t4014-format-patch` ████░░░░░░░░░░░░░░░░ 47/215 (168 left) — various format-patch tests
 
 ## 6. Transport (142 files)

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -837,7 +837,7 @@ t4212-log-corrupt	t4	yes	13	3	10	false	ok	0
 t4213-log-tabexpand	t4	yes	9	1	8	false	ok	0
 t4214-log-graph-octopus	t4	yes	17	17	0	true	ok	0
 t4215-log-skewed-merges	t4	yes	10	0	10	false	ok	0
-t4216-log-bloom	t4	yes	167	12	155	false	ok	0
+t4216-log-bloom	t4	yes	167	167	0	true	ok	0
 t4217-log-limit	t4	yes	3	1	2	false	ok	0
 t4218-log-no-walk	t4	yes	7	7	0	true	ok	0
 t4219-log-date-format	t4	yes	14	14	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,16 +141,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T04:39:17+00:00" class="gen-time" title="2026-04-09 04:39 UTC">2026-04-09 04:39 UTC</time> · <a href="https://github.com/schacon/grit/commit/75778543ac9aae2e69e7e001dd0fdb2a20ae006f" style="color:#58a6ff">7577854</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T04:41:08+00:00" class="gen-time" title="2026-04-09 04:41 UTC">2026-04-09 04:41 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ed901d6977ffb503a758a4eb7028a540987221a" style="color:#58a6ff">8ed901d</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">75.3%</div>
+      <div class="summary-big-val pct-blue">75.6%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,008</div>
+      <div class="summary-big-val">30,163</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -159,12 +159,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:75.3%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:75.6%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>754 files fully passing</span>
+    <span>755 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -223,11 +223,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">70/178 files · 2 skipped · 2,067/3,542 tests</span>
+        <span class="group-meta">71/178 files · 2 skipped · 2,222/3,542 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:58.4%"></div></div>
-        <span class="group-pct pct-orange">58.4%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:62.7%"></div></div>
+        <span class="group-pct pct-blue">62.7%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:39:17+00:00" class="gen-time" title="2026-04-09 04:39 UTC">2026-04-09 04:39 UTC</time> · <a href="https://github.com/schacon/grit/commit/75778543ac9aae2e69e7e001dd0fdb2a20ae006f" style="color:#58a6ff">7577854</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:41:08+00:00" class="gen-time" title="2026-04-09 04:41 UTC">2026-04-09 04:41 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ed901d6977ffb503a758a4eb7028a540987221a" style="color:#58a6ff">8ed901d</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,008</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">75.3%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,163</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">75.6%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -8527,14 +8527,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="167" data-passed="12">
+<tr class="" data-group="t4" data-tests="167" data-passed="167" data-full-pass="1">
   <td class="mono">t4216-log-bloom</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">167</td>
-  <td class="right">12</td>
+  <td class="right">167</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:7.2%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="3" data-passed="1">

--- a/logs/2026-04-09_t4216-log-bloom.md
+++ b/logs/2026-04-09_t4216-log-bloom.md
@@ -1,0 +1,13 @@
+# t4216-log-bloom
+
+**Date:** 2026-04-09  
+**Branch:** `cursor/t4216-log-bloom-tests-e3bd`
+
+## Outcome
+
+`./scripts/run-tests.sh t4216-log-bloom.sh` reports **167/167** passing on current `grit` (no Rust changes in this session).
+
+## Actions
+
+- Re-ran harness to refresh `data/test-files.csv` and dashboards (`docs/index.html`, `docs/testfiles.html`).
+- Marked task complete in `PLAN.md` and updated `progress.md` counts.

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   256 |
+| Completed   |   257 |
 | In progress |     4 |
-| Remaining   |   508 |
+| Remaining   |   507 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 256 completed (`[x]`), 4 in progress (`[~]`), 508 remaining (`[ ]`).
+Task lines in `PLAN.md`: 257 completed (`[x]`), 4 in progress (`[~]`), 507 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t4216-log-bloom` — 167/167 tests pass (commit-graph changed-path Bloom filters: `read-graph` bloom chunks, `GIT_TRACE2_PERF` statistics for path-limited `log`, incompatible settings/version warnings, split chains, trace2 filter counters; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t5334-incremental-multi-pack-index` — 16/16 tests pass (incremental MIDX chain, bitmap/rev sidecars in `multi-pack-index.d`, `midx verify`, clone with `pack.allowPackReuse`; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t4120-apply-popt` — 12/12 tests pass (`git apply -p`: strip path components, malformed `-p` errors, traditional quoted paths, `--stat` with oversized strip, mode-only and rename patches with `--index`; harness CSV/dashboards refreshed)
 - `t5320-delta-islands` — 15/15 tests pass (`repack` delta islands: `pack.island` / `pack.islandcore`, superset-island delta rules, verify-pack ordering; harness CSV/dashboards refreshed)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t4216-log-bloom.sh` already passes fully against current `grit` (167/167). This change records that in project tracking and refreshes harness-generated artifacts from a clean run.

## Changes

- **PLAN.md**: Mark `t4216-log-bloom` complete (167/167).
- **progress.md**: Update checkbox-derived counts (+1 completed, −1 remaining).
- **Harness**: `data/test-files.csv`, `docs/index.html`, `docs/testfiles.html` refreshed via `./scripts/run-tests.sh t4216-log-bloom.sh`.
- **logs/**: Short session log for verification.

## Verification

```bash
./scripts/run-tests.sh t4216-log-bloom.sh
# → 167/167
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52baa968-58fc-4627-ac91-7a6554bee8c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52baa968-58fc-4627-ac91-7a6554bee8c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

