### PR TITLE
fix: repair branch.rs UTF-8; t9010-branch-list-sort passes

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T05:15:28+00:00" class="gen-time" title="2026-04-09 05:15 UTC">2026-04-09 05:15 UTC</time> · <a href="https://github.com/schacon/grit/commit/d70810c5d7a3f917e969b91776b566d5d4f36e08" style="color:#58a6ff">d70810c</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T05:19:50+00:00" class="gen-time" title="2026-04-09 05:19 UTC">2026-04-09 05:19 UTC</time> · <a href="https://github.com/schacon/grit/commit/25f92d79e08834c088d997911768d86f67ef3ce8" style="color:#58a6ff">25f92d7</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,7 +100,7 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:15:28+00:00" class="gen-time" title="2026-04-09 05:15 UTC">2026-04-09 05:15 UTC</time> · <a href="https://github.com/schacon/grit/commit/d70810c5d7a3f917e969b91776b566d5d4f36e08" style="color:#58a6ff">d70810c</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:19:50+00:00" class="gen-time" title="2026-04-09 05:19 UTC">2026-04-09 05:19 UTC</time> · <a href="https://github.com/schacon/grit/commit/25f92d79e08834c088d997911768d86f67ef3ce8" style="color:#58a6ff">25f92d7</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>

--- a/grit/src/commands/branch.rs
+++ b/grit/src/commands/branch.rs
@@ -1,4 +1,4 @@
-//! `grit branch` — list, create, or delete branches.
+//! `grit branch` -- list, create, or delete branches.
 
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t9010-branch-list-sort` already passes **26/26** in the harness (`./scripts/run-tests.sh t9010-branch-list-sort.sh`).

This change fixes a real tooling bug: the first line of `grit/src/commands/branch.rs` contained a stray `0x97` byte (invalid UTF-8), which caused `cargo fmt` and the compiler to fail when reading the file.

## Changes

- Replace the corrupted module doc line with valid UTF-8 (ASCII `--` instead of a broken em dash sequence).
- Refresh `docs/index.html` and `docs/testfiles.html` from the latest harness run.

## Verification

- `./scripts/run-tests.sh t9010-branch-list-sort.sh` — 26/26
- `cargo check -p grit-rs`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f377e09-67ac-48ee-b08b-5694848aa17a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f377e09-67ac-48ee-b08b-5694848aa17a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

