### PR TITLE
chore: verify t4207 log-decoration harness

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -827,7 +827,7 @@ t4205-log-pretty-formats	t4	yes	123	35	88	false	ok	2
 t4206-log-follow	t4	yes	26	26	0	true	ok	0
 t4206-log-follow-harder-copies	t4	yes	7	3	4	false	ok	0
 t4207-log-decoration	t4	yes	23	23	0	true	ok	0
-t4207-log-decoration-colors	t4	yes	4	1	3	false	ok	0
+t4207-log-decoration-colors	t4	yes	4	4	0	true	ok	0
 t4208-diff-pathspec-magic	t4	yes	22	21	1	false	ok	0
 t4208-log-magic-pathspec	t4	yes	21	12	9	false	ok	0
 t4209-log-pickaxe	t4	yes	0	0	0	false	timeout	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T04:56:53+00:00" class="gen-time" title="2026-04-09 04:56 UTC">2026-04-09 04:56 UTC</time> · <a href="https://github.com/schacon/grit/commit/d0129166cdef10aeeecf6827ec943e2c87c3c3e5" style="color:#58a6ff">d012916</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T04:58:49+00:00" class="gen-time" title="2026-04-09 04:58 UTC">2026-04-09 04:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/d9b67b576d7b348d86e8c6fbd0c298273a434e62" style="color:#58a6ff">d9b67b5</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,286</div>
+      <div class="summary-big-val">30,289</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>760 files fully passing</span>
+    <span>761 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -223,11 +223,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">71/178 files · 2 skipped · 2,222/3,542 tests</span>
+        <span class="group-meta">72/178 files · 2 skipped · 2,225/3,542 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:62.7%"></div></div>
-        <span class="group-pct pct-blue">62.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:62.8%"></div></div>
+        <span class="group-pct pct-blue">62.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:56:53+00:00" class="gen-time" title="2026-04-09 04:56 UTC">2026-04-09 04:56 UTC</time> · <a href="https://github.com/schacon/grit/commit/d0129166cdef10aeeecf6827ec943e2c87c3c3e5" style="color:#58a6ff">d012916</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:58:49+00:00" class="gen-time" title="2026-04-09 04:58 UTC">2026-04-09 04:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/d9b67b576d7b348d86e8c6fbd0c298273a434e62" style="color:#58a6ff">d9b67b5</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,286</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,289</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">76.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -8427,14 +8427,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="4" data-passed="1">
+<tr class="" data-group="t4" data-tests="4" data-passed="4" data-full-pass="1">
   <td class="mono">t4207-log-decoration-colors</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">4</td>
-  <td class="right">1</td>
+  <td class="right">4</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:25.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="22" data-passed="21">

--- a/logs/2026-04-09_t4207-log-decoration.md
+++ b/logs/2026-04-09_t4207-log-decoration.md
@@ -1,0 +1,6 @@
+# t4207-log-decoration
+
+- Ran `./scripts/run-tests.sh t4207-log-decoration.sh` → 23/23 pass.
+- Ran `./scripts/run-tests.sh t4207-log-decoration-colors.sh` → 4/4 pass.
+- `cargo build --release -p grit-rs` succeeded; re-ran t4207 with release binary.
+- No Rust changes required; refreshed `data/test-files.csv` and dashboards from harness run.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Verified `t4207-log-decoration` and `t4207-log-decoration-colors` against the harness after a release build. Both files report full pass counts (23/23 and 4/4). No Rust changes were required.

## Changes

- Refreshed `data/test-files.csv` and generated dashboards from `./scripts/run-tests.sh`.
- Added a short log entry under `logs/2026-04-09_t4207-log-decoration.md`.

## Testing

- `cargo build --release -p grit-rs`
- `./scripts/run-tests.sh t4207-log-decoration.sh`
- `./scripts/run-tests.sh t4207-log-decoration-colors.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e617b25b-5904-4c6c-8260-ff337349cd62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e617b25b-5904-4c6c-8260-ff337349cd62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

