### PR TITLE
test: t6437-submodule-merge fully passing (22/22)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -745,7 +745,7 @@ commit → check it off → move on.
 
 - [ ] `t6003-rev-list-topo-order` ███████████░░░░░░░░░ 21/36 (15 left) — Tests git rev-list --topo-order functionality
 - [ ] `t6601-path-walk` ░░░░░░░░░░░░░░░░░░░░ 0/15 (15 left) — direct path-walk API tests
-- [ ] `t6437-submodule-merge` █████░░░░░░░░░░░░░░░ 6/22 (16 left) — merging with submodules
+- [x] `t6437-submodule-merge` — merging with submodules (22/22)
 - [ ] `t6006-rev-list-format` ███████████████░░░░░ 63/80 (17 left) — git rev-list --pretty=format test
 - [ ] `t6422-merge-rename-corner-cases` ██████░░░░░░░░░░░░░░ 9/26 (17 left) — recursive merge corner cases w/ renames but not criss-crosses
 - [ ] `t6000-rev-list-misc` █████░░░░░░░░░░░░░░░ 6/23 (17 left) — miscellaneous rev-list tests

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1136,7 +1136,7 @@ t6434-merge-with-no-common-ancestor	t6	yes	3	3	0	true	ok	0
 t6435-merge-sparse	t6	yes	6	4	2	false	ok	0
 t6435-merge-sparse-directory	t6	yes	2	2	0	true	ok	0
 t6436-merge-overwrite	t6	yes	18	10	8	false	ok	0
-t6437-submodule-merge	t6	yes	20	8	12	false	ok	2
+t6437-submodule-merge	t6	yes	22	22	0	true	ok	0
 t6438-submodule-directory-file-conflicts	t6	yes	56	12	44	false	ok	0
 t6439-merge-co-error-msgs	t6	yes	6	6	0	true	ok	0
 t6500-gc	t6	yes	0	0	0	false	timeout	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T05:56:57+00:00" class="gen-time" title="2026-04-09 05:56 UTC">2026-04-09 05:56 UTC</time> · <a href="https://github.com/schacon/grit/commit/96a28b5f513ee67296260925fd30f1e90dca143d" style="color:#58a6ff">96a28b5</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T06:00:21+00:00" class="gen-time" title="2026-04-09 06:00 UTC">2026-04-09 06:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/73e113347402cf2e762f1156f5d4c68c7fb6a17f" style="color:#58a6ff">73e1133</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,11 +150,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,427</div>
+      <div class="summary-big-val">30,441</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">39,873</div>
+      <div class="summary-big-val">39,875</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>773 files fully passing</span>
+    <span>774 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -245,11 +245,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t6</span>
         <span class="group-desc">Revision tree commands (e.g. merge-base)</span>
-        <span class="group-meta">47/105 files · 3 skipped · 1,218/2,135 tests</span>
+        <span class="group-meta">48/105 files · 3 skipped · 1,232/2,137 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:57.0%"></div></div>
-        <span class="group-pct pct-orange">57.0%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:57.7%"></div></div>
+        <span class="group-pct pct-orange">57.7%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t7">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:56:57+00:00" class="gen-time" title="2026-04-09 05:56 UTC">2026-04-09 05:56 UTC</time> · <a href="https://github.com/schacon/grit/commit/96a28b5f513ee67296260925fd30f1e90dca143d" style="color:#58a6ff">96a28b5</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:00:21+00:00" class="gen-time" title="2026-04-09 06:00 UTC">2026-04-09 06:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/73e113347402cf2e762f1156f5d4c68c7fb6a17f" style="color:#58a6ff">73e1133</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,427</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n" id="sum-tests">39,875</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,441</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">76.3%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -11517,15 +11517,15 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:55.6%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t6" data-tests="20" data-passed="8">
+<tr class="" data-group="t6" data-tests="22" data-passed="22" data-full-pass="1">
   <td class="mono">t6437-submodule-merge</td>
   <td>t6</td>
-  <td></td>
-  <td class="right">20</td>
-  <td class="right">8</td>
+  <td><span class="badge ok">full pass</span></td>
+  <td class="right">22</td>
+  <td class="right">22</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:40.0%"></div></div></td>
-  <td class="right small">2</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t6" data-tests="56" data-passed="12">
   <td class="mono">t6438-submodule-directory-file-conflicts</td>

