### PR TITLE
fix(blame): Git-compatible blame coloring config for t8012

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1293,7 +1293,7 @@ t8009-blame-vs-topicbranches	t8	yes	2	1	1	false	ok	0
 t8010-cat-file-batch	t8	yes	26	26	0	true	ok	0
 t8010-cat-file-filters	t8	yes	9	9	0	true	ok	0
 t8011-blame-split-file	t8	yes	10	10	0	true	ok	0
-t8012-blame-colors	t8	yes	120	48	72	false	ok	0
+t8012-blame-colors	t8	yes	120	120	0	true	ok	0
 t8013-blame-ignore-revs	t8	yes	19	18	1	false	ok	0
 t8014-blame-ignore-fuzzy	t8	yes	16	16	0	true	ok	0
 t8015-blame-diff-algorithm	t8	yes	7	7	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,16 +141,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T05:04:56+00:00" class="gen-time" title="2026-04-09 05:04 UTC">2026-04-09 05:04 UTC</time> · <a href="https://github.com/schacon/grit/commit/8fd2d959e0f92453d4ad4828144fcde69f64ba8c" style="color:#58a6ff">8fd2d95</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T05:18:14+00:00" class="gen-time" title="2026-04-09 05:18 UTC">2026-04-09 05:18 UTC</time> · <a href="https://github.com/schacon/grit/commit/3c70760499d6758150e6356d7d2bc84b73e2c862" style="color:#58a6ff">3c70760</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">76.0%</div>
+      <div class="summary-big-val pct-blue">76.2%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,313</div>
+      <div class="summary-big-val">30,385</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -159,12 +159,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:76.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:76.2%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>763 files fully passing</span>
+    <span>764 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -267,11 +267,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t8</span>
         <span class="group-desc">Porcelainish commands concerning forensics</span>
-        <span class="group-meta">83/105 files · 0 skipped · 2,894/3,116 tests</span>
+        <span class="group-meta">84/105 files · 0 skipped · 2,966/3,116 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:92.9%"></div></div>
-        <span class="group-pct pct-green">92.9%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:95.2%"></div></div>
+        <span class="group-pct pct-green">95.2%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t9">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:04:56+00:00" class="gen-time" title="2026-04-09 05:04 UTC">2026-04-09 05:04 UTC</time> · <a href="https://github.com/schacon/grit/commit/8fd2d959e0f92453d4ad4828144fcde69f64ba8c" style="color:#58a6ff">8fd2d95</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:18:14+00:00" class="gen-time" title="2026-04-09 05:18 UTC">2026-04-09 05:18 UTC</time> · <a href="https://github.com/schacon/grit/commit/3c70760499d6758150e6356d7d2bc84b73e2c862" style="color:#58a6ff">3c70760</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,313</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">76.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,385</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">76.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -13087,14 +13087,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t8" data-tests="120" data-passed="48">
+<tr class="" data-group="t8" data-tests="120" data-passed="120" data-full-pass="1">
   <td class="mono">t8012-blame-colors</td>
   <td>t8</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">120</td>
-  <td class="right">48</td>
+  <td class="right">120</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:40.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t8" data-tests="19" data-passed="18">

--- a/grit/src/commands/blame.rs
+++ b/grit/src/commands/blame.rs
@@ -2,11 +2,12 @@
 
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
-use grit_lib::config::ConfigSet;
+use grit_lib::config::{parse_color, ConfigSet};
 use grit_lib::crlf::{
     convert_to_git, get_file_attrs, load_gitattributes, load_gitattributes_from_index,
     ConversionConfig, GitAttributes,
 };
+use grit_lib::git_date::approx::approxidate_careful;
 use grit_lib::objects::{parse_commit, parse_tree, CommitData, ObjectId, ObjectKind};
 use grit_lib::odb::Odb;
 use grit_lib::repo::Repository;
@@ -1463,6 +1464,98 @@ fn config_bool(config: &ConfigSet, key: &str) -> bool {
     matches!(config.get_bool(key), Some(Ok(true)))
 }
 
