### PR TITLE
docs: t5514-fetch-multiple fully passing (25/25)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -654,7 +654,7 @@ commit → check it off → move on.
 - [ ] `t5100-mailinfo` ████████████░░░░░░░░ 33/52 (19 left) — git mailinfo and git mailsplit test
 - [ ] `t5541-http-push-smart` █░░░░░░░░░░░░░░░░░░░ 2/21 (19 left) — test smart pushing over http via http-backend
 - [ ] `t5001-archive-attr` ██████████░░░░░░░░░░ 24/44 (20 left) — git archive attribute tests
-- [ ] `t5514-fetch-multiple` ███░░░░░░░░░░░░░░░░░ 4/25 (21 left) — fetch --all works correctly
+- [x] `t5514-fetch-multiple` — fetch --all works correctly (25/25)
 - [ ] `t5710-promisor-remote-capability` ░░░░░░░░░░░░░░░░░░░░ 1/22 (21 left) — handling of promisor remote advertisement
 - [ ] `t5703-upload-pack-ref-in-want` ███░░░░░░░░░░░░░░░░░ 4/26 (22 left) — upload-pack ref-in-want
 - [ ] `t5329-pack-objects-cruft` ██░░░░░░░░░░░░░░░░░░ 3/25 (22 left) — cruft pack related pack-objects tests

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -929,7 +929,7 @@ t5510-fetch	t5	yes	215	81	134	false	ok	0
 t5511-refspec	t5	yes	47	24	23	false	ok	0
 t5512-ls-remote	t5	yes	0	0	0	false	timeout	0
 t5513-fetch-track	t5	yes	2	2	0	true	ok	0
-t5514-fetch-multiple	t5	yes	25	4	21	false	ok	0
+t5514-fetch-multiple	t5	yes	25	25	0	true	ok	0
 t5515-fetch-merge-logic	t5	yes	65	1	64	false	ok	0
 t5516-fetch-push	t5	yes	124	10	114	false	ok	0
 t5517-push-mirror	t5	yes	13	8	5	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T05:40:34+00:00" class="gen-time" title="2026-04-09 05:40 UTC">2026-04-09 05:40 UTC</time> · <a href="https://github.com/schacon/grit/commit/2926157e42242007604c964f419d7dab1dd7b2ef" style="color:#58a6ff">2926157</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T05:43:12+00:00" class="gen-time" title="2026-04-09 05:43 UTC">2026-04-09 05:43 UTC</time> · <a href="https://github.com/schacon/grit/commit/d7de157322f26a418c8ff0dcd3a130bf1233db7b" style="color:#58a6ff">d7de157</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,416</div>
+      <div class="summary-big-val">30,437</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>770 files fully passing</span>
+    <span>771 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">42/167 files · 17 skipped · 1,485/3,949 tests</span>
+        <span class="group-meta">43/167 files · 17 skipped · 1,506/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.6%"></div></div>
-        <span class="group-pct pct-red">37.6%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:38.1%"></div></div>
+        <span class="group-pct pct-red">38.1%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:40:34+00:00" class="gen-time" title="2026-04-09 05:40 UTC">2026-04-09 05:40 UTC</time> · <a href="https://github.com/schacon/grit/commit/2926157e42242007604c964f419d7dab1dd7b2ef" style="color:#58a6ff">2926157</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:43:12+00:00" class="gen-time" title="2026-04-09 05:43 UTC">2026-04-09 05:43 UTC</time> · <a href="https://github.com/schacon/grit/commit/d7de157322f26a418c8ff0dcd3a130bf1233db7b" style="color:#58a6ff">d7de157</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,416</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,437</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">76.3%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -9447,14 +9447,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="25" data-passed="4">
+<tr class="" data-group="t5" data-tests="25" data-passed="25" data-full-pass="1">
   <td class="mono">t5514-fetch-multiple</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">25</td>
-  <td class="right">4</td>
+  <td class="right">25</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:16.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="65" data-passed="1">

