### PR TITLE
chore: t1508-at-combinations 35/35 — refresh harness + plan

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -118,7 +118,7 @@ commit → check it off → move on.
 - [ ] `t0613-reftable-write-options` ░░░░░░░░░░░░░░░░░░░░ 0/11 (11 left) — reftable write options
 - [ ] `t1419-exclude-refs` █░░░░░░░░░░░░░░░░░░░ 1/13 (12 left) — test exclude_patterns functionality in main ref store
 - [ ] `t0211-trace2-perf` ████░░░░░░░░░░░░░░░░ 4/17 (13 left) — test trace2 facility (perf target)
-- [ ] `t1508-at-combinations` ████████████░░░░░░░░ 21/35 (14 left) — test various @{X} syntax combinations together
+- [x] `t1508-at-combinations` ████████████████████ 35/35 (0 left) — test various @{X} syntax combinations together
 - [x] `t1405-main-ref-store` ████████████████████ 16/16 (0 left) — test main ref store api
 - [ ] `t0210-trace2-normal` ░░░░░░░░░░░░░░░░░░░░ 0/14 (14 left) — test trace2 facility (normal target)
 - [ ] `t1050-large` █████████░░░░░░░░░░░ 14/29 (15 left) — adding and checking out large blobs

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -442,7 +442,7 @@ t1504-revision-range	t1	yes	28	28	0	true	ok	0
 t1505-rev-parse-last	t1	yes	7	7	0	true	ok	0
 t1506-rev-parse-diagnosis	t1	yes	30	30	0	true	ok	0
 t1507-rev-parse-upstream	t1	yes	29	23	6	false	ok	0
-t1508-at-combinations	t1	yes	35	33	2	false	ok	0
+t1508-at-combinations	t1	yes	35	35	0	true	ok	0
 t1509-root-work-tree	t1	yes	0	0	0	false	ok	0
 t1510-repo-setup	t1	yes	109	107	2	false	ok	0
 t1511-rev-parse-caret	t1	yes	17	11	6	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T06:26:18+00:00" class="gen-time" title="2026-04-09 06:26 UTC">2026-04-09 06:26 UTC</time> · <a href="https://github.com/schacon/grit/commit/e3345ffb3a9baa4a00781a3b6968148e1e5d9449" style="color:#58a6ff">e3345ff</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T06:29:05+00:00" class="gen-time" title="2026-04-09 06:29 UTC">2026-04-09 06:29 UTC</time> · <a href="https://github.com/schacon/grit/commit/28cf6974e1bc99b308cc3fa745fe22c68de62829" style="color:#58a6ff">28cf697</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,464</div>
+      <div class="summary-big-val">30,466</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>778 files fully passing</span>
+    <span>779 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -190,7 +190,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">282/368 files · 8 skipped · 10,784/11,373 tests</span>
+        <span class="group-meta">283/368 files · 8 skipped · 10,786/11,373 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-green" style="width:94.8%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:26:18+00:00" class="gen-time" title="2026-04-09 06:26 UTC">2026-04-09 06:26 UTC</time> · <a href="https://github.com/schacon/grit/commit/e3345ffb3a9baa4a00781a3b6968148e1e5d9449" style="color:#58a6ff">e3345ff</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:29:05+00:00" class="gen-time" title="2026-04-09 06:29 UTC">2026-04-09 06:29 UTC</time> · <a href="https://github.com/schacon/grit/commit/28cf6974e1bc99b308cc3fa745fe22c68de62829" style="color:#58a6ff">28cf697</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,464</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,466</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">76.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -4577,14 +4577,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:79.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="35" data-passed="33">
+<tr class="" data-group="t1" data-tests="35" data-passed="35" data-full-pass="1">
   <td class="mono">t1508-at-combinations</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">35</td>
-  <td class="right">33</td>
+  <td class="right">35</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:94.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="0" data-passed="0">

--- a/logs/2026-04-09_t1508-at-combinations.md
+++ b/logs/2026-04-09_t1508-at-combinations.md
@@ -1,0 +1,5 @@
+# t1508-at-combinations
+
+- Ran `./scripts/run-tests.sh t1508-at-combinations.sh`: **35/35** pass.
+- No Rust changes required; prior implementation already satisfied `@{X}` combinations (reflog, upstream, `@`, `@@{u}`, branch names with `@`, pathspec `@:file`, empty/single-entry reflog edge cases).
+- Refreshed `data/test-files.csv` and dashboards; marked task complete in `PLAN.md` / `t1-plan.md` and updated `progress.md` counts.

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   264 |
+| Completed   |   265 |
 | In progress |     4 |
-| Remaining   |   500 |
+| Remaining   |   499 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 264 completed (`[x]`), 4 in progress (`[~]`), 500 remaining (`[ ]`).
+Task lines in `PLAN.md`: 265 completed (`[x]`), 4 in progress (`[~]`), 499 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t1508-at-combinations` — 35/35 tests pass (`@{X}` combinations: reflog, upstream, `@`/`@@{u}`, branches with `@`, `@:path`, reflog expire edge cases; harness CSV/dashboards refreshed; `PLAN.md` / `t1-plan.md` marked complete)
 - `t12650-config-null-value` — 34/34 tests pass (null/implicit-true keys, empty `=`, `--bool`/`--int` including k/m/g suffixes, `config -l`, `--get-regexp` / `--name-only`; harness CSV/dashboards refreshed; `t1-plan.md` marked complete)
 - `t7450-bad-git-dotfiles` — 50/50 tests pass (submodule name/url validation, fsck symlink and `.gitmodules` checks, nested submodule git dirs, harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t5351-unpack-large-objects` — 7/7 tests pass (`GIT_ALLOC_LIMIT` + `core.bigFileThreshold` streaming unpack, dry-run, trace2 fsync batch path, skip already-packed objects; harness CSV/dashboards refreshed; `PLAN.md` marked complete)

--- a/t1-plan.md
+++ b/t1-plan.md
@@ -207,7 +207,7 @@
 (-- cursor 3 --)
 - [ ] t1506-rev-parse-diagnosis.sh
 - [ ] t1507-rev-parse-upstream.sh
-- [ ] t1508-at-combinations.sh                                                                          - [ ] t1509-root-work-tree.sh
+- [x] t1508-at-combinations.sh                                                                          - [ ] t1509-root-work-tree.sh
 
 (-- cursor 2 --)
 - [ ] t1510-repo-setup.sh                                                                               - [ ] t1511-rev-parse-caret.sh


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t1508-at-combinations.sh` already passes **35/35** against current `grit`; no Rust changes were required.

## Changes

- Refreshed `data/test-files.csv` and generated dashboards (`docs/index.html`, `docs/testfiles.html`) via `./scripts/run-tests.sh t1508-at-combinations.sh`.
- Marked the task complete in `PLAN.md` and `t1-plan.md`, updated `progress.md` counts, and added `logs/2026-04-09_t1508-at-combinations.md`.

## Verification

```bash
./scripts/run-tests.sh t1508-at-combinations.sh
# ✓ t1508-at-combinations (35/35)
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-714a4977-04f8-4543-bc35-557b4b27d8fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-714a4977-04f8-4543-bc35-557b4b27d8fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

