### PR TITLE
fix: make t4035-diff-quiet fully pass

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -464,7 +464,7 @@ commit → check it off → move on.
 - [ ] `t4252-am-options` ██░░░░░░░░░░░░░░░░░░ 1/8 (7 left) — git am with options and not losing them
 - [x] `t4070-diff-pairs` ████████████████████ 7/7 (0 left) — basic diff-pairs tests (`diff-pairs` is now native (stdin raw `-z` parser + `--raw`/`-p` rendering + queue flush handling + tree/pathspec error modes); `diff-tree` now supports `-z` NUL-terminated raw output used by this plumbing flow; upstream harness passes 7/7 while this local mirror still reports 3/7 due simplified `tests/test-lib.sh` cwd persistence causing post-setup `unknown revision: 'base'` lookups between tests)
 - [ ] `t4017-diff-retval` ███████████████░░░░░ 30/38 (8 left) — Return value of diffs
-- [ ] `t4035-diff-quiet` █████████████░░░░░░░ 15/23 (8 left) — Return value of diffs
+- [x] `t4035-diff-quiet` — Return value of diffs (23/23)
 - [ ] `t4213-log-tabexpand` ██░░░░░░░░░░░░░░░░░░ 1/9 (8 left) — log/show --expand-tabs
 - [ ] `t4058-diff-duplicates` ████████░░░░░░░░░░░░ 7/16 (9 left) — test tree diff when trees have duplicate entries
 - [ ] `t4008-diff-break-rewrite` ███████░░░░░░░░░░░░░ 5/14 (9 left) — Break and then rename

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -712,7 +712,7 @@ t4031-diff-rewrite-binary	t4	yes	8	3	5	false	ok	0
 t4032-diff-inter-hunk-context	t4	yes	37	19	18	false	ok	0
 t4033-diff-patience	t4	yes	11	4	7	false	ok	0
 t4034-diff-words	t4	yes	66	7	59	false	ok	0
-t4035-diff-quiet	t4	yes	0	0	0	false	timeout	0
+t4035-diff-quiet	t4	yes	23	23	0	true	ok	0
 t4036-format-patch-signer-mime	t4	yes	5	5	0	true	ok	0
 t4037-diff-r-t-dirs	t4	yes	2	2	0	true	ok	0
 t4038-diff-combined	t4	yes	25	6	19	false	ok	1

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T04:39:17+00:00" class="gen-time" title="2026-04-09 04:39 UTC">2026-04-09 04:39 UTC</time> · <a href="https://github.com/schacon/grit/commit/75778543ac9aae2e69e7e001dd0fdb2a20ae006f" style="color:#58a6ff">7577854</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T04:58:47+00:00" class="gen-time" title="2026-04-09 04:58 UTC">2026-04-09 04:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ed901d6977ffb503a758a4eb7028a540987221a" style="color:#58a6ff">8ed901d</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,11 +150,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,008</div>
+      <div class="summary-big-val">30,031</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">39,873</div>
+      <div class="summary-big-val">39,896</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>754 files fully passing</span>
+    <span>755 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -223,11 +223,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">70/178 files · 2 skipped · 2,067/3,542 tests</span>
+        <span class="group-meta">71/178 files · 2 skipped · 2,090/3,565 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:58.4%"></div></div>
-        <span class="group-pct pct-orange">58.4%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:58.6%"></div></div>
+        <span class="group-pct pct-orange">58.6%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:39:17+00:00" class="gen-time" title="2026-04-09 04:39 UTC">2026-04-09 04:39 UTC</time> · <a href="https://github.com/schacon/grit/commit/75778543ac9aae2e69e7e001dd0fdb2a20ae006f" style="color:#58a6ff">7577854</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:58:47+00:00" class="gen-time" title="2026-04-09 04:58 UTC">2026-04-09 04:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ed901d6977ffb503a758a4eb7028a540987221a" style="color:#58a6ff">8ed901d</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,008</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n" id="sum-tests">39,896</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,031</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">75.3%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -7277,14 +7277,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:10.6%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="0" data-passed="0">
+<tr class="" data-group="t4" data-tests="23" data-passed="23" data-full-pass="1">
   <td class="mono">t4035-diff-quiet</td>
   <td>t4</td>
