### PR TITLE
docs: t7105-reset-patch fully passing (13/13)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -839,7 +839,7 @@ commit → check it off → move on.
 
 - [ ] `t7611-merge-abort` ██████████░░░░░░░░░░ 10/19 (9 left) — test aborting in-progress merges
 
-- [ ] `t7105-reset-patch` ██████░░░░░░░░░░░░░░ 4/13 (9 left) — git reset --patch
+- [x] `t7105-reset-patch` ████████████████████ 13/13 (0 left) — git reset --patch
 - [ ] `t7526-commit-pathspec-file` ███░░░░░░░░░░░░░░░░░ 2/11 (9 left) — commit --pathspec-from-file
 - [ ] `t7007-show` ████████░░░░░░░░░░░░ 8/18 (10 left) — git show
 - [ ] `t7703-repack-geometric` ████████░░░░░░░░░░░░ 8/18 (10 left) — git repack --geometric works correctly

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1183,7 +1183,7 @@ t7101-reset-empty-subdirs	t7	yes	10	10	0	true	ok	0
 t7102-reset	t7	yes	38	22	16	false	ok	0
 t7103-reset-bare	t7	yes	13	11	2	false	ok	0
 t7104-reset-hard	t7	yes	3	3	0	true	ok	0
-t7105-reset-patch	t7	yes	13	6	7	false	ok	0
+t7105-reset-patch	t7	yes	13	13	0	true	ok	0
 t7106-reset-unborn-branch	t7	yes	7	7	0	true	ok	0
 t7107-reset-pathspec-file	t7	yes	11	0	11	false	ok	0
 t7110-reset-merge	t7	yes	21	7	14	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,16 +141,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T05:20:37+00:00" class="gen-time" title="2026-04-09 05:20 UTC">2026-04-09 05:20 UTC</time> · <a href="https://github.com/schacon/grit/commit/fd6cf838aa30de2a2efba9a644bfd9ade1e63236" style="color:#58a6ff">fd6cf83</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T05:23:02+00:00" class="gen-time" title="2026-04-09 05:23 UTC">2026-04-09 05:23 UTC</time> · <a href="https://github.com/schacon/grit/commit/f06364b33a6ac32cde51553af39ed57f8e5795b8" style="color:#58a6ff">f06364b</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">76.0%</div>
+      <div class="summary-big-val pct-blue">76.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,318</div>
+      <div class="summary-big-val">30,325</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -159,12 +159,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:76.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:76.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>765 files fully passing</span>
+    <span>766 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -256,11 +256,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">48/126 files · 11 skipped · 1,939/2,944 tests</span>
+        <span class="group-meta">49/126 files · 11 skipped · 1,946/2,944 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:65.9%"></div></div>
-        <span class="group-pct pct-blue">65.9%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:66.1%"></div></div>
+        <span class="group-pct pct-blue">66.1%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:20:37+00:00" class="gen-time" title="2026-04-09 05:20 UTC">2026-04-09 05:20 UTC</time> · <a href="https://github.com/schacon/grit/commit/fd6cf838aa30de2a2efba9a644bfd9ade1e63236" style="color:#58a6ff">fd6cf83</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:23:02+00:00" class="gen-time" title="2026-04-09 05:23 UTC">2026-04-09 05:23 UTC</time> · <a href="https://github.com/schacon/grit/commit/f06364b33a6ac32cde51553af39ed57f8e5795b8" style="color:#58a6ff">f06364b</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,318</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">76.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,325</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">76.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -11987,14 +11987,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="13" data-passed="6">
+<tr class="" data-group="t7" data-tests="13" data-passed="13" data-full-pass="1">
   <td class="mono">t7105-reset-patch</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">13</td>
-  <td class="right">6</td>
+  <td class="right">13</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:46.2%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="7" data-passed="7" data-full-pass="1">

--- a/logs/2026-04-09_t7105-reset-patch.md
+++ b/logs/2026-04-09_t7105-reset-patch.md
@@ -1,0 +1,10 @@
+# t7105-reset-patch
+
+## Goal
+
+Ensure `tests/t7105-reset-patch.sh` passes fully under the harness (`grit` as `git`).
+
+## Result
+
+- `./scripts/run-tests.sh t7105-reset-patch.sh` → **13/13** pass (no Rust changes required on this branch; implementation already satisfied the file).
+- Refreshed `data/test-files.csv` and dashboards; marked task complete in `PLAN.md` and updated `progress.md` counts.

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   262 |
+| Completed   |   263 |
 | In progress |     4 |
-| Remaining   |   502 |
+| Remaining   |   501 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 262 completed (`[x]`), 4 in progress (`[~]`), 502 remaining (`[ ]`).
+Task lines in `PLAN.md`: 263 completed (`[x]`), 4 in progress (`[~]`), 501 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t7105-reset-patch` — 13/13 tests pass (`git reset -p`: interactive hunk prompts, `HEAD`/`@`/default tree, `HEAD^`/`HEAD^{tree}`, blob/unknown ref failures, pathspec `-- dir` and `HEAD^ -- dir`; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t5308-pack-detect-duplicates` — 6/6 tests pass (`index-pack` allows duplicate OIDs by default; `--strict` rejects duplicates with non-zero exit and leaves objects out of the ODB; `cat-file --batch-check` resolves OIDs in packs with duplicate runs; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t7402-submodule-rebase` — 6/6 tests pass (rebase with dirty submodule, interactive rebase, dirty file+submodule failure, stash dirty submodule, submodule gitlink conflict message; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t5317-pack-objects-filter-objects` — 33/33 tests pass (`pack-objects --filter` object filtering; harness CSV/dashboards refreshed; `PLAN.md` marked complete)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t7105-reset-patch` already passes all harness tests on current `grit`; this change records that in tracking artifacts.

## Changes

- Ran `./scripts/run-tests.sh t7105-reset-patch.sh` → **13/13** pass.
- Updated `data/test-files.csv` and regenerated dashboards (`docs/index.html`, `docs/testfiles.html`).
- Marked `t7105-reset-patch` complete in `PLAN.md` and adjusted counts in `progress.md`.
- Added `logs/2026-04-09_t7105-reset-patch.md`.

No Rust code changes were required for this test file.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de475f73-1614-4c27-a0dc-96a3034601e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de475f73-1614-4c27-a0dc-96a3034601e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