--- a/logs/2026-04-09_t5514-fetch-multiple.md
+++ b/logs/2026-04-09_t5514-fetch-multiple.md
@@ -1,0 +1,21 @@
+# t5514-fetch-multiple
+
+**Date:** 2026-04-09
+
+## Outcome
+
+`./scripts/run-tests.sh t5514-fetch-multiple.sh` reports **25/25** passing on current `grit` (branch `cursor/t5514-fetch-multiple-tests-58ba`). No Rust code changes were required in this session; the harness run refreshed `data/test-files.csv` and dashboards.
+
+## Coverage (from upstream test file)
+
+- `git fetch --all` across multiple remotes; `--no-write-fetch-head`
+- Continue after a bad remote; reject extra arguments with `--all`
+- `git fetch --multiple` (one/two remotes, bad remote names)
+- `remote.<name>.skipFetchAll` vs explicit `--multiple`
+- `--all --no-tags` / `--all --tags`
+- Parallel `fetch --jobs=2 --multiple` (trace + error messages)
+- `fetch.all` config, `git fetch` default vs explicit remote, `--no-all` interaction with `--all`
+
+## Follow-up
+
+None for this file.

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   264 |
+| Completed   |   265 |
 | In progress |     4 |
-| Remaining   |   500 |
+| Remaining   |   499 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 264 completed (`[x]`), 4 in progress (`[~]`), 500 remaining (`[ ]`).
+Task lines in `PLAN.md`: 265 completed (`[x]`), 4 in progress (`[~]`), 499 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t5514-fetch-multiple` — 25/25 tests pass (`fetch --all` / `--multiple`, `fetch.all` / `--no-all`, `skipFetchAll`, parallel `--jobs`, tags; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t7450-bad-git-dotfiles` — 50/50 tests pass (submodule name/url validation, fsck symlink and `.gitmodules` checks, nested submodule git dirs, harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t5351-unpack-large-objects` — 7/7 tests pass (`GIT_ALLOC_LIMIT` + `core.bigFileThreshold` streaming unpack, dry-run, trace2 fsync batch path, skip already-packed objects; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t5308-pack-detect-duplicates` — 6/6 tests pass (`index-pack` allows duplicate OIDs by default; `--strict` rejects duplicates with non-zero exit and leaves objects out of the ODB; `cat-file --batch-check` resolves OIDs in packs with duplicate runs; harness CSV/dashboards refreshed; `PLAN.md` marked complete)

--- a/test-results.md
+++ b/test-results.md
@@ -2,6 +2,7 @@
 
 **Updated:** 2026-04-09
 
+- `./scripts/run-tests.sh t5514-fetch-multiple.sh`: 25/25 passing (`fetch --all` / `--multiple`, `fetch.all` / `--no-all`, `remote.*.skipFetchAll`, `--jobs` parallel fetch, tag options; harness CSV/dashboards refreshed).
 - `./scripts/run-tests.sh t5308-pack-detect-duplicates.sh`: 6/6 passing (duplicate objects in pack: default `index-pack` accepts; `--strict` rejects and leaves ODB unchanged; `cat-file --batch-check` over duplicated pack; harness CSV/dashboards refreshed).
 - `./scripts/run-tests.sh t4120-apply-popt.sh`: 12/12 passing (`git apply -p` strip count, invalid `-p` diagnostics, quoted traditional diff paths, `--stat` oversized strip, mode-only and rename with `--index`; harness CSV/dashboards refreshed).
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Verified `./scripts/run-tests.sh t5514-fetch-multiple.sh` passes **25/25** on current `grit`. No code changes were required.

## Changes

- Refreshed `data/test-files.csv` and generated dashboards (`docs/index.html`, `docs/testfiles.html`) from the harness run.
- Marked `t5514-fetch-multiple` complete in `PLAN.md` and adjusted counts in `progress.md`.
- Added a harness note to `test-results.md` and a short log in `logs/2026-04-09_t5514-fetch-multiple.md`.

## Testing

- `./scripts/run-tests.sh t5514-fetch-multiple.sh`
- `cargo test -p grit-lib --lib` (121/121)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d8f6fd7-d1c4-436e-aa30-e0a6c1cad703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d8f6fd7-d1c4-436e-aa30-e0a6c1cad703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