-  <td></td>
-  <td class="right">0</td>
-  <td class="right">0</td>
-  <td class="right">timeout</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td><span class="badge ok">full pass</span></td>
+  <td class="right">23</td>
+  <td class="right">23</td>
+  <td class="right">ok</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="5" data-passed="5" data-full-pass="1">

--- a/grit/src/commands/diff.rs
+++ b/grit/src/commands/diff.rs
@@ -524,6 +524,11 @@ pub fn run(mut args: Args) -> Result<()> {
     let has_separator = raw_args.iter().any(|a| a == "--");
     let (mut revs, paths) = parse_rev_and_paths(&args.args, has_separator);
 
+    // Outside any repository, `git diff <path> <path>` behaves like `diff --no-index` (t4035).
+    if Repository::discover(None).is_err() && revs.is_empty() && paths.len() == 2 && !args.cached {
+        return run_no_index(&args);
+    }
+
     let repo = Repository::discover(None).context("not a git repository")?;
 
     let emit_unified_patch = diff_emit_unified_patch_from_argv(&raw_args);
@@ -538,6 +543,12 @@ pub fn run(mut args: Args) -> Result<()> {
         && split_treeish_colon(&revs[0]).is_some()
     {
         return run_diff_blob_vs_file(&repo, &args, &revs[0], &paths[0], &src_prefix, &dst_prefix);
+    }
+
+    // `git diff <path> <path>` — compare a worktree file to another path (e.g. outside the repo).
+    // Triggered when parse_rev_and_paths found two paths and no revisions (first token exists on disk).
+    if revs.is_empty() && paths.len() == 2 && !args.cached {
+        return run_diff_two_paths(&repo, &args, &paths[0], &paths[1], &src_prefix, &dst_prefix);
     }
 
     // Expand A...B (symmetric diff) → merge-base(A,B)..B
@@ -1411,6 +1422,128 @@ fn run_diff_blob_vs_file(
     Ok(())
 }
 
+/// Compare a path relative to the repository work tree to a second path (often outside the repo).
+///
+/// This matches `git diff <in-repo-path> <other-path>` when both arguments exist on disk and are
+/// not revision specs.
+fn run_diff_two_paths(
+    repo: &Repository,
+    args: &Args,
+    path_in_repo: &str,
+    path_other: &str,
+    src_prefix: &str,
+    dst_prefix: &str,
+) -> Result<()> {
+    let wt = repo
+        .work_tree
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("this operation must be run in a work tree"))?;
+
+    let read_path_or_symlink = |p: &Path, name: &str| -> Result<Vec<u8>> {
+        if let Ok(meta) = std::fs::symlink_metadata(p) {
+            if meta.file_type().is_symlink() {
+                return std::fs::read_link(p)
+                    .map(|target| target.to_string_lossy().into_owned().into_bytes())
+                    .with_context(|| format!("could not read symlink '{name}'"));
+            }
+        }
+        std::fs::read(p).with_context(|| format!("could not read '{name}'"))
+    };
+
+    let abs_in_repo = wt.join(path_in_repo);
+    let other = Path::new(path_other);
+    let abs_other = if other.is_absolute() {
+        other.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|_| wt.to_path_buf())
+            .join(other)
+    };
+
+    let data_a = read_path_or_symlink(&abs_in_repo, path_in_repo)?;
+    let data_b = read_path_or_symlink(&abs_other, path_other)?;
+
+    let text_a = String::from_utf8_lossy(&data_a);
+    let text_b = String::from_utf8_lossy(&data_b);
+
+    let ws_mode = WhitespaceMode {
+        ignore_all_space: args.ignore_all_space,
+        ignore_space_change: args.ignore_space_change,
+        ignore_space_at_eol: args.ignore_space_at_eol,
+        ignore_blank_lines: args.ignore_blank_lines,
+        ignore_cr_at_eol: args.ignore_cr_at_eol,
+    };
+
+    let mut has_diff = text_a != text_b;
+    if has_diff && ws_mode.any() && ws_mode.normalize(&text_a) == ws_mode.normalize(&text_b) {
+        has_diff = false;
+    }
+
+    if !has_diff {
+        return Ok(());
+    }
+
+    if args.quiet {
+        std::process::exit(1);
+    }
+
+    let context_lines = if let Some(u) = args.unified {
+        u
+    } else {
+        grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true)
+            .ok()
+            .and_then(|cfg| cfg.get("diff.context"))
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(3)
+    };
+
+    let old_label = format!("{src_prefix}{path_in_repo}");
+    let new_label = format!("{dst_prefix}{path_other}");
+    let patch = unified_diff(
+        text_a.as_ref(),
+        text_b.as_ref(),
+        &old_label,
+        &new_label,
+        context_lines,
+    );
+
+    let mut out = io::stdout().lock();
+    let show_patch = !args.no_patch;
+    if show_patch {
+        let use_color = match args.color.as_deref() {
+            Some("always") => true,
+            Some("never") => false,
+            Some("auto") | None => io::stdout().is_terminal(),
+            Some(_) => false,
+        };
+        if use_color {
+            for line in patch.lines() {
+                if line.starts_with("@@") {
+                    writeln!(out, "{CYAN}{line}{RESET}")?;
+                } else if line.starts_with('+') && !line.starts_with("+++") {
+                    writeln!(out, "{GREEN}{line}{RESET}")?;
+                } else if line.starts_with('-') && !line.starts_with("---") {
+                    writeln!(out, "{RED}{line}{RESET}")?;
+                } else if line.starts_with("diff ")
+                    || line.starts_with("---")
+                    || line.starts_with("+++")
+                {
+                    writeln!(out, "{BOLD}{line}{RESET}")?;
+                } else {
+                    writeln!(out, "{line}")?;
+                }
+            }
+        } else {
+            write!(out, "{patch}")?;
+        }
+    }
+
+    if (args.exit_code || args.quiet) && has_diff {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
 /// Split args on `--` to separate revisions from paths.
 ///
 /// Run `diff --no-index <path_a> <path_b>` — compare two files outside a repo.
@@ -1459,15 +1592,14 @@ fn run_no_index(args: &Args) -> Result<()> {
         ignore_cr_at_eol: args.ignore_cr_at_eol,
     };
 
-    // --quiet / --exit-code: just exit 1 for differences, no output
-    if args.quiet {
-        std::process::exit(1);
-    }
-
     let text_a = String::from_utf8_lossy(&data_a);
     let text_b = String::from_utf8_lossy(&data_b);
     if ws_mode.any() && ws_mode.normalize(&text_a) == ws_mode.normalize(&text_b) {
         return Ok(());
+    }
+
+    if args.quiet {
+        std::process::exit(1);
     }
     let context_lines = args.unified.unwrap_or(3);
 

--- a/grit/src/commands/diff_tree.rs
+++ b/grit/src/commands/diff_tree.rs
@@ -11,7 +11,7 @@ use clap::Args as ClapArgs;
 use grit_lib::config::ConfigSet;
 use grit_lib::diff::{
     count_changes, detect_renames, diff_trees, diff_trees_show_tree_entries, format_raw,
-    format_raw_abbrev, unified_diff, DiffEntry, DiffStatus,
+    format_raw_abbrev, unified_diff, zero_oid, DiffEntry, DiffStatus,
 };
 use grit_lib::merge_diff::{
     combined_diff_paths, format_combined_textconv_patch, is_binary_for_diff,
@@ -117,6 +117,12 @@ struct Options {
     remerge_diff: bool,
     /// Swap the two tree sides (`-R`), inverting raw/patch output like Git.
     reverse: bool,
+    /// Pickaxe: only entries where `-S` string occurrence count changes between blobs.
+    pickaxe_string: Option<String>,
+    /// Pickaxe: only entries whose diff has added/removed lines matching `-G` regex.
+    pickaxe_grep: Option<String>,
+    /// Treat `-S` pattern as a regex (count regex matches per side).
+    pickaxe_regex: bool,
 }
 
 impl Default for Options {
@@ -153,6 +159,9 @@ impl Default for Options {
             quiet: false,
             remerge_diff: false,
             reverse: false,
+            pickaxe_string: None,
+            pickaxe_grep: None,
+            pickaxe_regex: false,
         }
     }
 }
@@ -303,13 +312,33 @@ fn parse_options(argv: &[String]) -> Result<Options> {
                         }
                     }
                 }
