### PR TITLE
chore: t3700 pathspec-file harness — t3704 fully passing

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -656,7 +656,7 @@ t3700-add-pathspec-file	t3	yes	24	24	0	true	ok	0
 t3701-add-interactive	t3	yes	130	27	103	false	ok	0
 t3702-add-edit	t3	yes	3	1	2	false	ok	0
 t3703-add-magic-pathspec	t3	yes	6	6	0	true	ok	0
-t3704-add-pathspec-file	t3	yes	11	3	8	false	ok	0
+t3704-add-pathspec-file	t3	yes	11	11	0	true	ok	0
 t3705-add-sparse-checkout	t3	yes	20	3	17	false	ok	0
 t3800-mktag	t3	yes	151	62	89	false	ok	0
 t3900-i18n-commit	t3	yes	38	11	27	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T06:05:48+00:00" class="gen-time" title="2026-04-09 06:05 UTC">2026-04-09 06:05 UTC</time> · <a href="https://github.com/schacon/grit/commit/f0d7e5057547bfb56c1a68a1de6e61d8f8abe586" style="color:#58a6ff">f0d7e50</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T06:07:29+00:00" class="gen-time" title="2026-04-09 06:07 UTC">2026-04-09 06:07 UTC</time> · <a href="https://github.com/schacon/grit/commit/26332639ee6ebcc1dd9c992427d49f9206a6b81b" style="color:#58a6ff">2633263</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,452</div>
+      <div class="summary-big-val">30,460</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>775 files fully passing</span>
+    <span>776 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,11 +212,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">49/141 files · 2 skipped · 3,439/4,619 tests</span>
+        <span class="group-meta">50/141 files · 2 skipped · 3,447/4,619 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:74.5%"></div></div>
-        <span class="group-pct pct-blue">74.5%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:74.6%"></div></div>
+        <span class="group-pct pct-blue">74.6%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:05:48+00:00" class="gen-time" title="2026-04-09 06:05 UTC">2026-04-09 06:05 UTC</time> · <a href="https://github.com/schacon/grit/commit/f0d7e5057547bfb56c1a68a1de6e61d8f8abe586" style="color:#58a6ff">f0d7e50</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:07:29+00:00" class="gen-time" title="2026-04-09 06:07 UTC">2026-04-09 06:07 UTC</time> · <a href="https://github.com/schacon/grit/commit/26332639ee6ebcc1dd9c992427d49f9206a6b81b" style="color:#58a6ff">2633263</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,452</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,460</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">76.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -6717,14 +6717,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="11" data-passed="3">
+<tr class="" data-group="t3" data-tests="11" data-passed="11" data-full-pass="1">
   <td class="mono">t3704-add-pathspec-file</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">11</td>
-  <td class="right">3</td>
+  <td class="right">11</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:27.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="20" data-passed="3">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Verified `tests/t3700-add-pathspec-file.sh` passes **24/24** (already recorded as fully passing in the harness).
- Ran `tests/t3704-add-pathspec-file.sh` (upstream-style `git add --pathspec-from-file` suite); it passes **11/11**.
- Refreshed `data/test-files.csv` and dashboards to mark **t3704-add-pathspec-file** as fully passing.

## Testing

- `./scripts/run-tests.sh t3700-add-pathspec-file.sh`
- `./scripts/run-tests.sh t3704-add-pathspec-file.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a282739-9195-4bc9-bfeb-ad9af9067c33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a282739-9195-4bc9-bfeb-ad9af9067c33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

