### PR TITLE
fix: assume-unchanged / skip-worktree index–worktree diff matches Git

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -716,7 +716,7 @@ t4035-diff-quiet	t4	yes	0	0	0	false	timeout	0
 t4036-format-patch-signer-mime	t4	yes	5	5	0	true	ok	0
 t4037-diff-r-t-dirs	t4	yes	2	2	0	true	ok	0
 t4038-diff-combined	t4	yes	25	6	19	false	ok	1
-t4039-diff-assume-unchanged	t4	yes	4	3	1	false	ok	0
+t4039-diff-assume-unchanged	t4	yes	4	4	0	true	ok	0
 t4040-whitespace-status	t4	yes	11	9	2	false	ok	0
 t4041-diff-submodule-option	t4	yes	46	5	41	false	ok	0
 t4042-diff-textconv-caching	t4	yes	0	0	0	false	timeout	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T06:31:44+00:00" class="gen-time" title="2026-04-09 06:31 UTC">2026-04-09 06:31 UTC</time> · <a href="https://github.com/schacon/grit/commit/1aa751fe37189cceae4d3566dc92a0fe9279e5b7" style="color:#58a6ff">1aa751f</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T06:39:42+00:00" class="gen-time" title="2026-04-09 06:39 UTC">2026-04-09 06:39 UTC</time> · <a href="https://github.com/schacon/grit/commit/235e4c8ec7a9a9dcdc00ac135e84bd468d98097a" style="color:#58a6ff">235e4c8</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">31,111</div>
+      <div class="summary-big-val">31,112</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>803 files fully passing</span>
+    <span>804 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -223,7 +223,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">83/178 files · 2 skipped · 2,616/3,774 tests</span>
+        <span class="group-meta">84/178 files · 2 skipped · 2,617/3,774 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.3%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:31:44+00:00" class="gen-time" title="2026-04-09 06:31 UTC">2026-04-09 06:31 UTC</time> · <a href="https://github.com/schacon/grit/commit/1aa751fe37189cceae4d3566dc92a0fe9279e5b7" style="color:#58a6ff">1aa751f</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:39:42+00:00" class="gen-time" title="2026-04-09 06:39 UTC">2026-04-09 06:39 UTC</time> · <a href="https://github.com/schacon/grit/commit/235e4c8ec7a9a9dcdc00ac135e84bd468d98097a" style="color:#58a6ff">235e4c8</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">40,109</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">31,111</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">31,112</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">77.6%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -7317,14 +7317,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:24.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t4" data-tests="4" data-passed="3">
+<tr class="" data-group="t4" data-tests="4" data-passed="4" data-full-pass="1">
   <td class="mono">t4039-diff-assume-unchanged</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">4</td>
-  <td class="right">3</td>
+  <td class="right">4</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:75.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="11" data-passed="9">

--- a/grit-lib/src/diff.rs
+++ b/grit-lib/src/diff.rs
@@ -538,6 +538,9 @@ pub fn diff_index_to_tree(
 ///
 /// This shows "unstaged" changes — modifications not yet staged.
 ///
+/// Entries with [`IndexEntry::assume_unchanged`] or [`IndexEntry::skip_worktree`] are treated as
+/// matching the work tree without examining the filesystem (Git `CE_VALID` / skip-worktree).
+///
 /// # Parameters
 ///
 /// - `odb` — object database (for hashing worktree files).
@@ -585,6 +588,10 @@ pub fn diff_index_to_worktree(
         // only allocate String if we need it for DiffEntry output.
         let path_str_ref = std::str::from_utf8(&ie.path).unwrap_or("");
         let is_intent_to_add = ie.intent_to_add();
+
+        if ie.assume_unchanged() || ie.skip_worktree() {
+            continue;
+        }
 
         // Gitlink entries (submodules): compare checked-out HEAD to the recorded commit.
         // An uninitialized path (no `.git` in the directory) is not dirty — same as Git.

--- a/grit/src/commands/diff_files.rs
+++ b/grit/src/commands/diff_files.rs
@@ -409,7 +409,7 @@ fn collect_changes(
     // "unmerged"; we report them as 'U' when stage==0.
     let mut stage0: BTreeMap<String, (u32, ObjectId, &IndexEntry)> = BTreeMap::new();
     let mut unmerged_paths: BTreeSet<String> = BTreeSet::new();
-    let mut staged: BTreeMap<String, (u32, ObjectId)> = BTreeMap::new();
+    let mut staged: BTreeMap<String, (u32, ObjectId, bool)> = BTreeMap::new();
 
     for entry in &index.entries {
         let Ok(path) = String::from_utf8(entry.path.clone()) else {
@@ -427,7 +427,8 @@ fn collect_changes(
         } else {
             unmerged_paths.insert(path.clone());
             if s == options.stage {
-                staged.insert(path, (entry.mode, entry.oid));
+                let skip_wt_examine = entry.assume_unchanged() || entry.skip_worktree();
+                staged.insert(path, (entry.mode, entry.oid, skip_wt_examine));
             }
         }
     }
@@ -505,7 +506,10 @@ fn collect_changes(
         }
     } else {
         // Stage-specific mode: compare requested stage entries against worktree.
-        for (path, (idx_mode, idx_oid)) in &staged {
+        for (path, (idx_mode, idx_oid, skip_wt_examine)) in &staged {
+            if *skip_wt_examine {
+                continue;
+            }
             let abs = work_tree.join(path);
             match read_worktree_info(repo, &abs)? {
                 Some((wt_mode, wt_oid)) => {
@@ -902,6 +906,10 @@ fn read_worktree_info_fast(
     abs_path: &Path,
     index_entry: &IndexEntry,
 ) -> Result<WorktreeStatus> {
+    if index_entry.assume_unchanged() || index_entry.skip_worktree() {
+        return Ok(WorktreeStatus::Unchanged);
+    }
+
     let meta = match fs::symlink_metadata(abs_path) {
         Ok(m) => m,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns index-vs-worktree diff with Git’s `diff-lib` behavior for `CE_VALID` (assume-unchanged) and skip-worktree entries: those paths are not examined on disk, so they never appear as unstaged changes.

## Changes

- **`grit-lib`**: `diff_index_to_worktree` skips stage-0 entries when `assume_unchanged()` or `skip_worktree()` is set.
- **`diff-files`**: Same skip in `read_worktree_info_fast` and in stage-specific (`-1`/`-2`/`-3`) mode.

## Validation

- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t4039-diff-assume-unchanged.sh` → 4/4

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d881dfc4-99db-4561-8185-f290b3b8d5b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d881dfc4-99db-4561-8185-f290b3b8d5b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

