### PR TITLE
t4071-diff-empty-tree: harness refresh (32/32 passing)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -754,7 +754,7 @@ t4069-diff-summary	t4	yes	34	34	0	true	ok	0
 t4069-remerge-diff	t4	yes	16	8	8	false	ok	0
 t4070-diff-pairs	t4	yes	7	7	0	true	ok	0
 t4070-diff-submodule	t4	yes	31	31	0	true	ok	0
-t4071-diff-empty-tree	t4	yes	32	29	3	false	ok	0
+t4071-diff-empty-tree	t4	yes	32	32	0	true	ok	0
 t4071-diff-minimal	t4	yes	1	1	0	true	ok	0
 t4072-diff-max-depth	t4	yes	50	47	3	false	ok	0
 t4073-diff-stat-name-width	t4	yes	6	4	2	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T05:15:28+00:00" class="gen-time" title="2026-04-09 05:15 UTC">2026-04-09 05:15 UTC</time> · <a href="https://github.com/schacon/grit/commit/d70810c5d7a3f917e969b91776b566d5d4f36e08" style="color:#58a6ff">d70810c</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T05:18:12+00:00" class="gen-time" title="2026-04-09 05:18 UTC">2026-04-09 05:18 UTC</time> · <a href="https://github.com/schacon/grit/commit/25f92d79e08834c088d997911768d86f67ef3ce8" style="color:#58a6ff">25f92d7</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,318</div>
+      <div class="summary-big-val">30,321</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>765 files fully passing</span>
+    <span>766 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -223,11 +223,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">72/178 files · 2 skipped · 2,225/3,542 tests</span>
+        <span class="group-meta">73/178 files · 2 skipped · 2,228/3,542 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:62.8%"></div></div>
-        <span class="group-pct pct-blue">62.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:62.9%"></div></div>
+        <span class="group-pct pct-blue">62.9%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:15:28+00:00" class="gen-time" title="2026-04-09 05:15 UTC">2026-04-09 05:15 UTC</time> · <a href="https://github.com/schacon/grit/commit/d70810c5d7a3f917e969b91776b566d5d4f36e08" style="color:#58a6ff">d70810c</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:18:12+00:00" class="gen-time" title="2026-04-09 05:18 UTC">2026-04-09 05:18 UTC</time> · <a href="https://github.com/schacon/grit/commit/25f92d79e08834c088d997911768d86f67ef3ce8" style="color:#58a6ff">25f92d7</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,318</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,321</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">76.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -7697,14 +7697,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="32" data-passed="29">
+<tr class="" data-group="t4" data-tests="32" data-passed="32" data-full-pass="1">
   <td class="mono">t4071-diff-empty-tree</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">32</td>
-  <td class="right">29</td>
+  <td class="right">32</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.6%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="1" data-passed="1" data-full-pass="1">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t4071-diff-empty-tree.sh` already passes all 32 tests against current Grit. The working tree had stale harness rows (29/32); re-running `./scripts/run-tests.sh t4071-diff-empty-tree.sh` updated `data/test-files.csv` and dashboards to **32/32**.

## Changes

- Refreshed `data/test-files.csv`, `docs/index.html`, and `docs/testfiles.html` after a clean harness run.

## Verification

```bash
./scripts/run-tests.sh t4071-diff-empty-tree.sh
# ✓ t4071-diff-empty-tree (32/32)
```

No Rust changes were required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eccafeb1-4f30-4191-b56e-8c4825be4a68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eccafeb1-4f30-4191-b56e-8c4825be4a68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

