### PR TITLE
docs: t3427-rebase-subtree harness 3/3 + plan refresh

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -261,7 +261,7 @@ commit → check it off → move on.
 - [x] `t3305-notes-fanout` ████████████████████ 7/7 (0 left) — Test that adding/removing many notes triggers automatic fanout restructuring
 - [ ] `t3005-ls-files-relative` █████░░░░░░░░░░░░░░░ 1/4 (3 left) — ls-files tests with relative paths
 
-- [ ] `t3427-rebase-subtree` ░░░░░░░░░░░░░░░░░░░░ 0/3 (3 left) — git rebase tests for -Xsubtree
+- [x] `t3427-rebase-subtree` ████████████████████ 3/3 (0 left) — git rebase tests for -Xsubtree
 
 - [ ] `t3506-cherry-pick-ff` ████████████░░░░░░░░ 7/11 (4 left) — test cherry-picking with --ff option
 - [ ] `t3103-ls-tree-misc` ████████████░░░░░░░░ 6/10 (4 left) — 

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -613,7 +613,7 @@ t3423-rebase-reword	t3	yes	3	1	2	false	ok	0
 t3424-rebase-empty	t3	yes	19	3	16	false	ok	1
 t3425-rebase-topology-merges	t3	yes	13	13	0	true	ok	0
 t3426-rebase-submodule	t3	yes	29	2	27	false	ok	0
-t3427-rebase-subtree	t3	yes	3	0	3	false	ok	0
+t3427-rebase-subtree	t3	yes	3	3	0	true	ok	0
 t3428-rebase-signoff	t3	yes	7	1	6	false	ok	0
 t3429-rebase-edit-todo	t3	yes	7	2	5	false	ok	0
 t3430-rebase-merges	t3	yes	34	34	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T06:26:18+00:00" class="gen-time" title="2026-04-09 06:26 UTC">2026-04-09 06:26 UTC</time> · <a href="https://github.com/schacon/grit/commit/e3345ffb3a9baa4a00781a3b6968148e1e5d9449" style="color:#58a6ff">e3345ff</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T06:29:34+00:00" class="gen-time" title="2026-04-09 06:29 UTC">2026-04-09 06:29 UTC</time> · <a href="https://github.com/schacon/grit/commit/28cf6974e1bc99b308cc3fa745fe22c68de62829" style="color:#58a6ff">28cf697</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,464</div>
+      <div class="summary-big-val">30,467</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>778 files fully passing</span>
+    <span>779 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,11 +212,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">50/141 files · 2 skipped · 3,447/4,619 tests</span>
+        <span class="group-meta">51/141 files · 2 skipped · 3,450/4,619 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:74.6%"></div></div>
-        <span class="group-pct pct-blue">74.6%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:74.7%"></div></div>
+        <span class="group-pct pct-blue">74.7%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:26:18+00:00" class="gen-time" title="2026-04-09 06:26 UTC">2026-04-09 06:26 UTC</time> · <a href="https://github.com/schacon/grit/commit/e3345ffb3a9baa4a00781a3b6968148e1e5d9449" style="color:#58a6ff">e3345ff</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:29:34+00:00" class="gen-time" title="2026-04-09 06:29 UTC">2026-04-09 06:29 UTC</time> · <a href="https://github.com/schacon/grit/commit/28cf6974e1bc99b308cc3fa745fe22c68de62829" style="color:#58a6ff">28cf697</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,464</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,467</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">76.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -6287,14 +6287,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:6.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="3" data-passed="0">
+<tr class="" data-group="t3" data-tests="3" data-passed="3" data-full-pass="1">
   <td class="mono">t3427-rebase-subtree</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">3</td>
-  <td class="right">0</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="7" data-passed="1">

--- a/logs/2026-04-09_t3427-rebase-subtree.md
+++ b/logs/2026-04-09_t3427-rebase-subtree.md
@@ -1,0 +1,4 @@
+# t3427-rebase-subtree
+
+- 2026-04-09: Verified `./scripts/run-tests.sh t3427-rebase-subtree.sh` — 3/3 passing on branch `cursor/t3427-rebase-subtree-passing-e619` (no Rust changes required; implementation already correct).
+- Updated `PLAN.md`, `progress.md`, and committed harness CSV + dashboard refresh.

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   264 |
+| Completed   |   265 |
 | In progress |     4 |
-| Remaining   |   500 |
+| Remaining   |   499 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 264 completed (`[x]`), 4 in progress (`[~]`), 500 remaining (`[ ]`).
+Task lines in `PLAN.md`: 265 completed (`[x]`), 4 in progress (`[~]`), 499 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t3427-rebase-subtree` — 3/3 tests pass (`rebase -Xsubtree=…`, `--empty=ask` stops for empty pick then `--skip`, with and without `--rebase-merges --onto`; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t12650-config-null-value` — 34/34 tests pass (null/implicit-true keys, empty `=`, `--bool`/`--int` including k/m/g suffixes, `config -l`, `--get-regexp` / `--name-only`; harness CSV/dashboards refreshed; `t1-plan.md` marked complete)
 - `t7450-bad-git-dotfiles` — 50/50 tests pass (submodule name/url validation, fsck symlink and `.gitmodules` checks, nested submodule git dirs, harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t5351-unpack-large-objects` — 7/7 tests pass (`GIT_ALLOC_LIMIT` + `core.bigFileThreshold` streaming unpack, dry-run, trace2 fsync batch path, skip already-packed objects; harness CSV/dashboards refreshed; `PLAN.md` marked complete)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t3427-rebase-subtree.sh` already passes fully against current `grit` (3/3). This change records that in tracking docs and refreshes harness outputs from `./scripts/run-tests.sh t3427-rebase-subtree.sh`.

## Changes

- Mark `t3427-rebase-subtree` complete in `PLAN.md` and bump counts in `progress.md`
- Refresh `data/test-files.csv`, `docs/index.html`, `docs/testfiles.html`
- Add `logs/2026-04-09_t3427-rebase-subtree.md`

## Verification

```bash
cargo build --release -p grit-rs
./scripts/run-tests.sh t3427-rebase-subtree.sh
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b19ee534-c6e8-4a5b-80ef-fdef50d1ced9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b19ee534-c6e8-4a5b-80ef-fdef50d1ced9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

