### PR TITLE
chore: refresh harness for t3010-ls-files-killed-modified (6/6)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -539,7 +539,7 @@ t3006-ls-files-long	t3	yes	3	3	0	true	ok	0
 t3007-ls-files-recurse-submodules	t3	yes	24	1	23	false	ok	0
 t3008-ls-files-lazy-init-name-hash	t3	yes	1	0	1	false	ok	0
 t3009-ls-files-others-nonsubmodule	t3	yes	2	2	0	true	ok	0
-t3010-ls-files-killed-modified	t3	yes	6	3	3	false	ok	0
+t3010-ls-files-killed-modified	t3	yes	6	6	0	true	ok	0
 t3011-common-prefixes-and-directory-traversal	t3	yes	20	16	4	false	ok	1
 t3011-ls-files-staged	t3	yes	29	29	0	true	ok	0
 t3012-ls-files-dedup	t3	yes	3	3	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T05:07:55+00:00" class="gen-time" title="2026-04-09 05:07 UTC">2026-04-09 05:07 UTC</time> · <a href="https://github.com/schacon/grit/commit/3ca17ee7edef3c6913b2c4cdee684bea084956de" style="color:#58a6ff">3ca17ee</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T05:14:41+00:00" class="gen-time" title="2026-04-09 05:14 UTC">2026-04-09 05:14 UTC</time> · <a href="https://github.com/schacon/grit/commit/7a4c633329f2484646de82dc5ba4802c9f2abedd" style="color:#58a6ff">7a4c633</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,315</div>
+      <div class="summary-big-val">30,318</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>764 files fully passing</span>
+    <span>765 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,11 +212,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">48/141 files · 2 skipped · 3,436/4,619 tests</span>
+        <span class="group-meta">49/141 files · 2 skipped · 3,439/4,619 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:74.4%"></div></div>
-        <span class="group-pct pct-blue">74.4%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:74.5%"></div></div>
+        <span class="group-pct pct-blue">74.5%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:07:55+00:00" class="gen-time" title="2026-04-09 05:07 UTC">2026-04-09 05:07 UTC</time> · <a href="https://github.com/schacon/grit/commit/3ca17ee7edef3c6913b2c4cdee684bea084956de" style="color:#58a6ff">3ca17ee</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:14:41+00:00" class="gen-time" title="2026-04-09 05:14 UTC">2026-04-09 05:14 UTC</time> · <a href="https://github.com/schacon/grit/commit/7a4c633329f2484646de82dc5ba4802c9f2abedd" style="color:#58a6ff">7a4c633</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,315</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,318</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">76.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -5547,14 +5547,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="6" data-passed="3">
+<tr class="" data-group="t3" data-tests="6" data-passed="6" data-full-pass="1">
   <td class="mono">t3010-ls-files-killed-modified</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">6</td>
-  <td class="right">3</td>
+  <td class="right">6</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="20" data-passed="16">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t3010-ls-files-killed-modified.sh` already passes all six cases with the current Grit implementation. This change only refreshes harness metadata after `./scripts/run-tests.sh t3010-ls-files-killed-modified.sh`.

## Verification

```bash
./scripts/run-tests.sh t3010-ls-files-killed-modified.sh
# Result: 6/6 passing
```

## Files

- `data/test-files.csv` — updated counts for t3010 row
- `docs/index.html`, `docs/testfiles.html` — regenerated dashboards
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5dc30142-1216-44b0-8c0d-d2155ddace82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5dc30142-1216-44b0-8c0d-d2155ddace82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

