### PR TITLE
fix: git refs exists + raw ref lookup (t1462)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -431,7 +431,7 @@ t1450-fsck-flags	t1	yes	10	10	0	true	ok	0
 t1451-fsck-buffer	t1	yes	72	72	0	true	ok	0
 t1460-refs-migrate	t1	skip	22	0	0	false	ok	0
 t1461-refs-list	t1	yes	0	0	0	false	timeout	0
-t1462-refs-exists	t1	yes	12	3	9	false	ok	0
+t1462-refs-exists	t1	yes	12	12	0	true	ok	0
 t1463-refs-optimize	t1	yes	0	0	0	false	ok	0
 t1500-rev-parse	t1	yes	81	70	11	false	ok	0
 t1501-work-tree	t1	yes	39	28	11	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T06:26:18+00:00" class="gen-time" title="2026-04-09 06:26 UTC">2026-04-09 06:26 UTC</time> · <a href="https://github.com/schacon/grit/commit/e3345ffb3a9baa4a00781a3b6968148e1e5d9449" style="color:#58a6ff">e3345ff</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T06:37:05+00:00" class="gen-time" title="2026-04-09 06:37 UTC">2026-04-09 06:37 UTC</time> · <a href="https://github.com/schacon/grit/commit/28cf6974e1bc99b308cc3fa745fe22c68de62829" style="color:#58a6ff">28cf697</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">30,464</div>
+      <div class="summary-big-val">30,473</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>778 files fully passing</span>
+    <span>779 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -190,11 +190,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">282/368 files · 8 skipped · 10,784/11,373 tests</span>
+        <span class="group-meta">283/368 files · 8 skipped · 10,793/11,373 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:94.8%"></div></div>
-        <span class="group-pct pct-green">94.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:94.9%"></div></div>
+        <span class="group-pct pct-green">94.9%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t2">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:26:18+00:00" class="gen-time" title="2026-04-09 06:26 UTC">2026-04-09 06:26 UTC</time> · <a href="https://github.com/schacon/grit/commit/e3345ffb3a9baa4a00781a3b6968148e1e5d9449" style="color:#58a6ff">e3345ff</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:37:05+00:00" class="gen-time" title="2026-04-09 06:37 UTC">2026-04-09 06:37 UTC</time> · <a href="https://github.com/schacon/grit/commit/28cf6974e1bc99b308cc3fa745fe22c68de62829" style="color:#58a6ff">28cf697</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">39,873</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">30,464</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">30,473</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">76.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -4467,14 +4467,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="12" data-passed="3">
+<tr class="" data-group="t1" data-tests="12" data-passed="12" data-full-pass="1">
   <td class="mono">t1462-refs-exists</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">12</td>
-  <td class="right">3</td>
+  <td class="right">12</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:25.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="0" data-passed="0">

--- a/grit-lib/src/refs.rs
+++ b/grit-lib/src/refs.rs
@@ -156,6 +156,134 @@ fn resolve_ref_depth(
     Err(Error::InvalidRef(format!("ref not found: {refname}")))
 }
 
