### PR TITLE
chore: refresh harness for t7111-reset-table (42/42 passing)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1188,7 +1188,7 @@ t7106-reset-unborn-branch	t7	yes	7	7	0	true	ok	0
 t7107-reset-pathspec-file	t7	yes	11	0	11	false	ok	0
 t7110-reset-merge	t7	yes	21	7	14	false	ok	0
 t7110-reset-modes	t7	yes	20	20	0	true	ok	0
-t7111-reset-table	t7	yes	42	33	9	false	ok	0
+t7111-reset-table	t7	yes	42	42	0	true	ok	0
 t7112-reset-submodule	t7	yes	76	3	73	false	ok	0
 t7113-post-index-change-hook	t7	yes	4	1	3	false	ok	0
 t7201-co	t7	yes	46	15	31	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T05:32:07+00:00" class="gen-time" title="2026-04-09 05:32 UTC">2026-04-09 05:32 UTC</time> · <a href="https://github.com/schacon/grit/commit/beba4a6f4d5a49844910ab6b42132605d29bc6e8" style="color:#58a6ff">beba4a6</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T05:34:33+00:00" class="gen-time" title="2026-04-09 05:34 UTC">2026-04-09 05:34 UTC</time> · <a href="https://github.com/schacon/grit/commit/d48011cb0c0c5114b32d5848a4e2344b6d627809" style="color:#58a6ff">d48011c</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,407</div>
+      <div class="summary-big-val">30,416</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>769 files fully passing</span>
+    <span>770 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -256,11 +256,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">49/126 files · 11 skipped · 1,963/2,944 tests</span>
+        <span class="group-meta">50/126 files · 11 skipped · 1,972/2,944 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:66.7%"></div></div>
-        <span class="group-pct pct-blue">66.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:67.0%"></div></div>
+        <span class="group-pct pct-blue">67.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:32:07+00:00" class="gen-time" title="2026-04-09 05:32 UTC">2026-04-09 05:32 UTC</time> · <a href="https://github.com/schacon/grit/commit/beba4a6f4d5a49844910ab6b42132605d29bc6e8" style="color:#58a6ff">beba4a6</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:34:33+00:00" class="gen-time" title="2026-04-09 05:34 UTC">2026-04-09 05:34 UTC</time> · <a href="https://github.com/schacon/grit/commit/d48011cb0c0c5114b32d5848a4e2344b6d627809" style="color:#58a6ff">d48011c</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,407</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,416</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">76.3%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -12037,14 +12037,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="42" data-passed="33">
+<tr class="" data-group="t7" data-tests="42" data-passed="42" data-full-pass="1">
   <td class="mono">t7111-reset-table</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">42</td>
-  <td class="right">33</td>
+  <td class="right">42</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:78.6%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="76" data-passed="3">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t7111-reset-table.sh` already passes all 42 tests against the current `grit` binary. The harness metadata in `data/test-files.csv` was stale (33 passed / 9 failed).

## Changes

- Re-ran `./scripts/run-tests.sh t7111-reset-table.sh`, which updated `data/test-files.csv` to **42/42** and regenerated `docs/index.html` and `docs/testfiles.html`.

No Rust or test script changes were required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64c58f6d-ed58-4214-8174-a9a77c19e01b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64c58f6d-ed58-4214-8174-a9a77c19e01b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

