### PR TITLE
fix: complete t4058-diff-duplicates (16/16)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -466,7 +466,7 @@ commit → check it off → move on.
 - [ ] `t4017-diff-retval` ███████████████░░░░░ 30/38 (8 left) — Return value of diffs
 - [ ] `t4035-diff-quiet` █████████████░░░░░░░ 15/23 (8 left) — Return value of diffs
 - [ ] `t4213-log-tabexpand` ██░░░░░░░░░░░░░░░░░░ 1/9 (8 left) — log/show --expand-tabs
-- [ ] `t4058-diff-duplicates` ████████░░░░░░░░░░░░ 7/16 (9 left) — test tree diff when trees have duplicate entries
+- [x] `t4058-diff-duplicates` ████████████████████ 16/16 (0 left) — test tree diff when trees have duplicate entries
 - [ ] `t4008-diff-break-rewrite` ███████░░░░░░░░░░░░░ 5/14 (9 left) — Break and then rename
 
 - [x] `t4120-apply-popt` ████████████████████ 12/12 (0 left) — git apply -p handling.

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -738,7 +738,7 @@ t4054-diff-bogus-tree	t4	yes	14	14	0	true	ok	0
 t4055-diff-context	t4	yes	10	7	3	false	ok	0
 t4056-diff-order	t4	yes	23	10	13	false	ok	0
 t4057-diff-combined-paths	t4	yes	4	0	4	false	ok	0
-t4058-diff-duplicates	t4	yes	14	7	7	false	ok	2
+t4058-diff-duplicates	t4	yes	16	16	0	true	ok	0
 t4059-diff-submodule-not-initialized	t4	yes	8	1	7	false	ok	0
 t4060-diff-submodule-option-diff-format	t4	yes	51	29	22	false	ok	0
 t4061-diff-indent	t4	yes	33	5	28	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T05:48:26+00:00" class="gen-time" title="2026-04-09 05:48 UTC">2026-04-09 05:48 UTC</time> · <a href="https://github.com/schacon/grit/commit/4e9e2ce5aa0e435473c37603aa3042d29f73665c" style="color:#58a6ff">4e9e2ce</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T05:52:45+00:00" class="gen-time" title="2026-04-09 05:52 UTC">2026-04-09 05:52 UTC</time> · <a href="https://github.com/schacon/grit/commit/1ab2ac875f58dfa7b23e53cd448a41194234990e" style="color:#58a6ff">1ab2ac8</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,11 +150,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,421</div>
+      <div class="summary-big-val">30,430</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">39,873</div>
+      <div class="summary-big-val">39,875</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>771 files fully passing</span>
+    <span>772 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -223,11 +223,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">73/178 files · 2 skipped · 2,278/3,542 tests</span>
+        <span class="group-meta">74/178 files · 2 skipped · 2,287/3,544 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.3%"></div></div>
-        <span class="group-pct pct-blue">64.3%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.5%"></div></div>
+        <span class="group-pct pct-blue">64.5%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:48:26+00:00" class="gen-time" title="2026-04-09 05:48 UTC">2026-04-09 05:48 UTC</time> · <a href="https://github.com/schacon/grit/commit/4e9e2ce5aa0e435473c37603aa3042d29f73665c" style="color:#58a6ff">4e9e2ce</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:52:45+00:00" class="gen-time" title="2026-04-09 05:52 UTC">2026-04-09 05:52 UTC</time> · <a href="https://github.com/schacon/grit/commit/1ab2ac875f58dfa7b23e53cd448a41194234990e" style="color:#58a6ff">1ab2ac8</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,421</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n" id="sum-tests">39,875</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,430</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">76.3%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -7537,15 +7537,15 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="14" data-passed="7">
+<tr class="" data-group="t4" data-tests="16" data-passed="16" data-full-pass="1">
   <td class="mono">t4058-diff-duplicates</td>
   <td>t4</td>
-  <td></td>
-  <td class="right">14</td>
-  <td class="right">7</td>
+  <td><span class="badge ok">full pass</span></td>
+  <td class="right">16</td>
+  <td class="right">16</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
-  <td class="right small">2</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="8" data-passed="1">
   <td class="mono">t4059-diff-submodule-not-initialized</td>

--- a/grit-lib/src/wildmatch.rs
+++ b/grit-lib/src/wildmatch.rs
@@ -1,10 +1,10 @@
-/// Git-compatible wildmatch pattern matching.
-///
-/// Implements shell-style pattern matching for `?`, `\`, `[]`, and `*`
-/// characters, with special handling of `**` for directory matching.
-///
-/// Based on the algorithm by Rich Salz (1986), modified by Wayne Davison
-/// for special `/` handling and `**` glob support.
+//! Git-compatible wildmatch pattern matching.
+//!
+//! Implements shell-style pattern matching for `?`, `\`, `[]`, and `*`
+//! characters, with special handling of `**` for directory matching.
+//!
+//! Based on the algorithm by Rich Salz (1986), modified by Wayne Davison
+//! for special `/` handling and `**` glob support.
 
 pub const WM_CASEFOLD: u32 = 1;
 pub const WM_PATHNAME: u32 = 2;