+                _ if arg.starts_with("-S") => {
+                    if arg.len() > 2 {
+                        opts.pickaxe_string = Some(arg[2..].to_owned());
+                    } else {
+                        i += 1;
+                        let next = argv
+                            .get(i)
+                            .ok_or_else(|| anyhow::anyhow!("-S requires an argument"))?;
+                        opts.pickaxe_string = Some(next.clone());
+                    }
+                }
+                _ if arg.starts_with("-G") => {
+                    if arg.len() > 2 {
+                        opts.pickaxe_grep = Some(arg[2..].to_owned());
+                    } else {
+                        i += 1;
+                        let next = argv
+                            .get(i)
+                            .ok_or_else(|| anyhow::anyhow!("-G requires an argument"))?;
+                        opts.pickaxe_grep = Some(next.clone());
+                    }
+                }
+                "--pickaxe-regex" => opts.pickaxe_regex = true,
+                "--pickaxe-all" => {}
                 _ if arg.starts_with("--diff-filter=")
                     || arg.starts_with("--diff-merges=")
                     || arg.starts_with("--format=")
-                    || arg.starts_with("-S")
-                    || arg.starts_with("-G")
-                    || arg.starts_with("--pickaxe-all")
-                    || arg.starts_with("--pickaxe-regex")
                     || arg.starts_with("-O")
                     || arg.starts_with("--relative") =>
                 {
@@ -403,7 +432,7 @@ fn run_two_trees(repo: &Repository, opts: &Options, out: &mut impl Write) -> Res
         validate_tree_depth_limit(&repo.odb, tree_oid, 0, max_tree_depth)?;
     }
     let entries = diff_with_opts(&repo.odb, old_tree, new_tree, opts)?;
