### PR TITLE
test: t1092 sparse-checkout — flip vanished TODOs, 106/106

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -191,7 +191,7 @@ t1090-sparse-checkout-scope	t1	yes	7	3	4	false	ok	0
 t10900-for-each-ref-pattern-sort	t1	yes	34	34	0	true	ok	0
 t1091-sparse-checkout-builtin	t1	yes	76	53	23	false	ok	1
 t10910-show-ref-tags-branches	t1	yes	35	35	0	true	ok	0
-t1092-sparse-checkout-compatibility	t1	yes	104	39	65	false	ok	3
+t1092-sparse-checkout-compatibility	t1	yes	106	106	0	true	ok	0
 t10920-update-ref-create-delete	t1	yes	29	29	0	true	ok	0
 t10930-symbolic-ref-read-write	t1	yes	29	28	1	false	ok	0
 t10940-check-ignore-dir-pattern	t1	yes	35	35	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,30 +141,30 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T05:24:13+00:00" class="gen-time" title="2026-04-09 05:24 UTC">2026-04-09 05:24 UTC</time> · <a href="https://github.com/schacon/grit/commit/9f46c4c4ce3884047ed3253c04d65860f8068e27" style="color:#58a6ff">9f46c4c</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T05:31:30+00:00" class="gen-time" title="2026-04-09 05:31 UTC">2026-04-09 05:31 UTC</time> · <a href="https://github.com/schacon/grit/commit/22db1678e9a783f0b38c469074803ab58ec88f17" style="color:#58a6ff">22db167</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">76.1%</div>
+      <div class="summary-big-val pct-blue">76.2%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,330</div>
+      <div class="summary-big-val">30,397</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">39,873</div>
+      <div class="summary-big-val">39,875</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:76.1%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:76.2%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>767 files fully passing</span>
+    <span>768 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -190,11 +190,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">281/368 files · 8 skipped · 10,783/11,373 tests</span>
+        <span class="group-meta">282/368 files · 8 skipped · 10,850/11,375 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:94.8%"></div></div>
-        <span class="group-pct pct-green">94.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:95.4%"></div></div>
+        <span class="group-pct pct-green">95.4%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t2">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:24:13+00:00" class="gen-time" title="2026-04-09 05:24 UTC">2026-04-09 05:24 UTC</time> · <a href="https://github.com/schacon/grit/commit/9f46c4c4ce3884047ed3253c04d65860f8068e27" style="color:#58a6ff">9f46c4c</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:31:30+00:00" class="gen-time" title="2026-04-09 05:31 UTC">2026-04-09 05:31 UTC</time> · <a href="https://github.com/schacon/grit/commit/22db1678e9a783f0b38c469074803ab58ec88f17" style="color:#58a6ff">22db167</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,330</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">76.1%</div><div class="lbl">Pass rate</div></div>
+  <div class="card"><div class="n" id="sum-tests">39,875</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,397</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">76.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -2067,15 +2067,15 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="104" data-passed="39">
+<tr class="" data-group="t1" data-tests="106" data-passed="106" data-full-pass="1">
   <td class="mono">t1092-sparse-checkout-compatibility</td>
   <td>t1</td>
-  <td></td>
-  <td class="right">104</td>
-  <td class="right">39</td>
+  <td><span class="badge ok">full pass</span></td>
+  <td class="right">106</td>
+  <td class="right">106</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:37.5%"></div></div></td>
-  <td class="right small">3</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="29" data-passed="29" data-full-pass="1">
   <td class="mono">t10920-update-ref-create-delete</td>

--- a/logs/2026-04-09_t1092-sparse-checkout-compatibility.md
+++ b/logs/2026-04-09_t1092-sparse-checkout-compatibility.md
@@ -1,0 +1,5 @@
+# t1092 sparse-checkout compatibility
+
+- Harness reported 104/106: two `test_expect_failure` cases passed with grit (TODO vanished).
+- Flipped to `test_expect_success`: grep recurse-submodules without full-index expansion; `diff --check` with pathspec under sparse directory.
+- Re-ran `./scripts/run-tests.sh t1092-sparse-checkout-compatibility.sh` → 106/106.

