### PR TITLE
test: t4000-diff-format fully passing (41/41)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -672,7 +672,7 @@ t3908-stash-in-worktree	t3	yes	2	1	1	false	ok	0
 t3909-stash-pathspec-file	t3	yes	5	5	0	true	ok	0
 t3910-mac-os-precompose	t3	yes	0	0	0	false	ok	1
 t3920-crlf-messages	t3	yes	18	6	12	false	ok	0
-t4000-diff-format	t4	yes	41	17	24	false	ok	0
+t4000-diff-format	t4	yes	41	41	0	true	ok	0
 t4001-diff-rename	t4	yes	23	23	0	true	ok	0
 t4002-diff-basic	t4	yes	63	63	0	true	ok	0
 t4003-diff-rename-1	t4	yes	7	3	4	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,16 +141,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T06:37:21+00:00" class="gen-time" title="2026-04-09 06:37 UTC">2026-04-09 06:37 UTC</time> · <a href="https://github.com/schacon/grit/commit/96a90e5a1764e9aaad3497091c090c097960a142" style="color:#58a6ff">96a90e5</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T06:41:23+00:00" class="gen-time" title="2026-04-09 06:41 UTC">2026-04-09 06:41 UTC</time> · <a href="https://github.com/schacon/grit/commit/71825e209c982a5bc3786ca5cafe93e49082d2de" style="color:#58a6ff">71825e2</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">78.6%</div>
+      <div class="summary-big-val pct-blue">78.7%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">31,703</div>
+      <div class="summary-big-val">31,727</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -159,12 +159,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:78.6%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:78.7%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>817 files fully passing</span>
+    <span>818 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -223,11 +223,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">85/178 files · 2 skipped · 2,636/3,774 tests</span>
+        <span class="group-meta">86/178 files · 2 skipped · 2,660/3,774 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.8%"></div></div>
-        <span class="group-pct pct-blue">69.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:70.5%"></div></div>
+        <span class="group-pct pct-blue">70.5%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:37:21+00:00" class="gen-time" title="2026-04-09 06:37 UTC">2026-04-09 06:37 UTC</time> · <a href="https://github.com/schacon/grit/commit/96a90e5a1764e9aaad3497091c090c097960a142" style="color:#58a6ff">96a90e5</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:41:23+00:00" class="gen-time" title="2026-04-09 06:41 UTC">2026-04-09 06:41 UTC</time> · <a href="https://github.com/schacon/grit/commit/71825e209c982a5bc3786ca5cafe93e49082d2de" style="color:#58a6ff">71825e2</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">40,309</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">31,703</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">78.6%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">31,727</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">78.7%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -6877,14 +6877,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:33.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="41" data-passed="17">
+<tr class="" data-group="t4" data-tests="41" data-passed="41" data-full-pass="1">
   <td class="mono">t4000-diff-format</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">41</td>
-  <td class="right">17</td>
+  <td class="right">41</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:41.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="23" data-passed="23" data-full-pass="1">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t4000-diff-format.sh` now passes all 41 tests with Grit. This change records the harness result in `data/test-files.csv` and regenerates the dashboards.

## Verification

```bash
./scripts/run-tests.sh t4000-diff-format.sh
```

Result: 41/41 passing.

## Notes

No Rust code changes in this commit; the implementation on this branch already satisfies the test file. The CSV previously showed 17/41 passing; a fresh run confirmed full pass and updated aggregate counts.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ed1d611-450a-4e76-afc8-0f8efe96e0b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ed1d611-450a-4e76-afc8-0f8efe96e0b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

