### PR TITLE
chore: t4108-apply-threeway fully passing (18/18)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -777,7 +777,7 @@ t4104-apply-boundary	t4	yes	24	24	0	true	ok	0
 t4105-apply-fuzz	t4	yes	9	9	0	true	ok	0
 t4106-apply-stdin	t4	yes	3	3	0	true	ok	0
 t4107-apply-ignore-whitespace	t4	yes	11	11	0	true	ok	0
-t4108-apply-threeway	t4	yes	18	3	15	false	ok	0
+t4108-apply-threeway	t4	yes	18	18	0	true	ok	0
 t4109-apply-multifrag	t4	yes	3	0	3	false	ok	0
 t4110-apply-scan	t4	yes	1	1	0	true	ok	0
 t4111-apply-subdir	t4	yes	10	3	7	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,16 +141,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T06:01:33+00:00" class="gen-time" title="2026-04-09 06:01 UTC">2026-04-09 06:01 UTC</time> · <a href="https://github.com/schacon/grit/commit/af7058806f04ec42cbcd11363aa5233ada99f42d" style="color:#58a6ff">af70588</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T06:05:13+00:00" class="gen-time" title="2026-04-09 06:05 UTC">2026-04-09 06:05 UTC</time> · <a href="https://github.com/schacon/grit/commit/afb4d1e00a25aa02a68c88a73b8e08f6822bed63" style="color:#58a6ff">afb4d1e</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">76.3%</div>
+      <div class="summary-big-val pct-blue">76.4%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,437</div>
+      <div class="summary-big-val">30,452</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -159,12 +159,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:76.3%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:76.4%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>774 files fully passing</span>
+    <span>775 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -223,11 +223,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">74/178 files · 2 skipped · 2,288/3,542 tests</span>
+        <span class="group-meta">75/178 files · 2 skipped · 2,303/3,542 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.6%"></div></div>
-        <span class="group-pct pct-blue">64.6%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:65.0%"></div></div>
+        <span class="group-pct pct-blue">65.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:01:33+00:00" class="gen-time" title="2026-04-09 06:01 UTC">2026-04-09 06:01 UTC</time> · <a href="https://github.com/schacon/grit/commit/af7058806f04ec42cbcd11363aa5233ada99f42d" style="color:#58a6ff">af70588</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:05:13+00:00" class="gen-time" title="2026-04-09 06:05 UTC">2026-04-09 06:05 UTC</time> · <a href="https://github.com/schacon/grit/commit/afb4d1e00a25aa02a68c88a73b8e08f6822bed63" style="color:#58a6ff">afb4d1e</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,437</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">76.3%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,452</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">76.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -7927,14 +7927,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="18" data-passed="3">
+<tr class="" data-group="t4" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t4108-apply-threeway</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">3</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:16.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="3" data-passed="0">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`tests/t4108-apply-threeway.sh` already passes against the current `grit` implementation (18/18). This change refresifies harness metadata after `./scripts/run-tests.sh t4108-apply-threeway.sh`.

## Changes

- Update `data/test-files.csv` row for `t4108-apply-threeway` to reflect 18 passed / 0 failed and `fully_passing=true`
- Regenerate `docs/index.html` and `docs/testfiles.html`

## Verification

```bash
cargo build --release -p grit-rs
./scripts/run-tests.sh t4108-apply-threeway.sh
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3711bed1-d68e-4abe-b019-f2251c32e796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3711bed1-d68e-4abe-b019-f2251c32e796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

