### PR TITLE
docs: t5309-pack-delta-cycles verified 7/7, refresh harness

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -569,6 +569,7 @@ commit → check it off → move on.
 - [ ] `t5583-push-branches` ████████████░░░░░░░░ 5/8 (3 left) — check the consisitency of behavior of --all and --branches
 - [ ] `t5536-fetch-conflicts` ███████████░░░░░░░░░ 4/7 (3 left) — fetch handles conflicting refspecs correctly
 - [x] `t5308-pack-detect-duplicates` ████████████████████ 6/6 (0 left) — handling of duplicate objects in incoming packfiles
+- [x] `t5309-pack-delta-cycles` ████████████████████ 7/7 (0 left) — test index-pack handling of delta cycles in packfiles
 - [ ] `t5549-fetch-push-http` ░░░░░░░░░░░░░░░░░░░░ 0/3 (3 left) — fetch/push functionality using the HTTP protocol
 - [x] `t5704-protocol-violations` ████████████████████ 3/3 — Test responses to violations of the network protocol. In most
 
@@ -605,7 +606,6 @@ commit → check it off → move on.
 - [ ] `t5617-clone-submodules-remote` ████░░░░░░░░░░░░░░░░ 2/9 (7 left) — Test cloning repos with submodules using remote-tracking branches
 - [ ] `t5538-push-shallow` ██░░░░░░░░░░░░░░░░░░ 1/8 (7 left) — push from/to a shallow clone
 - [ ] `t5539-fetch-http-shallow` ██░░░░░░░░░░░░░░░░░░ 1/8 (7 left) — fetch/clone from a shallow clone over http
-- [ ] `t5309-pack-delta-cycles` ░░░░░░░░░░░░░░░░░░░░ 0/7 (7 left) — test index-pack handling of delta cycles in packfiles
 - [ ] `t5810-proto-disable-local` █████████████████░░░ 46/54 (8 left) — test disabling of local paths in clone/fetch
 - [ ] `t5545-push-options` ███████░░░░░░░░░░░░░ 5/13 (8 left) — pushing to a repository using push options
 - [ ] `t5322-pack-objects-sparse` █████░░░░░░░░░░░░░░░ 3/11 (8 left) — pack-objects object selection using sparse algorithm

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -875,7 +875,7 @@ t5305-include-tag	t5	yes	15	8	7	false	ok	0
 t5306-pack-nobase	t5	yes	4	4	0	true	ok	0
 t5307-pack-missing-commit	t5	yes	5	5	0	true	ok	0
 t5308-pack-detect-duplicates	t5	yes	6	6	0	true	ok	0
-t5309-pack-delta-cycles	t5	yes	7	2	5	false	ok	0
+t5309-pack-delta-cycles	t5	yes	7	7	0	true	ok	0
 t5310-pack-bitmaps	t5	yes	236	23	213	false	ok	0
 t5311-pack-bitmaps-shallow	t5	yes	6	6	0	true	ok	0
 t5312-prune-corruption	t5	yes	11	5	6	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T06:26:18+00:00" class="gen-time" title="2026-04-09 06:26 UTC">2026-04-09 06:26 UTC</time> · <a href="https://github.com/schacon/grit/commit/e3345ffb3a9baa4a00781a3b6968148e1e5d9449" style="color:#58a6ff">e3345ff</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T06:27:59+00:00" class="gen-time" title="2026-04-09 06:27 UTC">2026-04-09 06:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/28cf6974e1bc99b308cc3fa745fe22c68de62829" style="color:#58a6ff">28cf697</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,464</div>
+      <div class="summary-big-val">30,469</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>778 files fully passing</span>
+    <span>779 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">44/167 files · 17 skipped · 1,494/3,949 tests</span>
+        <span class="group-meta">45/167 files · 17 skipped · 1,499/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
-        <span class="group-pct pct-red">37.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:38.0%"></div></div>
+        <span class="group-pct pct-red">38.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:26:18+00:00" class="gen-time" title="2026-04-09 06:26 UTC">2026-04-09 06:26 UTC</time> · <a href="https://github.com/schacon/grit/commit/e3345ffb3a9baa4a00781a3b6968148e1e5d9449" style="color:#58a6ff">e3345ff</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:27:59+00:00" class="gen-time" title="2026-04-09 06:27 UTC">2026-04-09 06:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/28cf6974e1bc99b308cc3fa745fe22c68de62829" style="color:#58a6ff">28cf697</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,464</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,469</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">76.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -8907,14 +8907,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="7" data-passed="2">
+<tr class="" data-group="t5" data-tests="7" data-passed="7" data-full-pass="1">
   <td class="mono">t5309-pack-delta-cycles</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">7</td>
