### PR TITLE
t3905-stash-include-untracked: verify full pass, refresh harness

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -665,7 +665,7 @@ t3902-quoted	t3	yes	13	5	8	false	ok	0
 t3902-quoted-ls-tree	t3	yes	8	8	0	true	ok	0
 t3903-stash	t3	yes	0	0	0	false	timeout	0
 t3904-stash-patch	t3	yes	10	4	6	false	ok	0
-t3905-stash-include-untracked	t3	yes	34	13	21	false	ok	0
+t3905-stash-include-untracked	t3	yes	34	34	0	true	ok	0
 t3906-stash-submodule	t3	yes	8	0	8	false	ok	0
 t3907-stash-show-config	t3	yes	10	1	9	false	ok	0
 t3908-stash-in-worktree	t3	yes	2	1	1	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,16 +141,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T06:35:56+00:00" class="gen-time" title="2026-04-09 06:35 UTC">2026-04-09 06:35 UTC</time> · <a href="https://github.com/schacon/grit/commit/11062af89b6dccc88c13e1d3edc199ed69bc2828" style="color:#58a6ff">11062af</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T06:37:50+00:00" class="gen-time" title="2026-04-09 06:37 UTC">2026-04-09 06:37 UTC</time> · <a href="https://github.com/schacon/grit/commit/57986d85944b92ea876ef222537828a3ff6285c7" style="color:#58a6ff">57986d8</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">78.6%</div>
+      <div class="summary-big-val pct-blue">78.7%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">31,655</div>
+      <div class="summary-big-val">31,676</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -159,12 +159,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:78.6%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:78.7%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>815 files fully passing</span>
+    <span>816 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,11 +212,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">55/141 files · 2 skipped · 3,507/4,640 tests</span>
+        <span class="group-meta">56/141 files · 2 skipped · 3,528/4,640 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:75.6%"></div></div>
-        <span class="group-pct pct-blue">75.6%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:76.0%"></div></div>
+        <span class="group-pct pct-blue">76.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:35:56+00:00" class="gen-time" title="2026-04-09 06:35 UTC">2026-04-09 06:35 UTC</time> · <a href="https://github.com/schacon/grit/commit/11062af89b6dccc88c13e1d3edc199ed69bc2828" style="color:#58a6ff">11062af</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:37:50+00:00" class="gen-time" title="2026-04-09 06:37 UTC">2026-04-09 06:37 UTC</time> · <a href="https://github.com/schacon/grit/commit/57986d85944b92ea876ef222537828a3ff6285c7" style="color:#58a6ff">57986d8</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">40,261</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">31,655</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">78.6%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">31,676</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">78.7%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -6807,14 +6807,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:40.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="34" data-passed="13">
+<tr class="" data-group="t3" data-tests="34" data-passed="34" data-full-pass="1">
   <td class="mono">t3905-stash-include-untracked</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">34</td>
-  <td class="right">13</td>
+  <td class="right">34</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:38.2%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="8" data-passed="0">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`tests/t3905-stash-include-untracked.sh` passes **34/34** against current Grit (`./scripts/run-tests.sh t3905-stash-include-untracked.sh`).

This change commits the harness bookkeeping update (`data/test-files.csv` and generated dashboards) so the repo reflects that status.

## Verification

```bash
./scripts/run-tests.sh t3905-stash-include-untracked.sh
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3031b21-af33-4c0e-abd2-644028e81ee3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3031b21-af33-4c0e-abd2-644028e81ee3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

