### PR TITLE
fix: Git-compatible diff --dirstat (t4047)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -516,7 +516,7 @@ commit → check it off → move on.
 - [ ] `t4301-merge-tree-write-tree` ░░░░░░░░░░░░░░░░░░░░ 1/33 (32 left) — git merge-tree --write-tree
 - [ ] `t4209-log-pickaxe` ██████░░░░░░░░░░░░░░ 15/48 (33 left) — log --grep/--author/--regexp-ignore-case/-S/-G
 - [ ] `t4068-diff-symmetric-merge-base` ░░░░░░░░░░░░░░░░░░░░ 1/36 (35 left) — behavior of diff with symmetric-diff setups and --merge-base
-- [ ] `t4047-diff-dirstat` █░░░░░░░░░░░░░░░░░░░ 4/41 (37 left) — diff --dirstat tests
+- [x] `t4047-diff-dirstat` — diff --dirstat tests (41/41)
 - [ ] `t4041-diff-submodule-option` █░░░░░░░░░░░░░░░░░░░ 4/46 (42 left) — Support for verbose submodule differences in git diff
 
 - [ ] `t4060-diff-submodule-option-diff-format` ██░░░░░░░░░░░░░░░░░░ 6/50 (44 left) — Support for diff format verbose submodule difference in git diff

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -724,7 +724,7 @@ t4043-diff-rename-binary	t4	yes	3	3	0	true	ok	0
 t4044-diff-index-unique-abbrev	t4	yes	2	1	1	false	ok	0
 t4045-diff-relative	t4	yes	38	32	6	false	ok	1
 t4046-diff-unmerged	t4	yes	8	3	5	false	ok	0
-t4047-diff-dirstat	t4	yes	41	4	37	false	ok	0
+t4047-diff-dirstat	t4	yes	41	41	0	true	ok	0
 t4047-diff-numstat	t4	yes	26	26	0	true	ok	0
 t4048-diff-combined-binary	t4	yes	14	14	0	true	ok	0
 t4049-diff-stat-count	t4	yes	4	1	3	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,16 +141,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T05:45:11+00:00" class="gen-time" title="2026-04-09 05:45 UTC">2026-04-09 05:45 UTC</time> · <a href="https://github.com/schacon/grit/commit/9ed4c49b9f8f1171666d55538b4bf772b83335d8" style="color:#58a6ff">9ed4c49</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T06:08:00+00:00" class="gen-time" title="2026-04-09 06:08 UTC">2026-04-09 06:08 UTC</time> · <a href="https://github.com/schacon/grit/commit/1bce41abab0c0289cc3e958ebec122a62e1a11ef" style="color:#58a6ff">1bce41a</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">76.3%</div>
+      <div class="summary-big-val pct-blue">76.4%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,416</div>
+      <div class="summary-big-val">30,453</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -159,12 +159,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:76.3%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:76.4%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>770 files fully passing</span>
+    <span>771 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -223,11 +223,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">73/178 files · 2 skipped · 2,278/3,542 tests</span>
+        <span class="group-meta">74/178 files · 2 skipped · 2,315/3,542 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.3%"></div></div>
-        <span class="group-pct pct-blue">64.3%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:65.4%"></div></div>
+        <span class="group-pct pct-blue">65.4%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:45:11+00:00" class="gen-time" title="2026-04-09 05:45 UTC">2026-04-09 05:45 UTC</time> · <a href="https://github.com/schacon/grit/commit/9ed4c49b9f8f1171666d55538b4bf772b83335d8" style="color:#58a6ff">9ed4c49</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:08:00+00:00" class="gen-time" title="2026-04-09 06:08 UTC">2026-04-09 06:08 UTC</time> · <a href="https://github.com/schacon/grit/commit/1bce41abab0c0289cc3e958ebec122a62e1a11ef" style="color:#58a6ff">1bce41a</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,416</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">76.3%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,453</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">76.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -7397,14 +7397,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:37.5%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="41" data-passed="4">
+<tr class="" data-group="t4" data-tests="41" data-passed="41" data-full-pass="1">
   <td class="mono">t4047-diff-dirstat</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">41</td>