--- a/logs/2026-04-09_t4058-diff-duplicates.md
+++ b/logs/2026-04-09_t4058-diff-duplicates.md
@@ -1,0 +1,23 @@
+# t4058-diff-duplicates
+
+**Date:** 2026-04-09
+
+## Outcome
+
+Harness reported 14/16 with 2 `test_expect_failure` blocks still marked TODO. Running the script showed both as "known breakage vanished" — grit already passes those cases.
+
+## Changes
+
+- `tests/t4058-diff-duplicates.sh`: `test_expect_failure` → `test_expect_success` for:
+  - `can switch to another branch when status is empty`
+  - `clean status, switch branches, status still clean`
+- `PLAN.md` / `progress.md`: mark file complete, refresh counts.
+
+## Verification
+
+```bash
+./scripts/run-tests.sh t4058-diff-duplicates.sh
+# expect 16/16, 0 test_expect_failure in file
+```
+
+Full TAP run from `tests/` with `GUST_BIN=./grit`: all 16 ok, exit 0.

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   264 |
+| Completed   |   265 |
 | In progress |     4 |
-| Remaining   |   500 |
+| Remaining   |   499 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 264 completed (`[x]`), 4 in progress (`[~]`), 500 remaining (`[ ]`).
+Task lines in `PLAN.md`: 265 completed (`[x]`), 4 in progress (`[~]`), 499 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t4058-diff-duplicates` — 16/16 tests pass (duplicate-tree diff/checkout: flip `test_expect_failure` → `test_expect_success` for empty-status branch switches; behavior already matched Git)
 - `t7450-bad-git-dotfiles` — 50/50 tests pass (submodule name/url validation, fsck symlink and `.gitmodules` checks, nested submodule git dirs, harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t5351-unpack-large-objects` — 7/7 tests pass (`GIT_ALLOC_LIMIT` + `core.bigFileThreshold` streaming unpack, dry-run, trace2 fsync batch path, skip already-packed objects; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t5308-pack-detect-duplicates` — 6/6 tests pass (`index-pack` allows duplicate OIDs by default; `--strict` rejects duplicates with non-zero exit and leaves objects out of the ODB; `cat-file --batch-check` resolves OIDs in packs with duplicate runs; harness CSV/dashboards refreshed; `PLAN.md` marked complete)

--- a/tests/t4058-diff-duplicates.sh
+++ b/tests/t4058-diff-duplicates.sh
@@ -158,7 +158,7 @@ test_expect_success 'git diff HEAD does not segfault' '
 	test_grep "error: corrupted cache-tree has entries not present in index" err
 '
 
-test_expect_failure 'can switch to another branch when status is empty' '
+test_expect_success 'can switch to another branch when status is empty' '
 	git clean -ffdqx &&
 	git status --porcelain -uno >actual &&
 	test_must_be_empty actual &&
@@ -175,7 +175,7 @@ test_expect_success 'fast-forward from non-duplicate entries to duplicate' '
 	git merge final
 '
 
-test_expect_failure 'clean status, switch branches, status still clean' '
+test_expect_success 'clean status, switch branches, status still clean' '
 	git status --porcelain -uno >actual &&
 	test_must_be_empty actual &&
 	git checkout base &&


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t4058-diff-duplicates` now reports **16/16** in the harness.

## Changes

- **`tests/t4058-diff-duplicates.sh`**: The two cases that were still `test_expect_failure` were passing under grit (“known breakage vanished”). They are now `test_expect_success`, matching AGENTS.md guidance for fixed behavior.
- **`PLAN.md` / `progress.md`**: Mark the file complete and refresh task counts.
- **`logs/2026-04-09_t4058-diff-duplicates.md`**: Short task log.
- **Harness artifacts**: `data/test-files.csv`, `docs/index.html`, `docs/testfiles.html` refreshed via `./scripts/run-tests.sh t4058-diff-duplicates.sh`.
- **`grit-lib/src/wildmatch.rs`**: Module-level `//!` docs instead of a detached outer `///` block so `cargo clippy … -D warnings` does not trip `empty_line_after_doc_comments` on the first item.

## Verification

- `./scripts/run-tests.sh t4058-diff-duplicates.sh` → 16/16
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77a510b9-a0bb-4890-b57c-c41a9243f25c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77a510b9-a0bb-4890-b57c-c41a9243f25c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

