### PR TITLE
docs: t7401-submodule-summary fully passing (25/25)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -870,7 +870,7 @@ commit → check it off → move on.
 - [ ] `t7411-submodule-config` ██░░░░░░░░░░░░░░░░░░ 2/20 (18 left) — Test submodules config cache infrastructure
 
 - [ ] `t7519-status-fsmonitor` ████████░░░░░░░░░░░░ 14/33 (19 left) — git status with file system watcher
-- [ ] `t7401-submodule-summary` ████░░░░░░░░░░░░░░░░ 6/25 (19 left) — Summary support for submodules
+- [x] `t7401-submodule-summary` — Summary support for submodules (25/25)
 
 - [ ] `t7704-repack-cruft` ████░░░░░░░░░░░░░░░░ 6/25 (19 left) — git repack works correctly
 - [ ] `t7407-submodule-foreach` ██░░░░░░░░░░░░░░░░░░ 3/23 (20 left) — Test 

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1195,7 +1195,7 @@ t7201-co	t7	yes	46	15	31	false	ok	0
 t7300-clean	t7	yes	53	52	1	false	ok	2
 t7301-clean-interactive	t7	yes	23	8	15	false	ok	0
 t7400-submodule-basic	t7	yes	0	0	0	false	timeout	0
-t7401-submodule-summary	t7	yes	25	6	19	false	ok	0
+t7401-submodule-summary	t7	yes	25	25	0	true	ok	0
 t7402-submodule-rebase	t7	yes	6	6	0	true	ok	0
 t7403-submodule-sync	t7	yes	18	10	8	false	ok	0
 t7406-submodule-update	t7	yes	0	0	0	false	timeout	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T06:31:44+00:00" class="gen-time" title="2026-04-09 06:31 UTC">2026-04-09 06:31 UTC</time> · <a href="https://github.com/schacon/grit/commit/1aa751fe37189cceae4d3566dc92a0fe9279e5b7" style="color:#58a6ff">1aa751f</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T06:35:40+00:00" class="gen-time" title="2026-04-09 06:35 UTC">2026-04-09 06:35 UTC</time> · <a href="https://github.com/schacon/grit/commit/235e4c8ec7a9a9dcdc00ac135e84bd468d98097a" style="color:#58a6ff">235e4c8</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">31,111</div>
+      <div class="summary-big-val">31,130</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>803 files fully passing</span>
+    <span>804 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -256,11 +256,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">52/126 files · 11 skipped · 1,981/2,944 tests</span>
+        <span class="group-meta">53/126 files · 11 skipped · 2,000/2,944 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:67.3%"></div></div>
-        <span class="group-pct pct-blue">67.3%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:67.9%"></div></div>
+        <span class="group-pct pct-blue">67.9%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:31:44+00:00" class="gen-time" title="2026-04-09 06:31 UTC">2026-04-09 06:31 UTC</time> · <a href="https://github.com/schacon/grit/commit/1aa751fe37189cceae4d3566dc92a0fe9279e5b7" style="color:#58a6ff">1aa751f</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:35:40+00:00" class="gen-time" title="2026-04-09 06:35 UTC">2026-04-09 06:35 UTC</time> · <a href="https://github.com/schacon/grit/commit/235e4c8ec7a9a9dcdc00ac135e84bd468d98097a" style="color:#58a6ff">235e4c8</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">40,109</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">31,111</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">31,130</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">77.6%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -12107,14 +12107,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="25" data-passed="6">
+<tr class="" data-group="t7" data-tests="25" data-passed="25" data-full-pass="1">
   <td class="mono">t7401-submodule-summary</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">25</td>
-  <td class="right">6</td>
+  <td class="right">25</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:24.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="6" data-full-pass="1">

--- a/logs/2026-04-09_t7401-submodule-summary.md
+++ b/logs/2026-04-09_t7401-submodule-summary.md
@@ -1,0 +1,5 @@
+# t7401-submodule-summary
+
+- Ran `./scripts/run-tests.sh t7401-submodule-summary.sh`: **25/25** pass on current `grit` (no Rust changes this turn).
+- Refreshed harness artifacts: `data/test-files.csv`, `docs/index.html`, `docs/testfiles.html` (fully_passing, 0 failing).
+- Marked `t7401-submodule-summary` complete in `PLAN.md`; updated `progress.md` counts and recently completed list.

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   274 |
+| Completed   |   275 |
 | In progress |     4 |
-| Remaining   |   490 |
+| Remaining   |   489 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 274 completed (`[x]`), 4 in progress (`[~]`), 490 remaining (`[ ]`).
+Task lines in `PLAN.md`: 275 completed (`[x]`), 4 in progress (`[~]`), 489 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t7401-submodule-summary` — 25/25 tests pass (`git submodule summary`: added/modified/deleted/typechanged submodules, `--cached`/`--files`, `--summary-limit`, path filter, commit argument, `--for-status`, incompatible flags, empty repo; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t10860-switch-force-create` — 30/30 tests pass (`switch`: `-c`/`--create`, start points, `switch -`, detach/orphan, `--discard-changes`, untracked preservation; harness CSV/dashboards refreshed; `t1-plan.md` marked complete)
 - `t5900-repo-selection` — 8/8 tests pass (local `fetch`/`clone` remote path resolution: `.git` dir in worktree, bare `foo` vs `foo.git` disambiguation, non-git `foo` directory ignored, inner worktree preferred when outer is bare; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t4047-diff-dirstat` — 41/41 tests pass (Git-compatible `--dirstat` / `-X`: changes/lines/files, cumulative, thresholds, `diff.dirstat` warnings, `--shortstat` + dirstat; harness CSV/dashboards refreshed)

--- a/test-results.md
+++ b/test-results.md
@@ -2,6 +2,8 @@
 
 **Updated:** 2026-04-09
 
+- `./scripts/run-tests.sh t7401-submodule-summary.sh`: 25/25 passing (`git submodule summary`; harness CSV/dashboards refreshed).
+- `cargo test -p grit-lib --lib`: 126/126 passing.
 - `./scripts/run-tests.sh t4047-diff-dirstat.sh`: 41/41 passing (`diff --dirstat` / `-X` aligned with Git: changes/lines/files, cumulative, thresholds, `diff.dirstat` warnings, `--shortstat --dirstat`; harness CSV/dashboards refreshed).
 - `./scripts/run-tests.sh t5514-fetch-multiple.sh`: 25/25 passing (`fetch --all` / `--multiple`, `fetch.all` / `--no-all`, `remote.*.skipFetchAll`, `--jobs` parallel fetch, tag options; harness CSV/dashboards refreshed).
 - `cargo test -p grit-lib --lib`: 121/121 passing.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t7401-submodule-summary` already passes all 25 harness tests on current `grit` (`./scripts/run-tests.sh t7401-submodule-summary.sh`). This change records that in the test pipeline and planning docs.

## Changes

- Refreshed `data/test-files.csv` and dashboards (`docs/index.html`, `docs/testfiles.html`) after a clean run.
- Marked `t7401-submodule-summary` complete in `PLAN.md` and adjusted `progress.md` counts.
- Added `logs/2026-04-09_t7401-submodule-summary.md` and updated `test-results.md` (including `cargo test -p grit-lib --lib`: 126/126).

## Verification

- `./scripts/run-tests.sh t7401-submodule-summary.sh` → 25/25
- `cargo test -p grit-lib --lib` → 126/126
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3865f10b-0f63-4331-bfb7-34168223c3a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3865f10b-0f63-4331-bfb7-34168223c3a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

