### PR TITLE
test: t5318-pack-objects-revs-exclude harness 9/9

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -885,7 +885,7 @@ t5315-pack-objects-compression	t5	yes	9	5	4	false	ok	0
 t5316-pack-delta-depth	t5	yes	5	3	2	false	ok	0
 t5317-pack-objects-filter-objects	t5	yes	33	33	0	true	ok	0
 t5318-commit-graph	t5	skip	85	0	0	false	ok	0
-t5318-pack-objects-revs-exclude	t5	yes	9	6	3	false	ok	0
+t5318-pack-objects-revs-exclude	t5	yes	9	9	0	true	ok	0
 t5319-multi-pack-index	t5	yes	0	0	0	false	timeout	0
 t5320-delta-islands	t5	yes	15	15	0	true	ok	0
 t5321-pack-large-objects	t5	yes	2	0	2	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T05:45:11+00:00" class="gen-time" title="2026-04-09 05:45 UTC">2026-04-09 05:45 UTC</time> · <a href="https://github.com/schacon/grit/commit/9ed4c49b9f8f1171666d55538b4bf772b83335d8" style="color:#58a6ff">9ed4c49</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T05:49:54+00:00" class="gen-time" title="2026-04-09 05:49 UTC">2026-04-09 05:49 UTC</time> · <a href="https://github.com/schacon/grit/commit/1bce41abab0c0289cc3e958ebec122a62e1a11ef" style="color:#58a6ff">1bce41a</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,416</div>
+      <div class="summary-big-val">30,419</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>770 files fully passing</span>
+    <span>771 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">42/167 files · 17 skipped · 1,485/3,949 tests</span>
+        <span class="group-meta">43/167 files · 17 skipped · 1,488/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.6%"></div></div>
-        <span class="group-pct pct-red">37.6%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
+        <span class="group-pct pct-red">37.7%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:45:11+00:00" class="gen-time" title="2026-04-09 05:45 UTC">2026-04-09 05:45 UTC</time> · <a href="https://github.com/schacon/grit/commit/9ed4c49b9f8f1171666d55538b4bf772b83335d8" style="color:#58a6ff">9ed4c49</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:49:54+00:00" class="gen-time" title="2026-04-09 05:49 UTC">2026-04-09 05:49 UTC</time> · <a href="https://github.com/schacon/grit/commit/1bce41abab0c0289cc3e958ebec122a62e1a11ef" style="color:#58a6ff">1bce41a</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,416</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,419</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">76.3%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -9007,14 +9007,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="9" data-passed="6">
+<tr class="" data-group="t5" data-tests="9" data-passed="9" data-full-pass="1">
   <td class="mono">t5318-pack-objects-revs-exclude</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">9</td>
-  <td class="right">6</td>
+  <td class="right">9</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:66.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="0" data-passed="0">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`tests/t5318-pack-objects-revs-exclude.sh` already passes fully against current `grit` (pack-objects `--revs` with `^ref` exclusion, `--delta-base-offset`, `--stdin-packs`, and `index-pack --verify`).

This change only **refreshes harness metadata** after a clean run:

- `data/test-files.csv` — 9/9 passed, `fully_passing=true`
- Regenerated `docs/index.html` and `docs/testfiles.html`

## Verification

```bash
./scripts/run-tests.sh t5318-pack-objects-revs-exclude.sh
cargo test -p grit-lib --lib
```

Also confirmed with `GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME=main` (9/9).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bdf3f240-8a0a-4454-bc9f-0a5a12d74145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bdf3f240-8a0a-4454-bc9f-0a5a12d74145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

