### PR TITLE
test: t3401 rebase --apply and am directory-rename fully passing

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -589,7 +589,7 @@ t3315-notes-merge	t3	yes	4	4	0	true	ok	0
 t3320-notes-merge-worktrees	t3	yes	9	8	1	false	ok	0
 t3321-notes-stripspace	t3	yes	27	1	26	false	ok	0
 t3400-rebase	t3	yes	39	21	18	false	ok	0
-t3401-rebase-and-am-rename	t3	yes	8	5	3	false	ok	2
+t3401-rebase-and-am-rename	t3	yes	10	10	0	true	ok	0
 t3401-rebase-basic	t3	yes	32	32	0	true	ok	0
 t3402-rebase-merge	t3	yes	13	2	11	false	ok	0
 t3403-rebase-skip	t3	yes	20	10	10	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T06:26:18+00:00" class="gen-time" title="2026-04-09 06:26 UTC">2026-04-09 06:26 UTC</time> · <a href="https://github.com/schacon/grit/commit/e3345ffb3a9baa4a00781a3b6968148e1e5d9449" style="color:#58a6ff">e3345ff</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T06:30:15+00:00" class="gen-time" title="2026-04-09 06:30 UTC">2026-04-09 06:30 UTC</time> · <a href="https://github.com/schacon/grit/commit/28cf6974e1bc99b308cc3fa745fe22c68de62829" style="color:#58a6ff">28cf697</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,11 +150,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,464</div>
+      <div class="summary-big-val">30,469</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">39,873</div>
+      <div class="summary-big-val">39,875</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>778 files fully passing</span>
+    <span>779 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,11 +212,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">50/141 files · 2 skipped · 3,447/4,619 tests</span>
+        <span class="group-meta">51/141 files · 2 skipped · 3,452/4,621 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:74.6%"></div></div>
-        <span class="group-pct pct-blue">74.6%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:74.7%"></div></div>
+        <span class="group-pct pct-blue">74.7%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:26:18+00:00" class="gen-time" title="2026-04-09 06:26 UTC">2026-04-09 06:26 UTC</time> · <a href="https://github.com/schacon/grit/commit/e3345ffb3a9baa4a00781a3b6968148e1e5d9449" style="color:#58a6ff">e3345ff</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:30:15+00:00" class="gen-time" title="2026-04-09 06:30 UTC">2026-04-09 06:30 UTC</time> · <a href="https://github.com/schacon/grit/commit/28cf6974e1bc99b308cc3fa745fe22c68de62829" style="color:#58a6ff">28cf697</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,464</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n" id="sum-tests">39,875</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,469</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">76.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -6047,15 +6047,15 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:53.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="8" data-passed="5">
+<tr class="" data-group="t3" data-tests="10" data-passed="10" data-full-pass="1">
   <td class="mono">t3401-rebase-and-am-rename</td>
   <td>t3</td>
-  <td></td>
-  <td class="right">8</td>
-  <td class="right">5</td>
+  <td><span class="badge ok">full pass</span></td>
+  <td class="right">10</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:62.5%"></div></div></td>
-  <td class="right small">2</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="32" data-passed="32" data-full-pass="1">
   <td class="mono">t3401-rebase-basic</td>

--- a/tests/t3401-rebase-and-am-rename.sh
+++ b/tests/t3401-rebase-and-am-rename.sh
@@ -52,7 +52,7 @@ test_expect_success 'rebase --interactive: directory rename detected' '
 	)
 '
 
-test_expect_failure 'rebase --apply: directory rename detected' '
+test_expect_success 'rebase --apply: directory rename detected' '
 	(
 		cd dir-rename &&
 
@@ -84,7 +84,7 @@ test_expect_success 'rebase --merge: directory rename detected' '
 	)
 '
 
-test_expect_failure 'am: directory rename detected' '
+test_expect_success 'am: directory rename detected' '
 	(
 		cd dir-rename &&
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`tests/t3401-rebase-and-am-rename.sh` had two cases still marked as `test_expect_failure` (known breakage) even though grit already passes them. That caused the harness to report "known breakage vanished" and a non-zero exit.

## Changes

- Flip **rebase --apply: directory rename detected** and **am: directory rename detected** to `test_expect_success`.
- Refresh `data/test-files.csv` and dashboards via `./scripts/run-tests.sh t3401-rebase-and-am-rename.sh` (10/10).

## Verification

- `./scripts/run-tests.sh t3401-rebase-and-am-rename.sh` → 10/10 pass, clean TAP summary.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ef5eab4-5f0d-4df0-b094-f5f1372657fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ef5eab4-5f0d-4df0-b094-f5f1372657fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

