### PR TITLE
test: make t9180-checkout-index-stdin reliable when run directly

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T05:20:37+00:00" class="gen-time" title="2026-04-09 05:20 UTC">2026-04-09 05:20 UTC</time> · <a href="https://github.com/schacon/grit/commit/fd6cf838aa30de2a2efba9a644bfd9ade1e63236" style="color:#58a6ff">fd6cf83</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T05:26:11+00:00" class="gen-time" title="2026-04-09 05:26 UTC">2026-04-09 05:26 UTC</time> · <a href="https://github.com/schacon/grit/commit/f06364b33a6ac32cde51553af39ed57f8e5795b8" style="color:#58a6ff">f06364b</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,7 +100,7 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:20:37+00:00" class="gen-time" title="2026-04-09 05:20 UTC">2026-04-09 05:20 UTC</time> · <a href="https://github.com/schacon/grit/commit/fd6cf838aa30de2a2efba9a644bfd9ade1e63236" style="color:#58a6ff">fd6cf83</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:26:11+00:00" class="gen-time" title="2026-04-09 05:26 UTC">2026-04-09 05:26 UTC</time> · <a href="https://github.com/schacon/grit/commit/f06364b33a6ac32cde51553af39ed57f8e5795b8" style="color:#58a6ff">f06364b</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>

--- a/tests/t9180-checkout-index-stdin.sh
+++ b/tests/t9180-checkout-index-stdin.sh
@@ -5,6 +5,24 @@
 
 test_description='grit checkout-index --stdin'
 
+# When run as `./t9180-checkout-index-stdin.sh`, `$0` has no directory segment, so
+# test-lib.sh's default `../../target/...` lookup would miss the workspace binary.
+# The harness sets GUST_BIN; discover it here for direct runs from `tests/`.
+if test -z "$GUST_BIN"
+then
+	_here="$(cd "$(dirname "$0")" && pwd)"
+	_root="$(cd "$_here/.." && pwd)"
+	for _c in "$_root/target/release/grit" "$_root/target/debug/grit"
+	do
+		if test -x "$_c"
+		then
+			GUST_BIN="$_c"
+			export GUST_BIN
+			break
+		fi
+	done
+fi
+
 cd "$(dirname "$0")" || exit 1
 . ./test-lib.sh
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`grit checkout-index --stdin` behavior already satisfied **tests/t9180-checkout-index-stdin.sh** (25/25 under `./scripts/run-tests.sh`).

The failure mode was **invoking the test as `./t9180-checkout-index-stdin.sh` from `tests/`** without `GUST_BIN`: `test-lib.sh` resolves the binary with `$(dirname "$(dirname "$0")")`, which becomes `.` when `$0` is `./script.sh`, so it looked for `tests/target/release/grit` and aborted.

## Changes

- **tests/t9180-checkout-index-stdin.sh**: Before `cd` + sourcing `test-lib.sh`, resolve `GUST_BIN` from the script’s real directory to `../target/{release,debug}/grit` when unset (harness still overrides via `GUST_BIN="$(pwd)/grit"`).
- Refreshed **docs/index.html** and **docs/testfiles.html** after a harness run.

## Verification

- `./scripts/run-tests.sh t9180-checkout-index-stdin.sh`
- `cd tests && ./t9180-checkout-index-stdin.sh` (no `GUST_BIN` required)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10993a74-6b3d-4b7c-bf58-ad422090de6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10993a74-6b3d-4b7c-bf58-ad422090de6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