-  <td class="right">4</td>
+  <td class="right">41</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:9.8%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="26" data-passed="26" data-full-pass="1">

--- a/grit-lib/src/diff.rs
+++ b/grit-lib/src/diff.rs
@@ -2425,7 +2425,11 @@ fn hash_blob_spans(buf: &[u8], is_text: bool) -> SpanHashTop {
 }
 
 /// Approximate copied vs added material between two blobs (Git `diffcore_count_changes`).
-fn diffcore_count_changes(old: &[u8], new: &[u8]) -> (u64, u64) {
+///
+/// Returns `(copied_bytes_from_src, literal_added_bytes_in_dst)` matching Git's
+/// `diffcore_count_changes` semantics (used for `--dirstat=changes` damage).
+#[must_use]
+pub fn diffcore_count_changes(old: &[u8], new: &[u8]) -> (u64, u64) {
     let src_is_text = !crate::merge_file::is_binary(old);
     let dst_is_text = !crate::merge_file::is_binary(new);
     let src_count = hash_blob_spans(old, src_is_text);

--- a/grit/src/commands/diff.rs
+++ b/grit/src/commands/diff.rs
@@ -16,8 +16,8 @@ use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::diff::{
     anchored_unified_diff, count_changes, count_git_lines, detect_renames, diff_index_to_tree,
-    diff_index_to_worktree, diff_tree_to_worktree, diff_trees, should_break_rewrite_for_stat,
-    unified_diff, zero_oid, DiffEntry, DiffStatus,
+    diff_index_to_worktree, diff_tree_to_worktree, diff_trees, diffcore_count_changes,
+    should_break_rewrite_for_stat, unified_diff, zero_oid, DiffEntry, DiffStatus,
 };
 use grit_lib::diffstat::{terminal_columns, write_diffstat_block, DiffstatOptions, FileStatInput};
 use grit_lib::error::Error;
@@ -388,15 +388,31 @@ pub struct Args {
     #[arg(short = 's', long = "no-patch")]
     pub no_patch: bool,
 
-    /// Directory-level diffstat (`--dirstat=lines`, etc.). Empty value means `lines`.
+    /// Directory-level diffstat (`--dirstat=lines`, etc.). Empty value means default `changes`.
+    /// Later `--dirstat` / `-X` options override earlier ones (Git semantics).
     #[arg(
         long = "dirstat",
         value_name = "PARAM",
         default_missing_value = "",
         num_args = 0..=1,
+        require_equals = true,
+        action = clap::ArgAction::Append
+    )]
+    pub dirstat: Vec<String>,
+
+    /// Synonym for `--dirstat=files` (optional `=<param>` like `--dirstat`).
+    #[arg(
+        long = "dirstat-by-file",
+        value_name = "PARAM",
+        default_missing_value = "",
+        num_args = 0..=1,
         require_equals = true
     )]
-    pub dirstat: Option<String>,
+    pub dirstat_by_file: Option<String>,
+
+    /// Set `--dirstat=cumulative` (Git synonym).
+    #[arg(long = "cumulative")]
+    pub dirstat_cumulative_flag: bool,
 
     /// Number of context lines in unified diff output (default: 3).
     #[arg(
