### PR TITLE
chore: t8330-switch-track harness 30/30 + metadata refresh

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1325,7 +1325,7 @@ t8290-log-grep-message	t8	yes	30	28	2	false	ok	0
 t8300-rev-list-objects	t8	yes	34	34	0	true	ok	0
 t8310-for-each-ref-format-deep	t8	yes	32	32	0	true	ok	0
 t8320-config-global-local	t8	yes	34	34	0	true	ok	0
-t8330-switch-track	t8	yes	30	10	20	false	ok	0
+t8330-switch-track	t8	yes	30	30	0	true	ok	0
 t8340-restore-staged	t8	yes	27	27	0	true	ok	0
 t8350-checkout-index-force	t8	yes	30	30	0	true	ok	0
 t8360-read-tree-twoway	t8	yes	25	20	5	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T04:59:38+00:00" class="gen-time" title="2026-04-09 04:59 UTC">2026-04-09 04:59 UTC</time> · <a href="https://github.com/schacon/grit/commit/7562795cfa41cdf65ae1b9e3a00095363a4c577c" style="color:#58a6ff">7562795</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T05:01:21+00:00" class="gen-time" title="2026-04-09 05:01 UTC">2026-04-09 05:01 UTC</time> · <a href="https://github.com/schacon/grit/commit/2a8d953e65845b8d4d46cb8fd960fe3d14c03a4a" style="color:#58a6ff">2a8d953</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,289</div>
+      <div class="summary-big-val">30,309</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>761 files fully passing</span>
+    <span>762 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -267,11 +267,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t8</span>
         <span class="group-desc">Porcelainish commands concerning forensics</span>
-        <span class="group-meta">82/105 files · 0 skipped · 2,874/3,116 tests</span>
+        <span class="group-meta">83/105 files · 0 skipped · 2,894/3,116 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:92.2%"></div></div>
-        <span class="group-pct pct-green">92.2%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:92.9%"></div></div>
+        <span class="group-pct pct-green">92.9%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t9">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:59:38+00:00" class="gen-time" title="2026-04-09 04:59 UTC">2026-04-09 04:59 UTC</time> · <a href="https://github.com/schacon/grit/commit/7562795cfa41cdf65ae1b9e3a00095363a4c577c" style="color:#58a6ff">7562795</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:01:21+00:00" class="gen-time" title="2026-04-09 05:01 UTC">2026-04-09 05:01 UTC</time> · <a href="https://github.com/schacon/grit/commit/2a8d953e65845b8d4d46cb8fd960fe3d14c03a4a" style="color:#58a6ff">2a8d953</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,289</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,309</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">76.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -13407,14 +13407,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t8" data-tests="30" data-passed="10">
+<tr class="" data-group="t8" data-tests="30" data-passed="30" data-full-pass="1">
   <td class="mono">t8330-switch-track</td>
   <td>t8</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">30</td>
-  <td class="right">10</td>
+  <td class="right">30</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:33.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t8" data-tests="27" data-passed="27" data-full-pass="1">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t8330-switch-track.sh` already passes all 30 cases against the current `grit` implementation. The branch `data/test-files.csv` row was stale (10 passed / 20 failed).

## Changes

- Refreshed `data/test-files.csv` after `./scripts/run-tests.sh t8330-switch-track.sh` so the row reflects **30/30** and `fully_passing=true`.
- Regenerated `docs/index.html` and `docs/testfiles.html` from the CSV.

## Verification

```bash
cargo build --release -p grit-rs
./scripts/run-tests.sh t8330-switch-track.sh
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba613cad-05e9-4807-a08d-bcf2c3be03af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba613cad-05e9-4807-a08d-bcf2c3be03af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

