### PR TITLE
t4203-mailmap: harness refresh (74/74 passing)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -820,7 +820,7 @@ t4201-log-graph	t4	yes	23	22	1	false	ok	0
 t4201-shortlog	t4	yes	32	3	29	false	ok	0
 t4202-log	t4	skip	145	0	0	false	ok	0
 t4203-log-diff-filter	t4	yes	7	7	0	true	ok	0
-t4203-mailmap	t4	yes	74	21	53	false	ok	0
+t4203-mailmap	t4	yes	74	74	0	true	ok	0
 t4204-log-follow	t4	yes	5	5	0	true	ok	0
 t4204-patch-id	t4	yes	26	26	0	true	ok	0
 t4205-log-pretty-formats	t4	yes	123	35	88	false	ok	2

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,16 +141,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T05:24:13+00:00" class="gen-time" title="2026-04-09 05:24 UTC">2026-04-09 05:24 UTC</time> · <a href="https://github.com/schacon/grit/commit/9f46c4c4ce3884047ed3253c04d65860f8068e27" style="color:#58a6ff">9f46c4c</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T05:27:35+00:00" class="gen-time" title="2026-04-09 05:27 UTC">2026-04-09 05:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/22db1678e9a783f0b38c469074803ab58ec88f17" style="color:#58a6ff">22db167</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">76.1%</div>
+      <div class="summary-big-val pct-blue">76.2%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,330</div>
+      <div class="summary-big-val">30,383</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -159,12 +159,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:76.1%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:76.2%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>767 files fully passing</span>
+    <span>768 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -223,11 +223,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">72/178 files · 2 skipped · 2,225/3,542 tests</span>
+        <span class="group-meta">73/178 files · 2 skipped · 2,278/3,542 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:62.8%"></div></div>
-        <span class="group-pct pct-blue">62.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.3%"></div></div>
+        <span class="group-pct pct-blue">64.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:24:13+00:00" class="gen-time" title="2026-04-09 05:24 UTC">2026-04-09 05:24 UTC</time> · <a href="https://github.com/schacon/grit/commit/9f46c4c4ce3884047ed3253c04d65860f8068e27" style="color:#58a6ff">9f46c4c</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:27:35+00:00" class="gen-time" title="2026-04-09 05:27 UTC">2026-04-09 05:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/22db1678e9a783f0b38c469074803ab58ec88f17" style="color:#58a6ff">22db167</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,330</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">76.1%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,383</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">76.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -8357,14 +8357,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="74" data-passed="21">
+<tr class="" data-group="t4" data-tests="74" data-passed="74" data-full-pass="1">
   <td class="mono">t4203-mailmap</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">74</td>
-  <td class="right">21</td>
+  <td class="right">74</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:28.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="5" data-passed="5" data-full-pass="1">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t4203-mailmap.sh` already passes fully against the current `grit` implementation (74/74). This change records that in the harness metadata and regenerated dashboards.

## Verification

```bash
cargo build --release -p grit-rs
./scripts/run-tests.sh t4203-mailmap.sh
```

## Files

- `data/test-files.csv` — updated counts for `t4203-mailmap`
- `docs/index.html`, `docs/testfiles.html` — regenerated from CSV
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d82db9bc-6b7e-419c-87ca-451cb93d619b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d82db9bc-6b7e-419c-87ca-451cb93d619b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

