### PR TITLE
t5308: pack duplicate detection — full pass + harness refresh

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -568,7 +568,7 @@ commit → check it off → move on.
 - [ ] `t5529-push-errors` ████████████░░░░░░░░ 5/8 (3 left) — detect some push errors early (before contacting remote)
 - [ ] `t5583-push-branches` ████████████░░░░░░░░ 5/8 (3 left) — check the consisitency of behavior of --all and --branches
 - [ ] `t5536-fetch-conflicts` ███████████░░░░░░░░░ 4/7 (3 left) — fetch handles conflicting refspecs correctly
-- [ ] `t5308-pack-detect-duplicates` ██████████░░░░░░░░░░ 3/6 (3 left) — handling of duplicate objects in incoming packfiles
+- [x] `t5308-pack-detect-duplicates` ████████████████████ 6/6 (0 left) — handling of duplicate objects in incoming packfiles
 - [ ] `t5549-fetch-push-http` ░░░░░░░░░░░░░░░░░░░░ 0/3 (3 left) — fetch/push functionality using the HTTP protocol
 - [x] `t5704-protocol-violations` ████████████████████ 3/3 — Test responses to violations of the network protocol. In most
 

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -874,7 +874,7 @@ t5304-prune-packed	t5	yes	20	18	2	false	ok	0
 t5305-include-tag	t5	yes	15	8	7	false	ok	0
 t5306-pack-nobase	t5	yes	4	4	0	true	ok	0
 t5307-pack-missing-commit	t5	yes	5	5	0	true	ok	0
-t5308-pack-detect-duplicates	t5	yes	6	2	4	false	ok	0
+t5308-pack-detect-duplicates	t5	yes	6	6	0	true	ok	0
 t5309-pack-delta-cycles	t5	yes	7	2	5	false	ok	0
 t5310-pack-bitmaps	t5	yes	236	23	213	false	ok	0
 t5311-pack-bitmaps-shallow	t5	yes	6	6	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T05:02:15+00:00" class="gen-time" title="2026-04-09 05:02 UTC">2026-04-09 05:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/366a3313f2efeac6a9e780151ae05c52ee1cccd6" style="color:#58a6ff">366a331</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T05:03:12+00:00" class="gen-time" title="2026-04-09 05:03 UTC">2026-04-09 05:03 UTC</time> · <a href="https://github.com/schacon/grit/commit/e34aa38c934a376ff8c41745e932971ab77a9e0b" style="color:#58a6ff">e34aa38</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,309</div>
+      <div class="summary-big-val">30,313</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>762 files fully passing</span>
+    <span>763 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">39/167 files · 17 skipped · 1,469/3,949 tests</span>
+        <span class="group-meta">40/167 files · 17 skipped · 1,473/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.2%"></div></div>
-        <span class="group-pct pct-red">37.2%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.3%"></div></div>
+        <span class="group-pct pct-red">37.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:02:15+00:00" class="gen-time" title="2026-04-09 05:02 UTC">2026-04-09 05:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/366a3313f2efeac6a9e780151ae05c52ee1cccd6" style="color:#58a6ff">366a331</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:03:12+00:00" class="gen-time" title="2026-04-09 05:03 UTC">2026-04-09 05:03 UTC</time> · <a href="https://github.com/schacon/grit/commit/e34aa38c934a376ff8c41745e932971ab77a9e0b" style="color:#58a6ff">e34aa38</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,309</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,313</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">76.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -8897,14 +8897,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="6" data-passed="2">
+<tr class="" data-group="t5" data-tests="6" data-passed="6" data-full-pass="1">
   <td class="mono">t5308-pack-detect-duplicates</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">6</td>
-  <td class="right">2</td>
+  <td class="right">6</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:33.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="7" data-passed="2">

--- a/logs/2026-04-09_t5308-pack-detect-duplicates.md
+++ b/logs/2026-04-09_t5308-pack-detect-duplicates.md
@@ -1,0 +1,12 @@
+# t5308-pack-detect-duplicates
+
+**Date:** 2026-04-09
+
+## Outcome
+
+`./scripts/run-tests.sh t5308-pack-detect-duplicates.sh` reports **6/6** passing. No Rust changes were required on this branch; behavior is already implemented in `grit/src/commands/index_pack.rs` (`--strict` duplicate detection via `HashSet` over resolved OIDs, default path allows duplicates).
+
+## Actions
+
+- Refreshed `data/test-files.csv` and dashboards (`docs/index.html`, `docs/testfiles.html`) from the harness run.
+- Marked the task complete in `PLAN.md` and updated counts in `progress.md`.

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   261 |
+| Completed   |   262 |
 | In progress |     4 |
-| Remaining   |   503 |
+| Remaining   |   502 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 261 completed (`[x]`), 4 in progress (`[~]`), 503 remaining (`[ ]`).
+Task lines in `PLAN.md`: 262 completed (`[x]`), 4 in progress (`[~]`), 502 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t5308-pack-detect-duplicates` — 6/6 tests pass (`index-pack` allows duplicate OIDs by default; `--strict` rejects duplicates with non-zero exit and leaves objects out of the ODB; `cat-file --batch-check` resolves OIDs in packs with duplicate runs; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t7402-submodule-rebase` — 6/6 tests pass (rebase with dirty submodule, interactive rebase, dirty file+submodule failure, stash dirty submodule, submodule gitlink conflict message; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t5317-pack-objects-filter-objects` — 33/33 tests pass (`pack-objects --filter` object filtering; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t5603-clone-dirname` — 47/47 tests pass (clone default directory from `host:path`, `ssh://` URLs: strip trailing slashes and `.git`, redact userinfo for dirname, preserve path segments like `foo@bar` and `test:1234`; harness CSV/dashboards refreshed)

--- a/test-results.md
+++ b/test-results.md
@@ -2,6 +2,7 @@
 
 **Updated:** 2026-04-09
 
+- `./scripts/run-tests.sh t5308-pack-detect-duplicates.sh`: 6/6 passing (duplicate objects in pack: default `index-pack` accepts; `--strict` rejects and leaves ODB unchanged; `cat-file --batch-check` over duplicated pack; harness CSV/dashboards refreshed).
 - `./scripts/run-tests.sh t4120-apply-popt.sh`: 12/12 passing (`git apply -p` strip count, invalid `-p` diagnostics, quoted traditional diff paths, `--stat` oversized strip, mode-only and rename with `--index`; harness CSV/dashboards refreshed).
 
 **Updated:** 2026-04-08


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t5308-pack-detect-duplicates` now reports **6/6** in the harness. Grit already implements the required behavior in `index-pack` (`--strict` rejects duplicate OIDs; default mode accepts them).

## Changes

- Refreshed `data/test-files.csv` and dashboards from `./scripts/run-tests.sh t5308-pack-detect-duplicates.sh`.
- Marked the task complete in `PLAN.md`, updated counts in `progress.md`, noted the run in `test-results.md`, and added `logs/2026-04-09_t5308-pack-detect-duplicates.md`.

## Verification

- `./scripts/run-tests.sh t5308-pack-detect-duplicates.sh`: 6/6
- `cargo test -p grit-lib --lib`: 121/121
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c466abc-3967-4134-b35b-e0d09dc379a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c466abc-3967-4134-b35b-e0d09dc379a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

