### PR TITLE
test: t5523-push-upstream harness refresh (17/17)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -938,7 +938,7 @@ t5519-push-alternates	t5	yes	8	2	6	false	ok	0
 t5520-pull	t5	yes	80	12	68	false	ok	0
 t5521-pull-options	t5	yes	22	6	16	false	ok	0
 t5522-pull-symlink	t5	yes	4	3	1	false	ok	0
-t5523-push-upstream	t5	yes	17	10	7	false	ok	0
+t5523-push-upstream	t5	yes	17	17	0	true	ok	0
 t5524-fmt-merge-msg	t5	yes	58	58	0	true	ok	0
 t5524-pull-msg	t5	yes	3	3	0	true	ok	0
 t5525-fetch-tagopt	t5	yes	5	5	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T06:26:18+00:00" class="gen-time" title="2026-04-09 06:26 UTC">2026-04-09 06:26 UTC</time> · <a href="https://github.com/schacon/grit/commit/e3345ffb3a9baa4a00781a3b6968148e1e5d9449" style="color:#58a6ff">e3345ff</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T06:30:52+00:00" class="gen-time" title="2026-04-09 06:30 UTC">2026-04-09 06:30 UTC</time> · <a href="https://github.com/schacon/grit/commit/28cf6974e1bc99b308cc3fa745fe22c68de62829" style="color:#58a6ff">28cf697</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,464</div>
+      <div class="summary-big-val">30,471</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>778 files fully passing</span>
+    <span>779 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">44/167 files · 17 skipped · 1,494/3,949 tests</span>
+        <span class="group-meta">45/167 files · 17 skipped · 1,501/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
-        <span class="group-pct pct-red">37.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:38.0%"></div></div>
+        <span class="group-pct pct-red">38.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:26:18+00:00" class="gen-time" title="2026-04-09 06:26 UTC">2026-04-09 06:26 UTC</time> · <a href="https://github.com/schacon/grit/commit/e3345ffb3a9baa4a00781a3b6968148e1e5d9449" style="color:#58a6ff">e3345ff</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:30:52+00:00" class="gen-time" title="2026-04-09 06:30 UTC">2026-04-09 06:30 UTC</time> · <a href="https://github.com/schacon/grit/commit/28cf6974e1bc99b308cc3fa745fe22c68de62829" style="color:#58a6ff">28cf697</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,464</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,471</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">76.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -9537,14 +9537,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:75.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="17" data-passed="10">
+<tr class="" data-group="t5" data-tests="17" data-passed="17" data-full-pass="1">
   <td class="mono">t5523-push-upstream</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">17</td>
-  <td class="right">10</td>
+  <td class="right">17</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:58.8%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="58" data-passed="58" data-full-pass="1">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t5523-push-upstream.sh` already passes fully against the current `grit` build (17/17). The harness metadata was stale (10 pass / 7 fail).

## Changes

- Update `data/test-files.csv` to record 17/17 and `fully_passing=true`
- Regenerate `docs/index.html` and `docs/testfiles.html` via `scripts/run-tests.sh`

## Verification

```bash
./scripts/run-tests.sh t5523-push-upstream.sh
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c5dff6f-8f93-4ed2-9240-56f724869da9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c5dff6f-8f93-4ed2-9240-56f724869da9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

