### PR TITLE
chore: t5900-repo-selection fully passing — refresh harness + plan

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -612,7 +612,7 @@ commit → check it off → move on.
 - [ ] `t5620-backfill` ████░░░░░░░░░░░░░░░░ 2/10 (8 left) — git backfill on partial clones
 - [ ] `t5315-pack-objects-compression` ██░░░░░░░░░░░░░░░░░░ 1/9 (8 left) — pack-object compression configuration
 - [ ] `t5506-remote-groups` ██░░░░░░░░░░░░░░░░░░ 1/9 (8 left) — git remote group handling
-- [ ] `t5900-repo-selection` ░░░░░░░░░░░░░░░░░░░░ 0/8 (8 left) — selecting remote repo in ambiguous cases
+- [x] `t5900-repo-selection` — selecting remote repo in ambiguous cases (8/8)
 - [ ] `t5582-fetch-negative-refspec` ████████░░░░░░░░░░░░ 7/16 (9 left) — 
 - [ ] `t5305-include-tag` ████████░░░░░░░░░░░░ 6/15 (9 left) — git pack-object --include-tag
 - [ ] `t5401-update-hooks` ██████░░░░░░░░░░░░░░ 4/13 (9 left) — Test the update hook infrastructure.

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1035,7 +1035,7 @@ t5812-proto-disable-http	t5	yes	29	11	18	false	ok	0
 t5813-proto-disable-ssh	t5	yes	81	57	24	false	ok	0
 t5814-proto-disable-ext	t5	yes	27	11	16	false	ok	0
 t5815-submodule-protos	t5	yes	8	5	3	false	ok	0
-t5900-repo-selection	t5	yes	8	0	8	false	ok	0
+t5900-repo-selection	t5	yes	8	8	0	true	ok	0
 t6000-rev-list-misc	t6	yes	23	9	14	false	ok	0
 t6001-rev-list-graft	t6	yes	14	14	0	true	ok	0
 t6002-rev-list-bisect	t6	yes	53	4	49	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T06:09:35+00:00" class="gen-time" title="2026-04-09 06:09 UTC">2026-04-09 06:09 UTC</time> · <a href="https://github.com/schacon/grit/commit/6529566ae7007f4b558ab767a1c583b651c13540" style="color:#58a6ff">6529566</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T06:16:13+00:00" class="gen-time" title="2026-04-09 06:16 UTC">2026-04-09 06:16 UTC</time> · <a href="https://github.com/schacon/grit/commit/26db6736faecca784905ae037f50e6b922325e46" style="color:#58a6ff">26db673</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,460</div>
+      <div class="summary-big-val">30,468</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>776 files fully passing</span>
+    <span>777 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">44/167 files · 17 skipped · 1,494/3,949 tests</span>
+        <span class="group-meta">45/167 files · 17 skipped · 1,502/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
-        <span class="group-pct pct-red">37.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:38.0%"></div></div>
+        <span class="group-pct pct-red">38.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:09:35+00:00" class="gen-time" title="2026-04-09 06:09 UTC">2026-04-09 06:09 UTC</time> · <a href="https://github.com/schacon/grit/commit/6529566ae7007f4b558ab767a1c583b651c13540" style="color:#58a6ff">6529566</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:16:13+00:00" class="gen-time" title="2026-04-09 06:16 UTC">2026-04-09 06:16 UTC</time> · <a href="https://github.com/schacon/grit/commit/26db6736faecca784905ae037f50e6b922325e46" style="color:#58a6ff">26db673</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,460</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,468</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">76.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -10507,14 +10507,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:62.5%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="8" data-passed="0">
+<tr class="" data-group="t5" data-tests="8" data-passed="8" data-full-pass="1">
   <td class="mono">t5900-repo-selection</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">8</td>
-  <td class="right">0</td>
+  <td class="right">8</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t6" data-tests="23" data-passed="9">

--- a/logs/2026-04-09_t5900-repo-selection.md
+++ b/logs/2026-04-09_t5900-repo-selection.md
@@ -1,0 +1,12 @@
+# t5900-repo-selection
+
+**Date:** 2026-04-09
+
+## Outcome
+
+`./scripts/run-tests.sh t5900-repo-selection.sh` reports **8/8** passing. No Rust changes were required; implementation already matches Git’s ambiguous local remote path rules exercised by the test file.
+
+## Actions
+
+- Refreshed `data/test-files.csv` and dashboards via the harness run.
+- Marked the corresponding task complete in `PLAN.md` and updated `progress.md` counts.

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   264 |
+| Completed   |   265 |
 | In progress |     4 |
-| Remaining   |   500 |
+| Remaining   |   499 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 264 completed (`[x]`), 4 in progress (`[~]`), 500 remaining (`[ ]`).
+Task lines in `PLAN.md`: 265 completed (`[x]`), 4 in progress (`[~]`), 499 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t5900-repo-selection` — 8/8 tests pass (local `fetch`/`clone` remote path resolution: `.git` dir in worktree, bare `foo` vs `foo.git` disambiguation, non-git `foo` directory ignored, inner worktree preferred when outer is bare; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t7450-bad-git-dotfiles` — 50/50 tests pass (submodule name/url validation, fsck symlink and `.gitmodules` checks, nested submodule git dirs, harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t5351-unpack-large-objects` — 7/7 tests pass (`GIT_ALLOC_LIMIT` + `core.bigFileThreshold` streaming unpack, dry-run, trace2 fsync batch path, skip already-packed objects; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t5308-pack-detect-duplicates` — 6/6 tests pass (`index-pack` allows duplicate OIDs by default; `--strict` rejects duplicates with non-zero exit and leaves objects out of the ODB; `cat-file --batch-check` resolves OIDs in packs with duplicate runs; harness CSV/dashboards refreshed; `PLAN.md` marked complete)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t5900-repo-selection` already passes all 8 harness tests (local remote path disambiguation for `fetch`/`clone`). This change refreshes harness metadata and marks the task complete in the project plan.

## Changes

- Run `./scripts/run-tests.sh t5900-repo-selection.sh` → update `data/test-files.csv`, `docs/index.html`, `docs/testfiles.html`
- Mark `t5900-repo-selection` complete in `PLAN.md` and bump counts in `progress.md`
- Add `logs/2026-04-09_t5900-repo-selection.md`

## Verification

```bash
./scripts/run-tests.sh t5900-repo-selection.sh
# 8/8 passing
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f669634-e514-42c8-a299-d7ed673c4343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f669634-e514-42c8-a299-d7ed673c4343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

