### PR TITLE
test: t10860-switch-force-create fully passing (30/30)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -183,7 +183,7 @@ t10820-commit-allow-amend	t1	yes	30	30	0	true	ok	0
 t10830-add-pathspec-force	t1	yes	32	32	0	true	ok	0
 t10840-rm-dry-run-force	t1	yes	33	33	0	true	ok	0
 t10850-mv-multi-source	t1	yes	30	30	0	true	ok	0
-t10860-switch-force-create	t1	yes	30	27	3	false	ok	0
+t10860-switch-force-create	t1	yes	30	30	0	true	ok	0
 t10870-restore-head-source	t1	yes	31	31	0	true	ok	0
 t10880-reset-hard-soft-path	t1	yes	31	31	0	true	ok	0
 t10890-cherry-pick-message	t1	yes	30	30	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T06:09:35+00:00" class="gen-time" title="2026-04-09 06:09 UTC">2026-04-09 06:09 UTC</time> · <a href="https://github.com/schacon/grit/commit/6529566ae7007f4b558ab767a1c583b651c13540" style="color:#58a6ff">6529566</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T06:17:22+00:00" class="gen-time" title="2026-04-09 06:17 UTC">2026-04-09 06:17 UTC</time> · <a href="https://github.com/schacon/grit/commit/26db6736faecca784905ae037f50e6b922325e46" style="color:#58a6ff">26db673</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,460</div>
+      <div class="summary-big-val">30,463</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>776 files fully passing</span>
+    <span>777 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -190,7 +190,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">281/368 files · 8 skipped · 10,783/11,373 tests</span>
+        <span class="group-meta">282/368 files · 8 skipped · 10,786/11,373 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-green" style="width:94.8%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:09:35+00:00" class="gen-time" title="2026-04-09 06:09 UTC">2026-04-09 06:09 UTC</time> · <a href="https://github.com/schacon/grit/commit/6529566ae7007f4b558ab767a1c583b651c13540" style="color:#58a6ff">6529566</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:17:22+00:00" class="gen-time" title="2026-04-09 06:17 UTC">2026-04-09 06:17 UTC</time> · <a href="https://github.com/schacon/grit/commit/26db6736faecca784905ae037f50e6b922325e46" style="color:#58a6ff">26db673</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,460</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,463</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">76.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1987,14 +1987,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="30" data-passed="27">
+<tr class="" data-group="t1" data-tests="30" data-passed="30" data-full-pass="1">
   <td class="mono">t10860-switch-force-create</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">30</td>
-  <td class="right">27</td>
+  <td class="right">30</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="31" data-passed="31" data-full-pass="1">

--- a/logs/2026-04-09_t10860-switch-force-create.md
+++ b/logs/2026-04-09_t10860-switch-force-create.md
@@ -1,0 +1,17 @@
+# t10860-switch-force-create
+
+**Date:** 2026-04-09
+
+## Outcome
+
+`./scripts/run-tests.sh t10860-switch-force-create.sh` reports **30/30** passing on current `grit` (no Rust code changes required in this session).
+
+## Actions
+
+- Refreshed `data/test-files.csv` row from 27/30 → 30/30, `fully_passing=true`.
+- Regenerated `docs/index.html` and `docs/testfiles.html` via harness.
+- Marked `t10860-switch-force-create.sh` complete in `t1-plan.md`.
+
+## Notes
+
+Prior CSV showed 3 failing tests; re-run confirms implementation already matches the suite.

--- a/progress.md
+++ b/progress.md
@@ -15,6 +15,7 @@ Task lines in `PLAN.md`: 264 completed (`[x]`), 4 in progress (`[~]`), 500 remai
 
 ## Recently completed
 
+- `t10860-switch-force-create` — 30/30 tests pass (`switch`: `-c`/`--create`, start points, `switch -`, detach/orphan, `--discard-changes`, untracked preservation; harness CSV/dashboards refreshed; `t1-plan.md` marked complete)
 - `t7450-bad-git-dotfiles` — 50/50 tests pass (submodule name/url validation, fsck symlink and `.gitmodules` checks, nested submodule git dirs, harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t5351-unpack-large-objects` — 7/7 tests pass (`GIT_ALLOC_LIMIT` + `core.bigFileThreshold` streaming unpack, dry-run, trace2 fsync batch path, skip already-packed objects; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t5308-pack-detect-duplicates` — 6/6 tests pass (`index-pack` allows duplicate OIDs by default; `--strict` rejects duplicates with non-zero exit and leaves objects out of the ODB; `cat-file --batch-check` resolves OIDs in packs with duplicate runs; harness CSV/dashboards refreshed; `PLAN.md` marked complete)

--- a/t1-plan.md
+++ b/t1-plan.md
@@ -46,7 +46,7 @@
 - [ ] t10830-add-pathspec-force.sh
 - [ ] t10840-rm-dry-run-force.sh
 - [ ] t10850-mv-multi-source.sh
-- [ ] t10860-switch-force-create.sh
+- [x] t10860-switch-force-create.sh
 - [ ] t10870-restore-head-source.sh
 - [ ] t10880-reset-hard-soft-path.sh
 - [ ] t10890-cherry-pick-message.sh


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Verified `./scripts/run-tests.sh t10860-switch-force-create.sh` passes **30/30**. No Rust changes were required; the implementation already satisfies the suite.

## Changes

- Refreshed `data/test-files.csv` (row now 30/30, `fully_passing=true`) and regenerated dashboards (`docs/index.html`, `docs/testfiles.html`).
- Marked `t10860-switch-force-create.sh` complete in `t1-plan.md`.
- Added `logs/2026-04-09_t10860-switch-force-create.md` and noted the run in `progress.md`.

## Testing

```bash
cargo build --release -p grit-rs
./scripts/run-tests.sh t10860-switch-force-create.sh
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63542627-c2dd-4c91-8d50-a3fd8004d4a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63542627-c2dd-4c91-8d50-a3fd8004d4a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