@@ -486,6 +502,106 @@ pub struct Args {
     /// Commits or paths. Use `--` to separate revisions from paths.
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     pub args: Vec<String>,
+}
+
+/// Parsed `--dirstat` / `diff.dirstat` options (Git-compatible).
+#[derive(Clone, Debug)]
+struct DirstatOptions {
+    /// `changes` (byte damage), `lines` (insertion+deletion lines), or `files` (1 per file).
+    mode: DirstatMode,
+    cumulative: bool,
+    /// Minimum permille (parts per thousand) to print a line; default 30 = 3%.
+    permille: u32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DirstatMode {
+    Changes,
+    Lines,
+    Files,
+}
+
+impl Default for DirstatOptions {
+    fn default() -> Self {
+        Self {
+            mode: DirstatMode::Changes,
+            cumulative: false,
+            permille: 30,
+        }
+    }
+}
+
+impl DirstatOptions {
+    fn is_default_everything(&self) -> bool {
+        self.mode == DirstatMode::Changes && !self.cumulative && self.permille == 30
+    }
+}
+
+fn parse_dirstat_apply_tokens(
+    params: &str,
+    opts: &mut DirstatOptions,
+    strict: bool,
+    warnings: &mut Vec<String>,
+) -> Result<()> {
+    if params.is_empty() {
+        return Ok(());
+    }
+    for raw in params.split(',') {
+        let p = raw.trim();
+        if p.is_empty() {
+            continue;
+        }
+        if p.eq_ignore_ascii_case("changes") {
+            opts.mode = DirstatMode::Changes;
+        } else if p.eq_ignore_ascii_case("lines") {
+            opts.mode = DirstatMode::Lines;
+        } else if p.eq_ignore_ascii_case("files") {
+            opts.mode = DirstatMode::Files;
+        } else if p.eq_ignore_ascii_case("noncumulative") {
+            opts.cumulative = false;
+        } else if p.eq_ignore_ascii_case("cumulative") {
+            opts.cumulative = true;
+        } else if p.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+            match parse_dirstat_percentage_permille(p) {
+                Some(pm) => opts.permille = pm,
+                None => {
+                    let msg = format!(
+                        "Failed to parse --dirstat/-X option parameter:\n  Failed to parse dirstat cut-off percentage '{p}'\n"
+                    );
+                    if strict {
+                        bail!("{msg}");
+                    }
+                    warnings.push(format!(
+                        "Found errors in 'diff.dirstat' config variable:\n  Failed to parse dirstat cut-off percentage '{p}'\n"
+                    ));
+                }
+            }
+        } else {
+            let msg = format!(
+                "Failed to parse --dirstat/-X option parameter:\n  Unknown dirstat parameter '{p}'\n"
+            );
+            if strict {
+                bail!("{msg}");
+            }
+            warnings.push(format!(
+                "Found errors in 'diff.dirstat' config variable:\n  Unknown dirstat parameter '{p}'\n"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn parse_dirstat_params_lenient(params: &str) -> (DirstatOptions, Vec<String>) {
+    let mut o = DirstatOptions::default();
+    let mut warnings = Vec::new();
+    let _ = parse_dirstat_apply_tokens(params, &mut o, false, &mut warnings);
+    (o, warnings)
+}
+
+#[derive(Clone, Debug)]
+struct DirstatFile {
+    name: String,
+    changed: u64,
 }
 
 /// Run the `diff` command.
@@ -725,10 +841,24 @@ pub fn run(mut args: Args) -> Result<()> {
                     // Accepted for compatibility
                 }
                 s if s == "--dirstat" => {
-                    args.dirstat = Some(String::new());
+                    args.dirstat.push(String::new());
                 }
                 s if s.starts_with("--dirstat=") => {
-                    args.dirstat = Some(s.strip_prefix("--dirstat=").unwrap_or("").to_owned());
+                    args.dirstat
+                        .push(s.strip_prefix("--dirstat=").unwrap_or("").to_owned());
+                }
+                s if s == "--dirstat-by-file" => {
+                    args.dirstat_by_file = Some(String::new());
+                }
+                s if s.starts_with("--dirstat-by-file=") => {
+                    args.dirstat_by_file = Some(
+                        s.strip_prefix("--dirstat-by-file=")
+                            .unwrap_or("")
+                            .to_owned(),
+                    );
+                }
+                "--cumulative" => {
+                    args.dirstat_cumulative_flag = true;
                 }
                 _ => {
                     extra_revs.push(r.clone());
@@ -1188,6 +1318,10 @@ pub fn run(mut args: Args) -> Result<()> {
 
     // `--quiet` alone suppresses stdout, but it still must honor `--exit-code` (below). `-s` /
     // `--no-patch` suppresses the unified patch without implying `--quiet`.
+    let dirstat_cli_active = !args.dirstat.is_empty() || args.dirstat_by_file.is_some();
+    let (dirstat_opts, dirstat_config_warnings) =
+        resolve_dirstat_options(&args, &repo.git_dir, dirstat_cli_active)?;
+
     let format_besides_unified_patch = args.shortstat
         || stat_enabled
         || args.stat_count.is_some()
@@ -1199,8 +1333,12 @@ pub fn run(mut args: Args) -> Result<()> {
         || args.name_only
         || args.name_status
         || (args.summary && !stat_enabled)
-        || args.dirstat.is_some();
+        || dirstat_opts.is_some();
     let quiet_suppresses_stdout = args.quiet && !format_besides_unified_patch;
+
+    for w in &dirstat_config_warnings {
+        eprintln!("warning: {w}");
+    }
 
     if !quiet_suppresses_stdout {
         let config_context = if args.unified.is_none() {
@@ -1221,6 +1359,16 @@ pub fn run(mut args: Args) -> Result<()> {
                 wt_for_content,
                 args.break_rewrites,
             )?;
+            if let Some(ref ds) = dirstat_opts {
+                write_dirstat(
+                    &mut out,
+                    ds,
+                    &entries,
+                    &repo.odb,
+                    wt_for_content,
+                    args.break_rewrites,
+                )?;
+            }
         } else if stat_enabled
             || args.stat_count.is_some()
             || args.stat_width.is_some()
@@ -1280,8 +1428,15 @@ pub fn run(mut args: Args) -> Result<()> {
                     write!(out, "{patch}")?;
                 }
             }
-            if args.dirstat.is_some() {
-                write_dirstat_lines(&mut out, &entries, &repo.odb, wt_for_content)?;
+            if let Some(ref ds) = dirstat_opts {
+                write_dirstat(
+                    &mut out,
+                    ds,
+                    &entries,
+                    &repo.odb,
+                    wt_for_content,
+                    args.break_rewrites,
+                )?;
             }
             if show_unified {
                 write_patch_with_prefix(
@@ -1891,39 +2046,222 @@ fn diff_emit_unified_patch_from_argv(argv: &[String]) -> bool {
     emit
 }
 
-/// Lines-mode `--dirstat`: one line per top-level directory, `pct% path/`.
-fn write_dirstat_lines(
+fn resolve_dirstat_options(
+    args: &Args,
+    git_dir: &std::path::Path,
+    cli_active: bool,
+) -> Result<(Option<DirstatOptions>, Vec<String>)> {
+    use grit_lib::config::ConfigSet;
+    let config = ConfigSet::load(Some(git_dir), false).unwrap_or_else(|_| ConfigSet::new());
+    let mut warnings = Vec::new();
+
+    let mut opts = DirstatOptions::default();
+
+    if let Some(ref cfg_val) = config.get("diff.dirstat") {
+        let (o, w) = parse_dirstat_params_lenient(cfg_val);
+        warnings.extend(w);
+        opts = o;
+    }
+
+    if args.dirstat_cumulative_flag {
+        parse_dirstat_apply_tokens("cumulative", &mut opts, true, &mut warnings)?;
+    }
+
+    if let Some(ref p) = args.dirstat_by_file {
+        parse_dirstat_apply_tokens("files", &mut opts, true, &mut warnings)?;
+        if !p.is_empty() {
+            parse_dirstat_apply_tokens(p, &mut opts, true, &mut warnings)?;
+        }
+    }
+
+    for param in &args.dirstat {
+        if param.is_empty() {
+            opts = DirstatOptions::default();
+        } else {
+            parse_dirstat_apply_tokens(param, &mut opts, true, &mut warnings)?;
+        }
+    }
+
+    if !cli_active
+        && opts.is_default_everything() && config.get("diff.dirstat").is_none() {
+            return Ok((None, warnings));
+        }
+
+    Ok((Some(opts), warnings))
+}
+
+fn parse_dirstat_percentage_permille(s: &str) -> Option<u32> {
+    let mut parts = s.splitn(2, '.');
+    let whole = parts.next()?.parse::<u32>().ok()?;
+    let mut permille = whole.saturating_mul(10);
+    if let Some(rest) = parts.next() {
+        let mut chars = rest.chars();
+        let d = chars.next()?;
+        if !d.is_ascii_digit() {
+            return None;
+        }
+        permille = permille.saturating_add(d.to_digit(10)?);
+        if chars.next().is_some_and(|c| c.is_ascii_digit()) {
+            // Git ignores further fractional digits after the first
+        }
+        if chars.any(|c| !c.is_ascii_digit()) {
+            return None;
+        }
+    }
+    Some(permille)
+}
+
+fn dirstat_damage_for_entry(
+    odb: &Odb,
+    entry: &DiffEntry,
+    work_tree: Option<&Path>,
+    break_rewrites: bool,
+    mode: DirstatMode,
+) -> u64 {
+    let path = entry.path();
+    let old_raw = read_content_raw(odb, &entry.old_oid);
+    let new_raw = read_content_raw_or_worktree(odb, &entry.new_oid, work_tree, path);
+
+    match mode {
+        DirstatMode::Files => 1,
+        DirstatMode::Lines => {
+            if break_rewrites
+                && entry.status == DiffStatus::Modified
+                && !is_binary(&old_raw)
+                && !is_binary(&new_raw)
+                && should_break_rewrite_for_stat(&old_raw, &new_raw)
+            {
+                let ins = count_git_lines(&new_raw) as u64;
+                let del = count_git_lines(&old_raw) as u64;
+                return ins.saturating_add(del);
+            }
+            let old_content = String::from_utf8_lossy(&old_raw).into_owned();
+            let new_content = String::from_utf8_lossy(&new_raw).into_owned();
+            let (ins, del) = count_changes(&old_content, &new_content);
+            let mut damage = (ins as u64).saturating_add(del as u64);
+            if is_binary(&old_raw) || is_binary(&new_raw) {
+                damage = damage.div_ceil(64);
+            }
+            damage
+        }
+        DirstatMode::Changes => {
+            if entry.old_oid == entry.new_oid {
+                return 0;
+            }
+            if entry.status == DiffStatus::Added {
+                return new_raw.len() as u64;
+            }
+            if entry.status == DiffStatus::Deleted {
+                return old_raw.len() as u64;
+            }
+            let (copied, added) = diffcore_count_changes(&old_raw, &new_raw);
+            let old_len = old_raw.len() as u64;
+            let removed = old_len.saturating_sub(copied);
+            let mut damage = removed.saturating_add(added);
+            if damage == 0 {
+                damage = 1;
+            }
+            damage
+        }
+    }
+}
+
+fn gather_dirstat_recursive(
     out: &mut impl Write,
+    files: &[DirstatFile],
+    idx: &mut usize,
+    changed_total: u64,
+    base_len: usize,
+    base: &str,
+    permille: u32,
+    cumulative: bool,
+) -> Result<u64> {
+    let mut sum = 0u64;
+    let mut sources = 0u32;
+
+    while *idx < files.len() {
+        let f = &files[*idx];
+        let name = f.name.as_str();
+        if name.len() < base_len {
+            break;
+        }
+        if !name.starts_with(base) {
+            break;
+        }
+        let rel = &name[base_len..];
+        if let Some(slash_rel) = rel.find('/') {
+            let slash_abs = base_len + slash_rel;
+            let new_base_len = slash_abs + 1;
+            let sub = gather_dirstat_recursive(
+                out,
+                files,
+                idx,
+                changed_total,
+                new_base_len,
+                &name[..new_base_len],
+                permille,
+                cumulative,
+            )?;
+            sum = sum.saturating_add(sub);
+            sources = sources.saturating_add(1);
+        } else {
+            sum = sum.saturating_add(f.changed);
+            *idx += 1;
+            sources = sources.saturating_add(2);
+        }
+    }
+
+    if base_len > 0 && sources != 1 && sum > 0 && changed_total > 0 {
+        let permille_val = ((sum as u128) * 1000 / (changed_total as u128)) as u32;
+        if permille_val >= permille {
+            let int_part = permille_val / 10;
+            let frac = permille_val % 10;
+            writeln!(out, " {:>4}.{}% {}", int_part, frac, &base[..base_len])?;
+            if !cumulative {
+                return Ok(sum);
+            }
+        }
+    }
+    Ok(if cumulative { 0 } else { sum })
+}
+
+fn write_dirstat(
+    out: &mut impl Write,
+    opts: &DirstatOptions,
     entries: &[DiffEntry],
     odb: &Odb,
     work_tree: Option<&Path>,
+    break_rewrites: bool,
 ) -> Result<()> {
     if entries.is_empty() {
         return Ok(());
     }
-    let mut total_lines: usize = 0;
-    let mut per_dir: std::collections::BTreeMap<String, usize> = std::collections::BTreeMap::new();
+    let mut files: Vec<DirstatFile> = Vec::with_capacity(entries.len());
+    let mut changed_total = 0u64;
     for e in entries {
-        let path = e.path();
-        let top = path.split('/').next().unwrap_or(path).to_string();
-        let old = read_content(odb, &e.old_oid, None, path);
-        let new = read_content(odb, &e.new_oid, work_tree, path);
-        let old_lc = old.lines().count();
-        let new_lc = new.lines().count();
-        let delta = old_lc.abs_diff(new_lc);
-        total_lines = total_lines.saturating_add(delta);
-        *per_dir.entry(top).or_insert(0) += delta;
+        let name = e.path().to_string();
+        let damage = dirstat_damage_for_entry(odb, e, work_tree, break_rewrites, opts.mode);
+        changed_total = changed_total.saturating_add(damage);
+        files.push(DirstatFile {
+            name,
+            changed: damage,
+        });
     }
-    if total_lines == 0 {
+    if changed_total == 0 {
         return Ok(());
     }
-    for (dir, lines) in per_dir {
-        if lines == 0 {
-            continue;
-        }
-        let pct = (lines as f64) * 100.0 / (total_lines as f64);
-        writeln!(out, " {pct:.1}% {dir}/")?;
-    }
+    files.sort_by(|a, b| a.name.cmp(&b.name));
+    let mut idx = 0usize;
+    gather_dirstat_recursive(
+        out,
+        &files,
+        &mut idx,
+        changed_total,
+        0,
+        "",
+        opts.permille,
+        opts.cumulative,
+    )?;
     Ok(())
 }
 

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -2862,6 +2862,23 @@ fn preprocess_diff_args(rest: &[String]) -> Vec<String> {
     let word_diff_modes = ["plain", "color", "porcelain", "none"];
     while i < rest.len() {
         let arg = &rest[i];
+        if arg == "-X" {
+            if i + 1 < rest.len() && !rest[i + 1].starts_with('-') {
+                result.push(format!("--dirstat={}", rest[i + 1]));
+                i += 2;
+            } else {
+                result.push("--dirstat=".to_owned());
+                i += 1;
+            }
+            continue;
+        }
+        if let Some(param) = arg.strip_prefix("-X") {
+            if !param.is_empty() {
+                result.push(format!("--dirstat={param}"));
+                i += 1;
+                continue;
+            }
+        }
         if arg == "-U" {
             // `-U <N>` with a space — merge into `--unified=<N>`
             if i + 1 < rest.len() {

--- a/logs/2026-04-09_t4047-diff-dirstat.md
+++ b/logs/2026-04-09_t4047-diff-dirstat.md
@@ -1,0 +1,17 @@
+# t4047-diff-dirstat
+
+## Problem
+
+`git diff --dirstat` used a line-count delta (`abs_diff` of line counts), so edits that kept the same number of lines produced **zero** total damage and no dirstat lines. Git’s default mode is **changes** (byte damage via `diffcore_count_changes`).
+
+## Fix
+
+- Exported `diffcore_count_changes` from `grit-lib` for reuse.
+- Implemented Git-aligned dirstat: `changes` / `lines` / `files`, cumulative vs non-cumulative, permille threshold parsing (including one decimal digit), recursive directory aggregation, `diff.dirstat` with warnings on bad tokens, `-X` preprocessing in `main.rs`, `--dirstat-by-file`, `--cumulative`.
+- `--shortstat --dirstat`: emit dirstat after the shortstat line (matches test expectations).
+- Multiple `--dirstat` / `-X` flags accumulate parameters like Git.
+
+## Verification
+
+- `./scripts/run-tests.sh t4047-diff-dirstat.sh` → 41/41
+- `cargo test -p grit-lib --lib`

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   264 |
+| Completed   |   265 |
 | In progress |     4 |
-| Remaining   |   500 |
+| Remaining   |   499 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 264 completed (`[x]`), 4 in progress (`[~]`), 500 remaining (`[ ]`).
+Task lines in `PLAN.md`: 265 completed (`[x]`), 4 in progress (`[~]`), 499 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t4047-diff-dirstat` — 41/41 tests pass (Git-compatible `--dirstat` / `-X`: changes/lines/files, cumulative, thresholds, `diff.dirstat` warnings, `--shortstat` + dirstat; harness CSV/dashboards refreshed)
 - `t7450-bad-git-dotfiles` — 50/50 tests pass (submodule name/url validation, fsck symlink and `.gitmodules` checks, nested submodule git dirs, harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t5351-unpack-large-objects` — 7/7 tests pass (`GIT_ALLOC_LIMIT` + `core.bigFileThreshold` streaming unpack, dry-run, trace2 fsync batch path, skip already-packed objects; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t5308-pack-detect-duplicates` — 6/6 tests pass (`index-pack` allows duplicate OIDs by default; `--strict` rejects duplicates with non-zero exit and leaves objects out of the ODB; `cat-file --batch-check` resolves OIDs in packs with duplicate runs; harness CSV/dashboards refreshed; `PLAN.md` marked complete)

--- a/test-results.md
+++ b/test-results.md
@@ -2,6 +2,8 @@
 
 **Updated:** 2026-04-09
 
+- `./scripts/run-tests.sh t4047-diff-dirstat.sh`: 41/41 passing (`diff --dirstat` / `-X` aligned with Git: changes/lines/files, cumulative, thresholds, `diff.dirstat` warnings, `--shortstat --dirstat`; harness CSV/dashboards refreshed).
+- `cargo test -p grit-lib --lib`: 121/121 passing.
 - `./scripts/run-tests.sh t5308-pack-detect-duplicates.sh`: 6/6 passing (duplicate objects in pack: default `index-pack` accepts; `--strict` rejects and leaves ODB unchanged; `cat-file --batch-check` over duplicated pack; harness CSV/dashboards refreshed).
 - `./scripts/run-tests.sh t4120-apply-popt.sh`: 12/12 passing (`git apply -p` strip count, invalid `-p` diagnostics, quoted traditional diff paths, `--stat` oversized strip, mode-only and rename with `--index`; harness CSV/dashboards refreshed).
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements `git diff --dirstat` behavior aligned with upstream Git so `tests/t4047-diff-dirstat.sh` passes (41/41).

## Changes

- **Damage model:** Default mode is **changes** (byte damage via `diffcore_count_changes`), not line-count delta. Fixes same-length edits producing no dirstat output.
- **Modes & options:** `lines`, `files`, `cumulative` / `noncumulative`, percentage thresholds (permille, one decimal digit), recursive directory aggregation matching Git’s `gather_dirstat`.
- **CLI:** `-X` / `-X<param>` preprocessed to `--dirstat`; `--dirstat-by-file`, `--cumulative`; repeated `--dirstat` / `-X` accumulate tokens like Git.
- **Config:** `diff.dirstat` with **warnings** on unknown tokens (strict CLI vs lenient config per tests).
- **`--shortstat --dirstat`:** Emit dirstat lines after the shortstat summary.
- **Library:** `pub fn diffcore_count_changes` exported from `grit-lib`.

## Verification

- `./scripts/run-tests.sh t4047-diff-dirstat.sh`
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f445029b-c21f-4ce9-a8b6-896330c1ad94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f445029b-c21f-4ce9-a8b6-896330c1ad94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

