### PR TITLE
fix(log): --simplify-by-decoration without --decorate

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -842,7 +842,7 @@ t4217-log-limit	t4	yes	3	1	2	false	ok	0
 t4218-log-no-walk	t4	yes	7	7	0	true	ok	0
 t4219-log-date-format	t4	yes	14	14	0	true	ok	0
 t4220-log-source	t4	yes	4	4	0	true	ok	0
-t4221-log-simplify-decoration	t4	yes	4	3	1	false	ok	0
+t4221-log-simplify-decoration	t4	yes	4	4	0	true	ok	0
 t4252-am-options	t4	yes	8	1	7	false	ok	0
 t4253-am-keep-cr-dos	t4	yes	7	7	0	true	ok	0
 t4254-am-corrupt	t4	yes	4	1	3	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T06:01:33+00:00" class="gen-time" title="2026-04-09 06:01 UTC">2026-04-09 06:01 UTC</time> · <a href="https://github.com/schacon/grit/commit/af7058806f04ec42cbcd11363aa5233ada99f42d" style="color:#58a6ff">af70588</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T06:10:19+00:00" class="gen-time" title="2026-04-09 06:10 UTC">2026-04-09 06:10 UTC</time> · <a href="https://github.com/schacon/grit/commit/afb4d1e00a25aa02a68c88a73b8e08f6822bed63" style="color:#58a6ff">afb4d1e</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,437</div>
+      <div class="summary-big-val">30,438</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>774 files fully passing</span>
+    <span>775 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -223,7 +223,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">74/178 files · 2 skipped · 2,288/3,542 tests</span>
+        <span class="group-meta">75/178 files · 2 skipped · 2,289/3,542 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.6%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:01:33+00:00" class="gen-time" title="2026-04-09 06:01 UTC">2026-04-09 06:01 UTC</time> · <a href="https://github.com/schacon/grit/commit/af7058806f04ec42cbcd11363aa5233ada99f42d" style="color:#58a6ff">af70588</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:10:19+00:00" class="gen-time" title="2026-04-09 06:10 UTC">2026-04-09 06:10 UTC</time> · <a href="https://github.com/schacon/grit/commit/afb4d1e00a25aa02a68c88a73b8e08f6822bed63" style="color:#58a6ff">afb4d1e</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,437</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,438</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">76.3%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -8577,14 +8577,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="4" data-passed="3">
+<tr class="" data-group="t4" data-tests="4" data-passed="4" data-full-pass="1">
   <td class="mono">t4221-log-simplify-decoration</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">4</td>
-  <td class="right">3</td>
+  <td class="right">4</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:75.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="8" data-passed="1">

--- a/grit/src/commands/log.rs
+++ b/grit/src/commands/log.rs
@@ -2270,11 +2270,22 @@ pub fn run(mut args: Args) -> Result<()> {
 
     let (show_decorations, decorate_full) =
         resolve_decoration_display(&args, format_requires_decorations);
-    let decorations = if !show_decorations {
-        None
-    } else {
+    // `--simplify-by-decoration` needs ref→OID mapping even when decorations are not shown
+    // (`--oneline` does not imply `--decorate`). Use a separate map for display so we do not
+    // print `(refs)` unless `--decorate` / `%d` requests it; OID keys match for full vs short maps.
+    let decoration_map_for_display = if show_decorations {
         Some(collect_decorations(&repo, decorate_full)?)
+    } else {
+        None
     };
+    let decoration_map_for_simplify_only = if args.simplify_by_decoration && !show_decorations {
+        Some(collect_decorations(&repo, false)?)
+    } else {
+        None
+    };
+    let decoration_map_for_simplify = decoration_map_for_simplify_only
+        .as_ref()
+        .or(decoration_map_for_display.as_ref());
 
     // Walk commits
     let mut combined_pathspecs = args.pathspecs.clone();
@@ -2347,7 +2358,7 @@ pub fn run(mut args: Args) -> Result<()> {
                 &args,
                 diff_filter_str,
                 find_oid,
-                decorations.as_ref(),
+                decoration_map_for_simplify,
                 since_threshold,
                 until_threshold,
             )? {
@@ -2375,7 +2386,7 @@ pub fn run(mut args: Args) -> Result<()> {
                 &oid,
                 &commit_data,
                 &args,
-                decorations.as_ref(),
+                decoration_map_for_display.as_ref(),
                 use_color,
                 &mut notes_cache,
                 &repo.odb,
@@ -2465,7 +2476,7 @@ pub fn run(mut args: Args) -> Result<()> {
 
         // Apply --simplify-by-decoration: only show commits with decorations
         let commits = if args.simplify_by_decoration {
-            match &decorations {
+            match decoration_map_for_simplify {
                 Some(dec_map) => commits
                     .into_iter()
                     .filter(|(oid, _)| dec_map.contains_key(&oid.to_hex()))
@@ -2538,7 +2549,7 @@ pub fn run(mut args: Args) -> Result<()> {
                 oid,
                 commit_data,
                 &args,
-                decorations.as_ref(),
+                decoration_map_for_display.as_ref(),
                 use_color,
                 &mut notes_cache,
                 &repo.odb,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`grit log --simplify-by-decoration` with default (no `--decorate`) uses the streaming walker. We only loaded the ref→OID decoration map when decorations were shown, so `commit_passes_post_walk_filters` saw `None` and never filtered—every commit appeared.

## Changes

- Load a ref map for simplify-by-decoration when decorations are not displayed, while still passing `None` to `format_commit` so `--oneline` output stays free of `(refs)` unless `--decorate` / `%d` requests it.
- Reuse the display map for simplify when both are active (same OID keys for full vs short labels).
- Refreshed harness metadata for `t4221-log-simplify-decoration` (4/4 passing).

## Validation

- `cargo check -p grit-rs`
- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t4221-log-simplify-decoration.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c826b824-c596-4134-b618-237aad7333e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c826b824-c596-4134-b618-237aad7333e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

