### PR TITLE
fix: make t3650-replay-basics fully pass

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -343,7 +343,7 @@ commit → check it off → move on.
 
 - [ ] `t3311-notes-merge-fanout` ░░░░░░░░░░░░░░░░░░░░ 1/24 (23 left) — Test notes merging at various fanout levels
 - [ ] `t3418-rebase-continue` ████░░░░░░░░░░░░░░░░ 6/30 (24 left) — git rebase --continue tests
-- [ ] `t3650-replay-basics` ███░░░░░░░░░░░░░░░░░ 6/31 (25 left) — basic git replay tests
+- [x] `t3650-replay-basics` — basic git replay tests (31/31)
 - [ ] `t3426-rebase-submodule` ██░░░░░░░░░░░░░░░░░░ 4/29 (25 left) — rebase can handle submodules
 - [ ] `t3452-history-split` ░░░░░░░░░░░░░░░░░░░░ 0/25 (25 left) — tests for git-history split subcommand
 - [ ] `t3203-branch-output` ███████░░░░░░░░░░░░░ 15/41 (26 left) — git branch display tests

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -650,7 +650,7 @@ t3514-cherry-pick-revert-gpg	t3	skip	2	0	0	false	ok	0
 t3600-rm	t3	yes	82	54	28	false	ok	0
 t3601-rm-pathspec-file	t3	yes	5	2	3	false	ok	0
 t3602-rm-sparse-checkout	t3	yes	13	2	11	false	ok	0
-t3650-replay-basics	t3	yes	0	0	0	false	timeout	0
+t3650-replay-basics	t3	yes	31	31	0	true	ok	0
 t3700-add	t3	yes	58	42	16	false	ok	0
 t3700-add-pathspec-file	t3	yes	24	24	0	true	ok	0
 t3701-add-interactive	t3	yes	130	27	103	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T04:39:17+00:00" class="gen-time" title="2026-04-09 04:39 UTC">2026-04-09 04:39 UTC</time> · <a href="https://github.com/schacon/grit/commit/75778543ac9aae2e69e7e001dd0fdb2a20ae006f" style="color:#58a6ff">7577854</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T05:04:29+00:00" class="gen-time" title="2026-04-09 05:04 UTC">2026-04-09 05:04 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ed901d6977ffb503a758a4eb7028a540987221a" style="color:#58a6ff">8ed901d</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,11 +150,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,008</div>
+      <div class="summary-big-val">30,039</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">39,873</div>
+      <div class="summary-big-val">39,904</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>754 files fully passing</span>
+    <span>755 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,11 +212,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">46/141 files · 2 skipped · 3,387/4,619 tests</span>
+        <span class="group-meta">47/141 files · 2 skipped · 3,418/4,650 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:73.3%"></div></div>
-        <span class="group-pct pct-blue">73.3%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:73.5%"></div></div>
+        <span class="group-pct pct-blue">73.5%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:39:17+00:00" class="gen-time" title="2026-04-09 04:39 UTC">2026-04-09 04:39 UTC</time> · <a href="https://github.com/schacon/grit/commit/75778543ac9aae2e69e7e001dd0fdb2a20ae006f" style="color:#58a6ff">7577854</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:04:29+00:00" class="gen-time" title="2026-04-09 05:04 UTC">2026-04-09 05:04 UTC</time> · <a href="https://github.com/schacon/grit/commit/8ed901d6977ffb503a758a4eb7028a540987221a" style="color:#58a6ff">8ed901d</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,008</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n" id="sum-tests">39,904</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,039</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">75.3%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -6657,14 +6657,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:15.4%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="0" data-passed="0">
+<tr class="" data-group="t3" data-tests="31" data-passed="31" data-full-pass="1">
   <td class="mono">t3650-replay-basics</td>
   <td>t3</td>
-  <td></td>
-  <td class="right">0</td>
-  <td class="right">0</td>
-  <td class="right">timeout</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td><span class="badge ok">full pass</span></td>
+  <td class="right">31</td>
+  <td class="right">31</td>
+  <td class="right">ok</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="58" data-passed="42">

