### PR TITLE
fix: ls-tree --format for t3104

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -556,7 +556,7 @@ t3100-ls-tree-restrict	t3	yes	14	13	1	false	ok	0
 t3101-ls-tree-dirname	t3	yes	19	18	1	false	ok	0
 t3102-ls-tree-wildcards	t3	yes	4	2	2	false	ok	0
 t3103-ls-tree-misc	t3	yes	10	10	0	true	ok	0
-t3104-ls-tree-format	t3	yes	0	0	0	false	timeout	0
+t3104-ls-tree-format	t3	yes	19	19	0	true	ok	0
 t3105-ls-tree-output	t3	yes	60	60	0	true	ok	0
 t3200-branch	t3	yes	0	0	0	false	timeout	0
 t3201-branch-contains	t3	yes	24	24	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T04:59:38+00:00" class="gen-time" title="2026-04-09 04:59 UTC">2026-04-09 04:59 UTC</time> · <a href="https://github.com/schacon/grit/commit/7562795cfa41cdf65ae1b9e3a00095363a4c577c" style="color:#58a6ff">7562795</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T05:07:44+00:00" class="gen-time" title="2026-04-09 05:07 UTC">2026-04-09 05:07 UTC</time> · <a href="https://github.com/schacon/grit/commit/2a8d953e65845b8d4d46cb8fd960fe3d14c03a4a" style="color:#58a6ff">2a8d953</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,11 +150,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,289</div>
+      <div class="summary-big-val">30,308</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">39,873</div>
+      <div class="summary-big-val">39,892</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>761 files fully passing</span>
+    <span>762 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,11 +212,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">48/141 files · 2 skipped · 3,436/4,619 tests</span>
+        <span class="group-meta">49/141 files · 2 skipped · 3,455/4,638 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:74.4%"></div></div>
-        <span class="group-pct pct-blue">74.4%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:74.5%"></div></div>
+        <span class="group-pct pct-blue">74.5%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T04:59:38+00:00" class="gen-time" title="2026-04-09 04:59 UTC">2026-04-09 04:59 UTC</time> · <a href="https://github.com/schacon/grit/commit/7562795cfa41cdf65ae1b9e3a00095363a4c577c" style="color:#58a6ff">7562795</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:07:44+00:00" class="gen-time" title="2026-04-09 05:07 UTC">2026-04-09 05:07 UTC</time> · <a href="https://github.com/schacon/grit/commit/2a8d953e65845b8d4d46cb8fd960fe3d14c03a4a" style="color:#58a6ff">2a8d953</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,289</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n" id="sum-tests">39,892</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,308</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">76.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -5717,14 +5717,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="0" data-passed="0">
+<tr class="" data-group="t3" data-tests="19" data-passed="19" data-full-pass="1">
   <td class="mono">t3104-ls-tree-format</td>
   <td>t3</td>
-  <td></td>
-  <td class="right">0</td>
-  <td class="right">0</td>
-  <td class="right">timeout</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td><span class="badge ok">full pass</span></td>
+  <td class="right">19</td>
+  <td class="right">19</td>
+  <td class="right">ok</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="60" data-passed="60" data-full-pass="1">

--- a/grit/src/commands/ls_tree.rs
+++ b/grit/src/commands/ls_tree.rs
@@ -9,6 +9,7 @@ use grit_lib::config::ConfigSet;
 use grit_lib::objects::{parse_commit, parse_tag, parse_tree, ObjectId, ObjectKind, TreeEntry};
 use grit_lib::refs::resolve_ref;
 use grit_lib::repo::Repository;
+use grit_lib::rev_parse::abbreviate_object_id;
 
 /// Default maximum tree recursion depth when `core.maxtreedepth` is unset.
 const DEFAULT_MAX_TREE_DEPTH: usize = 2048;
