### PR TITLE
fix: shallow submodule cloning (t5614)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1008,7 +1008,7 @@ t5610-clone-detached	t5	skip	13	2	11	false	ok	1
 t5611-clone-config	t5	yes	13	9	4	false	ok	0
 t5612-clone-refspec	t5	yes	13	13	0	true	ok	0
 t5613-info-alternate	t5	yes	13	13	0	true	ok	0
-t5614-clone-submodules-shallow	t5	yes	9	4	5	false	ok	0
+t5614-clone-submodules-shallow	t5	yes	9	9	0	true	ok	0
 t5615-alternate-env	t5	yes	9	9	0	true	ok	0
 t5616-partial-clone	t5	yes	47	9	38	false	ok	0
 t5617-clone-submodules-remote	t5	yes	9	3	6	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T06:31:44+00:00" class="gen-time" title="2026-04-09 06:31 UTC">2026-04-09 06:31 UTC</time> · <a href="https://github.com/schacon/grit/commit/1aa751fe37189cceae4d3566dc92a0fe9279e5b7" style="color:#58a6ff">1aa751f</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T06:48:58+00:00" class="gen-time" title="2026-04-09 06:48 UTC">2026-04-09 06:48 UTC</time> · <a href="https://github.com/schacon/grit/commit/235e4c8ec7a9a9dcdc00ac135e84bd468d98097a" style="color:#58a6ff">235e4c8</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">31,111</div>
+      <div class="summary-big-val">31,116</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>803 files fully passing</span>
+    <span>804 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">52/167 files · 17 skipped · 1,602/3,949 tests</span>
+        <span class="group-meta">53/167 files · 17 skipped · 1,607/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:40.6%"></div></div>
-        <span class="group-pct pct-orange">40.6%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:40.7%"></div></div>
+        <span class="group-pct pct-orange">40.7%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:31:44+00:00" class="gen-time" title="2026-04-09 06:31 UTC">2026-04-09 06:31 UTC</time> · <a href="https://github.com/schacon/grit/commit/1aa751fe37189cceae4d3566dc92a0fe9279e5b7" style="color:#58a6ff">1aa751f</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:48:58+00:00" class="gen-time" title="2026-04-09 06:48 UTC">2026-04-09 06:48 UTC</time> · <a href="https://github.com/schacon/grit/commit/235e4c8ec7a9a9dcdc00ac135e84bd468d98097a" style="color:#58a6ff">235e4c8</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">40,109</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">31,111</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">31,116</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">77.6%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -10237,14 +10237,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="9" data-passed="4">
+<tr class="" data-group="t5" data-tests="9" data-passed="9" data-full-pass="1">
   <td class="mono">t5614-clone-submodules-shallow</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">9</td>
-  <td class="right">4</td>
+  <td class="right">9</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:44.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="9" data-passed="9" data-full-pass="1">