+/// Outcome of a single storage-level ref lookup (Git `refs_read_raw_ref` style).
+///
+/// This checks whether a ref **name** exists in the ref store without applying
+/// DWIM rules. A symbolic ref is considered to exist if its ref file (or
+/// reftable record) is present, even when the target is missing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RawRefLookup {
+    /// A loose ref file, packed ref line, or reftable record exists for this name.
+    Exists,
+    /// No ref is recorded under this exact name.
+    NotFound,
+    /// A path component exists as a directory where a ref file was expected (e.g. `refs/heads`).
+    IsDirectory,
+}
+
+/// Return whether `refname` exists as a ref in the repository's ref storage.
+///
+/// This matches `git refs exists` / `git show-ref --exists`: no DWIM, no
+/// resolution of symbolic targets. Dispatches to the reftable backend when
+/// configured.
+///
+/// # Parameters
+///
+/// - `git_dir` — path to the git directory (worktree gitdir or bare `.git`).
+/// - `refname` — full ref name (e.g. `HEAD`, `refs/heads/main`, `CHERRY_PICK_HEAD`).
+///
+/// # Errors
+///
+/// Propagates I/O and reftable errors other than "not found".
+pub fn read_raw_ref(git_dir: &Path, refname: &str) -> Result<RawRefLookup> {
+    if crate::reftable::is_reftable_repo(git_dir) {
+        read_raw_ref_reftable(git_dir, refname)
+    } else {
+        read_raw_ref_files(git_dir, refname)
+    }
+}
+
+fn read_raw_ref_files(git_dir: &Path, refname: &str) -> Result<RawRefLookup> {
+    let common = common_dir(git_dir);
+
+    if let Some(lookup) = read_raw_ref_at(git_dir.join(refname))? {
+        return Ok(lookup);
+    }
+
+    if let Some(cdir) = common.as_ref() {
+        if *cdir != git_dir && !notes_merge_state_ref(refname) {
+            if let Some(lookup) = read_raw_ref_at(cdir.join(refname))? {
+                return Ok(lookup);
+            }
+        }
+    }
+
+    let packed_dir = common.as_deref().unwrap_or(git_dir);
+    if packed_ref_name_exists(packed_dir, refname)? {
+        return Ok(RawRefLookup::Exists);
+    }
+    if common.is_some() && common.as_deref() != Some(git_dir)
+        && packed_ref_name_exists(git_dir, refname)? {
+            return Ok(RawRefLookup::Exists);
+        }
+
+    Ok(RawRefLookup::NotFound)
+}
+
+fn read_raw_ref_at(path: PathBuf) -> Result<Option<RawRefLookup>> {
+    match fs::symlink_metadata(&path) {
+        Ok(meta) => {
+            if meta.is_dir() {
+                return Ok(Some(RawRefLookup::IsDirectory));
+            }
+            Ok(Some(RawRefLookup::Exists))
+        }
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(Error::Io(e)),
+    }
+}
+
+fn packed_ref_name_exists(git_dir: &Path, refname: &str) -> Result<bool> {
+    let packed = git_dir.join("packed-refs");
+    let content = match fs::read_to_string(&packed) {
+        Ok(c) => c,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(false),
+        Err(e) => return Err(Error::Io(e)),
+    };
+    for line in content.lines() {
+        if line.is_empty() || line.starts_with('#') || line.starts_with('^') {
+            continue;
+        }
+        let mut parts = line.split_whitespace();
+        let _oid = parts.next();
+        if let Some(name) = parts.next() {
+            if name == refname {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
+}
+
+fn read_raw_ref_reftable(git_dir: &Path, refname: &str) -> Result<RawRefLookup> {
+    if refname == "HEAD" {
+        let head_path = git_dir.join("HEAD");
+        match fs::symlink_metadata(&head_path) {
+            Ok(meta) => {
+                if meta.is_dir() {
+                    return Ok(RawRefLookup::IsDirectory);
+                }
+                return Ok(RawRefLookup::Exists);
+            }
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(RawRefLookup::NotFound),
+            Err(e) => return Err(Error::Io(e)),
+        }
+    }
+
+    if let Some(lookup) = read_raw_ref_at(git_dir.join(refname))? {
+        return Ok(lookup);
+    }
+
+    let stack = crate::reftable::ReftableStack::open(git_dir)?;
+    match stack.lookup_ref(refname)? {
+        Some(rec) => match rec.value {
+            crate::reftable::RefValue::Deletion => Ok(RawRefLookup::NotFound),
+            _ => Ok(RawRefLookup::Exists),
+        },
+        None => Ok(RawRefLookup::NotFound),
+    }
+}
+
 /// Look up a refname in `packed-refs`.
 fn lookup_packed_ref(git_dir: &Path, refname: &str) -> Result<Option<ObjectId>> {
     let packed = git_dir.join("packed-refs");
@@ -732,4 +860,64 @@ fn collect_packed_refs(
         out.push((refname.to_string(), oid));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod read_raw_ref_tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn loose_ref_file_is_exists() {
+        let dir = tempdir().unwrap();
+        let git_dir = dir.path();
+        fs::create_dir_all(git_dir.join("refs/heads")).unwrap();
+        fs::write(
+            git_dir.join("refs/heads/side"),
+            "0000000000000000000000000000000000000000\n",
+        )
+        .unwrap();
+        assert_eq!(
+            read_raw_ref(git_dir, "refs/heads/side").unwrap(),
+            RawRefLookup::Exists
+        );
+    }
+
+    #[test]
+    fn missing_ref_is_not_found() {
+        let dir = tempdir().unwrap();
+        let git_dir = dir.path();
+        fs::create_dir_all(git_dir.join("refs/heads")).unwrap();
+        assert_eq!(
+            read_raw_ref(git_dir, "refs/heads/nope").unwrap(),
+            RawRefLookup::NotFound
+        );
+    }
+
+    #[test]
+    fn directory_where_ref_expected_is_is_directory() {
+        let dir = tempdir().unwrap();
+        let git_dir = dir.path();
+        fs::create_dir_all(git_dir.join("refs/heads")).unwrap();
+        assert_eq!(
+            read_raw_ref(git_dir, "refs/heads").unwrap(),
+            RawRefLookup::IsDirectory
+        );
+    }
+
+    #[test]
+    fn packed_ref_name_is_exists() {
+        let dir = tempdir().unwrap();
+        let git_dir = dir.path();
+        fs::write(
+            git_dir.join("packed-refs"),
+            "# pack-refs with: peeled fully-peeled \n\
+             0000000000000000000000000000000000000000 refs/heads/packed\n",
+        )
+        .unwrap();
+        assert_eq!(
+            read_raw_ref(git_dir, "refs/heads/packed").unwrap(),
+            RawRefLookup::Exists
+        );
+    }
 }

--- a/grit/src/commands/refs.rs
+++ b/grit/src/commands/refs.rs
@@ -3,6 +3,7 @@
 //! Provides subcommands for ref database operations:
 //! - `verify`  — verify the ref database integrity
 //! - `migrate` — migrate ref storage format (stub)
+//! - `exists`  — check whether a ref name exists in storage (no DWIM)
 
 use anyhow::{Context, Result};
 use clap::{Args as ClapArgs, Subcommand};
@@ -10,6 +11,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use grit_lib::config::ConfigSet;
+use grit_lib::refs::RawRefLookup;
 use grit_lib::repo::Repository;
 
 /// Arguments for `grit refs`.
@@ -33,6 +35,12 @@ pub enum RefsAction {
     Optimize,
     /// List all refs.
     List,
+    /// Check whether a single reference exists (storage-level; no DWIM).
+    Exists {
+        /// Reference to test (exact name, e.g. `HEAD`, `refs/heads/main`).
+        #[arg(value_name = "REF")]
+        reference: String,
+    },
 }
 
 /// Run `grit refs`.
@@ -44,6 +52,18 @@ pub fn run(args: Args) -> Result<()> {
         RefsAction::Migrate { ref_format } => migrate_refs(&repo, &ref_format),
         RefsAction::Optimize => optimize_refs(&repo),
         RefsAction::List => list_refs(&repo),
+        RefsAction::Exists { reference } => run_refs_exists(&repo, &reference),
+    }
+}
+
+fn run_refs_exists(repo: &Repository, reference: &str) -> Result<()> {
+    match grit_lib::refs::read_raw_ref(&repo.git_dir, reference) {
+        Ok(RawRefLookup::Exists) => Ok(()),
+        Ok(RawRefLookup::NotFound) | Ok(RawRefLookup::IsDirectory) => {
+            eprintln!("error: reference does not exist");
+            std::process::exit(2);
+        }
+        Err(err) => Err(err.into()),
     }
 }
 

--- a/grit/src/commands/show_ref.rs
+++ b/grit/src/commands/show_ref.rs
@@ -3,8 +3,9 @@
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::objects::{ObjectId, ObjectKind};
+use grit_lib::refs::RawRefLookup;
 use grit_lib::repo::Repository;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::fs;
 use std::io;
 use std::path::Path;
@@ -113,9 +114,9 @@ fn run_exists_mode(repo: &Repository, args: &Args) -> Result<()> {
     }
     let reference = &args.refs_or_patterns[0];
 
-    match raw_ref_exists(&repo.git_dir, reference) {
-        Ok(true) => Ok(()),
-        Ok(false) => {
+    match grit_lib::refs::read_raw_ref(&repo.git_dir, reference) {
+        Ok(RawRefLookup::Exists) => Ok(()),
+        Ok(RawRefLookup::NotFound) | Ok(RawRefLookup::IsDirectory) => {
             eprintln!("error: reference does not exist");
             std::process::exit(2);
         }
@@ -392,34 +393,6 @@ fn parse_packed_refs(git_dir: &Path) -> Result<Vec<(String, ObjectId)>> {
         }
     }
     Ok(entries)
-}
-
-fn raw_ref_exists(git_dir: &Path, reference: &str) -> io::Result<bool> {
-    let path = git_dir.join(reference);
-    match fs::metadata(&path) {
-        Ok(meta) => return Ok(meta.is_file()),
-        Err(err) if err.kind() == io::ErrorKind::NotFound => {}
-        Err(err) => return Err(err),
-    }
-
-    let packed = git_dir.join("packed-refs");
-    let text = match fs::read_to_string(packed) {
-        Ok(text) => text,
-        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(false),
-        Err(err) => return Err(err),
-    };
-    let mut names = BTreeSet::new();
-    for line in text.lines() {
-        if line.is_empty() || line.starts_with('#') || line.starts_with('^') {
-            continue;
-        }
-        let mut parts = line.split_whitespace();
-        let _ = parts.next();
-        if let Some(name) = parts.next() {
-            names.insert(name.to_owned());
-        }
-    }
-    Ok(names.contains(reference))
 }
 
 fn is_safe_refname(reference: &str) -> bool {

--- a/logs/2026-04-09_t1462-refs-exists.md
+++ b/logs/2026-04-09_t1462-refs-exists.md
@@ -1,0 +1,17 @@
+# t1462-refs-exists
+
+## Goal
+
+Implement `git refs exists <ref>` and align `show-ref --exists` with Git’s storage-level ref lookup (`refs_read_raw_ref` semantics).
+
+## Changes
+
+- Added `grit_lib::refs::read_raw_ref` and `RawRefLookup` (loose file via `symlink_metadata`, packed-refs name scan, worktree `commondir`, reftable stack lookup; dangling symrefs count as exists).
+- Wired `grit refs exists <REF>`: success vs exit 2 with `error: reference does not exist` (matches harness greps).
+- `show-ref --exists` now uses the same library helper (removes duplicate `raw_ref_exists`).
+
+## Verification
+
+- `cargo test -p grit-lib --lib`
+- `./scripts/run-tests.sh t1462-refs-exists.sh` → 12/12
+- Manual: `grit refs exists HEAD` in new repo exits 0

--- a/progress.md
+++ b/progress.md
@@ -15,6 +15,7 @@ Task lines in `PLAN.md`: 264 completed (`[x]`), 4 in progress (`[~]`), 500 remai
 
 ## Recently completed
 
+- `t1462-refs-exists` — 12/12 tests pass (`git refs exists` subcommand; `read_raw_ref` in grit-lib for `show-ref --exists` + reftable/worktree paths; harness CSV/dashboards refreshed; `t1-plan.md` marked complete)
 - `t12650-config-null-value` — 34/34 tests pass (null/implicit-true keys, empty `=`, `--bool`/`--int` including k/m/g suffixes, `config -l`, `--get-regexp` / `--name-only`; harness CSV/dashboards refreshed; `t1-plan.md` marked complete)
 - `t7450-bad-git-dotfiles` — 50/50 tests pass (submodule name/url validation, fsck symlink and `.gitmodules` checks, nested submodule git dirs, harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t5351-unpack-large-objects` — 7/7 tests pass (`GIT_ALLOC_LIMIT` + `core.bigFileThreshold` streaming unpack, dry-run, trace2 fsync batch path, skip already-packed objects; harness CSV/dashboards refreshed; `PLAN.md` marked complete)

--- a/t1-plan.md
+++ b/t1-plan.md
@@ -197,7 +197,7 @@
 - [ ] t1450-fsck-flags.sh
 - [x] t1451-fsck-buffer.sh
 - [ ] t1461-refs-list.sh
-- [ ] t1462-refs-exists.sh
+- [x] t1462-refs-exists.sh
 - [ ] t1463-refs-optimize.sh
 - [ ] t1500-rev-parse.sh
 - [ ] t1501-work-tree.sh


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements `git refs exists <ref>` to match upstream Git’s `cmd_refs_exists` behavior and centralizes storage-level ref existence in `grit-lib` so `show-ref --exists` stays consistent (including worktree `commondir`, packed-refs, and reftable repos).

## Details

- **`grit_lib::refs::read_raw_ref`** returns `RawRefLookup::{Exists, NotFound, IsDirectory}` using `symlink_metadata` (so dangling symlinks count as existing refs), packed-refs name scan, common-dir overlay, and reftable `lookup_ref`.
- **`grit refs exists`** exits 0 when the ref exists, 2 with `error: reference does not exist` when it does not (matches harness expectations).
- **`show-ref --exists`** now calls the same helper instead of duplicating path/packed logic.

## Testing

- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t1462-refs-exists.sh` (12/12)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c481ad3-2607-4040-bed3-6658ed1d383e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c481ad3-2607-4040-bed3-6658ed1d383e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

