### PR TITLE
fix: reject mixed reset in bare repos (t7103-reset-bare)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1181,7 +1181,7 @@ t7090-rm-advanced	t7	yes	31	31	0	true	ok	0
 t7101-reset	t7	yes	11	11	0	true	ok	0
 t7101-reset-empty-subdirs	t7	yes	10	10	0	true	ok	0
 t7102-reset	t7	yes	38	22	16	false	ok	0
-t7103-reset-bare	t7	yes	13	11	2	false	ok	0
+t7103-reset-bare	t7	yes	13	13	0	true	ok	0
 t7104-reset-hard	t7	yes	3	3	0	true	ok	0
 t7105-reset-patch	t7	yes	13	6	7	false	ok	0
 t7106-reset-unborn-branch	t7	yes	7	7	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T06:09:35+00:00" class="gen-time" title="2026-04-09 06:09 UTC">2026-04-09 06:09 UTC</time> · <a href="https://github.com/schacon/grit/commit/6529566ae7007f4b558ab767a1c583b651c13540" style="color:#58a6ff">6529566</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T06:22:31+00:00" class="gen-time" title="2026-04-09 06:22 UTC">2026-04-09 06:22 UTC</time> · <a href="https://github.com/schacon/grit/commit/26db6736faecca784905ae037f50e6b922325e46" style="color:#58a6ff">26db673</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,460</div>
+      <div class="summary-big-val">30,462</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>776 files fully passing</span>
+    <span>777 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -256,11 +256,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">50/126 files · 11 skipped · 1,972/2,944 tests</span>
+        <span class="group-meta">51/126 files · 11 skipped · 1,974/2,944 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:67.0%"></div></div>
-        <span class="group-pct pct-blue">67.0%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:67.1%"></div></div>
+        <span class="group-pct pct-blue">67.1%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:09:35+00:00" class="gen-time" title="2026-04-09 06:09 UTC">2026-04-09 06:09 UTC</time> · <a href="https://github.com/schacon/grit/commit/6529566ae7007f4b558ab767a1c583b651c13540" style="color:#58a6ff">6529566</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:22:31+00:00" class="gen-time" title="2026-04-09 06:22 UTC">2026-04-09 06:22 UTC</time> · <a href="https://github.com/schacon/grit/commit/26db6736faecca784905ae037f50e6b922325e46" style="color:#58a6ff">26db673</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,460</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,462</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">76.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -11967,14 +11967,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:57.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="13" data-passed="11">
+<tr class="" data-group="t7" data-tests="13" data-passed="13" data-full-pass="1">
   <td class="mono">t7103-reset-bare</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">13</td>
-  <td class="right">11</td>
+  <td class="right">13</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:84.6%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="3" data-passed="3" data-full-pass="1">

--- a/grit/src/commands/reset.rs
+++ b/grit/src/commands/reset.rs
@@ -408,6 +408,9 @@ fn reset_paths(
     _quiet: bool,
     intent_to_add: bool,
 ) -> Result<()> {
+    if repo.work_tree.is_none() {
+        bail!("fatal: mixed reset is not allowed in a bare repository");
+    }
     // On an unborn branch, the tree is empty (no commit exists yet).
     let tree_entries = match resolve_to_commit(repo, commit_spec) {
         Ok(commit_oid) => {
@@ -526,6 +529,9 @@ fn reset_commit(
                     return Ok(());
                 }
                 ResetMode::Mixed => {
+                    if repo.work_tree.is_none() {
+                        bail!("fatal: mixed reset is not allowed in a bare repository");
+                    }
                     // Mixed on unborn: clear the index
                     let index_path = repo.index_path();
                     let mut new_index = Index::new();
@@ -555,6 +561,10 @@ fn reset_commit(
         }
         Err(e) => return Err(e),
     };
+
+    if mode == ResetMode::Mixed && repo.work_tree.is_none() {
+        bail!("fatal: mixed reset is not allowed in a bare repository");
+    }
 
     // For --keep, we need to check safety before making any changes.
     if mode == ResetMode::Keep {

--- a/logs/2026-04-09_t7103-reset-bare.md
+++ b/logs/2026-04-09_t7103-reset-bare.md
@@ -1,0 +1,20 @@
+# t7103-reset-bare
+
+## Issue
+
+`git reset` (mixed) in a bare repository must fail with the same message as upstream Git. Grit was updating HEAD and the index because `work_tree` is `None` for bare repos but mixed reset was only gated for hard/merge/keep.
+
+## Fix
+
+In `grit/src/commands/reset.rs`:
+
+- After resolving the target commit, if mode is mixed and `repo.work_tree.is_none()`, bail with `fatal: mixed reset is not allowed in a bare repository` (before moving HEAD).
+- Same check for unborn-branch mixed reset and for pathspec mixed reset (`reset_paths`).
+
+`GIT_WORK_TREE` on a bare repo sets `work_tree` to `Some`, matching Git (mixed reset allowed with a work tree).
+
+## Validation
+
+- `./scripts/run-tests.sh t7103-reset-bare.sh` — 13/13
+- `cargo test -p grit-lib --lib`
+- `cargo check -p grit-rs`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Upstream Git refuses **mixed** reset when there is no working tree (`fatal: mixed reset is not allowed in a bare repository`). Grit only blocked hard/merge/keep in that situation, so bare mixed reset could still move HEAD and rewrite the index.

## Changes

- In `reset_commit`, after resolving the target commit, bail on mixed reset when `repo.work_tree.is_none()` **before** updating HEAD (matches Git’s ordering).
- Apply the same rule for unborn-branch mixed reset and for pathspec mixed reset (`reset_paths`).
- When `GIT_WORK_TREE` is set, `work_tree` is `Some` and mixed reset remains allowed, consistent with Git.

## Testing

- `./scripts/run-tests.sh t7103-reset-bare.sh` (13/13)
- `cargo test -p grit-lib --lib`
- `cargo check -p grit-rs`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8cb640cf-46df-413f-a518-f57b5d7f81ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8cb640cf-46df-413f-a518-f57b5d7f81ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