--- a/grit/src/commands/clone.rs
+++ b/grit/src/commands/clone.rs
@@ -118,6 +118,10 @@ pub struct Args {
     #[arg(long = "shallow-submodules")]
     pub shallow_submodules: bool,
 
+    /// Do not use shallow submodule clones (overrides `.gitmodules` shallow recommendation).
+    #[arg(long = "no-shallow-submodules")]
+    pub no_shallow_submodules: bool,
+
     /// Use a custom upload-pack command on the remote side.
     #[arg(short = 'u', long = "upload-pack", value_name = "UPLOAD_PACK")]
     pub upload_pack: Option<String>,
@@ -428,7 +432,7 @@ pub fn run(mut args: Args) -> Result<()> {
     let remote_name = resolve_remote_name(&args)?;
 
     // Determine target directory
-    let target_name = args.directory.unwrap_or_else(|| {
+    let target_name = args.directory.clone().unwrap_or_else(|| {
         let base = source_path
             .file_name()
             .unwrap_or_default()
@@ -928,7 +932,7 @@ pub fn run(mut args: Args) -> Result<()> {
     // Recurse into submodules if requested
     if args.recurse_submodules && !args.bare {
         if let Some(ref wt) = dest.work_tree {
-            clone_submodules(wt, &dest, args.quiet).context("cloning submodules")?;
+            clone_submodules(wt, &dest, &args).context("cloning submodules")?;
         }
     }
 
@@ -1181,7 +1185,7 @@ fn run_git_clone(args: Args) -> Result<()> {
 
     if args.recurse_submodules && !args.bare {
         if let Some(ref wt) = dest.work_tree {
-            clone_submodules(wt, &dest, args.quiet).context("cloning submodules")?;
+            clone_submodules(wt, &dest, &args).context("cloning submodules")?;
         }
     }
 
@@ -1613,7 +1617,7 @@ fn run_ssh_clone(args: Args) -> Result<()> {
 
     if args.recurse_submodules && !args.bare {
         if let Some(ref wt) = dest.work_tree {
-            clone_submodules(wt, &dest, args.quiet).context("cloning submodules")?;
+            clone_submodules(wt, &dest, &args).context("cloning submodules")?;
         }
     }
 
@@ -1672,47 +1676,15 @@ fn collect_gitlink_paths(
     Ok(())
 }
 
-fn clone_submodules(work_tree: &Path, repo: &Repository, quiet: bool) -> Result<()> {
+fn clone_submodules(work_tree: &Path, repo: &Repository, clone_args: &Args) -> Result<()> {
+    let quiet = clone_args.quiet;
     let gitmodules_path = work_tree.join(".gitmodules");
     if !gitmodules_path.exists() {
         return Ok(());
     }
 
-    let content = fs::read_to_string(&gitmodules_path).context("reading .gitmodules")?;
-
-    grit_lib::gitmodules::write_gitmodules_cli_option_warnings(&mut std::io::stderr(), &content)
-        .ok();
-
-    // Simple parser for .gitmodules
-    let mut submodules: Vec<(String, String)> = Vec::new(); // (path, url)
-    let mut current_path: Option<String> = None;
-    let mut current_url: Option<String> = None;
-
-    for line in content.lines() {
-        let trimmed = line.trim();
-        if trimmed.starts_with('[') {
-            // Flush previous
-            if let (Some(p), Some(u)) = (current_path.take(), current_url.take()) {
-                submodules.push((p, u));
-            }
-            continue;
-        }
-        if let Some(val) = trimmed
-            .strip_prefix("path = ")
-            .or_else(|| trimmed.strip_prefix("path="))
-        {
-            current_path = Some(gitmodules_config_value(val));
-        }
-        if let Some(val) = trimmed
-            .strip_prefix("url = ")
-            .or_else(|| trimmed.strip_prefix("url="))
-        {
-            current_url = Some(gitmodules_config_value(val));
-        }
-    }
-    if let (Some(p), Some(u)) = (current_path.take(), current_url.take()) {
-        submodules.push((p, u));
-    }
+    let modules =
+        crate::commands::submodule::parse_gitmodules_for_clone(work_tree).unwrap_or_default();
 
     // Relative submodule URLs resolve against the default remote's repository root (Git parity),
     // not the current work tree — so a clone into `dst/` still finds `../upstream` next to `.`.
@@ -1729,25 +1701,25 @@ fn clone_submodules(work_tree: &Path, repo: &Repository, quiet: bool) -> Result<
     // cloning would delete the checked-out tree (`t2080` clone + verify_checkout).
     let gitlink_paths = gitlink_paths_at_head(work_tree).unwrap_or_default();
 
-    for (path, url) in &submodules {
-        if !gitlink_paths.contains(path) {
+    for sm in &modules {
+        if !gitlink_paths.contains(&sm.path) {
             continue;
         }
 
-        let sub_dest = work_tree.join(path);
+        let sub_dest = work_tree.join(&sm.path);
 
-        let resolved_url = if url.starts_with("./") || url.starts_with("../") {
+        let resolved_url = if sm.url.starts_with("./") || sm.url.starts_with("../") {
             let base = origin_repo_root
                 .as_ref()
                 .cloned()
                 .unwrap_or_else(|| work_tree.to_path_buf());
-            let joined = base.join(url);
+            let joined = base.join(&sm.url);
             fs::canonicalize(&joined)
                 .unwrap_or(joined)
                 .to_string_lossy()
                 .to_string()
         } else {
-            url.clone()
+            sm.url.clone()
         };
 
         if !quiet {
@@ -1763,23 +1735,32 @@ fn clone_submodules(work_tree: &Path, repo: &Repository, quiet: bool) -> Result<
             }
         }
 
+        let super_shallow = repo.git_dir.join("shallow").is_file();
+        let depth = crate::commands::submodule::submodule_clone_depth_for_superproject(
+            super_shallow,
+            clone_args.shallow_submodules,
+            clone_args.no_shallow_submodules,
+            false,
+            sm.shallow,
+        );
+
         let mut cmd = std::process::Command::new(&grit_bin);
         crate::grit_exe::strip_trace2_env(&mut cmd);
-        cmd.arg("clone")
-            .arg("-c")
-            .arg("protocol.file.allow=always")
-            .arg(&resolved_url)
-            .arg(&sub_dest);
+        cmd.arg("clone").arg("-c").arg("protocol.file.allow=always");
+        if let Some(d) = depth {
+            cmd.arg("--depth").arg(d.to_string());
+        }
+        cmd.arg(&resolved_url).arg(&sub_dest);
         if quiet {
             cmd.arg("-q");
         }
 
         let status = cmd
             .status()
-            .with_context(|| format!("failed to clone submodule '{}'", path))?;
+            .with_context(|| format!("failed to clone submodule '{}'", sm.path))?;
 
         if !status.success() {
-            eprintln!("warning: failed to clone submodule '{}'", path);
+            eprintln!("warning: failed to clone submodule '{}'", sm.path);
             anyhow::bail!(
                 "clone of '{}' into submodule path '{}' failed",
                 resolved_url,
@@ -1790,28 +1771,30 @@ fn clone_submodules(work_tree: &Path, repo: &Repository, quiet: bool) -> Result<
 
     let mut upd = std::process::Command::new(&grit_bin);
     crate::grit_exe::strip_trace2_env(&mut upd);
-    let status = upd
-        .args(["submodule", "update", "--init", "--recursive"])
-        .current_dir(work_tree)
-        .status()
-        .context("submodule update after clone")?;
+    upd.args(["submodule", "update", "--init", "--recursive"])
+        .current_dir(work_tree);
+    if clone_args.shallow_submodules {
+        upd.env(
+            crate::commands::submodule::CLONE_SHALLOW_SUBMODULES_ENV,
+            "1",
+        );
+    } else {
+        upd.env_remove(crate::commands::submodule::CLONE_SHALLOW_SUBMODULES_ENV);
+    }
+    if clone_args.no_shallow_submodules {
+        upd.env(
+            crate::commands::submodule::CLONE_NO_SHALLOW_SUBMODULES_ENV,
+            "1",
+        );
+    } else {
+        upd.env_remove(crate::commands::submodule::CLONE_NO_SHALLOW_SUBMODULES_ENV);
+    }
+    let status = upd.status().context("submodule update after clone")?;
     if !status.success() {
         bail!("submodule update failed after clone");
     }
 
     Ok(())
-}
-
-/// Strip Git config-style quoting from a `.gitmodules` value (`path = "-sub"` → `-sub`).
-fn gitmodules_config_value(raw: &str) -> String {
-    let t = raw.trim();
-    if t.len() >= 2 && t.starts_with('"') && t.ends_with('"') {
-        t[1..t.len() - 1]
-            .replace("\\\"", "\"")
-            .replace("\\\\", "\\")
-    } else {
-        t.to_string()
-    }
 }
 
 /// Extract a remote URL from config content.

--- a/grit/src/commands/submodule.rs
+++ b/grit/src/commands/submodule.rs
@@ -21,6 +21,65 @@ use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+/// Set by `clone --recurse-submodules` when `--shallow-submodules` was used.
+pub(crate) const CLONE_SHALLOW_SUBMODULES_ENV: &str = "GRIT_CLONE_SHALLOW_SUBMODULES";
+
+/// Set by `clone --recurse-submodules` when `--no-shallow-submodules` was used.
+pub(crate) const CLONE_NO_SHALLOW_SUBMODULES_ENV: &str = "GRIT_CLONE_NO_SHALLOW_SUBMODULES";
+
+/// Parse `.gitmodules` for clone-time submodule URLs and shallow recommendations.
+pub(crate) fn parse_gitmodules_for_clone(work_tree: &Path) -> Result<Vec<SubmoduleInfo>> {
+    let gitmodules_path = work_tree.join(".gitmodules");
+    if !gitmodules_path.exists() {
+        return Ok(Vec::new());
+    }
+    let content = fs::read_to_string(&gitmodules_path).context("reading .gitmodules")?;
+    let _ = grit_lib::gitmodules::write_gitmodules_cli_option_warnings(&mut io::stderr(), &content);
+    parse_gitmodules_with_repo(work_tree, None)
+}
+
+/// Submodule `git clone --depth N` when `Some(1)`; `None` means a non-shallow clone.
+///
+/// `super_shallow` is true when the superproject has a `.git/shallow` file (clone used `--depth` /
+/// shallow negotiation). A shallow superproject does **not** imply shallow submodules unless
+/// `--shallow-submodules` is set or `.gitmodules` recommends shallow (matches `t5614`).
+#[must_use]
+pub(crate) fn submodule_clone_depth_for_superproject(
+    super_shallow: bool,
+    shallow_submodules_cli: bool,
+    no_shallow_submodules_cli: bool,
+    no_recommend_shallow: bool,
+    gitmodules_shallow: Option<bool>,
+) -> Option<usize> {
+    if no_shallow_submodules_cli {
+        return None;
+    }
+    if shallow_submodules_cli {
+        return Some(1);
+    }
+    if !no_recommend_shallow {
+        if let Some(s) = gitmodules_shallow {
+            return if s { Some(1) } else { None };
+        }
+    }
+    if super_shallow {
+        return None;
+    }
+    None
+}
+
+fn clone_shallow_submodules_from_env() -> bool {
+    std::env::var_os(CLONE_SHALLOW_SUBMODULES_ENV)
+        .as_deref()
+        .is_some_and(|v| !v.is_empty())
+}
+
+fn clone_no_shallow_submodules_from_env() -> bool {
+    std::env::var_os(CLONE_NO_SHALLOW_SUBMODULES_ENV)
+        .as_deref()
+        .is_some_and(|v| !v.is_empty())
+}
+
 /// Spawn grit for a nested operation without inheriting the superproject's `GIT_DIR` /
 /// `GIT_WORK_TREE` (tests and detached work trees set those in the parent shell).
 fn grit_subprocess(grit_bin: &Path) -> Command {
@@ -119,6 +178,10 @@ pub struct UpdateArgs {
     /// Recurse into nested submodules.
     #[arg(long)]
     pub recursive: bool,
+
+    /// Ignore `.gitmodules` shallow recommendations (still shallow when the superproject is shallow).
+    #[arg(long = "no-recommend-shallow")]
+    pub no_recommend_shallow: bool,
 }
 
 #[derive(Debug, ClapArgs)]
@@ -212,12 +275,14 @@ pub struct SetUrlArgs {
     pub newurl: String,
 }
 
-/// Parsed entry from .gitmodules.
+/// Parsed entry from `.gitmodules`.
 #[derive(Debug, Clone)]
-struct SubmoduleInfo {
-    name: String,
-    path: String,
-    url: String,
+pub(crate) struct SubmoduleInfo {
+    pub(crate) name: String,
+    pub(crate) path: String,
+    pub(crate) url: String,
+    /// `submodule.<name>.shallow` from `.gitmodules`, when set.
+    pub(crate) shallow: Option<bool>,
 }
 
 /// Update submodule working trees to the commits recorded in the superproject index.
@@ -230,6 +295,7 @@ pub(crate) fn update_after_superproject_merge(init: bool, recursive: bool) -> Re
         checkout: false,
         remote: false,
         recursive,
+        no_recommend_shallow: false,
     })
 }
 
@@ -627,7 +693,8 @@ fn parse_gitmodules_with_repo(
         .context("failed to parse .gitmodules")?;
 
     // Collect entries by submodule name.
-    let mut modules: BTreeMap<String, (Option<String>, Option<String>)> = BTreeMap::new();
+    let mut modules: BTreeMap<String, (Option<String>, Option<String>, Option<bool>)> =
+        BTreeMap::new();
 
     for entry in &config.entries {
         // Keys look like: submodule.<name>.path, submodule.<name>.url
@@ -640,19 +707,42 @@ fn parse_gitmodules_with_repo(
         if let Some(last_dot) = rest.rfind('.') {
             let name = &rest[..last_dot];
             let var = &rest[last_dot + 1..];
-            let entry_val = modules.entry(name.to_string()).or_insert((None, None));
+            let entry_val = modules
+                .entry(name.to_string())
+                .or_insert((None, None, None));
             match var {
                 "path" => entry_val.0 = entry.value.clone(),
                 "url" => entry_val.1 = entry.value.clone(),
+                "shallow" => {
+                    if let Some(v) = entry.value.as_deref() {
+                        let v = v.trim();
+                        if v.eq_ignore_ascii_case("true")
+                            || v == "1"
+                            || v.eq_ignore_ascii_case("yes")
+                        {
+                            entry_val.2 = Some(true);
+                        } else if v.eq_ignore_ascii_case("false")
+                            || v == "0"
+                            || v.eq_ignore_ascii_case("no")
+                        {
+                            entry_val.2 = Some(false);
+                        }
+                    }
+                }
                 _ => {}
             }
         }
     }
 
     let mut result = Vec::new();
-    for (name, (path, url)) in modules {
+    for (name, (path, url, shallow)) in modules {
         if let (Some(path), Some(url)) = (path, url) {
-            result.push(SubmoduleInfo { name, path, url });
+            result.push(SubmoduleInfo {
+                name,
+                path,
+                url,
+                shallow,
+            });
         }
     }
 
@@ -949,6 +1039,7 @@ fn run_init(args: &InitArgs) -> Result<()> {
 fn run_update(args: &UpdateArgs) -> Result<()> {
     let repo = Repository::discover(None).context("not a git repository")?;
     let work_tree = repo.work_tree.as_ref().context("bare repository")?;
+    let super_shallow = repo.git_dir.join("shallow").is_file();
 
     if args.init {
         run_init(&InitArgs {
@@ -1055,11 +1146,23 @@ fn run_update(args: &UpdateArgs) -> Result<()> {
                 let clone_src_str =
                     resolve_submodule_super_url(work_tree, &repo.git_dir, &clone_url)?;
 
-                let status = grit_subprocess(&grit_bin)
-                    .arg("clone")
+                let submodule_depth = submodule_clone_depth_for_superproject(
+                    super_shallow,
+                    clone_shallow_submodules_from_env(),
+                    clone_no_shallow_submodules_from_env(),
+                    args.no_recommend_shallow,
+                    m.shallow,
+                );
+
+                let mut cmd = grit_subprocess(&grit_bin);
+                cmd.arg("clone")
                     .arg("--no-checkout")
                     .arg("--separate-git-dir")
-                    .arg(&modules_dir)
+                    .arg(&modules_dir);
+                if let Some(d) = submodule_depth {
+                    cmd.arg("--depth").arg(d.to_string());
+                }
+                let status = cmd
                     .arg(&clone_src_str)
                     .arg(&sub_path)
                     .current_dir(work_tree)
@@ -1193,8 +1296,12 @@ fn run_update(args: &UpdateArgs) -> Result<()> {
             if parse_gitmodules(&sub_path).unwrap_or_default().is_empty() {
                 continue;
             }
-            let status = grit_subprocess(&grit_bin)
-                .args(["submodule", "update", "--init", "--recursive"])
+            let mut nested = grit_subprocess(&grit_bin);
+            nested.args(["submodule", "update", "--init", "--recursive"]);
+            if args.no_recommend_shallow {
+                nested.arg("--no-recommend-shallow");
+            }
+            let status = nested
                 .current_dir(&sub_path)
                 .status()
                 .with_context(|| format!("nested submodule update in {}", m.path))?;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible shallow submodule behavior for `clone --recurse-submodules` and `submodule update`, matching `t5614-clone-submodules-shallow`.

## Changes

- Parse `submodule.<name>.shallow` from `.gitmodules` (true/false).
- Add `--no-shallow-submodules` on `clone`.
- Add `submodule update --no-recommend-shallow`.
- Apply `--depth 1` to submodule clones when:
  - `--shallow-submodules` is set, or
  - `.gitmodules` recommends shallow (and not overridden by `--no-recommend-shallow` / `--no-shallow-submodules`).
- A shallow **superproject** alone does **not** imply shallow submodules (per t5614).
- Propagate `clone` shallow flags to the follow-up `submodule update` via `GRIT_CLONE_SHALLOW_SUBMODULES` / `GRIT_CLONE_NO_SHALLOW_SUBMODULES` so `separate-git-dir` submodule clones get the same rules.
- Fix `clone` when `--directory` is omitted: clone `args.directory` instead of moving it so `clone_submodules` can still read clone flags.

## Validation

- `./scripts/run-tests.sh t5614-clone-submodules-shallow.sh` (9/9)
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10998fd4-c6a4-44f7-b4a0-f4f2979cd0da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10998fd4-c6a4-44f7-b4a0-f4f2979cd0da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