@@ -553,13 +554,7 @@ fn print_entry(
     };
 
     if let Some(fmt) = &args.format {
-        let line = fmt
-            .replace("%(objectmode)", &format!("{:06o}", entry.mode))
-            .replace("%(objecttype)", kind_str)
-            .replace("%(objectname)", &entry.oid.to_hex())
-            .replace("%(path)", name);
-        // Expand %xNN hex escapes (e.g. %x09 -> tab)
-        let line = expand_hex_escapes(&line);
+        let line = expand_ls_tree_format(repo, fmt, entry, name, kind_str, args)?;
         write!(out, "{line}")?;
     } else if args.name_only {
         if args.null_terminated {
@@ -568,9 +563,7 @@ fn print_entry(
             write!(out, "{}", quote_path_name(name))?;
         }
     } else if args.object_only {
-        let hex = entry.oid.to_hex();
-        let abbrev = ls_tree_abbrev_len(args);
-        write!(out, "{}", &hex[..abbrev.min(hex.len())])?;
+        write!(out, "{}", ls_tree_object_name(repo, entry, args)?)?;
     } else if args.long {
         let size_str = if kind_str == "blob" {
             match repo.odb.read(&entry.oid) {
@@ -580,59 +573,157 @@ fn print_entry(
         } else {
             "      -".to_string()
         };
-        let hex = entry.oid.to_hex();
-        let abbrev = ls_tree_abbrev_len(args);
-        let oid_str = &hex[..abbrev.min(hex.len())];
         write!(
             out,
-            "{:06o} {kind_str} {oid_str} {size_str}\t{name}",
-            entry.mode
+            "{:06o} {kind_str} {} {size_str}\t{name}",
+            entry.mode,
+            ls_tree_object_name(repo, entry, args)?
         )?;
     } else {
-        let hex = entry.oid.to_hex();
-        let abbrev = ls_tree_abbrev_len(args);
-        let oid_str = &hex[..abbrev.min(hex.len())];
-        write!(out, "{:06o} {kind_str} {oid_str}\t{name}", entry.mode)?;
+        write!(
+            out,
+            "{:06o} {kind_str} {}\t{name}",
+            entry.mode,
+            ls_tree_object_name(repo, entry, args)?
+        )?;
     }
     out.write_all(&[term])?;
     Ok(())
 }
 
-fn expand_hex_escapes(s: &str) -> String {
-    let mut result = String::with_capacity(s.len());
-    let mut chars = s.chars().peekable();
-    while let Some(c) = chars.next() {
-        if c == '%' {
-            if chars.peek() == Some(&'x') || chars.peek() == Some(&'X') {
-                chars.next();
-                let mut hex = String::new();
-                for _ in 0..2 {
-                    if let Some(&d) = chars.peek() {
-                        if d.is_ascii_hexdigit() {
-                            hex.push(d);
-                            chars.next();
-                        } else {
-                            break;
-                        }
-                    }
-                }
-                if hex.len() == 2 {
-                    if let Ok(byte) = u8::from_str_radix(&hex, 16) {
-                        result.push(byte as char);
-                        continue;
-                    }
-                }
-                result.push('%');
-                result.push('x');
-                result.push_str(&hex);
-            } else {
-                result.push(c);
-            }
+/// Object name for `ls-tree` output: full hex unless `--abbrev`, then a unique prefix (Git:
+/// `repo_find_unique_abbrev`).
+fn ls_tree_object_name(repo: &Repository, entry: &TreeEntry, args: &Args) -> Result<String> {
+    let min_len = ls_tree_abbrev_len(args);
+    if min_len >= 40 {
+        return Ok(entry.oid.to_hex());
+    }
+    abbreviate_object_id(repo, entry.oid, min_len).map_err(|e| anyhow::anyhow!("{e}"))
+}
+
+fn ls_tree_object_size_field(
+    repo: &Repository,
+    entry: &TreeEntry,
+    kind_str: &str,
+    padded: bool,
+) -> String {
+    if kind_str != "blob" {
+        return if padded {
+            format!("{:>7}", "-")
         } else {
-            result.push(c);
+            "-".to_string()
+        };
+    }
+    match repo.odb.read(&entry.oid) {
+        Ok(obj) => {
+            if padded {
+                format!("{:>7}", obj.data.len())
+            } else {
+                format!("{}", obj.data.len())
+            }
+        }
+        Err(_) => {
+            if padded {
+                "      -".to_string()
+            } else {
+                "-".to_string()
+            }
         }
     }
-    result
+}
+
+/// Expand `git ls-tree --format` placeholders (see `builtin/ls-tree.c` `show_tree_fmt`).
+fn expand_ls_tree_format(
+    repo: &Repository,
+    fmt: &str,
+    entry: &TreeEntry,
+    display_path: &str,
+    kind_str: &str,
+    args: &Args,
+) -> Result<String> {
+    let mut out = String::new();
+    let bs = fmt.as_bytes();
+    let mut i = 0usize;
+    while i < bs.len() {
+        if bs[i] != b'%' {
+            let start = i;
+            while i < bs.len() && bs[i] != b'%' {
+                i += 1;
+            }
+            out.push_str(&fmt[start..i]);
+            continue;
+        }
+        i += 1;
+        if i >= bs.len() {
+            break;
+        }
+        match bs[i] {
+            b'%' => {
+                out.push('%');
+                i += 1;
+            }
+            b'n' => {
+                out.push('\n');
+                i += 1;
+            }
+            b'x' | b'X' => {
+                i += 1;
+                let Some(b1) = bs.get(i).copied() else {
+                    bail!("bad ls-tree format: incomplete %x escape");
+                };
+                let Some(b2) = bs.get(i + 1).copied() else {
+                    bail!("bad ls-tree format: incomplete %x escape");
+                };
+                let h1 = (b1 as char).to_digit(16);
+                let h2 = (b2 as char).to_digit(16);
+                let Some((d1, d2)) = h1.zip(h2) else {
+                    bail!("bad ls-tree format: invalid %x escape");
+                };
+                out.push(char::from_u32(d1 * 16 + d2).unwrap_or('\u{FFFD}'));
+                i += 2;
+            }
+            b'(' => {
+                let tail = &fmt[i..];
+                let consumed = if tail.starts_with("(objectsize:padded)") {
+                    out.push_str(&ls_tree_object_size_field(repo, entry, kind_str, true));
+                    "(objectsize:padded)".len()
+                } else if tail.starts_with("(objectsize)") {
+                    out.push_str(&ls_tree_object_size_field(repo, entry, kind_str, false));
+                    "(objectsize)".len()
+                } else if tail.starts_with("(objectmode)") {
+                    out.push_str(&format!("{:06o}", entry.mode));
+                    "(objectmode)".len()
+                } else if tail.starts_with("(objecttype)") {
+                    out.push_str(kind_str);
+                    "(objecttype)".len()
+                } else if tail.starts_with("(objectname)") {
+                    out.push_str(&ls_tree_object_name(repo, entry, args)?);
+                    "(objectname)".len()
+                } else if tail.starts_with("(path)") {
+                    out.push_str(&quote_path_for_ls_tree_format(
+                        display_path,
+                        args.null_terminated,
+                    ));
+                    "(path)".len()
+                } else {
+                    let end = tail.find(')').map(|p| p + 1).unwrap_or(tail.len());
+                    bail!("bad ls-tree format: %{}", &tail[..end]);
+                };
+                i += consumed;
+            }
+            _ => bail!("bad ls-tree format: unknown % escape"),
+        }
+    }
+    Ok(out)
+}
+
+/// `%(path)` uses C-style quoting like `quote_c_style` when not `-z` (see `show_tree_fmt`).
+fn quote_path_for_ls_tree_format(path: &str, null_terminated: bool) -> String {
+    if null_terminated {
+        path.to_string()
+    } else {
+        quote_path_name(path)
+    }
 }
 
 fn quote_path_name(name: &str) -> String {

--- a/logs/2026-04-09-t3104-ls-tree-format.md
+++ b/logs/2026-04-09-t3104-ls-tree-format.md
@@ -1,0 +1,8 @@
+# t3104-ls-tree-format
+
+- Implemented Git-compatible `ls-tree --format` expansion in `grit/src/commands/ls_tree.rs`:
+  - `%(objectsize)`, `%(objectsize:padded)`, `%%`, `%n`, `%xNN`
+  - `%(objectname)` uses `abbreviate_object_id` when `--abbrev` is set (matches `--object-only --abbrev`)
+  - `%(path)` uses the same C-style quoting as `--name-only` when not `-z`
+- Default/long `ls-tree` output now uses unique abbreviation for OIDs when `--abbrev` is set.
+- Verified: `./scripts/run-tests.sh t3104-ls-tree-format.sh` → 19/19 pass.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible `ls-tree --format` expansion so `t3104-ls-tree-format` passes (19/19).

## Changes

- **Format placeholders** (aligned with `git/builtin/ls-tree.c` `show_tree_fmt`): `%(objectmode)`, `%(objecttype)`, `%(objectname)`, `%(objectsize)`, `%(objectsize:padded)`, `%(path)`, plus `%%`, `%n`, and `%xNN` escapes.
- **`%(objectsize*)`**: blob sizes from the object database with the same padded width as `--long`; non-blobs show `-` / right-aligned `-`.
- **`--abbrev`**: `%(objectname)` and default/long `ls-tree` lines now use `abbreviate_object_id` (unique prefix) instead of a fixed slice of the full hex.

## Verification

- `./scripts/run-tests.sh t3104-ls-tree-format.sh` → 19/19
- `cargo test -p grit-lib --lib` → pass
- `cargo check -p grit-rs` → pass

Note: Workspace `cargo clippy -p grit-rs -- -D warnings` still reports many pre-existing issues across the crate; this change does not address those.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a484c738-0070-472c-ac28-56a823fbca1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a484c738-0070-472c-ac28-56a823fbca1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

