### PR TITLE
chore: refresh harness — t4126-apply-empty 8/8

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -795,7 +795,7 @@ t4122-apply-symlink-inside	t4	yes	7	3	4	false	ok	0
 t4123-apply-shrink	t4	yes	2	2	0	true	ok	0
 t4124-apply-ws-rule	t4	yes	85	71	14	false	ok	0
 t4125-apply-ws-fuzz	t4	yes	4	2	2	false	ok	0
-t4126-apply-empty	t4	yes	8	7	1	false	ok	0
+t4126-apply-empty	t4	yes	8	8	0	true	ok	0
 t4127-apply-same-fn	t4	yes	7	7	0	true	ok	0
 t4128-apply-root	t4	yes	12	1	11	false	ok	0
 t4129-apply-samemode	t4	yes	23	8	15	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T05:44:08+00:00" class="gen-time" title="2026-04-09 05:44 UTC">2026-04-09 05:44 UTC</time> · <a href="https://github.com/schacon/grit/commit/d7de157322f26a418c8ff0dcd3a130bf1233db7b" style="color:#58a6ff">d7de157</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T05:46:45+00:00" class="gen-time" title="2026-04-09 05:46 UTC">2026-04-09 05:46 UTC</time> · <a href="https://github.com/schacon/grit/commit/9ed4c49b9f8f1171666d55538b4bf772b83335d8" style="color:#58a6ff">9ed4c49</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,416</div>
+      <div class="summary-big-val">30,417</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>770 files fully passing</span>
+    <span>771 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -223,7 +223,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">73/178 files · 2 skipped · 2,278/3,542 tests</span>
+        <span class="group-meta">74/178 files · 2 skipped · 2,279/3,542 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.3%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:44:08+00:00" class="gen-time" title="2026-04-09 05:44 UTC">2026-04-09 05:44 UTC</time> · <a href="https://github.com/schacon/grit/commit/d7de157322f26a418c8ff0dcd3a130bf1233db7b" style="color:#58a6ff">d7de157</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:46:45+00:00" class="gen-time" title="2026-04-09 05:46 UTC">2026-04-09 05:46 UTC</time> · <a href="https://github.com/schacon/grit/commit/9ed4c49b9f8f1171666d55538b4bf772b83335d8" style="color:#58a6ff">9ed4c49</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,416</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,417</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">76.3%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -8107,14 +8107,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="8" data-passed="7">
+<tr class="" data-group="t4" data-tests="8" data-passed="8" data-full-pass="1">
   <td class="mono">t4126-apply-empty</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">8</td>
-  <td class="right">7</td>
+  <td class="right">8</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:87.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="7" data-passed="7" data-full-pass="1">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t4126-apply-empty` already passes **8/8** against the current `grit` binary. The working tree had stale harness rows (7/8); this updates `data/test-files.csv` and the generated dashboards to match the latest run.

## Verification

```bash
cargo build --release -p grit-rs
./scripts/run-tests.sh t4126-apply-empty.sh
```

Result: **8/8** passing.

## Changes

- `data/test-files.csv` — refreshed counts for `t4126-apply-empty`
- `docs/index.html`, `docs/testfiles.html` — regenerated from CSV
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-884ae158-8727-456f-b827-f49c8d20d27c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-884ae158-8727-456f-b827-f49c8d20d27c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

