### PR TITLE
fix: check-ref-format --branch rejects HEAD (match git)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T06:09:35+00:00" class="gen-time" title="2026-04-09 06:09 UTC">2026-04-09 06:09 UTC</time> · <a href="https://github.com/schacon/grit/commit/6529566ae7007f4b558ab767a1c583b651c13540" style="color:#58a6ff">6529566</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T06:20:35+00:00" class="gen-time" title="2026-04-09 06:20 UTC">2026-04-09 06:20 UTC</time> · <a href="https://github.com/schacon/grit/commit/26db6736faecca784905ae037f50e6b922325e46" style="color:#58a6ff">26db673</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,7 +100,7 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:09:35+00:00" class="gen-time" title="2026-04-09 06:09 UTC">2026-04-09 06:09 UTC</time> · <a href="https://github.com/schacon/grit/commit/6529566ae7007f4b558ab767a1c583b651c13540" style="color:#58a6ff">6529566</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:20:35+00:00" class="gen-time" title="2026-04-09 06:20 UTC">2026-04-09 06:20 UTC</time> · <a href="https://github.com/schacon/grit/commit/26db6736faecca784905ae037f50e6b922325e46" style="color:#58a6ff">26db673</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>

--- a/grit/src/commands/check_ref_format.rs
+++ b/grit/src/commands/check_ref_format.rs
@@ -81,6 +81,9 @@ fn run_branch_mode(arg: &str) -> Result<()> {
             if n >= 1 {
                 match resolve_at_minus_for_branch(n) {
                     Some(name) => {
+                        if name == "HEAD" {
+                            std::process::exit(1);
+                        }
                         println!("{name}");
                         return Ok(());
                     }
@@ -106,6 +109,10 @@ fn run_branch_mode(arg: &str) -> Result<()> {
 
     match check_refname_format(arg, &opts) {
         Ok(_) => {
+            // Match git's `check_branch_ref`: `refs/heads/HEAD` is never a valid branch ref.
+            if arg == "HEAD" {
+                std::process::exit(1);
+            }
             println!("{arg}");
             Ok(())
         }

--- a/logs/2026-04-09-check-ref-format-branch-head.md
+++ b/logs/2026-04-09-check-ref-format-branch-head.md
@@ -1,0 +1,15 @@
+# check-ref-format --branch: reject `HEAD`
+
+## Change
+
+Git's `check_branch_ref` splices `refs/heads/` and rejects when the full ref is exactly `refs/heads/HEAD`. Grit previously accepted `grit check-ref-format --branch HEAD` while `/usr/bin/git` fails.
+
+## Fix
+
+- In `--branch` mode, exit 1 (no output) when the validated shorthand is `HEAD`, or when `@{-N}` resolves to `HEAD`.
+
+## Validation
+
+- `./scripts/run-tests.sh t9440-check-ref-format-branch.sh` — 34/34
+- Manual: `grit check-ref-format --branch HEAD` now exits 1 like git
+- `cargo test -p grit-lib --lib`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t9440-check-ref-format-branch` already passed in the harness, but `grit check-ref-format --branch HEAD` incorrectly succeeded while upstream Git rejects it (`check_branch_ref` forbids `refs/heads/HEAD`).

## Changes

- After successful branch-shorthand validation, exit with code 1 when the name is `HEAD`.
- When `@{-N}` expansion resolves to `HEAD`, exit 1 as well.

## Verification

- `./scripts/run-tests.sh t9440-check-ref-format-branch.sh` (34/34)
- `cargo test -p grit-lib --lib`
- Compared behavior with `/usr/bin/git check-ref-format --branch HEAD`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5567017c-1934-4bf9-9b3c-1c770fd67719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5567017c-1934-4bf9-9b3c-1c770fd67719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