+/// Git `color.blame.highlightRecent` / `parse_color_fields` in `git/builtin/blame.c`: comma-separated
+/// tokens alternate color, date, color, date, … and must end after a color; the final slot's hop is `TIME_MAX`.
+fn parse_blame_highlight_recent(value: &str) -> Result<Vec<(i64, String)>> {
+    let parts: Vec<&str> = value.split(',').map(str::trim).collect();
+    let mut slots: Vec<(i64, String)> = Vec::new();
+    let mut expect_date = false;
+    for item in parts {
+        if item.is_empty() {
+            continue;
+        }
+        if !expect_date {
+            let ansi = parse_color(item).map_err(|e| {
+                anyhow::anyhow!("invalid color in color.blame.highlightRecent: {e}")
+            })?;
+            slots.push((0, ansi));
+            expect_date = true;
+        } else {
+            let hop = approxidate_careful(item, None) as i64;
+            let last = slots.last_mut().ok_or_else(|| {
+                anyhow::anyhow!("color.blame.highlightRecent: internal parse error")
+            })?;
+            last.0 = hop;
+            expect_date = false;
+        }
+    }
+    if !expect_date {
+        bail!("color.blame.highlightRecent must end with a color");
+    }
+    let last = slots.last_mut().ok_or_else(|| {
+        anyhow::anyhow!("color.blame.highlightRecent must contain at least one color")
+    })?;
+    last.0 = i64::MAX;
+    Ok(slots)
+}
+
+/// ANSI sequence for repeated-line blame metadata (Git default cyan when unset).
+const GIT_COLOR_CYAN: &str = "\x1b[36m";
+
+/// Applies `blame.coloring` when no `--color-lines` / `--color-by-age` flags are given, and loads
+/// color strings from `color.blame.*` (matches `git/builtin/blame.c`).
+fn apply_blame_color_config(config: &ConfigSet, args: &mut Args) -> Result<BlameColorStyle> {
+    let cli_color = args.color_lines || args.color_by_age;
+    if !cli_color {
+        match config.get("blame.coloring").as_deref() {
+            Some("repeatedLines") => args.color_lines = true,
+            Some("highlightRecent") => args.color_by_age = true,
+            Some("none") => {}
+            Some(other) => {
+                eprintln!("warning: invalid value for 'blame.coloring': '{other}'");
+            }
+            None => {}
+        }
+    }
+
+    let mut style = BlameColorStyle::default();
+
+    if args.color_lines {
+        if let Some(raw) = config.get("color.blame.repeatedLines") {
+            if raw.trim().is_empty() {
+                style.repeated_lines_ansi.clear();
+            } else {
+                style.repeated_lines_ansi = parse_color(raw.trim()).map_err(|e| {
+                    anyhow::anyhow!("invalid value for 'color.blame.repeatedLines': {e}")
+                })?;
+            }
+        }
+        if style.repeated_lines_ansi.is_empty() {
+            style.repeated_lines_ansi = GIT_COLOR_CYAN.to_string();
+        }
+    }
+
+    if args.color_by_age {
+        let default_spec = "blue,12 month ago,white,1 month ago,red";
+        let spec = config
+            .get("color.blame.highlightRecent")
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| default_spec.to_string());
+        style.age_buckets = parse_blame_highlight_recent(&spec)?;
+    }
+
+    Ok(style)
+}
+
+/// Parsed `color.blame.*` settings for default blame output.
+#[derive(Debug, Default)]
+struct BlameColorStyle {
+    /// ANSI start sequence for contiguous lines from the same commit (`--color-lines`).
+    repeated_lines_ansi: String,
+    /// `(hop, ansi)` buckets for `--color-by-age` / `highlightRecent` (last hop is `i64::MAX`).
+    age_buckets: Vec<(i64, String)>,
+}
+
 fn peel_to_commit_oid(odb: &Odb, mut oid: ObjectId) -> Result<Option<ObjectId>> {
     loop {
         let obj = odb.read(&oid)?;
@@ -1842,7 +1935,7 @@ fn line_similarity_and_lcs(a: &str, b: &str) -> (f64, usize) {
     (sim, lcs)
 }
 
-pub fn run(args: Args) -> Result<()> {
+pub fn run(mut args: Args) -> Result<()> {
     let repo = Repository::discover(None).context("not a git repository")?;
     let odb = Odb::new(&repo.git_dir.join("objects"));
     let config = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
@@ -1927,6 +2020,8 @@ pub fn run(args: Args) -> Result<()> {
 
     let mark_unblamable = config_bool(&config, "blame.markUnblamableLines");
     let mark_ignored = config_bool(&config, "blame.markIgnoredLines");
+
+    let blame_color_style = apply_blame_color_config(&config, &mut args)?;
 
     let contents_override = if let Some(ref p) = args.contents {
         let path = PathBuf::from(p);
@@ -2108,6 +2203,7 @@ pub fn run(args: Args) -> Result<()> {
             &blame_lines,
             &commits,
             &args,
+            &blame_color_style,
             &file_path,
             mark_unblamable,
             mark_ignored,
@@ -3038,31 +3134,15 @@ fn annotate_author_and_time(
     (who, ts)
 }
 
-/// ANSI color codes.
 const RESET: &str = "\x1b[0m";
-const YELLOW: &str = "\x1b[33m";
-const BLUE: &str = "\x1b[34m";
-const CYAN: &str = "\x1b[36m";
-const WHITE: &str = "\x1b[37m";
 
-/// Classify a commit's age for --color-by-age.
-fn age_color(timestamp: i64) -> &'static str {
-    // Use a rough "now" based on the system clock
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0);
-    let age_secs = now - timestamp;
-    let one_month = 30 * 24 * 3600;
-    let one_year = 365 * 24 * 3600;
-
-    if age_secs < one_month {
-        CYAN
-    } else if age_secs < one_year {
-        WHITE
-    } else {
-        BLUE
+/// Pick the ANSI color for a commit's author timestamp (Git `determine_line_heat`).
+fn age_color_for_timestamp(author_time: i64, buckets: &[(i64, String)]) -> &str {
+    let mut i = 0usize;
+    while i < buckets.len() && author_time > buckets[i].0 {
+        i += 1;
     }
+    buckets.get(i).map(|(_, c)| c.as_str()).unwrap_or("")
 }
 
 fn write_default(
@@ -3070,6 +3150,7 @@ fn write_default(
     lines: &[BlameLine],
     commits: &HashMap<ObjectId, CommitData>,
     args: &Args,
+    color_style: &BlameColorStyle,
     file_path: &str,
     mark_unblamable: bool,
     mark_ignored: bool,
@@ -3118,10 +3199,10 @@ fn write_default(
         let (color_start, color_end) = if args.color_by_age {
             let commit = &commits[&bl.oid];
             let ai = parse_author_field(&commit.author);
-            (age_color(ai.timestamp), RESET)
+            let c = age_color_for_timestamp(ai.timestamp, &color_style.age_buckets);
+            (c, RESET)
         } else if args.color_lines && prev_oid == Some(bl.oid) {
-            // Repeated (contiguous) commit — highlight
-            (YELLOW, RESET)
+            (color_style.repeated_lines_ansi.as_str(), RESET)
         } else if use_color {
             ("", "")
         } else {

--- a/logs/2026-04-09_t8012-blame-colors-config.md
+++ b/logs/2026-04-09_t8012-blame-colors-config.md
@@ -1,0 +1,13 @@
+# t8012 blame colors — config parity
+
+## Work
+
+- Wired `blame.coloring` (`repeatedLines`, `highlightRecent`, `none`) to enable `--color-lines` / `--color-by-age` when flags are omitted, matching Git.
+- Parsed `color.blame.repeatedLines` via `parse_color`; default repeated-line color is cyan when unset (Git default).
+- Parsed `color.blame.highlightRecent` with Git’s comma state machine and `approxidate_careful`; default spec matches Git (`blue,12 month ago,white,1 month ago,red`).
+- Replaced wall-clock age heuristic in `write_default` with `determine_line_heat`-style bucket walk.
+
+## Validation
+
+- `cargo test -p grit-lib --lib`
+- `./scripts/run-tests.sh t8012-blame-colors.sh` (120/120)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-style blame coloring configuration so `t8012-blame-colors.sh` behavior matches upstream beyond the CLI flags alone.

## Changes

- **`blame.coloring`**: When `--color-lines` / `--color-by-age` are not passed, enable the corresponding mode for `repeatedLines` / `highlightRecent`; `none` clears. Invalid values log a warning (like Git).
- **`color.blame.repeatedLines`**: Parsed via `parse_color`; empty value disables the repeated-line highlight; unset defaults to cyan (Git default).
- **`color.blame.highlightRecent`**: Parsed with Git’s comma-separated state machine and `approxidate_careful`; default spec matches Git (`blue,12 month ago,white,1 month ago,red`). Age coloring uses the same bucket walk as `determine_line_heat` in `git/builtin/blame.c`.

## Validation

- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t8012-blame-colors.sh` (120/120)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dcf7ecc3-1fc4-4d30-b129-0b51baaf1b37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcf7ecc3-1fc4-4d30-b129-0b51baaf1b37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

