### PR TITLE
test: t3900-i18n-commit fully passing — refresh harness metadata

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -659,7 +659,7 @@ t3703-add-magic-pathspec	t3	yes	6	6	0	true	ok	0
 t3704-add-pathspec-file	t3	yes	11	11	0	true	ok	0
 t3705-add-sparse-checkout	t3	yes	20	3	17	false	ok	0
 t3800-mktag	t3	yes	151	62	89	false	ok	0
-t3900-i18n-commit	t3	yes	38	11	27	false	ok	0
+t3900-i18n-commit	t3	yes	38	38	0	true	ok	0
 t3901-i18n-patch	t3	yes	20	0	20	false	ok	0
 t3902-quoted	t3	yes	13	5	8	false	ok	0
 t3902-quoted-ls-tree	t3	yes	8	8	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,16 +141,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T06:15:35+00:00" class="gen-time" title="2026-04-09 06:15 UTC">2026-04-09 06:15 UTC</time> · <a href="https://github.com/schacon/grit/commit/5d7faff0355767630d3725b22e2d8bda8d69fdce" style="color:#58a6ff">5d7faff</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T06:22:44+00:00" class="gen-time" title="2026-04-09 06:22 UTC">2026-04-09 06:22 UTC</time> · <a href="https://github.com/schacon/grit/commit/88b66d83e7115ae29f682137112c1a7766f1b3d9" style="color:#58a6ff">88b66d8</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">76.4%</div>
+      <div class="summary-big-val pct-blue">76.5%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,461</div>
+      <div class="summary-big-val">30,488</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -159,12 +159,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:76.4%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:76.5%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>777 files fully passing</span>
+    <span>778 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,11 +212,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">50/141 files · 2 skipped · 3,447/4,619 tests</span>
+        <span class="group-meta">51/141 files · 2 skipped · 3,474/4,619 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:74.6%"></div></div>
-        <span class="group-pct pct-blue">74.6%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:75.2%"></div></div>
+        <span class="group-pct pct-blue">75.2%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:15:35+00:00" class="gen-time" title="2026-04-09 06:15 UTC">2026-04-09 06:15 UTC</time> · <a href="https://github.com/schacon/grit/commit/5d7faff0355767630d3725b22e2d8bda8d69fdce" style="color:#58a6ff">5d7faff</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:22:44+00:00" class="gen-time" title="2026-04-09 06:22 UTC">2026-04-09 06:22 UTC</time> · <a href="https://github.com/schacon/grit/commit/88b66d83e7115ae29f682137112c1a7766f1b3d9" style="color:#58a6ff">88b66d8</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,461</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">76.4%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,488</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">76.5%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -6747,14 +6747,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:41.1%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="38" data-passed="11">
+<tr class="" data-group="t3" data-tests="38" data-passed="38" data-full-pass="1">
   <td class="mono">t3900-i18n-commit</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">38</td>
-  <td class="right">11</td>
+  <td class="right">38</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:28.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="20" data-passed="0">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Verified `./scripts/run-tests.sh t3900-i18n-commit.sh` passes **38/38** tests. The working tree already had correct i18n commit behavior; this change updates the harness bookkeeping only.

## Changes

- `data/test-files.csv`: set `t3900-i18n-commit` to full pass counts and `fully_passing=true`
- Regenerated `docs/index.html` and `docs/testfiles.html` via the test runner

## Validation

```bash
cargo build --release -p grit-rs
./scripts/run-tests.sh t3900-i18n-commit.sh
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c1cafd2-d5f3-498a-a47f-4b51eb5f71f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c1cafd2-d5f3-498a-a47f-4b51eb5f71f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