--- a/logs/2026-04-09_t6437-submodule-merge.md
+++ b/logs/2026-04-09_t6437-submodule-merge.md
@@ -1,0 +1,17 @@
+# t6437-submodule-merge
+
+## Outcome
+
+Harness reported 20/22 with 2 `test_expect_failure` cases that now pass (known breakage vanished).
+
+## Change
+
+- `tests/t6437-submodule-merge.sh`: `test_expect_failure` → `test_expect_success` for:
+  - directory/submodule conflict; keep submodule clean
+  - directory/submodule conflict; merge --abort works afterward
+- `./scripts/run-tests.sh t6437-submodule-merge.sh` → 22/22
+- `PLAN.md` / `progress.md` updated
+
+## Note
+
+Grit already implements the behavior; the test file only needed to expect success per AGENTS.md exception for fixed breakage.

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   264 |
+| Completed   |   265 |
 | In progress |     4 |
-| Remaining   |   500 |
+| Remaining   |   499 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 264 completed (`[x]`), 4 in progress (`[~]`), 500 remaining (`[ ]`).
+Task lines in `PLAN.md`: 265 completed (`[x]`), 4 in progress (`[~]`), 499 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t6437-submodule-merge` — 22/22 tests pass (directory/submodule merge: submodule work tree preserved, conflict material relocated; `merge --abort` clears state; `test_expect_failure` → `test_expect_success` for cases now passing; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t7450-bad-git-dotfiles` — 50/50 tests pass (submodule name/url validation, fsck symlink and `.gitmodules` checks, nested submodule git dirs, harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t5351-unpack-large-objects` — 7/7 tests pass (`GIT_ALLOC_LIMIT` + `core.bigFileThreshold` streaming unpack, dry-run, trace2 fsync batch path, skip already-packed objects; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t5308-pack-detect-duplicates` — 6/6 tests pass (`index-pack` allows duplicate OIDs by default; `--strict` rejects duplicates with non-zero exit and leaves objects out of the ODB; `cat-file --batch-check` resolves OIDs in packs with duplicate runs; harness CSV/dashboards refreshed; `PLAN.md` marked complete)

--- a/tests/t6437-submodule-merge.sh
+++ b/tests/t6437-submodule-merge.sh
@@ -418,7 +418,7 @@ test_expect_success 'setup directory/submodule conflict' '
 	)
 '
 
-test_expect_failure 'directory/submodule conflict; keep submodule clean' '
+test_expect_success 'directory/submodule conflict; keep submodule clean' '
 	test_when_finished "git -C directory-submodule reset --hard" &&
 	(
 		cd directory-submodule &&
@@ -460,7 +460,7 @@ test_expect_success !FAIL_PREREQS 'directory/submodule conflict; should not trea
 	)
 '
 
-test_expect_failure 'directory/submodule conflict; merge --abort works afterward' '
+test_expect_success 'directory/submodule conflict; merge --abort works afterward' '
 	test_when_finished "git -C directory-submodule/path reset --hard" &&
 	test_when_finished "git -C directory-submodule reset --hard" &&
 	(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t6437-submodule-merge` was reporting **20/22** because two cases were still marked `test_expect_failure` while Grit already behaves like Git (“known breakage vanished”).

## Changes

- Flip **`test_expect_failure` → `test_expect_success`** for:
  - directory/submodule conflict; keep submodule clean
  - directory/submodule conflict; merge --abort works afterward
- Refresh harness artifacts (`data/test-files.csv`, dashboards).
- Mark **`t6437-submodule-merge`** complete in `PLAN.md`; bump counts in `progress.md`.
- Add **`logs/2026-04-09_t6437-submodule-merge.md`**.

## Verification

```bash
./scripts/run-tests.sh t6437-submodule-merge.sh
# ✓ t6437-submodule-merge (22/22)
```

This follows the AGENTS.md exception for flipping expect-failure when the underlying behavior is fixed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95b74b6b-00f9-49f5-9c31-036078b0b258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95b74b6b-00f9-49f5-9c31-036078b0b258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

