### PR TITLE
docs: t5530-upload-pack-error fully passing (11/11)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -617,7 +617,7 @@ commit → check it off → move on.
 - [ ] `t5305-include-tag` ████████░░░░░░░░░░░░ 6/15 (9 left) — git pack-object --include-tag
 - [ ] `t5401-update-hooks` ██████░░░░░░░░░░░░░░ 4/13 (9 left) — Test the update hook infrastructure.
 - [x] `t5621-clone-revision` — tests for git clone --revision (12/12)
-- [ ] `t5530-upload-pack-error` ███░░░░░░░░░░░░░░░░░ 2/11 (9 left) — errors in upload-pack
+- [x] `t5530-upload-pack-error` — errors in upload-pack (11/11)
 - [ ] `t5150-request-pull` ██░░░░░░░░░░░░░░░░░░ 1/10 (9 left) — Test workflows involving pull request.
 - [x] `t5320-delta-islands` ████████████████████ 15/15 (0 left) — exercise delta islands
 - [ ] `t5611-clone-config` ████░░░░░░░░░░░░░░░░ 3/13 (10 left) — tests for git clone -c key=value

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -946,7 +946,7 @@ t5526-fetch-submodules	t5	yes	56	4	52	false	ok	0
 t5527-fetch-odd-refs	t5	yes	5	5	0	true	ok	0
 t5528-push-default	t5	yes	31	13	18	false	ok	1
 t5529-push-errors	t5	yes	8	8	0	true	ok	0
-t5530-upload-pack-error	t5	yes	11	3	8	false	ok	0
+t5530-upload-pack-error	t5	yes	11	11	0	true	ok	0
 t5531-deep-nested-push	t5	yes	4	4	0	true	ok	0
 t5531-deep-submodule-push	t5	yes	29	6	23	false	ok	0
 t5532-fetch-proxy	t5	yes	5	4	1	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T05:02:15+00:00" class="gen-time" title="2026-04-09 05:02 UTC">2026-04-09 05:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/366a3313f2efeac6a9e780151ae05c52ee1cccd6" style="color:#58a6ff">366a331</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T05:03:54+00:00" class="gen-time" title="2026-04-09 05:03 UTC">2026-04-09 05:03 UTC</time> · <a href="https://github.com/schacon/grit/commit/e34aa38c934a376ff8c41745e932971ab77a9e0b" style="color:#58a6ff">e34aa38</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,309</div>
+      <div class="summary-big-val">30,317</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>762 files fully passing</span>
+    <span>763 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">39/167 files · 17 skipped · 1,469/3,949 tests</span>
+        <span class="group-meta">40/167 files · 17 skipped · 1,477/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.2%"></div></div>
-        <span class="group-pct pct-red">37.2%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.4%"></div></div>
+        <span class="group-pct pct-red">37.4%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:02:15+00:00" class="gen-time" title="2026-04-09 05:02 UTC">2026-04-09 05:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/366a3313f2efeac6a9e780151ae05c52ee1cccd6" style="color:#58a6ff">366a331</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:03:54+00:00" class="gen-time" title="2026-04-09 05:03 UTC">2026-04-09 05:03 UTC</time> · <a href="https://github.com/schacon/grit/commit/e34aa38c934a376ff8c41745e932971ab77a9e0b" style="color:#58a6ff">e34aa38</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,309</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,317</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">76.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -9617,14 +9617,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="3">
+<tr class="" data-group="t5" data-tests="11" data-passed="11" data-full-pass="1">
   <td class="mono">t5530-upload-pack-error</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">11</td>
-  <td class="right">3</td>
+  <td class="right">11</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:27.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="4" data-passed="4" data-full-pass="1">

--- a/logs/2026-04-09_t5530-upload-pack-error.md
+++ b/logs/2026-04-09_t5530-upload-pack-error.md
@@ -1,0 +1,4 @@
+# t5530-upload-pack-error
+
+- Ran `./scripts/run-tests.sh t5530-upload-pack-error.sh`: **11/11** pass on current `grit` (no Rust changes this session).
+- Refreshed `data/test-files.csv` and dashboards; marked task complete in `PLAN.md` and updated `progress.md` counts.

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   261 |
+| Completed   |   262 |
 | In progress |     4 |
-| Remaining   |   503 |
+| Remaining   |   502 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 261 completed (`[x]`), 4 in progress (`[~]`), 503 remaining (`[ ]`).
+Task lines in `PLAN.md`: 262 completed (`[x]`), 4 in progress (`[~]`), 502 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t5530-upload-pack-error` — 11/11 tests pass (corrupt-object upload-pack/pack-objects errors, bad want handling, stateless EOF, fetch failure, v0/v2 ACK dedup for repeated non-commit haves; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t7402-submodule-rebase` — 6/6 tests pass (rebase with dirty submodule, interactive rebase, dirty file+submodule failure, stash dirty submodule, submodule gitlink conflict message; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t5317-pack-objects-filter-objects` — 33/33 tests pass (`pack-objects --filter` object filtering; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t5603-clone-dirname` — 47/47 tests pass (clone default directory from `host:path`, `ssh://` URLs: strip trailing slashes and `.git`, redact userinfo for dirname, preserve path segments like `foo@bar` and `test:1234`; harness CSV/dashboards refreshed)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t5530-upload-pack-error.sh` already passes **11/11** on current `grit` (upload-pack error paths, bad wants, stateless EOF, fetch failure, v0/v2 ACK behavior). This change records that in the harness and planning docs.

## Changes

- Refresh `data/test-files.csv` and generated dashboards after `./scripts/run-tests.sh t5530-upload-pack-error.sh`.
- Mark `t5530-upload-pack-error` complete in `PLAN.md` and bump counts in `progress.md`.
- Add `logs/2026-04-09_t5530-upload-pack-error.md`.

## Verification

```bash
./scripts/run-tests.sh t5530-upload-pack-error.sh
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66d390cf-badb-42ea-bbde-61d4b8dd19e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66d390cf-badb-42ea-bbde-61d4b8dd19e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

