### PR TITLE
Mark t5618-alternate-refs complete (6/6), refresh harness

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -578,7 +578,7 @@ commit → check it off → move on.
 - [ ] `t5004-archive-corner-cases` ██████████████░░░░░░ 10/14 (4 left) — test corner cases of git-archive
 - [x] `t5351-unpack-large-objects` ████████████████████ 7/7 (0 left) — git unpack-objects with large objects
 - [ ] `t5404-tracking-branches` ████████░░░░░░░░░░░░ 3/7 (4 left) — tracking branch update checks for git push
-- [ ] `t5618-alternate-refs` ██████░░░░░░░░░░░░░░ 2/6 (4 left) — test handling of --alternate-refs traversal
+- [x] `t5618-alternate-refs` ████████████████████ 6/6 (0 left) — test handling of --alternate-refs traversal
 - [ ] `t5410-receive-pack` ████░░░░░░░░░░░░░░░░ 1/5 (4 left) — git receive-pack
 - [ ] `t5517-push-mirror` ████████████░░░░░░░░ 8/13 (5 left) — pushing to a mirror repository
 - [ ] `t5614-clone-submodules-shallow` ████████░░░░░░░░░░░░ 4/9 (5 left) — Test shallow cloning of repos with submodules

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1012,7 +1012,7 @@ t5614-clone-submodules-shallow	t5	yes	9	4	5	false	ok	0
 t5615-alternate-env	t5	yes	9	9	0	true	ok	0
 t5616-partial-clone	t5	yes	47	9	38	false	ok	0
 t5617-clone-submodules-remote	t5	yes	9	3	6	false	ok	0
-t5618-alternate-refs	t5	yes	6	2	4	false	ok	0
+t5618-alternate-refs	t5	yes	6	6	0	true	ok	0
 t5619-clone-local-ambiguous-transport	t5	yes	2	2	0	true	ok	0
 t5620-backfill	t5	yes	10	5	5	false	ok	0
 t5621-clone-revision	t5	yes	12	12	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,16 +141,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T06:37:21+00:00" class="gen-time" title="2026-04-09 06:37 UTC">2026-04-09 06:37 UTC</time> · <a href="https://github.com/schacon/grit/commit/96a90e5a1764e9aaad3497091c090c097960a142" style="color:#58a6ff">96a90e5</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T06:44:10+00:00" class="gen-time" title="2026-04-09 06:44 UTC">2026-04-09 06:44 UTC</time> · <a href="https://github.com/schacon/grit/commit/71825e209c982a5bc3786ca5cafe93e49082d2de" style="color:#58a6ff">71825e2</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">78.6%</div>
+      <div class="summary-big-val pct-blue">78.7%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">31,703</div>
+      <div class="summary-big-val">31,707</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -159,12 +159,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:78.6%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:78.7%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>817 files fully passing</span>
+    <span>818 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">55/167 files · 17 skipped · 1,962/3,949 tests</span>
+        <span class="group-meta">56/167 files · 17 skipped · 1,966/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:49.7%"></div></div>
-        <span class="group-pct pct-orange">49.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:49.8%"></div></div>
+        <span class="group-pct pct-orange">49.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:37:21+00:00" class="gen-time" title="2026-04-09 06:37 UTC">2026-04-09 06:37 UTC</time> · <a href="https://github.com/schacon/grit/commit/96a90e5a1764e9aaad3497091c090c097960a142" style="color:#58a6ff">96a90e5</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:44:10+00:00" class="gen-time" title="2026-04-09 06:44 UTC">2026-04-09 06:44 UTC</time> · <a href="https://github.com/schacon/grit/commit/71825e209c982a5bc3786ca5cafe93e49082d2de" style="color:#58a6ff">71825e2</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">40,309</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">31,703</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">78.6%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">31,707</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">78.7%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -10277,14 +10277,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:33.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="6" data-passed="2">
+<tr class="" data-group="t5" data-tests="6" data-passed="6" data-full-pass="1">
   <td class="mono">t5618-alternate-refs</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">6</td>
-  <td class="right">2</td>
+  <td class="right">6</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:33.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="2" data-passed="2" data-full-pass="1">

--- a/logs/2026-04-09_t5618-alternate-refs.md
+++ b/logs/2026-04-09_t5618-alternate-refs.md
@@ -1,0 +1,5 @@
+# t5618-alternate-refs
+
+- Verified `./scripts/run-tests.sh t5618-alternate-refs.sh`: 6/6 pass on branch `cursor/t5618-alternate-refs-7466` (no Rust changes required; behavior already matched Git).
+- Refreshed harness artifacts: `data/test-files.csv`, `docs/index.html`, `docs/testfiles.html`.
+- Marked task complete in `PLAN.md` and updated counts in `progress.md`.

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   280 |
+| Completed   |   281 |
 | In progress |     4 |
-| Remaining   |   484 |
+| Remaining   |   483 |
 | **Total**   |   768 |
 
-Task lines in `PLAN.md`: 280 completed (`[x]`), 4 in progress (`[~]`), 484 remaining (`[ ]`).
+Task lines in `PLAN.md`: 281 completed (`[x]`), 4 in progress (`[~]`), 483 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t5618-alternate-refs` — 6/6 tests pass (`rev-list` / `log`: `--alternate-refs`, `--not --alternate-refs`, `core.alternateRefsPrefixes`, `log --source` `.alternate` marker; harness CSV/dashboards refreshed)
 - `t3650-replay-basics` — 31/31 tests pass (`replay`: `--onto` / `--advance` / `--contained`, `--ref-action` + `replay.refAction`, `--branches` with branch refnames, `--ancestry-path`, detached `HEAD` updates, reflog messages, `merge.directoryRenames=false`; `rev_parse::expand_rev_token_circ_bang` for `topic1^!`; `log` `%d` uses short decorations like Git unless `--decorate=full`)
 - `t0040-parse-options` — 94/94 tests pass (`parse-options` / `parse-options-flags` / `parse-subcommand` test-tool: Git-style argv scanning with intermingled args and `+` NODASH; selective usage append; negated-option error names; stdout/stderr flush before `process::exit`; skip global `--git-completion-helper` when nested after `test-tool`; harness `test_run_` no longer wraps bodies in `$(...)` so backticks in heredocs are not executed)
 - `t1502-rev-parse-parseopt` — 37/37 tests pass (`rev-parse --parseopt`: stdin option spec parsing, `cat <<\\EOF` help output, `--keep-dashdash` / `--stop-at-non-option` / `--stuck-long`, negated long names + synthetic `no-<name>` parse entries for ambiguity; harness CSV/dashboards refreshed)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t5618-alternate-refs.sh` already passes all six tests on this branch (`rev-list` / `log` with `--alternate-refs`, `--not --alternate-refs`, `core.alternateRefsPrefixes`, and `log --source` showing the `.alternate` marker).

## Changes

- Ran `./scripts/run-tests.sh t5618-alternate-refs.sh` and committed updated `data/test-files.csv` plus generated dashboards.
- Marked the task complete in `PLAN.md` and adjusted counts / “Recently completed” in `progress.md`.
- Added `logs/2026-04-09_t5618-alternate-refs.md`.

No Rust code changes were required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8cc3415b-32e5-412c-84c5-2c5d3f23ee09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8cc3415b-32e5-412c-84c5-2c5d3f23ee09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

