### PR TITLE
test: t5100-mailinfo fully passing (52/52)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -859,7 +859,7 @@ t5002-archive-attr-pattern	t5	yes	19	5	14	false	ok	0
 t5003-archive-zip	t5	yes	82	78	4	false	ok	0
 t5004-archive-corner-cases	t5	yes	14	9	5	false	ok	0
 t5100-count-objects	t5	yes	26	24	2	false	ok	0
-t5100-mailinfo	t5	yes	52	7	45	false	ok	0
+t5100-mailinfo	t5	yes	52	52	0	true	ok	0
 t5150-request-pull	t5	yes	10	2	8	false	ok	0
 t5200-update-server-info	t5	yes	8	6	2	false	ok	0
 t5300-pack-object	t5	yes	63	38	25	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,16 +141,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T05:07:55+00:00" class="gen-time" title="2026-04-09 05:07 UTC">2026-04-09 05:07 UTC</time> · <a href="https://github.com/schacon/grit/commit/3ca17ee7edef3c6913b2c4cdee684bea084956de" style="color:#58a6ff">3ca17ee</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T05:17:18+00:00" class="gen-time" title="2026-04-09 05:17 UTC">2026-04-09 05:17 UTC</time> · <a href="https://github.com/schacon/grit/commit/7a4c633329f2484646de82dc5ba4802c9f2abedd" style="color:#58a6ff">7a4c633</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">76.0%</div>
+      <div class="summary-big-val pct-blue">76.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,315</div>
+      <div class="summary-big-val">30,360</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -159,12 +159,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:76.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:76.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>764 files fully passing</span>
+    <span>765 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">40/167 files · 17 skipped · 1,473/3,949 tests</span>
+        <span class="group-meta">41/167 files · 17 skipped · 1,518/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.3%"></div></div>
-        <span class="group-pct pct-red">37.3%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:38.4%"></div></div>
+        <span class="group-pct pct-red">38.4%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:07:55+00:00" class="gen-time" title="2026-04-09 05:07 UTC">2026-04-09 05:07 UTC</time> · <a href="https://github.com/schacon/grit/commit/3ca17ee7edef3c6913b2c4cdee684bea084956de" style="color:#58a6ff">3ca17ee</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:17:18+00:00" class="gen-time" title="2026-04-09 05:17 UTC">2026-04-09 05:17 UTC</time> · <a href="https://github.com/schacon/grit/commit/7a4c633329f2484646de82dc5ba4802c9f2abedd" style="color:#58a6ff">7a4c633</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,315</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">76.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,360</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">76.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -8747,14 +8747,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:92.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="52" data-passed="7">
+<tr class="" data-group="t5" data-tests="52" data-passed="52" data-full-pass="1">
   <td class="mono">t5100-mailinfo</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">52</td>
-  <td class="right">7</td>
+  <td class="right">52</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:13.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="10" data-passed="2">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t5100-mailinfo` now reports **52/52** passing in the harness. No Rust changes were required in this session—the implementation already satisfied the suite; this commit refreshes `data/test-files.csv` and the generated dashboards after `./scripts/run-tests.sh t5100-mailinfo.sh`.

## Verification

```bash
cargo build --release -p grit-rs
./scripts/run-tests.sh t5100-mailinfo.sh
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab9fc150-8812-4210-b7e3-bc6ef6a37e8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab9fc150-8812-4210-b7e3-bc6ef6a37e8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