-  <td class="right">2</td>
+  <td class="right">7</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:28.6%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="236" data-passed="23">

--- a/grit-lib/src/gitmodules.rs
+++ b/grit-lib/src/gitmodules.rs
@@ -235,10 +235,13 @@ fn check_submodule_name(name: &str) -> bool {
     }
     let b = name.as_bytes();
     // Git `check_submodule_name`: `goto in_component` before the loop — first component.
-    if b.len() >= 2 && b[0] == b'.' && b[1] == b'.'
-        && (b.len() == 2 || b[2] == b'/' || b[2] == b'\\') {
-            return false;
-        }
+    if b.len() >= 2
+        && b[0] == b'.'
+        && b[1] == b'.'
+        && (b.len() == 2 || b[2] == b'/' || b[2] == b'\\')
+    {
+        return false;
+    }
     let mut i = 0usize;
     while i < b.len() {
         let c = b[i];

--- a/logs/2026-04-09_t5309-pack-delta-cycles.md
+++ b/logs/2026-04-09_t5309-pack-delta-cycles.md
@@ -1,0 +1,14 @@
+# t5309-pack-delta-cycles
+
+**Date:** 2026-04-09
+
+## Outcome
+
+`./scripts/run-tests.sh t5309-pack-delta-cycles.sh` reports **7/7** passing on branch `cursor/t5309-pack-delta-cycles-53f9`. No Rust changes were required in this session; implementation was already correct.
+
+## Actions
+
+- Ran harness; confirmed all cases (single delta both directions, missing base, pure REF_DELTA cycle failure, failover via ODB / duplicate in-pack, thin pack clone + `index-pack --fix-thin`).
+- Updated `PLAN.md` (marked `[x]`, moved entry next to t5308).
+- Refreshed `progress.md` counts and “Recently completed”.
+- Committed `data/test-files.csv`, `docs/index.html`, `docs/testfiles.html` with the harness run.

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   264 |
+| Completed   |   265 |
 | In progress |     4 |
-| Remaining   |   500 |
+| Remaining   |   499 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 264 completed (`[x]`), 4 in progress (`[~]`), 500 remaining (`[ ]`).
+Task lines in `PLAN.md`: 265 completed (`[x]`), 4 in progress (`[~]`), 499 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t5309-pack-delta-cycles` — 7/7 tests pass (`index-pack` / `--fix-thin`: REF_DELTA cycles fail when bases are missing, succeed when bases exist in ODB or as duplicate undeltified objects in-pack; thin A→B→C chain with B on disk; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t12650-config-null-value` — 34/34 tests pass (null/implicit-true keys, empty `=`, `--bool`/`--int` including k/m/g suffixes, `config -l`, `--get-regexp` / `--name-only`; harness CSV/dashboards refreshed; `t1-plan.md` marked complete)
 - `t7450-bad-git-dotfiles` — 50/50 tests pass (submodule name/url validation, fsck symlink and `.gitmodules` checks, nested submodule git dirs, harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t5351-unpack-large-objects` — 7/7 tests pass (`GIT_ALLOC_LIMIT` + `core.bigFileThreshold` streaming unpack, dry-run, trace2 fsync batch path, skip already-packed objects; harness CSV/dashboards refreshed; `PLAN.md` marked complete)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t5309-pack-delta-cycles` already passes all 7 harness tests on this branch (`./scripts/run-tests.sh t5309-pack-delta-cycles.sh`). This change records that in `PLAN.md` / `progress.md`, adds a short log under `logs/`, and commits the refreshed `data/test-files.csv` and dashboard HTML from the clean run.

Follow-up: `cargo fmt` had left `grit-lib/src/gitmodules.rs` unstaged; that rustfmt-only tweak is committed as `708c5e9c` so the branch stays clean.

## Verification

```bash
./scripts/run-tests.sh t5309-pack-delta-cycles.sh
# 7/7
```

No functional Rust changes were required for t5309 in this session.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14d79bbe-774d-488f-9a51-c21a60a34633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14d79bbe-774d-488f-9a51-c21a60a34633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