--- a/grit-lib/src/rev_parse.rs
+++ b/grit-lib/src/rev_parse.rs
@@ -2287,6 +2287,44 @@ fn apply_peel(repo: &Repository, mut oid: ObjectId, peel: Option<&str>) -> Resul
     }
 }
 
+/// Expand a single revision token that ends with `^!` (Git: commit without its parents).
+///
+/// Returns one token unchanged when `^!` is absent. When present, returns two tokens: the base
+/// revision (without `^!`) and a negative spec `^<first-parent-hex>` so that `rev-list` includes
+/// exactly that commit when combined with the exclusion. Merge commits and other multi-parent
+/// commits are rejected with the same ambiguity error as Git.
+///
+/// # Errors
+///
+/// Returns [`Error::Message`] for ambiguous `^!` (merge commit) and resolution failures.
+pub fn expand_rev_token_circ_bang(repo: &Repository, token: &str) -> Result<Vec<String>> {
+    let Some(base) = token.strip_suffix("^!") else {
+        return Ok(vec![token.to_owned()]);
+    };
+    if base.is_empty() {
+        return Err(Error::Message(format!(
+            "fatal: ambiguous argument '{token}': unknown revision or path not in the working tree.\n\
+Use '--' to separate paths from revisions, like this:\n\
+'git <command> [<revision>...] -- [<file>...]'"
+        )));
+    }
+    let oid = resolve_revision_for_range_end(repo, base)?;
+    let commit_oid = peel_to_commit_for_merge_base(repo, oid)?;
+    let obj = repo.odb.read(&commit_oid)?;
+    let commit = parse_commit(&obj.data)?;
+    if commit.parents.len() != 1 {
+        return Err(Error::Message(format!(
+            "fatal: ambiguous argument '{token}': unknown revision or path not in the working tree.\n\
+Use '--' to separate paths from revisions, like this:\n\
+'git <command> [<revision>...] -- [<file>...]'"
+        )));
+    }
+    Ok(vec![
+        base.to_owned(),
+        format!("^{}", commit.parents[0].to_hex()),
+    ])
+}
+
 /// Split `spec` into `(base, peel_inner)` for `^{...}` / `^0` suffixes (same rules as revision parsing).
 #[must_use]
 pub fn parse_peel_suffix(spec: &str) -> (&str, Option<&str>) {

--- a/grit/src/commands/log.rs
+++ b/grit/src/commands/log.rs
@@ -840,7 +840,8 @@ fn parse_date_to_epoch(s: &str) -> Option<i64> {
 /// with `%d` / `%D` when decorations are required.
 fn resolve_decoration_display(args: &Args, format_requires_decorations: bool) -> (bool, bool) {
     let mut show = format_requires_decorations;
-    let mut full = format_requires_decorations;
+    // Git enables decorations for `%d` / `%D` with short ref names; `--decorate=full` opts in.
+    let mut full = false;
     for arg in std::env::args() {
         if arg == "--no-decorate" {
             show = false;

--- a/grit/src/commands/replay.rs
+++ b/grit/src/commands/replay.rs
@@ -1,8 +1,9 @@
-//! `grit replay` — replay commits on a new base.
+//! `grit replay` — replay commits on a new base (Git-compatible subset).
 //!
-//! Replays a linear range of commits onto a new base, using merge-ort style
-//! tree merging for each replayed commit and printing an `update-ref --stdin`
-//! command for the updated branch.
+//! Replays commits selected by `rev-list` semantics onto `--onto` or advances a
+//! single branch with `--advance`, using merge-ort style tree merging. Ref
+//! updates are applied atomically (best-effort) or printed with
+//! `--ref-action=print`.
 
 use crate::commands::merge::{
     merge_trees_for_replay, MergeDirectoryRenamesMode, MergeRenameOptions,
@@ -16,11 +17,12 @@ use grit_lib::merge_file::MergeFavor;
 use grit_lib::objects::{
     parse_commit, parse_tree, serialize_commit, CommitData, ObjectId, ObjectKind,
 };
-use grit_lib::refs::resolve_ref;
+use grit_lib::refs::{self, read_head, resolve_ref};
 use grit_lib::repo::Repository;
-use grit_lib::rev_parse::resolve_revision;
+use grit_lib::rev_list::{rev_list, split_revision_token, OrderingMode, RevListOptions};
+use grit_lib::rev_parse::{expand_rev_token_circ_bang, resolve_revision_as_commit};
 use grit_lib::write_tree::write_tree_from_index;
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::io::Write;
 use std::path::Path;
@@ -30,19 +32,30 @@ use time::OffsetDateTime;
 #[derive(Debug, ClapArgs)]
 #[command(about = "Replay commits on a new base")]
 pub struct Args {
-    /// Raw arguments forwarded to the system Git binary.
+    /// Raw arguments forwarded from the grit dispatcher.
     #[arg(value_name = "ARG", num_args = 0.., allow_hyphen_values = true, trailing_var_arg = true)]
     pub args: Vec<String>,
 }
 
-#[derive(Debug, Default)]
-struct ParsedReplayArgs {
-    onto: Option<String>,
-    range: Option<String>,
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RefAction {
+    Update,
+    Print,
 }
 
-fn parse_args(raw: &[String]) -> Result<ParsedReplayArgs> {
-    let mut parsed = ParsedReplayArgs::default();
+#[derive(Debug, Default)]
+struct ParsedReplayCli {
+    onto: Option<String>,
+    advance: Option<String>,
+    contained: bool,
+    ref_action_cli: Option<String>,
+    branches: bool,
+    ancestry_path: Option<String>,
+    revisions: Vec<String>,
+}
+
+fn parse_replay_cli(raw: &[String]) -> Result<ParsedReplayCli> {
+    let mut out = ParsedReplayCli::default();
     let mut i = 0usize;
     while i < raw.len() {
         let arg = &raw[i];
@@ -50,7 +63,7 @@ fn parse_args(raw: &[String]) -> Result<ParsedReplayArgs> {
             let Some(value) = raw.get(i + 1) else {
                 bail!("error: option '--onto' requires a value");
             };
-            parsed.onto = Some(value.clone());
+            out.onto = Some(value.clone());
             i += 2;
             continue;
         }
@@ -58,58 +71,284 @@ fn parse_args(raw: &[String]) -> Result<ParsedReplayArgs> {
             if value.is_empty() {
                 bail!("error: option '--onto' requires a value");
             }
-            parsed.onto = Some(value.to_owned());
+            out.onto = Some(value.to_owned());
+            i += 1;
+            continue;
+        }
+        if arg == "--advance" {
+            let Some(value) = raw.get(i + 1) else {
+                bail!("error: option '--advance' requires a value");
+            };
+            out.advance = Some(value.clone());
+            i += 2;
+            continue;
+        }
+        if let Some(value) = arg.strip_prefix("--advance=") {
+            if value.is_empty() {
+                bail!("error: option '--advance' requires a value");
+            }
+            out.advance = Some(value.to_owned());
+            i += 1;
+            continue;
+        }
+        if arg == "--contained" {
+            out.contained = true;
+            i += 1;
+            continue;
+        }
+        if arg == "--ref-action" {
+            let Some(value) = raw.get(i + 1) else {
+                bail!("error: option '--ref-action' requires a value");
+            };
+            out.ref_action_cli = Some(value.clone());
+            i += 2;
+            continue;
+        }
+        if let Some(value) = arg.strip_prefix("--ref-action=") {
+            if value.is_empty() {
+                bail!("error: option '--ref-action' requires a value");
+            }
+            out.ref_action_cli = Some(value.to_owned());
+            i += 1;
+            continue;
+        }
+        if arg == "--branches" {
+            out.branches = true;
+            i += 1;
+            continue;
+        }
+        if arg == "--ancestry-path" {
+            let Some(value) = raw.get(i + 1) else {
+                bail!("error: option '--ancestry-path' requires a value");
+            };
+            out.ancestry_path = Some(value.clone());
+            i += 2;
+            continue;
+        }
+        if let Some(value) = arg.strip_prefix("--ancestry-path=") {
+            if value.is_empty() {
+                bail!("error: option '--ancestry-path' requires a value");
+            }
+            out.ancestry_path = Some(value.to_owned());
             i += 1;
             continue;
         }
         if arg.starts_with('-') {
             bail!("unsupported option: {arg}");
         }
-        if parsed.range.is_some() {
-            bail!("error: multiple revision ranges are not supported");
-        }
-        parsed.range = Some(arg.clone());
+        out.revisions.push(arg.clone());
         i += 1;
     }
-    Ok(parsed)
+    Ok(out)
+}
+
+fn parse_ref_action_mode(raw: Option<&str>, source: &str) -> Result<RefAction> {
+    let s = raw.unwrap_or("update").trim();
+    if s.eq_ignore_ascii_case("update") {
+        return Ok(RefAction::Update);
+    }
+    if s.eq_ignore_ascii_case("print") {
+        return Ok(RefAction::Print);
+    }
+    bail!(
+        "invalid {source} value: '{raw}'",
+        raw = raw.unwrap_or_default()
+    );
+}
+
+fn ref_action_for_run(repo: &Repository, cli: Option<&str>) -> Result<RefAction> {
+    if let Some(v) = cli {
+        return parse_ref_action_mode(Some(v), "--ref-action");
+    }
+    let config = ConfigSet::load(Some(&repo.git_dir), true)?;
+    if let Some(v) = config.get("replay.refAction") {
+        return parse_ref_action_mode(Some(&v), "replay.refAction");
+    }
+    Ok(RefAction::Update)
+}
+
+fn peel_committish_for_mode(repo: &Repository, spec: &str, mode: &str) -> Result<ObjectId> {
+    resolve_revision_as_commit(repo, spec)
+        .map_err(|_| anyhow::anyhow!("fatal: '{spec}' is not a valid commit-ish for {mode}\n"))
+}
+
+fn try_dwim_single_branch_ref(git_dir: &Path, spec: &str) -> Result<Option<String>> {
+    let want_short = spec.strip_prefix("refs/heads/").unwrap_or(spec);
+    let mut matches: Vec<String> = Vec::new();
+    for (name, _) in refs::list_refs(git_dir, "refs/heads/")? {
+        if name == spec {
+            matches.push(name);
+            continue;
+        }
+        if let Some(tail) = name.strip_prefix("refs/heads/") {
+            if tail == want_short {
+                matches.push(name);
+            }
+        }
+    }
+    matches.sort();
+    matches.dedup();
+    if matches.len() == 1 {
+        Ok(Some(matches[0].clone()))
+    } else {
+        Ok(None)
+    }
+}
+
+fn collect_revision_specs(
+    repo: &Repository,
+    parsed: &ParsedReplayCli,
+) -> Result<(Vec<String>, Vec<String>)> {
+    let mut positive = Vec::new();
+    let mut negative = Vec::new();
+    for rev in &parsed.revisions {
+        for expanded in expand_rev_token_circ_bang(repo, rev)? {
+            let (pos, neg) = split_revision_token(&expanded);
+            positive.extend(pos);
+            negative.extend(neg);
+        }
+    }
+    if parsed.branches {
+        for (name, _) in refs::list_refs(&repo.git_dir, "refs/heads/")? {
+            positive.push(name);
+        }
+    }
+    Ok((positive, negative))
+}
+
+fn build_commit_to_refs_map(repo: &Repository) -> Result<HashMap<ObjectId, Vec<String>>> {
+    let mut map: HashMap<ObjectId, Vec<String>> = HashMap::new();
+    if let Ok(head_oid) = resolve_ref(&repo.git_dir, "HEAD") {
+        if let Ok(commit_oid) = grit_lib::rev_parse::peel_to_commit_for_merge_base(repo, head_oid) {
+            map.entry(commit_oid).or_default().push("HEAD".to_owned());
+        }
+    }
+    for (name, oid) in refs::list_refs(&repo.git_dir, "refs/")? {
+        let Ok(commit_oid) = grit_lib::rev_parse::peel_to_commit_for_merge_base(repo, oid) else {
+            continue;
+        };
+        map.entry(commit_oid).or_default().push(name);
+    }
+    Ok(map)
+}
+
+#[derive(Debug)]
+struct RefUpdateLine {
+    refname: String,
+    new_oid: ObjectId,
+    old_oid: ObjectId,
 }
 
 /// Run `grit replay`.
 pub fn run(args: Args) -> Result<()> {
-    let parsed = parse_args(&args.args)?;
-    let onto_spec = parsed
-        .onto
-        .ok_or_else(|| anyhow::anyhow!("error: option --onto is mandatory"))?;
-    let range = parsed
-        .range
-        .ok_or_else(|| anyhow::anyhow!("error: replay requires a revision range"))?;
-    let (upstream_spec, branch_spec) = range
-        .split_once("..")
-        .ok_or_else(|| anyhow::anyhow!("error: replay currently requires a <old>..<new> range"))?;
-    if upstream_spec.is_empty() || branch_spec.is_empty() {
-        bail!("error: invalid replay range '{range}'");
+    let parsed = parse_replay_cli(&args.args)?;
+    let has_onto = parsed.onto.is_some();
+    let has_advance = parsed.advance.is_some();
+    if !has_onto && !has_advance {
+        eprintln!("error: option --onto or --advance is mandatory");
+        eprintln!();
+        eprintln!("usage: git replay ([--contained] --onto <newbase> | --advance <branch>) [--ref-action[=<mode>]] <revision-range>");
+        std::process::exit(129);
+    }
+    if has_advance && parsed.contained {
+        bail!("fatal: options '--advance' and '--contained' cannot be used together");
+    }
+    if has_advance && has_onto {
+        bail!("fatal: options '--advance' and '--onto' cannot be used together");
     }
 
     let repo = Repository::discover(None).context("not a git repository")?;
-    let onto_oid = resolve_revision(&repo, &onto_spec)
-        .with_context(|| format!("bad revision '{onto_spec}'"))?;
-    let upstream_oid = resolve_revision(&repo, upstream_spec)
-        .with_context(|| format!("bad revision '{upstream_spec}'"))?;
-    let (target_ref, old_tip) = resolve_target_branch(&repo, branch_spec)?;
-    let branch_tip = resolve_revision(&repo, branch_spec)
-        .with_context(|| format!("bad revision '{branch_spec}'"))?;
-    let commits = collect_linear_commits_to_replay(&repo, upstream_oid, branch_tip)?;
+    let ref_mode = ref_action_for_run(&repo, parsed.ref_action_cli.as_deref())
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    let (positive_specs, negative_specs) = collect_revision_specs(&repo, &parsed)?;
+    if positive_specs.is_empty() {
+        bail!("fatal: need some commits to replay");
+    }
+
+    let mut rev_opts = RevListOptions::default();
+    rev_opts.ordering = OrderingMode::Topo;
+    rev_opts.reverse = true;
+    if let Some(ap) = parsed.ancestry_path.as_deref() {
+        rev_opts.ancestry_path = true;
+        let bottom = resolve_revision_as_commit(&repo, ap).map_err(|e| {
+            anyhow::anyhow!(
+                "{}",
+                e.to_string()
+                    .trim_start_matches("fatal: ")
+                    .trim_end_matches('\n')
+            )
+        })?;
+        rev_opts.ancestry_path_bottoms = vec![bottom];
+    }
+
+    let result = rev_list(&repo, &positive_specs, &negative_specs, &rev_opts)?;
+    let commits = result.commits;
+    if commits.is_empty() {
+        return Ok(());
+    }
+
+    let detached_head = read_head(&repo.git_dir)?.is_none();
+
+    let onto_oid = if let Some(onto_spec) = parsed.onto.as_deref() {
+        peel_committish_for_mode(&repo, onto_spec, "--onto")
+            .map_err(|e| anyhow::anyhow!("{}", e.to_string().trim_end_matches('\n')))?
+    } else {
+        let adv = parsed.advance.as_deref().expect("advance when no onto");
+        let full = try_dwim_single_branch_ref(&repo.git_dir, adv)?
+            .ok_or_else(|| anyhow::anyhow!("fatal: argument to --advance must be a reference"))?;
+        if positive_specs.len() > 1 {
+            bail!("fatal: cannot advance target with multiple sources because ordering would be ill-defined");
+        }
+        peel_committish_for_mode(&repo, &full, "--advance")
+            .map_err(|e| anyhow::anyhow!("{}", e.to_string().trim_end_matches('\n')))?
+    };
+
+    let positive_ref_fullnames: HashSet<String> = {
+        let mut s = HashSet::new();
+        for spec in &positive_specs {
+            if let Ok(Some(full)) = try_dwim_single_branch_ref(&repo.git_dir, spec) {
+                s.insert(full);
+            }
+        }
+        s
+    };
+
+    let advance_full_ref = if has_advance {
+        Some(
+            try_dwim_single_branch_ref(&repo.git_dir, parsed.advance.as_deref().expect("advance"))?
+                .ok_or_else(|| {
+                    anyhow::anyhow!("fatal: argument to --advance must be a reference")
+                })?,
+        )
+    } else {
+        None
+    };
+
+    if has_onto && positive_ref_fullnames.len() < positive_specs.len() {
+        bail!("fatal: all positive revisions given must be references");
+    }
+
+    let commit_to_refs = build_commit_to_refs_map(&repo)?;
+
     let merge_renormalize = read_merge_renormalize(&repo);
     let directory_renames = read_directory_renames(&repo);
+    let merge_dir_mode = MergeDirectoryRenamesMode::FromConfig;
+    let rename_opts = MergeRenameOptions::from_config(&repo);
+
+    let mut replayed: HashMap<ObjectId, ObjectId> = HashMap::new();
+    let mut replayed_tip = onto_oid;
     let mut cached_upstream_renames: HashMap<Vec<u8>, Vec<u8>> = HashMap::new();
 
-    let mut replayed_tip = onto_oid;
-    for commit_oid in commits {
+    for &commit_oid in &commits {
         let commit_obj = repo.odb.read(&commit_oid)?;
         let commit = parse_commit(&commit_obj.data)?;
         let parent_oid = *commit.parents.first().ok_or_else(|| {
-            anyhow::anyhow!("replaying down from root commit is not supported yet!")
+            anyhow::anyhow!("fatal: replaying down from root commit is not supported yet!")
         })?;
+        if commit.parents.len() > 1 {
+            bail!("fatal: replaying merge commits is not supported yet!");
+        }
 
         let base_tree = commit_tree(&repo, parent_oid)?;
         let ours_tree = commit_tree(&repo, replayed_tip)?;
@@ -179,8 +418,8 @@ pub fn run(args: Args) -> Result<()> {
             false,
             false,
             false,
-            MergeDirectoryRenamesMode::Disabled,
-            MergeRenameOptions::from_config(&repo),
+            merge_dir_mode,
+            rename_opts.clone(),
         )?;
         if merge_result.has_conflicts {
             let reason = merge_result
@@ -193,55 +432,105 @@ pub fn run(args: Args) -> Result<()> {
 
         let merged_tree = write_tree_from_index(&repo.odb, &merge_result.index, "")?;
 
-        // Drop commits that become empty after replay (matching git replay).
         if merged_tree == ours_tree && theirs_tree != base_tree {
+            replayed.insert(commit_oid, replayed_tip);
             continue;
         }
 
         replayed_tip = create_replayed_commit(&repo, replayed_tip, merged_tree, &commit)?;
+        replayed.insert(commit_oid, replayed_tip);
     }
 
-    println!(
-        "update refs/heads/{} {} {}",
-        target_ref,
-        replayed_tip.to_hex(),
-        old_tip.to_hex()
-    );
+    let mut updates: Vec<RefUpdateLine> = Vec::new();
+
+    if let Some(adv_full) = advance_full_ref {
+        let old_oid = resolve_ref(&repo.git_dir, &adv_full)?;
+        updates.push(RefUpdateLine {
+            refname: adv_full,
+            new_oid: replayed_tip,
+            old_oid,
+        });
+    } else {
+        let mut seen_ref: HashSet<String> = HashSet::new();
+        for commit_oid in &commits {
+            let Some(&new_tip) = replayed.get(commit_oid) else {
+                continue;
+            };
+            let Some(refs_at) = commit_to_refs.get(commit_oid) else {
+                continue;
+            };
+            for r in refs_at {
+                if r == "HEAD" {
+                    if !detached_head {
+                        continue;
+                    }
+                } else if !parsed.contained && !positive_ref_fullnames.contains(r) {
+                    continue;
+                }
+                if !seen_ref.insert(r.clone()) {
+                    continue;
+                }
+                let old_oid = resolve_ref(&repo.git_dir, r)?;
+                if old_oid == new_tip {
+                    continue;
+                }
+                updates.push(RefUpdateLine {
+                    refname: r.clone(),
+                    new_oid: new_tip,
+                    old_oid,
+                });
+            }
+        }
+    }
+
+    let reflog_msg = if has_advance {
+        format!(
+            "replay --advance {}",
+            parsed.advance.as_deref().expect("advance")
+        )
+    } else {
+        format!("replay --onto {}", onto_oid.to_hex())
+    };
+
+    match ref_mode {
+        RefAction::Print => {
+            let mut out = std::io::stdout().lock();
+            for u in &updates {
+                writeln!(
+                    out,
+                    "update {} {} {}",
+                    u.refname,
+                    u.new_oid.to_hex(),
+                    u.old_oid.to_hex()
+                )?;
+            }
+        }
+        RefAction::Update => {
+            for u in &updates {
+                refs::write_ref(&repo.git_dir, &u.refname, &u.new_oid)
+                    .with_context(|| format!("failed to update ref {}", u.refname))?;
+                if refs::should_autocreate_reflog(&repo.git_dir, &u.refname) {
+                    let _ = refs::append_reflog(
+                        &repo.git_dir,
+                        &u.refname,
+                        &u.old_oid,
+                        &u.new_oid,
+                        &resolve_committer_ident_string(&repo)?,
+                        &reflog_msg,
+                        false,
+                    );
+                }
+            }
+        }
+    }
+
     Ok(())
 }
 
-fn resolve_target_branch(repo: &Repository, spec: &str) -> Result<(String, ObjectId)> {
-    let refname = if spec.starts_with("refs/") {
-        spec.to_owned()
-    } else {
-        format!("refs/heads/{spec}")
-    };
-    let oid = resolve_ref(&repo.git_dir, &refname)
-        .with_context(|| format!("argument to replay range must be a local branch: {spec}"))?;
-    Ok((refname.trim_start_matches("refs/heads/").to_owned(), oid))
-}
-
-fn collect_linear_commits_to_replay(
-    repo: &Repository,
-    start_exclusive: ObjectId,
-    tip: ObjectId,
-) -> Result<Vec<ObjectId>> {
-    let mut commits = Vec::new();
-    let mut current = tip;
-    while current != start_exclusive {
-        let obj = repo.odb.read(&current)?;
-        let commit = parse_commit(&obj.data)?;
-        if commit.parents.is_empty() {
-            bail!("replaying down from root commit is not supported yet!");
-        }
-        if commit.parents.len() > 1 {
-            bail!("replaying merge commits is not supported yet!");
-        }
-        commits.push(current);
-        current = commit.parents[0];
-    }
-    commits.reverse();
-    Ok(commits)
+fn resolve_committer_ident_string(repo: &Repository) -> Result<String> {
+    let config = ConfigSet::load(Some(&repo.git_dir), true)?;
+    let now = OffsetDateTime::now_utc();
+    Ok(resolve_committer_ident(&config, now))
 }
 
 fn commit_tree(repo: &Repository, commit_oid: ObjectId) -> Result<ObjectId> {
@@ -760,8 +1049,6 @@ fn detect_side_renames(
         }
     }
 
-    // Fallback: if similarity-based rename detection missed some obvious
-    // one-to-one filename moves, match by identical basename.
     let mut deleted_by_name: HashMap<Vec<u8>, Vec<Vec<u8>>> = HashMap::new();
     let mut added_by_name: HashMap<Vec<u8>, Vec<Vec<u8>>> = HashMap::new();
     for entry in &diff_entries {

--- a/logs/2026-04-09_t3650-replay-basics.md
+++ b/logs/2026-04-09_t3650-replay-basics.md
@@ -1,0 +1,22 @@
+# t3650-replay-basics
+
+## Summary
+
+Implemented Git-compatible `grit replay` behavior needed for `tests/t3650-replay-basics.sh`:
+
+- CLI: `--onto`, `--advance`, `--contained`, `--ref-action`, `--branches`, `--ancestry-path`
+- Revision list via `rev_list` (topo + reverse), including `^!` expansion for single commits
+- `--branches` passes full `refs/heads/*` names so `--onto` mode satisfies “all positives are references”
+- Ref updates: print `update <ref> <new> <old>` or apply with `replay --onto <hex>` / `replay --advance <branch>` reflog messages
+- `expand_rev_token_circ_bang` in `grit-lib` for `topic1^!` style specs (reject merges like Git)
+
+Fixed `git log --format=%s%d`: templates with `%d` now use **short** ref decorations by default (Git behavior); full names only with `--decorate=full`.
+
+## Validation
+
+- `./scripts/run-tests.sh t3650-replay-basics.sh` — 31/31
+- `cargo test -p grit-lib --lib` — pass
+
+## Note
+
+Workspace `cargo clippy -- -D warnings` currently fails on many pre-existing `grit-lib` lints; not addressed in this change.

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   256 |
+| Completed   |   257 |
 | In progress |     4 |
-| Remaining   |   508 |
+| Remaining   |   507 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 256 completed (`[x]`), 4 in progress (`[~]`), 508 remaining (`[ ]`).
+Task lines in `PLAN.md`: 257 completed (`[x]`), 4 in progress (`[~]`), 507 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t3650-replay-basics` — 31/31 tests pass (`replay`: `--onto` / `--advance` / `--contained`, `--ref-action` + `replay.refAction`, `--branches` with branch refnames, `--ancestry-path`, detached `HEAD` updates, reflog messages, `merge.directoryRenames=false`; `rev_parse::expand_rev_token_circ_bang` for `topic1^!`; `log` `%d` uses short decorations like Git unless `--decorate=full`)
 - `t5334-incremental-multi-pack-index` — 16/16 tests pass (incremental MIDX chain, bitmap/rev sidecars in `multi-pack-index.d`, `midx verify`, clone with `pack.allowPackReuse`; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t4120-apply-popt` — 12/12 tests pass (`git apply -p`: strip path components, malformed `-p` errors, traditional quoted paths, `--stat` with oversized strip, mode-only and rename patches with `--index`; harness CSV/dashboards refreshed)
 - `t5320-delta-islands` — 15/15 tests pass (`repack` delta islands: `pack.island` / `pack.islandcore`, superset-island delta rules, verify-pack ordering; harness CSV/dashboards refreshed)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible `grit replay` coverage for `tests/t3650-replay-basics.sh` (31/31).

### `replay`

- Parses `--onto`, `--advance`, `--contained`, `--ref-action` / `replay.refAction`, `--branches`, `--ancestry-path`.
- Builds the commit list with `rev_list` (topological + reverse), matching Git’s replay walk.
- Expands `topic1^!` via new `grit_lib::rev_parse::expand_rev_token_circ_bang` (rejects merge commits like Git).
- `--branches` uses full `refs/heads/*` names so `--onto` mode satisfies “all positive revisions must be references”.
- Applies ref updates (print or write + reflog) with messages `replay --onto <onto_sha>` / `replay --advance <branch>`.

### `log`

- `%d` / `%D` in format strings now imply **short** ref decorations (Git default); full names only with `--decorate=full`. Fixes the “commits that become empty are dropped” assertion on `git log --format="%s%d"`.

### Meta

- Harness: `data/test-files.csv` + dashboards refreshed (`./scripts/run-tests.sh t3650-replay-basics.sh`).
- `PLAN.md` / `progress.md` updated; log: `logs/2026-04-09_t3650-replay-basics.md`.

## Testing

- `./scripts/run-tests.sh t3650-replay-basics.sh`
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0b6c531-eb03-4ec3-9561-60116ae76596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0b6c531-eb03-4ec3-9561-60116ae76596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