--- a/tests/t1092-sparse-checkout-compatibility.sh
+++ b/tests/t1092-sparse-checkout-compatibility.sh
@@ -2145,12 +2145,7 @@ test_expect_success 'grep is not expanded' '
 	ensure_not_expanded grep --cached a -- "deep/*"
 '
 
-# NEEDSWORK: when running `grep` in the superproject with --recurse-submodules,
-# Git expands the index of the submodules unexpectedly. Even though `grep`
-# builtin is marked as "command_requires_full_index = 0", this config is only
-# useful for the superproject. Namely, the submodules have their own configs,
-# which are _not_ populated by the one-time sparse-index feature switch.
-test_expect_failure 'grep within submodules is not expanded' '
+test_expect_success 'grep within submodules is not expanded' '
 	init_repos_as_submodules &&
 
 	# do not use ensure_not_expanded() here, because `grep` should be
@@ -2160,12 +2155,6 @@ test_expect_failure 'grep within submodules is not expanded' '
 	test_region ! index ensure_full_index trace2.txt
 '
 
-# NEEDSWORK: this test is not actually testing the code. The design purpose
-# of this test is to verify the grep result when the submodules are using a
-# sparse-index. Namely, we want "folder1/" as a tree (a sparse directory); but
-# because of the index expansion, we are now grepping the "folder1/a" blob.
-# Because of the problem stated above 'grep within submodules is not expanded',
-# we don't have the ideal test environment yet.
 test_expect_success 'grep sparse directory within submodules' '
 	init_repos_as_submodules &&
 
@@ -2377,15 +2366,7 @@ test_expect_success 'check-attr with pathspec outside sparse definition' '
 	test_all_match git check-attr -a --cached -- folder1/a
 '
 
-# NEEDSWORK: The 'diff --check' test is left as 'test_expect_failure' due
-# to an underlying issue in oneway_diff() within diff-lib.c.
-# 'do_oneway_diff()' is not called as expected for paths that could match
-# inside of a sparse directory. Specifically, the 'ce_path_match()' function
-# fails to recognize files inside a sparse directory (e.g., when 'folder1/'
-# is a sparse directory, 'folder1/a' cannot be recognized). The goal is to
-# proceed with 'do_oneway_diff()' if the pathspec could match inside of a
-# sparse directory.
-test_expect_failure 'diff --check with pathspec outside sparse definition' '
+test_expect_success 'diff --check with pathspec outside sparse definition' '
 	init_repos &&
 
 	write_script edit-contents <<-\EOF &&


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t1092-sparse-checkout-compatibility` was reporting **104/106** in the harness because two cases were still `test_expect_failure` while grit already passed them (TODO known breakage vanished). Per project rules, those are flipped to `test_expect_success`.

## Changes

- **`grep within submodules is not expanded`**: `test_expect_failure` → `test_expect_success` (removed obsolete NEEDSWORK comment block).
- **`diff --check with pathspec outside sparse definition`**: same.
- Removed the redundant NEEDSWORK paragraph before **`grep sparse directory within submodules`** (still `test_expect_success`).
- Refreshed **`data/test-files.csv`** and dashboards from `./scripts/run-tests.sh t1092-sparse-checkout-compatibility.sh`.
- Added **`logs/2026-04-09_t1092-sparse-checkout-compatibility.md`**.

## Verification

```bash
./scripts/run-tests.sh t1092-sparse-checkout-compatibility.sh
# → 106/106
```

No Rust code changes were required for this file’s full pass count.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae5ed9ee-4e9a-4dda-af6c-de42755ab4f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae5ed9ee-4e9a-4dda-af6c-de42755ab4f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

