### PR TITLE
docs: t2030-checkout-index-basic passing (27/27)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -185,6 +185,7 @@ commit → check it off → move on.
 - [x] `t2202-add-addremove` ████████████████████ 3/3 (0 left) — git add --all
 - [x] `t2018-checkout-branch` ████████████████████ 25/25 (0 left) — checkout
 - [x] `t2006-checkout-index-basic` ████████████████████ 9/9 (0 left) — basic checkout-index tests
+- [x] `t2030-checkout-index-basic` ████████████████████ 27/27 (0 left) — checkout-index --all/--force/--prefix/--temp/--stdin
 
 - [x] `t2019-checkout-ambiguous-ref` ████████████████████ 9/9 (0 left) — checkout handling of ambiguous (branch/tag) refs
 - [ ] `t2206-add-submodule-ignored` ██████████░░░░░░░░░░ 4/8 (4 left) — git add respects submodule ignore=all and explicit pathspec

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T06:05:48+00:00" class="gen-time" title="2026-04-09 06:05 UTC">2026-04-09 06:05 UTC</time> · <a href="https://github.com/schacon/grit/commit/f0d7e5057547bfb56c1a68a1de6e61d8f8abe586" style="color:#58a6ff">f0d7e50</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T06:07:58+00:00" class="gen-time" title="2026-04-09 06:07 UTC">2026-04-09 06:07 UTC</time> · <a href="https://github.com/schacon/grit/commit/26332639ee6ebcc1dd9c992427d49f9206a6b81b" style="color:#58a6ff">2633263</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,7 +100,7 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:05:48+00:00" class="gen-time" title="2026-04-09 06:05 UTC">2026-04-09 06:05 UTC</time> · <a href="https://github.com/schacon/grit/commit/f0d7e5057547bfb56c1a68a1de6e61d8f8abe586" style="color:#58a6ff">f0d7e50</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:07:58+00:00" class="gen-time" title="2026-04-09 06:07 UTC">2026-04-09 06:07 UTC</time> · <a href="https://github.com/schacon/grit/commit/26332639ee6ebcc1dd9c992427d49f9206a6b81b" style="color:#58a6ff">2633263</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>

--- a/logs/2026-04-09_t2030-checkout-index-basic.md
+++ b/logs/2026-04-09_t2030-checkout-index-basic.md
@@ -1,0 +1,5 @@
+# t2030-checkout-index-basic
+
+- Ran `./scripts/run-tests.sh t2030-checkout-index-basic.sh`: **27/27** pass (no Rust changes required on this branch).
+- Added missing `PLAN.md` checkbox for `t2030-checkout-index-basic`; refreshed `progress.md` counts (769 task lines).
+- Committed harness dashboard HTML updates from the test run.

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   264 |
+| Completed   |   265 |
 | In progress |     4 |
 | Remaining   |   500 |
-| **Total**   |   768 |
+| **Total**   |   769 |
 
-Task lines in `PLAN.md`: 264 completed (`[x]`), 4 in progress (`[~]`), 500 remaining (`[ ]`).
+Task lines in `PLAN.md`: 265 completed (`[x]`), 4 in progress (`[~]`), 500 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t2030-checkout-index-basic` — 27/27 tests pass (`checkout-index` flags and edge cases; `PLAN.md` entry added; harness dashboards refreshed)
 - `t7450-bad-git-dotfiles` — 50/50 tests pass (submodule name/url validation, fsck symlink and `.gitmodules` checks, nested submodule git dirs, harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t5351-unpack-large-objects` — 7/7 tests pass (`GIT_ALLOC_LIMIT` + `core.bigFileThreshold` streaming unpack, dry-run, trace2 fsync batch path, skip already-packed objects; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t5308-pack-detect-duplicates` — 6/6 tests pass (`index-pack` allows duplicate OIDs by default; `--strict` rejects duplicates with non-zero exit and leaves objects out of the ODB; `cat-file --batch-check` resolves OIDs in packs with duplicate runs; harness CSV/dashboards refreshed; `PLAN.md` marked complete)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t2030-checkout-index-basic` already passes the full harness (**27/27**). This change records that in `PLAN.md`, updates `progress.md` counts, refreshes dashboard HTML from `./scripts/run-tests.sh`, and adds a short log entry.

## Verification

```bash
./scripts/run-tests.sh t2030-checkout-index-basic.sh
```

No Rust changes were required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd478754-9d1a-4911-b818-77f562ad8533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd478754-9d1a-4911-b818-77f562ad8533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

