### PR TITLE
fix(mv): honor core.ignorecase for case-only renames

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -388,7 +388,7 @@ t13280-tag-list-format	t1	yes	34	34	0	true	ok	0
 t13290-commit-allow-empty-msg	t1	yes	30	30	0	true	ok	0
 t13300-add-executable-bit	t1	yes	32	32	0	true	ok	0
 t13310-rm-sparse-checkout	t1	yes	31	31	0	true	ok	0
-t13320-mv-case-sensitive	t1	yes	30	29	1	false	ok	0
+t13320-mv-case-sensitive	t1	yes	30	30	0	true	ok	0
 t13330-switch-reflog-entry	t1	yes	30	29	1	false	ok	0
 t13340-restore-merge-conflict	t1	yes	30	30	0	true	ok	0
 t13350-reset-orphan-branch	t1	yes	30	30	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,16 +141,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T04:42:02+00:00" class="gen-time" title="2026-04-09 04:42 UTC">2026-04-09 04:42 UTC</time> · <a href="https://github.com/schacon/grit/commit/7256d3831fdb0f20f2de6daea1a1faa8a3ae9ed8" style="color:#58a6ff">7256d38</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T04:51:14+00:00" class="gen-time" title="2026-04-09 04:51 UTC">2026-04-09 04:51 UTC</time> · <a href="https://github.com/schacon/grit/commit/43201d999fa10871c4b8e2a06a2e7cebd44164ff" style="color:#58a6ff">43201d9</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">75.6%</div>
+      <div class="summary-big-val pct-blue">75.7%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,163</div>
+      <div class="summary-big-val">30,164</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -159,12 +159,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:75.6%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:75.7%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>755 files fully passing</span>
+    <span>756 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -190,7 +190,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">280/368 files · 8 skipped · 10,781/11,373 tests</span>
+        <span class="group-meta">281/368 files · 8 skipped · 10,782/11,373 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-green" style="width:94.8%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:42:03+00:00" class="gen-time" title="2026-04-09 04:42 UTC">2026-04-09 04:42 UTC</time> · <a href="https://github.com/schacon/grit/commit/7256d3831fdb0f20f2de6daea1a1faa8a3ae9ed8" style="color:#58a6ff">7256d38</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:51:14+00:00" class="gen-time" title="2026-04-09 04:51 UTC">2026-04-09 04:51 UTC</time> · <a href="https://github.com/schacon/grit/commit/43201d999fa10871c4b8e2a06a2e7cebd44164ff" style="color:#58a6ff">43201d9</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,163</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">75.6%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,164</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">75.7%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -4037,14 +4037,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="30" data-passed="29">
+<tr class="" data-group="t1" data-tests="30" data-passed="30" data-full-pass="1">
   <td class="mono">t13320-mv-case-sensitive</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">30</td>
-  <td class="right">29</td>
+  <td class="right">30</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:96.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="30" data-passed="29">

--- a/grit-lib/src/gitmodules.rs
+++ b/grit-lib/src/gitmodules.rs
@@ -235,10 +235,13 @@ fn check_submodule_name(name: &str) -> bool {
     }
     let b = name.as_bytes();
     // Git `check_submodule_name`: `goto in_component` before the loop — first component.
-    if b.len() >= 2 && b[0] == b'.' && b[1] == b'.'
-        && (b.len() == 2 || b[2] == b'/' || b[2] == b'\\') {
-            return false;
-        }
+    if b.len() >= 2
+        && b[0] == b'.'
+        && b[1] == b'.'
+        && (b.len() == 2 || b[2] == b'/' || b[2] == b'\\')
+    {
+        return false;
+    }
     let mut i = 0usize;
     while i < b.len() {
         let c = b[i];

--- a/grit/src/commands/mv.rs
+++ b/grit/src/commands/mv.rs
@@ -97,6 +97,10 @@ pub fn run(args: Args) -> Result<()> {
     };
 
     let config = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+    let ignore_case = config
+        .get_bool("core.ignorecase")
+        .and_then(|r| r.ok())
+        .unwrap_or(false);
     let sparse_enabled = config
         .get("core.sparseCheckout")
         .map(|v| v.eq_ignore_ascii_case("true"))
@@ -434,7 +438,23 @@ pub fn run(args: Args) -> Result<()> {
             bail!("{msg}");
         }
 
-        if dst_abs.exists()
+        if src_rel == dst_rel {
+            let msg = format!(
+                "source and destination are the same, source='{src_rel}', destination='{dst_rel}'"
+            );
+            if args.skip_errors {
+                continue;
+            }
+            bail!("{msg}");
+        }
+
+        // Git `builtin/mv.c`: on case-insensitive filesystems (`core.ignorecase`), a path that
+        // only differs by case from the source is not a separate destination — `exists()` would
+        // still be true for the same inode.
+        let dst_fs_collides =
+            dst_abs.exists() && !(ignore_case && src_rel.eq_ignore_ascii_case(&dst_rel));
+
+        if dst_fs_collides
             && !(args.force && (dst_abs.is_file() || dst_abs.is_symlink()) && !dst_abs.is_dir())
         {
             if !args.force {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **`grit mv`** reads `core.ignorecase` and, when true, does not treat a destination that only differs from the source by ASCII case as a separate existing file on disk (aligned with Git `builtin/mv.c`). This fixes case-only renames on case-insensitive filesystems where `Path::exists()` would otherwise report a false collision.
- **Same-path moves** (`src == dst` as normalized repo-relative paths) are rejected with a dedicated error before the destination-exists logic, so `mv file file` still fails cleanly.
- **`cargo fmt`**: applied rustfmt to `grit-lib/src/gitmodules.rs` so `cargo fmt --check` passes (pre-existing formatting drift).

## Testing

- `./scripts/run-tests.sh t13320-mv-case-sensitive.sh` — 30/30
- `cargo test -p grit-lib --lib`
- `cargo check -p grit-rs`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e3f7565-d026-4864-860f-13d1b4fce5dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e3f7565-d026-4864-860f-13d1b4fce5dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

