### PR TITLE
fix: diff inter-hunk context (t4032)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -709,7 +709,7 @@ t4028-format-patch-mime-headers	t4	yes	3	3	0	true	ok	0
 t4029-diff-trailing-space	t4	yes	1	1	0	true	ok	0
 t4030-diff-textconv	t4	yes	19	3	16	false	ok	0
 t4031-diff-rewrite-binary	t4	yes	8	3	5	false	ok	0
-t4032-diff-inter-hunk-context	t4	yes	37	19	18	false	ok	0
+t4032-diff-inter-hunk-context	t4	yes	37	37	0	true	ok	0
 t4033-diff-patience	t4	yes	11	4	7	false	ok	0
 t4034-diff-words	t4	yes	66	7	59	false	ok	0
 t4035-diff-quiet	t4	yes	0	0	0	false	timeout	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,16 +141,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T05:58:19+00:00" class="gen-time" title="2026-04-09 05:58 UTC">2026-04-09 05:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/73e113347402cf2e762f1156f5d4c68c7fb6a17f" style="color:#58a6ff">73e1133</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T06:08:52+00:00" class="gen-time" title="2026-04-09 06:08 UTC">2026-04-09 06:08 UTC</time> · <a href="https://github.com/schacon/grit/commit/2ad7acea8dc1c0bf73faa5cf92bf5625ac2e550e" style="color:#58a6ff">2ad7ace</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">76.3%</div>
+      <div class="summary-big-val pct-blue">76.4%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,427</div>
+      <div class="summary-big-val">30,445</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -159,12 +159,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:76.3%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:76.4%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>773 files fully passing</span>
+    <span>774 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -223,11 +223,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">73/178 files · 2 skipped · 2,278/3,542 tests</span>
+        <span class="group-meta">74/178 files · 2 skipped · 2,296/3,542 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.3%"></div></div>
-        <span class="group-pct pct-blue">64.3%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.8%"></div></div>
+        <span class="group-pct pct-blue">64.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T05:58:19+00:00" class="gen-time" title="2026-04-09 05:58 UTC">2026-04-09 05:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/73e113347402cf2e762f1156f5d4c68c7fb6a17f" style="color:#58a6ff">73e1133</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:08:52+00:00" class="gen-time" title="2026-04-09 06:08 UTC">2026-04-09 06:08 UTC</time> · <a href="https://github.com/schacon/grit/commit/2ad7acea8dc1c0bf73faa5cf92bf5625ac2e550e" style="color:#58a6ff">2ad7ace</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,427</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">76.3%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,445</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">76.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -7247,14 +7247,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:37.5%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="37" data-passed="19">
+<tr class="" data-group="t4" data-tests="37" data-passed="37" data-full-pass="1">
   <td class="mono">t4032-diff-inter-hunk-context</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">37</td>
-  <td class="right">19</td>
+  <td class="right">37</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:51.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="11" data-passed="4">

--- a/grit-lib/src/diff.rs
+++ b/grit-lib/src/diff.rs
@@ -1710,6 +1710,7 @@ pub fn format_raw_abbrev(entry: &DiffEntry, abbrev_len: usize) -> String {
 /// - `old_path` — display path for the old side.
 /// - `new_path` — display path for the new side.
 /// - `context_lines` — number of context lines around changes (default: 3).
+/// - Inter-hunk context defaults to `0` (see [`unified_diff_with_prefix`]).
 ///
 /// # Returns
 ///
@@ -1727,18 +1728,23 @@ pub fn unified_diff(
         old_path,
         new_path,
         context_lines,
+        0,
         "a/",
         "b/",
     )
 }
 
 /// Same as `unified_diff` but with configurable source/destination prefixes.
