### PR TITLE
t3207-branch-submodule: full pass + harness refresh

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -566,7 +566,7 @@ t3204-branch-name-interpretation	t3	yes	16	10	6	false	ok	0
 t3205-branch-color	t3	yes	4	4	0	true	ok	0
 t3206-branch-advanced	t3	yes	29	29	0	true	ok	0
 t3206-range-diff	t3	yes	48	20	28	false	ok	0
-t3207-branch-submodule	t3	yes	20	2	18	false	ok	0
+t3207-branch-submodule	t3	yes	20	20	0	true	ok	0
 t3210-pack-refs	t3	yes	29	29	0	true	ok	0
 t3211-peel-ref	t3	yes	8	8	0	true	ok	0
 t3300-funny-names	t3	yes	21	8	13	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,16 +141,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T04:55:44+00:00" class="gen-time" title="2026-04-09 04:55 UTC">2026-04-09 04:55 UTC</time> · <a href="https://github.com/schacon/grit/commit/6de87be7c81f5795f766d860eefda5578b73223e" style="color:#58a6ff">6de87be</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T04:56:15+00:00" class="gen-time" title="2026-04-09 04:56 UTC">2026-04-09 04:56 UTC</time> · <a href="https://github.com/schacon/grit/commit/0833980d377dc6b347b8480202e468477e3a0e17" style="color:#58a6ff">0833980</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">75.9%</div>
+      <div class="summary-big-val pct-blue">76.0%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,268</div>
+      <div class="summary-big-val">30,286</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -159,12 +159,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:75.9%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:76.0%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>759 files fully passing</span>
+    <span>760 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,11 +212,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">47/141 files · 2 skipped · 3,418/4,619 tests</span>
+        <span class="group-meta">48/141 files · 2 skipped · 3,436/4,619 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:74.0%"></div></div>
-        <span class="group-pct pct-blue">74.0%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:74.4%"></div></div>
+        <span class="group-pct pct-blue">74.4%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:55:44+00:00" class="gen-time" title="2026-04-09 04:55 UTC">2026-04-09 04:55 UTC</time> · <a href="https://github.com/schacon/grit/commit/6de87be7c81f5795f766d860eefda5578b73223e" style="color:#58a6ff">6de87be</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:56:15+00:00" class="gen-time" title="2026-04-09 04:56 UTC">2026-04-09 04:56 UTC</time> · <a href="https://github.com/schacon/grit/commit/0833980d377dc6b347b8480202e468477e3a0e17" style="color:#58a6ff">0833980</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,268</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">75.9%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,286</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">76.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -5817,14 +5817,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:41.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="20" data-passed="2">
+<tr class="" data-group="t3" data-tests="20" data-passed="20" data-full-pass="1">
   <td class="mono">t3207-branch-submodule</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">20</td>
-  <td class="right">2</td>
+  <td class="right">20</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:10.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="29" data-passed="29" data-full-pass="1">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t3207-branch-submodule` already passes all 20 harness tests on this branch. This change refreshes `data/test-files.csv` and the generated dashboards after `./scripts/run-tests.sh t3207-branch-submodule.sh` so the repo reflects **20/20** passing.

## Verification

```bash
./scripts/run-tests.sh t3207-branch-submodule.sh
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee48a1f6-d641-4c86-8d67-de07838ac8ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee48a1f6-d641-4c86-8d67-de07838ac8ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