-    let filtered = filter_entries(entries, opts);
+    let filtered = filter_entries(&repo.odb, entries, opts)?;
     let has_diff = !filtered.is_empty();
     if !opts.quiet {
         print_diff(out, &repo.odb, &filtered, opts, old_tree, &repo.git_dir)?;
@@ -428,7 +457,7 @@ fn run_one_commit(repo: &Repository, opts: &Options, out: &mut impl Write) -> Re
             if commit.parents.is_empty() {
                 if opts.root {
                     let entries = diff_with_opts(&repo.odb, None, Some(&commit.tree), opts)?;
-                    let filtered = filter_entries(entries, opts);
+                    let filtered = filter_entries(&repo.odb, entries, opts)?;
                     has_diff = !filtered.is_empty();
                     if !opts.quiet && (has_diff || opts.pretty.is_some()) {
                         write_commit_header(out, &oid, &obj.data, opts)?;
@@ -497,7 +526,7 @@ fn run_one_commit(repo: &Repository, opts: &Options, out: &mut impl Write) -> Re
                 let parent_tree = commit_tree(&repo.odb, &commit.parents[0])?;
                 let entries =
                     diff_with_opts(&repo.odb, Some(&parent_tree), Some(&commit.tree), opts)?;
-                let filtered = filter_entries(entries, opts);
+                let filtered = filter_entries(&repo.odb, entries, opts)?;
                 has_diff = !filtered.is_empty();
                 if !opts.quiet && (has_diff || opts.pretty.is_some()) {
                     write_commit_header(out, &oid, &obj.data, opts)?;
@@ -587,11 +616,13 @@ fn process_stdin_commit(
 ) -> Result<bool> {
     let commit = parse_commit(data).context("parsing commit")?;
 
-    // Print commit-id header (unless suppressed).
+    // Print commit-id header (unless `--no-commit-id`). `--quiet` still prints this
+    // line (only the raw/patch diff is suppressed), matching `git diff-tree`.
     if !opts.no_commit_id {
         writeln!(out, "{}", oid.to_hex())?;
     }
 
+    // `-v` shows the commit message even with `--quiet` (raw diff and commit-id line stay off).
     if opts.verbose {
         writeln!(out, "commit {}", oid.to_hex())?;
         writeln!(out)?;
@@ -633,14 +664,18 @@ fn process_stdin_commit(
         let mut buf = Vec::new();
         write_remerge_diff(&mut buf, repo, &commit.tree, &parent_oids, &ro)?;
         let hd = !buf.is_empty();
-        out.write_all(&buf)?;
+        if !opts.quiet {
+            out.write_all(&buf)?;
+        }
         hd
     } else if parent_oids.is_empty() {
         if opts.root {
             let entries = diff_with_opts(&repo.odb, None, Some(&commit.tree), opts)?;
-            let filtered = filter_entries(entries, opts);
+            let filtered = filter_entries(&repo.odb, entries, opts)?;
             let hd = !filtered.is_empty();
-            print_diff(out, &repo.odb, &filtered, opts, None, &repo.git_dir)?;
+            if !opts.quiet {
+                print_diff(out, &repo.odb, &filtered, opts, None, &repo.git_dir)?;
+            }
             hd
         } else {
             false
@@ -648,9 +683,11 @@ fn process_stdin_commit(
     } else {
         let parent_tree = commit_tree(&repo.odb, &parent_oids[0])?;
         let entries = diff_with_opts(&repo.odb, Some(&parent_tree), Some(&commit.tree), opts)?;
-        let filtered = filter_entries(entries, opts);
+        let filtered = filter_entries(&repo.odb, entries, opts)?;
         let hd = !filtered.is_empty();
-        print_diff(out, &repo.odb, &filtered, opts, None, &repo.git_dir)?;
+        if !opts.quiet {
+            print_diff(out, &repo.odb, &filtered, opts, None, &repo.git_dir)?;
+        }
         hd
     };
 
@@ -673,8 +710,9 @@ fn process_stdin_two_trees(
         .parse::<ObjectId>()
         .with_context(|| format!("invalid OID: `{oid2_str}`"))?;
 
-    // Print both tree OIDs.
-    writeln!(out, "{} {}", oid1.to_hex(), oid2.to_hex())?;
+    if !opts.quiet {
+        writeln!(out, "{} {}", oid1.to_hex(), oid2.to_hex())?;
+    }
 
     let (old_side, new_side) = if opts.reverse {
         (Some(&oid2), Some(oid1))
@@ -682,8 +720,12 @@ fn process_stdin_two_trees(
         (Some(oid1), Some(&oid2))
     };
     let entries = diff_with_opts(&repo.odb, old_side, new_side, opts)?;
-    let filtered = filter_entries(entries, opts);
-    print_diff(out, &repo.odb, &filtered, opts, None, &repo.git_dir)
+    let filtered = filter_entries(&repo.odb, entries, opts)?;
+    let has_diff = !filtered.is_empty();
+    if !opts.quiet {
+        print_diff(out, &repo.odb, &filtered, opts, None, &repo.git_dir)?;
+    }
+    Ok(has_diff)
 }
 
 // ── Diff helpers ─────────────────────────────────────────────────────
@@ -1620,13 +1662,85 @@ fn read_blob_pair(odb: &Odb, entry: &DiffEntry) -> Result<(String, String)> {
 }
 
 /// Apply all post-diff filters: pathspecs and max-depth.
-fn filter_entries(entries: Vec<DiffEntry>, opts: &Options) -> Vec<DiffEntry> {
+fn filter_entries(odb: &Odb, entries: Vec<DiffEntry>, opts: &Options) -> Result<Vec<DiffEntry>> {
     let filtered = filter_pathspecs(entries, &opts.pathspecs);
-    if let Some(depth) = opts.max_depth {
+    let filtered = if let Some(depth) = opts.max_depth {
         filter_max_depth(filtered, depth, &opts.pathspecs)
     } else {
         filtered
+    };
+    apply_pickaxe_filter(odb, filtered, opts)
+}
+
+/// Read blob bytes for pickaxe checks (empty for missing/zero OIDs).
+fn read_content_raw_for_pickaxe(odb: &Odb, oid: &ObjectId) -> Vec<u8> {
+    if *oid == zero_oid() {
+        return Vec::new();
     }
+    odb.read(oid).map(|o| o.data).unwrap_or_default()
+}
+
+/// Keep only diff entries that match `-G` / `-S` pickaxe rules (same semantics as `git diff`).
+fn apply_pickaxe_filter(
+    odb: &Odb,
+    entries: Vec<DiffEntry>,
+    opts: &Options,
+) -> Result<Vec<DiffEntry>> {
+    if let Some(ref pattern) = opts.pickaxe_grep {
+        let re = regex::Regex::new(pattern)
+            .with_context(|| format!("invalid pickaxe regex: {pattern}"))?;
+        return Ok(entries
+            .into_iter()
+            .filter(|e| {
+                let old = read_content_raw_for_pickaxe(odb, &e.old_oid);
+                let new = read_content_raw_for_pickaxe(odb, &e.new_oid);
+                let old_s = String::from_utf8_lossy(&old);
+                let new_s = String::from_utf8_lossy(&new);
+                for line in new_s.lines() {
+                    if re.is_match(line) {
+                        return true;
+                    }
+                }
+                for line in old_s.lines() {
+                    if re.is_match(line) {
+                        return true;
+                    }
+                }
+                false
+            })
+            .collect());
+    }
+    if let Some(ref needle) = opts.pickaxe_string {
+        if opts.pickaxe_regex {
+            let re = regex::Regex::new(needle)
+                .with_context(|| format!("invalid pickaxe regex: {needle}"))?;
+            return Ok(entries
+                .into_iter()
+                .filter(|e| {
+                    let old = read_content_raw_for_pickaxe(odb, &e.old_oid);
+                    let new = read_content_raw_for_pickaxe(odb, &e.new_oid);
+                    let old_s = String::from_utf8_lossy(&old);
+                    let new_s = String::from_utf8_lossy(&new);
+                    let old_count = re.find_iter(&old_s).count();
+                    let new_count = re.find_iter(&new_s).count();
+                    old_count != new_count
+                })
+                .collect());
+        }
+        return Ok(entries
+            .into_iter()
+            .filter(|e| {
+                let old = read_content_raw_for_pickaxe(odb, &e.old_oid);
+                let new = read_content_raw_for_pickaxe(odb, &e.new_oid);
+                let old_s = String::from_utf8_lossy(&old);
+                let new_s = String::from_utf8_lossy(&new);
+                let old_count = old_s.matches(needle.as_str()).count();
+                let new_count = new_s.matches(needle.as_str()).count();
+                old_count != new_count
+            })
+            .collect());
+    }
+    Ok(entries)
 }
 
 fn filter_pathspecs(entries: Vec<DiffEntry>, pathspecs: &[String]) -> Vec<DiffEntry> {

--- a/logs/2026-04-09_t4035-diff-quiet.md
+++ b/logs/2026-04-09_t4035-diff-quiet.md
@@ -1,0 +1,23 @@
+# t4035-diff-quiet
+
+## Summary
+
+Made `tests/t4035-diff-quiet.sh` pass 23/23.
+
+## Changes
+
+- **`grit diff-tree` (`diff_tree.rs`)**
+  - `--quiet` in `--stdin` mode: suppress raw/patch output and remerge buffer; still print commit id line (matches Git); keep `-v` message output.
+  - Two-tree stdin lines: suppress tree OID header under `--quiet` while still computing exit status.
+  - Implemented `-S` / `-G` / `--pickaxe-regex` filtering on diff entries (blob occurrence / line regex), aligned with `git diff` logic.
+
+- **`grit diff` (`diff.rs`)**
+  - `git diff <path> <path>` when both are filesystem paths: compare worktree file in repo to second path (cwd-relative).
+  - When not in a repo and two paths: delegate to `--no-index` behavior (ceiling-directory case in t4035).
+  - `run_no_index`: apply whitespace-ignore normalization before `--quiet` exit 1.
+
+## Validation
+
+- `./scripts/run-tests.sh t4035-diff-quiet.sh` → 23/23
+- `cargo test -p grit-lib --lib`
+- `cargo check -p grit-rs`

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   256 |
+| Completed   |   257 |
 | In progress |     4 |
-| Remaining   |   508 |
+| Remaining   |   507 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 256 completed (`[x]`), 4 in progress (`[~]`), 508 remaining (`[ ]`).
+Task lines in `PLAN.md`: 257 completed (`[x]`), 4 in progress (`[~]`), 507 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t4035-diff-quiet` — 23/23 tests pass (`diff-tree --stdin --quiet` suppresses raw diff while keeping commit id; `-S`/`-G` pickaxe filtering for `diff-tree`; `diff` two-path mode in/out of repo + `run_no_index` `--quiet` after whitespace normalization; harness CSV refreshed)
 - `t5334-incremental-multi-pack-index` — 16/16 tests pass (incremental MIDX chain, bitmap/rev sidecars in `multi-pack-index.d`, `midx verify`, clone with `pack.allowPackReuse`; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t4120-apply-popt` — 12/12 tests pass (`git apply -p`: strip path components, malformed `-p` errors, traditional quoted paths, `--stat` with oversized strip, mode-only and rename patches with `--index`; harness CSV/dashboards refreshed)
 - `t5320-delta-islands` — 15/15 tests pass (`repack` delta islands: `pack.island` / `pack.islandcore`, superset-island delta rules, verify-pack ordering; harness CSV/dashboards refreshed)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t4035-diff-quiet` (return codes and quiet output for diff plumbing) now passes **23/23** in the harness.

## Changes

- **`diff-tree`**: `--quiet` with `--stdin` suppresses raw/patch output while still emitting the commit id line (matching Git). Two-tree stdin lines no longer print the tree header under `--quiet`. Implemented **`-S` / `-G` / `--pickaxe-regex`** pickaxe filtering on tree diffs so `-Snot-found` can yield exit 0.
- **`diff`**: Support **`git diff <in-repo-path> <other-path>`** (worktree file vs arbitrary path). When **not in a repository** and two paths are given, use **`--no-index`** semantics (covers `GIT_CEILING_DIRECTORIES` cases). In **`run_no_index`**, apply whitespace-ignore normalization **before** `--quiet` decides exit 1.

## Validation

- `./scripts/run-tests.sh t4035-diff-quiet.sh`
- `cargo test -p grit-lib --lib`
- `cargo check -p grit-rs`

Also refreshed `data/test-files.csv`, dashboards, `PLAN.md`, `progress.md`, and added `logs/2026-04-09_t4035-diff-quiet.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9a71385-01b9-44d8-93f3-e0b02670ef1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9a71385-01b9-44d8-93f3-e0b02670ef1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