+///
+/// `inter_hunk_context` is Git's `--inter-hunk-context`: adjacent hunks merge when
+/// the unchanged gap between them is at most `2 * context_lines + inter_hunk_context` lines.
 pub fn unified_diff_with_prefix(
     old_content: &str,
     new_content: &str,
     old_path: &str,
     new_path: &str,
     context_lines: usize,
+    inter_hunk_context: usize,
     src_prefix: &str,
     dst_prefix: &str,
 ) -> String {
@@ -1748,6 +1754,7 @@ pub fn unified_diff_with_prefix(
         old_path,
         new_path,
         context_lines,
+        inter_hunk_context,
         src_prefix,
         dst_prefix,
         None,
@@ -1762,6 +1769,7 @@ pub fn unified_diff_with_prefix_and_funcname(
     old_path: &str,
     new_path: &str,
     context_lines: usize,
+    inter_hunk_context: usize,
     src_prefix: &str,
     dst_prefix: &str,
     funcname_matcher: Option<&FuncnameMatcher>,
@@ -1772,6 +1780,7 @@ pub fn unified_diff_with_prefix_and_funcname(
         old_path,
         new_path,
         context_lines,
+        inter_hunk_context,
         src_prefix,
         dst_prefix,
         funcname_matcher,
@@ -1787,12 +1796,13 @@ pub fn unified_diff_with_prefix_and_funcname_and_algorithm(
     old_path: &str,
     new_path: &str,
     context_lines: usize,
+    inter_hunk_context: usize,
     src_prefix: &str,
     dst_prefix: &str,
     funcname_matcher: Option<&FuncnameMatcher>,
     algorithm: similar::Algorithm,
 ) -> String {
-    use similar::TextDiff;
+    use similar::{group_diff_ops, udiff::UnifiedDiffHunk, TextDiff};
 
     let diff = TextDiff::configure()
         .algorithm(algorithm)
@@ -1812,11 +1822,16 @@ pub fn unified_diff_with_prefix_and_funcname_and_algorithm(
 
     let old_lines: Vec<&str> = old_content.lines().collect();
 
-    for hunk in diff
-        .unified_diff()
-        .context_radius(context_lines)
-        .iter_hunks()
-    {
+    let group_radius = context_lines
+        .saturating_mul(2)
+        .saturating_add(inter_hunk_context);
+    let op_groups = group_diff_ops(diff.ops().to_vec(), group_radius);
+
+    for ops in op_groups {
+        if ops.is_empty() {
+            continue;
+        }
+        let hunk = UnifiedDiffHunk::new(ops, &diff, true);
         let hunk_str = format!("{hunk}");
         // The similar crate outputs @@ -a,b +c,d @@\n but Git adds
         // function context after the closing @@. Extract the hunk header

--- a/grit/src/commands/diff.rs
+++ b/grit/src/commands/diff.rs
@@ -526,6 +526,20 @@ pub fn run(mut args: Args) -> Result<()> {
 
     let repo = Repository::discover(None).context("not a git repository")?;
 
+    if args.inter_hunk_context.is_none() {
+        if let Ok(cfg) = grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true) {
+            if let Some(raw) = cfg.get("diff.interhunkcontext") {
+                match cfg.get_i64("diff.interhunkcontext") {
+                    Some(Ok(n)) if n < 0 => {
+                        anyhow::bail!("negative value for 'diff.interHunkContext': '{raw}'");
+                    }
+                    Some(Ok(_)) => {}
+                    _ => anyhow::bail!("invalid value for 'diff.interHunkContext': '{raw}'"),
+                }
+            }
+        }
+    }
+
     let emit_unified_patch = diff_emit_unified_patch_from_argv(&raw_args);
 
     // Resolve diff prefixes from config and command-line options
@@ -1213,6 +1227,15 @@ pub fn run(mut args: Args) -> Result<()> {
             None
         };
         let context_lines = args.unified.or(config_context).unwrap_or(3);
+        let inter_hunk_context = args
+            .inter_hunk_context
+            .or_else(|| {
+                grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true)
+                    .ok()
+                    .and_then(|cfg| cfg.get("diff.interhunkcontext"))
+                    .and_then(|s| s.parse().ok())
+            })
+            .unwrap_or(0);
         if args.shortstat {
             write_shortstat(
                 &mut out,
@@ -1295,7 +1318,7 @@ pub fn run(mut args: Args) -> Result<()> {
                     wt_for_content,
                     suppress_blank_empty,
                     patch_abbrev,
-                    args.inter_hunk_context,
+                    inter_hunk_context,
                     args.binary,
                     &src_prefix,
                     &dst_prefix,
@@ -2378,7 +2401,7 @@ fn write_patch_with_prefix(
     work_tree: Option<&Path>,
     suppress_blank_empty: bool,
     abbrev_len: usize,
-    _inter_hunk_context: Option<usize>,
+    inter_hunk_context: usize,
     show_binary: bool,
     src_prefix: &str,
     dst_prefix: &str,
@@ -2543,6 +2566,7 @@ fn write_patch_with_prefix(
                 display_old,
                 display_new,
                 context_lines,
+                inter_hunk_context,
                 src_prefix,
                 dst_prefix,
             );

--- a/grit/src/commands/log.rs
+++ b/grit/src/commands/log.rs
@@ -5401,6 +5401,7 @@ fn log_write_patch_entry(
         display_old,
         display_new,
         context_lines,
+        0,
         src_pfx,
         dst_pfx,
     );

--- a/logs/2026-04-09_t4032-diff-inter-hunk-context.md
+++ b/logs/2026-04-09_t4032-diff-inter-hunk-context.md
@@ -1,0 +1,6 @@
+# t4032-diff-inter-hunk-context
+
+- **Issue:** `diff --inter-hunk-context` and `diff.interHunkContext` were ignored; unified hunks did not fuse like Git/xdiff.
+- **Fix:** In `grit-lib::diff`, build hunks with `similar::group_diff_ops` using radius `2 * context + inter_hunk_context`, then render each group with `UnifiedDiffHunk` (same context radius as before). Extended `unified_diff_with_prefix` with `inter_hunk_context: usize` (default `0` via `unified_diff`).
+- **`grit diff`:** Resolve inter-hunk context from `--inter-hunk-context` or config `diff.interhunkcontext`; validate invalid/non-integer/negative values on diff entry when CLI flag not set (matches test expectations).
+- **Test:** `./scripts/run-tests.sh t4032-diff-inter-hunk-context.sh` → 37/37.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible **inter-hunk context** for unified diffs: hunks merge when the unchanged gap between change clusters is at most `2 * -U context + interhunk`, matching libxdiff’s `max_common` rule.

## Changes

- **`grit-lib`:** `unified_diff_with_prefix` (and the funcname/algorithm variants) take `inter_hunk_context: usize`. Hunk groups are built with `similar::group_diff_ops` at radius `context * 2 + inter_hunk_context`, then each group is rendered with `UnifiedDiffHunk` and the existing function-name header logic.
- **`grit diff`:** Resolves inter-hunk lines from `--inter-hunk-context` or `diff.interhunkcontext` (canonical `diff.interHunkContext`). When the flag is not set, invalid or negative config values fail the command like upstream tests expect.
- **`grit log`:** Passes `0` for inter-hunk context (unchanged behavior vs before this work).

## Testing

- `./scripts/run-tests.sh t4032-diff-inter-hunk-context.sh` — **37/37**
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2596171-bbcb-420e-b75b-579f521185e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2596171-bbcb-420e-b75b-579f521185e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

