### PR TITLE
t5612-clone-refspec: refresh harness (13/13 passing)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1006,7 +1006,7 @@ t5608-clone-2gb	t5	yes	0	0	0	false	ok	0
 t5609-clone-branch	t5	yes	7	5	2	false	ok	0
 t5610-clone-detached	t5	skip	13	2	11	false	ok	1
 t5611-clone-config	t5	yes	13	9	4	false	ok	0
-t5612-clone-refspec	t5	yes	13	4	9	false	ok	0
+t5612-clone-refspec	t5	yes	13	13	0	true	ok	0
 t5613-info-alternate	t5	yes	13	13	0	true	ok	0
 t5614-clone-submodules-shallow	t5	yes	9	4	5	false	ok	0
 t5615-alternate-env	t5	yes	9	9	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,16 +141,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T05:23:00+00:00" class="gen-time" title="2026-04-09 05:23 UTC">2026-04-09 05:23 UTC</time> · <a href="https://github.com/schacon/grit/commit/5056e7ea46acfc6bbe6e8982a07d498672183621" style="color:#58a6ff">5056e7e</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T05:23:31+00:00" class="gen-time" title="2026-04-09 05:23 UTC">2026-04-09 05:23 UTC</time> · <a href="https://github.com/schacon/grit/commit/b737357ef60e1d8a2c9c91a5daf050539a078292" style="color:#58a6ff">b737357</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">76.0%</div>
+      <div class="summary-big-val pct-blue">76.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,321</div>
+      <div class="summary-big-val">30,330</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -159,12 +159,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:76.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:76.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>766 files fully passing</span>
+    <span>767 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">41/167 files · 17 skipped · 1,476/3,949 tests</span>
+        <span class="group-meta">42/167 files · 17 skipped · 1,485/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.4%"></div></div>
-        <span class="group-pct pct-red">37.4%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.6%"></div></div>
+        <span class="group-pct pct-red">37.6%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:23:00+00:00" class="gen-time" title="2026-04-09 05:23 UTC">2026-04-09 05:23 UTC</time> · <a href="https://github.com/schacon/grit/commit/5056e7ea46acfc6bbe6e8982a07d498672183621" style="color:#58a6ff">5056e7e</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:23:31+00:00" class="gen-time" title="2026-04-09 05:23 UTC">2026-04-09 05:23 UTC</time> · <a href="https://github.com/schacon/grit/commit/b737357ef60e1d8a2c9c91a5daf050539a078292" style="color:#58a6ff">b737357</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,321</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">76.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,330</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">76.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -10217,14 +10217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:69.2%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="13" data-passed="4">
+<tr class="" data-group="t5" data-tests="13" data-passed="13" data-full-pass="1">
   <td class="mono">t5612-clone-refspec</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">13</td>
-  <td class="right">4</td>
+  <td class="right">13</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:30.8%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="13" data-passed="13" data-full-pass="1">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t5612-clone-refspec.sh` already passes all 13 tests against the current `grit` implementation. This change refreshes the harness metadata so `data/test-files.csv` and the generated dashboards reflect **13/13** (previously listed as 4/9).

## Verification

```bash
./scripts/run-tests.sh t5612-clone-refspec.sh
```

## Changes

- Update `data/test-files.csv` row for `t5612-clone-refspec`
- Regenerate `docs/index.html` and `docs/testfiles.html`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89add312-6130-4dee-b609-7ab2ec55ca76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89add312-6130-4dee-b609-7ab2ec55ca76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

