### PR TITLE
t7402-submodule-rebase: verify full pass, refresh dashboards

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -809,7 +809,7 @@ commit → check it off → move on.
 - [ ] `t7106-reset-unborn-branch` ████████░░░░░░░░░░░░ 3/7 (4 left) — git reset should work on unborn branch
 - [ ] `t7615-diff-algo-with-mergy-operations` ████████░░░░░░░░░░░░ 3/7 (4 left) — git merge and other operations that rely on merge
 
-- [ ] `t7402-submodule-rebase` ██████░░░░░░░░░░░░░░ 2/6 (4 left) — Test rebasing, stashing, etc. with submodules
+- [x] `t7402-submodule-rebase` — Test rebasing, stashing, etc. with submodules
 - [ ] `t7421-submodule-summary-add` ████░░░░░░░░░░░░░░░░ 1/5 (4 left) — Summary support for submodules, adding them using git submodule add
 
 - [ ] `t7518-ident-corner-cases` ████░░░░░░░░░░░░░░░░ 1/5 (4 left) — corner cases in ident strings

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1196,7 +1196,7 @@ t7300-clean	t7	yes	53	52	1	false	ok	2
 t7301-clean-interactive	t7	yes	23	8	15	false	ok	0
 t7400-submodule-basic	t7	yes	0	0	0	false	timeout	0
 t7401-submodule-summary	t7	yes	25	6	19	false	ok	0
-t7402-submodule-rebase	t7	yes	6	2	4	false	ok	0
+t7402-submodule-rebase	t7	yes	6	6	0	true	ok	0
 t7403-submodule-sync	t7	yes	18	10	8	false	ok	0
 t7406-submodule-update	t7	yes	0	0	0	false	timeout	0
 t7407-submodule-foreach	t7	yes	0	0	0	false	timeout	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T04:52:51+00:00" class="gen-time" title="2026-04-09 04:52 UTC">2026-04-09 04:52 UTC</time> · <a href="https://github.com/schacon/grit/commit/c31232979dee951275b6e0bdbaa09457511e4eb8" style="color:#58a6ff">c312329</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T04:54:41+00:00" class="gen-time" title="2026-04-09 04:54 UTC">2026-04-09 04:54 UTC</time> · <a href="https://github.com/schacon/grit/commit/9b3c71449cd8a9cf44a83685f7bcf12e26adf18a" style="color:#58a6ff">9b3c714</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,264</div>
+      <div class="summary-big-val">30,268</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>758 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -256,11 +256,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 1,935/2,944 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 1,939/2,944 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:65.7%"></div></div>
-        <span class="group-pct pct-blue">65.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:65.9%"></div></div>
+        <span class="group-pct pct-blue">65.9%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:52:51+00:00" class="gen-time" title="2026-04-09 04:52 UTC">2026-04-09 04:52 UTC</time> · <a href="https://github.com/schacon/grit/commit/c31232979dee951275b6e0bdbaa09457511e4eb8" style="color:#58a6ff">c312329</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:54:41+00:00" class="gen-time" title="2026-04-09 04:54 UTC">2026-04-09 04:54 UTC</time> · <a href="https://github.com/schacon/grit/commit/9b3c71449cd8a9cf44a83685f7bcf12e26adf18a" style="color:#58a6ff">9b3c714</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,264</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,268</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">75.9%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -12117,14 +12117,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:24.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="6" data-passed="2">
+<tr class="" data-group="t7" data-tests="6" data-passed="6" data-full-pass="1">
   <td class="mono">t7402-submodule-rebase</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">6</td>
-  <td class="right">2</td>
+  <td class="right">6</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:33.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="18" data-passed="10">

--- a/logs/2026-04-09_t7402-submodule-rebase.md
+++ b/logs/2026-04-09_t7402-submodule-rebase.md
@@ -1,0 +1,4 @@
+# t7402-submodule-rebase
+
+- Ran `./scripts/run-tests.sh t7402-submodule-rebase.sh`: **6/6** pass on current branch (no Rust changes required).
+- Refreshed `data/test-files.csv` and dashboards; marked task complete in `PLAN.md` and updated `progress.md` counts.

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   260 |
+| Completed   |   261 |
 | In progress |     4 |
-| Remaining   |   504 |
+| Remaining   |   503 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 260 completed (`[x]`), 4 in progress (`[~]`), 504 remaining (`[ ]`).
+Task lines in `PLAN.md`: 261 completed (`[x]`), 4 in progress (`[~]`), 503 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t7402-submodule-rebase` — 6/6 tests pass (rebase with dirty submodule, interactive rebase, dirty file+submodule failure, stash dirty submodule, submodule gitlink conflict message; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t5317-pack-objects-filter-objects` — 33/33 tests pass (`pack-objects --filter` object filtering; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t5603-clone-dirname` — 47/47 tests pass (clone default directory from `host:path`, `ssh://` URLs: strip trailing slashes and `.git`, redact userinfo for dirname, preserve path segments like `foo@bar` and `test:1234`; harness CSV/dashboards refreshed)
 - `t3507-cherry-pick-conflict` — 44/44 tests pass (cherry-pick/revert conflicts: `CHERRY_PICK_HEAD`/`REVERT_HEAD`, advice text, `MERGE_MSG` scissors, diff3 markers, sequencer cleanup, sparse-checkout, `--continue` flags; harness CSV/dashboards refreshed; `PLAN.md` marked complete)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`./scripts/run-tests.sh t7402-submodule-rebase.sh` reports **6/6** passing on this branch. No Rust changes were required; the harness CSV and generated dashboards were stale relative to actual behavior.

## Changes

- Refresh `data/test-files.csv`, `docs/index.html`, and `docs/testfiles.html` from the clean run.
- Mark `t7402-submodule-rebase` complete in `PLAN.md` and bump counts in `progress.md`.
- Add `logs/2026-04-09_t7402-submodule-rebase.md`.

## Verification

```bash
cargo build --release -p grit-rs
./scripts/run-tests.sh t7402-submodule-rebase.sh
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a78c20c-bf39-4938-a589-1460bbf45328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a78c20c-bf39-4938-a589-1460bbf45328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

