### PR TITLE
Refresh t3510-cherry-pick test results (65/65)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -641,7 +641,7 @@ t3506-cherry-pick-ff	t3	yes	11	11	0	true	ok	0
 t3507-cherry-pick-conflict	t3	yes	44	44	0	true	ok	0
 t3508-cherry-pick-many-commits	t3	yes	14	5	9	false	ok	0
 t3509-cherry-pick-merge-df	t3	yes	9	9	0	true	ok	0
-t3510-cherry-pick	t3	yes	65	63	2	false	ok	0
+t3510-cherry-pick	t3	yes	65	65	0	true	ok	0
 t3510-cherry-pick-sequence	t3	yes	0	0	0	false	timeout	0
 t3511-cherry-pick-x	t3	yes	22	10	12	false	ok	0
 t3512-cherry-pick-submodule	t3	yes	15	4	11	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T06:43:13+00:00" class="gen-time" title="2026-04-09 06:43 UTC">2026-04-09 06:43 UTC</time> · <a href="https://github.com/schacon/grit/commit/de1e6721ebf26c57a65817fc0d2f8bdc2cfcd0b3" style="color:#58a6ff">de1e672</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T06:45:57+00:00" class="gen-time" title="2026-04-09 06:45 UTC">2026-04-09 06:45 UTC</time> · <a href="https://github.com/schacon/grit/commit/00025d1f26b7c692b2641ed31e2cee07b5162cb2" style="color:#58a6ff">00025d1</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">31,706</div>
+      <div class="summary-big-val">31,708</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>818 files fully passing</span>
+    <span>819 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -212,11 +212,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">57/141 files · 2 skipped · 3,555/4,688 tests</span>
+        <span class="group-meta">58/141 files · 2 skipped · 3,557/4,688 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:75.8%"></div></div>
-        <span class="group-pct pct-blue">75.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:75.9%"></div></div>
+        <span class="group-pct pct-blue">75.9%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:43:13+00:00" class="gen-time" title="2026-04-09 06:43 UTC">2026-04-09 06:43 UTC</time> · <a href="https://github.com/schacon/grit/commit/de1e6721ebf26c57a65817fc0d2f8bdc2cfcd0b3" style="color:#58a6ff">de1e672</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:45:57+00:00" class="gen-time" title="2026-04-09 06:45 UTC">2026-04-09 06:45 UTC</time> · <a href="https://github.com/schacon/grit/commit/00025d1f26b7c692b2641ed31e2cee07b5162cb2" style="color:#58a6ff">00025d1</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">40,309</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">31,706</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">31,708</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.7%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -6567,14 +6567,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="65" data-passed="63">
+<tr class="" data-group="t3" data-tests="65" data-passed="65" data-full-pass="1">
   <td class="mono">t3510-cherry-pick</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">65</td>
-  <td class="right">63</td>
+  <td class="right">65</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:96.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="0" data-passed="0">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`tests/t3510-cherry-pick.sh` already passes fully against current `grit`. The branch only updates harness artifacts so `data/test-files.csv` and dashboards reflect **65/65** passing instead of the previous stale **63/65** count.

## Verification

```bash
./scripts/run-tests.sh t3510-cherry-pick.sh
```

## Changes

- `data/test-files.csv` — t3510-cherry-pick row: full pass, `in_scope` ok
- `docs/index.html`, `docs/testfiles.html` — regenerated from CSV
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-519c8008-8896-4216-bd9b-9df12310d7b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-519c8008-8896-4216-bd9b-9df12310d7b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

