### PR TITLE
fix: make t4017-diff-retval pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -691,7 +691,7 @@ t4014-format-patch	t4	yes	215	42	173	false	ok	0
 t4015-diff-whitespace	t4	yes	0	0	0	false	timeout	0
 t4015-format-patch-options	t4	yes	12	12	0	true	ok	0
 t4016-diff-quote	t4	yes	5	2	3	false	ok	0
-t4017-diff-retval	t4	yes	0	0	0	false	timeout	0
+t4017-diff-retval	t4	yes	38	38	0	true	ok	0
 t4018-diff-files	t4	yes	41	39	2	false	ok	0
 t4018-diff-funcname	t4	yes	0	0	0	false	timeout	0
 t4019-diff-options	t4	yes	26	26	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,30 +141,30 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T06:37:21+00:00" class="gen-time" title="2026-04-09 06:37 UTC">2026-04-09 06:37 UTC</time> · <a href="https://github.com/schacon/grit/commit/96a90e5a1764e9aaad3497091c090c097960a142" style="color:#58a6ff">96a90e5</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T07:15:02+00:00" class="gen-time" title="2026-04-09 07:15 UTC">2026-04-09 07:15 UTC</time> · <a href="https://github.com/schacon/grit/commit/71825e209c982a5bc3786ca5cafe93e49082d2de" style="color:#58a6ff">71825e2</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">78.6%</div>
+      <div class="summary-big-val pct-blue">78.7%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">31,703</div>
+      <div class="summary-big-val">31,741</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">40,309</div>
+      <div class="summary-big-val">40,347</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:78.6%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:78.7%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>817 files fully passing</span>
+    <span>818 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -223,11 +223,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">85/178 files · 2 skipped · 2,636/3,774 tests</span>
+        <span class="group-meta">86/178 files · 2 skipped · 2,674/3,812 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.8%"></div></div>
-        <span class="group-pct pct-blue">69.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:70.1%"></div></div>
+        <span class="group-pct pct-blue">70.1%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T06:37:21+00:00" class="gen-time" title="2026-04-09 06:37 UTC">2026-04-09 06:37 UTC</time> · <a href="https://github.com/schacon/grit/commit/96a90e5a1764e9aaad3497091c090c097960a142" style="color:#58a6ff">96a90e5</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T07:15:02+00:00" class="gen-time" title="2026-04-09 07:15 UTC">2026-04-09 07:15 UTC</time> · <a href="https://github.com/schacon/grit/commit/71825e209c982a5bc3786ca5cafe93e49082d2de" style="color:#58a6ff">71825e2</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">40,309</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">31,703</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">78.6%</div><div class="lbl">Pass rate</div></div>
+  <div class="card"><div class="n" id="sum-tests">40,347</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">31,741</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">78.7%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -7067,14 +7067,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:40.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="0" data-passed="0">
+<tr class="" data-group="t4" data-tests="38" data-passed="38" data-full-pass="1">
   <td class="mono">t4017-diff-retval</td>
   <td>t4</td>
-  <td></td>
-  <td class="right">0</td>
-  <td class="right">0</td>
-  <td class="right">timeout</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td><span class="badge ok">full pass</span></td>
+  <td class="right">38</td>
+  <td class="right">38</td>
+  <td class="right">ok</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="41" data-passed="39">

--- a/grit/src/commands/diff.rs
+++ b/grit/src/commands/diff.rs
@@ -14,6 +14,8 @@
 
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
+use grit_lib::config::ConfigSet;
+use grit_lib::crlf::{get_file_attrs, load_gitattributes, AttrRule};
 use grit_lib::diff::{
     anchored_unified_diff, count_changes, count_git_lines, detect_renames, diff_index_to_tree,
     diff_index_to_worktree, diff_tree_to_worktree, diff_trees, diffcore_count_changes,
@@ -1368,11 +1370,31 @@ pub fn run(mut args: Args) -> Result<()> {
             .unwrap_or(false)
     };
 
-    // --check: check for whitespace errors
+    // `--check`: whitespace / conflict-marker diagnostics. With `--exit-code`, Git uses 1 for a
+    // diff that passes the check and 3 when the check fails; without `--exit-code`, a failed
+    // check exits 2 (see t4017-diff-retval).
     if args.check {
-        let has_errors = check_whitespace_errors(&mut out, &entries, &repo.odb, wt_for_content)?;
-        if has_errors {
+        let attr_rules: Option<Vec<AttrRule>> = wt_for_content.map(load_gitattributes);
+        let config_for_attrs = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+        let has_ws_errors = check_whitespace_errors(
+            &mut out,
+            &entries,
+            &repo.odb,
+            wt_for_content,
+            attr_rules.as_deref(),
+            &config_for_attrs,
+        )?;
+        if has_ws_errors {
+            if args.exit_code {
+                std::process::exit(3);
+            }
             std::process::exit(2);
+        }
+        if args.exit_code || args.quiet {
+            if has_diff {
+                std::process::exit(1);
+            }
+            return Ok(());
         }
         return Ok(());
     }
@@ -2159,10 +2181,9 @@ fn resolve_dirstat_options(
         }
     }
 
-    if !cli_active
-        && opts.is_default_everything() && config.get("diff.dirstat").is_none() {
-            return Ok((None, warnings));
-        }
+    if !cli_active && opts.is_default_everything() && config.get("diff.dirstat").is_none() {
+        return Ok((None, warnings));
+    }
 
     Ok((Some(opts), warnings))
 }
@@ -3600,6 +3621,59 @@ fn write_name_status(out: &mut impl Write, entries: &[DiffEntry]) -> Result<()> 
     Ok(())
 }
 
+/// Git default conflict marker width (`DEFAULT_CONFLICT_MARKER_SIZE` in upstream).
+const DEFAULT_CONFLICT_MARKER_SIZE: usize = 7;
+
+fn conflict_marker_size_for_path(
+    rules: Option<&[AttrRule]>,
+    rel_path: &str,
+    config: &ConfigSet,
+) -> usize {
+    let mut size = DEFAULT_CONFLICT_MARKER_SIZE;
+    if let Some(rules) = rules {
+        let fa = get_file_attrs(rules, rel_path, config);
+        if let Some(ref s) = fa.conflict_marker_size {
+            if let Ok(n) = s.trim().parse::<i32>() {
+                if n > 0 {
+                    size = n as usize;
+                }
+            }
+        }
+    }
+    size
+}
+
+/// Match upstream `is_conflict_marker` in `git/diff.c`.
+fn is_conflict_marker_line(body: &str, marker_size: usize) -> bool {
+    let line = body.trim_end_matches(['\n', '\r']);
+    let len = line.len();
+    if len < marker_size {
+        return false;
+    }
+    let first = match line.as_bytes().first().copied() {
+        Some(b) => b,
+        None => return false,
+    };
+    if !matches!(first, b'=' | b'>' | b'<' | b'|') {
+        return false;
+    }
+    for i in 1..marker_size {
+        if line.as_bytes().get(i).copied() != Some(first) {
+            return false;
+        }
+    }
+    // Middle conflict line is exactly `marker_size` '=' characters (no trailing label).
+    if first == b'=' && len == marker_size {
+        return true;
+    }
+    if len < marker_size + 1 {
+        return false;
+    }
+    line.as_bytes()
+        .get(marker_size)
+        .is_some_and(|b| b.is_ascii_whitespace())
+}
+
 /// Check for whitespace errors in added/modified lines.
 /// Returns true if any errors were found.
 fn check_whitespace_errors(
@@ -3607,6 +3681,8 @@ fn check_whitespace_errors(
     entries: &[DiffEntry],
     odb: &Odb,
     work_tree: Option<&Path>,
+    attr_rules: Option<&[AttrRule]>,
+    config: &ConfigSet,
 ) -> Result<bool> {
     use grit_lib::diff::zero_oid;
     let mut has_errors = false;
@@ -3616,6 +3692,7 @@ fn check_whitespace_errors(
             continue;
         }
         let path = entry.path();
+        let marker_size = conflict_marker_size_for_path(attr_rules, path, config);
 
         // Read old and new content
         let old_content = if entry.old_oid == zero_oid() {
@@ -3645,11 +3722,7 @@ fn check_whitespace_errors(
                     let line = change.value();
                     // Check for conflict markers
                     let bare = line.trim_end_matches('\n').trim_end_matches('\r');
-                    if bare.starts_with("<<<<<<< ")
-                        || bare.starts_with(">>>>>>> ")
-                        || bare == "======="
-                        || bare.starts_with("=======")
-                    {
+                    if is_conflict_marker_line(bare, marker_size) {
                         writeln!(out, "{}:{}: leftover conflict marker", path, line_no)?;
                         write!(out, "+{}", line)?;
                         if !line.ends_with('\n') {

--- a/grit/src/commands/diff_tree.rs
+++ b/grit/src/commands/diff_tree.rs
@@ -21,6 +21,7 @@ use grit_lib::odb::Odb;
 use grit_lib::pathspec::{context_from_mode_octal, matches_pathspec_with_context};
 use grit_lib::repo::Repository;
 use grit_lib::rev_parse::resolve_revision;
+use regex::Regex;
 use std::io::{self, BufRead, Write};
 use std::path::Path;
 
@@ -113,6 +114,14 @@ struct Options {
     exit_code: bool,
     /// Suppress all output, implies exit_code.
     quiet: bool,
+    /// Pickaxe `-S<string>`: only show diffs where occurrence count of the string changes.
+    pickaxe_string: Option<String>,
+    /// Pickaxe `-G<pattern>`: only show diffs with added/removed lines matching the regex.
+    pickaxe_grep: Option<String>,
+    /// Treat `-S` argument as a regex (with `--pickaxe-regex`).
+    pickaxe_regex: bool,
+    /// Show all matching files, not only those with count changes (`--pickaxe-all`).
+    pickaxe_all: bool,
     /// Re-merge parents and diff against merge result tree.
     remerge_diff: bool,
     /// Swap the two tree sides (`-R`), inverting raw/patch output like Git.
@@ -151,6 +160,10 @@ impl Default for Options {
             max_depth: None,
             exit_code: false,
             quiet: false,
+            pickaxe_string: None,
+            pickaxe_grep: None,
+            pickaxe_regex: false,
+            pickaxe_all: false,
             remerge_diff: false,
             reverse: false,
         }
@@ -306,14 +319,38 @@ fn parse_options(argv: &[String]) -> Result<Options> {
                 _ if arg.starts_with("--diff-filter=")
                     || arg.starts_with("--diff-merges=")
                     || arg.starts_with("--format=")
-                    || arg.starts_with("-S")
-                    || arg.starts_with("-G")
-                    || arg.starts_with("--pickaxe-all")
-                    || arg.starts_with("--pickaxe-regex")
                     || arg.starts_with("-O")
                     || arg.starts_with("--relative") =>
                 {
-                    // ignored
+                    // Accepted for compatibility; not implemented for diff-tree.
+                }
+                "--pickaxe-regex" => opts.pickaxe_regex = true,
+                "--pickaxe-all" => opts.pickaxe_all = true,
+                s if s.starts_with("-S") => {
+                    if s.len() > 2 {
+                        opts.pickaxe_string = Some(s[2..].to_owned());
+                    } else {
+                        i += 1;
+                        if i >= argv.len() {
+                            bail!("option `-S` requires a value");
+                        }
+                        opts.pickaxe_string = Some(argv[i].clone());
+                    }
+                    i += 1;
+                    continue;
+                }
+                s if s.starts_with("-G") => {
+                    if s.len() > 2 {
+                        opts.pickaxe_grep = Some(s[2..].to_owned());
+                    } else {
+                        i += 1;
+                        if i >= argv.len() {
+                            bail!("option `-G` requires a value");
+                        }
+                        opts.pickaxe_grep = Some(argv[i].clone());
+                    }
+                    i += 1;
+                    continue;
                 }
                 _ => bail!("unknown option: {arg}"),
             }
@@ -403,7 +440,7 @@ fn run_two_trees(repo: &Repository, opts: &Options, out: &mut impl Write) -> Res
         validate_tree_depth_limit(&repo.odb, tree_oid, 0, max_tree_depth)?;
     }
     let entries = diff_with_opts(&repo.odb, old_tree, new_tree, opts)?;
-    let filtered = filter_entries(entries, opts);
+    let filtered = filter_entries(&repo.odb, entries, opts)?;
     let has_diff = !filtered.is_empty();
     if !opts.quiet {
         print_diff(out, &repo.odb, &filtered, opts, old_tree, &repo.git_dir)?;
@@ -428,7 +465,7 @@ fn run_one_commit(repo: &Repository, opts: &Options, out: &mut impl Write) -> Re
             if commit.parents.is_empty() {
                 if opts.root {
                     let entries = diff_with_opts(&repo.odb, None, Some(&commit.tree), opts)?;
-                    let filtered = filter_entries(entries, opts);
+                    let filtered = filter_entries(&repo.odb, entries, opts)?;
                     has_diff = !filtered.is_empty();
                     if !opts.quiet && (has_diff || opts.pretty.is_some()) {
                         write_commit_header(out, &oid, &obj.data, opts)?;
@@ -497,7 +534,7 @@ fn run_one_commit(repo: &Repository, opts: &Options, out: &mut impl Write) -> Re
                 let parent_tree = commit_tree(&repo.odb, &commit.parents[0])?;
                 let entries =
                     diff_with_opts(&repo.odb, Some(&parent_tree), Some(&commit.tree), opts)?;
-                let filtered = filter_entries(entries, opts);
+                let filtered = filter_entries(&repo.odb, entries, opts)?;
                 has_diff = !filtered.is_empty();
                 if !opts.quiet && (has_diff || opts.pretty.is_some()) {
                     write_commit_header(out, &oid, &obj.data, opts)?;
@@ -638,7 +675,7 @@ fn process_stdin_commit(
     } else if parent_oids.is_empty() {
         if opts.root {
             let entries = diff_with_opts(&repo.odb, None, Some(&commit.tree), opts)?;
-            let filtered = filter_entries(entries, opts);
+            let filtered = filter_entries(&repo.odb, entries, opts)?;
             let hd = !filtered.is_empty();
             print_diff(out, &repo.odb, &filtered, opts, None, &repo.git_dir)?;
             hd
@@ -648,7 +685,7 @@ fn process_stdin_commit(
     } else {
         let parent_tree = commit_tree(&repo.odb, &parent_oids[0])?;
         let entries = diff_with_opts(&repo.odb, Some(&parent_tree), Some(&commit.tree), opts)?;
-        let filtered = filter_entries(entries, opts);
+        let filtered = filter_entries(&repo.odb, entries, opts)?;
         let hd = !filtered.is_empty();
         print_diff(out, &repo.odb, &filtered, opts, None, &repo.git_dir)?;
         hd
@@ -682,7 +719,7 @@ fn process_stdin_two_trees(
         (Some(oid1), Some(&oid2))
     };
     let entries = diff_with_opts(&repo.odb, old_side, new_side, opts)?;
-    let filtered = filter_entries(entries, opts);
+    let filtered = filter_entries(&repo.odb, entries, opts)?;
     print_diff(out, &repo.odb, &filtered, opts, None, &repo.git_dir)
 }
 
@@ -1619,14 +1656,88 @@ fn read_blob_pair(odb: &Odb, entry: &DiffEntry) -> Result<(String, String)> {
     Ok((old_content, new_content))
 }
 
-/// Apply all post-diff filters: pathspecs and max-depth.
-fn filter_entries(entries: Vec<DiffEntry>, opts: &Options) -> Vec<DiffEntry> {
-    let filtered = filter_pathspecs(entries, &opts.pathspecs);
+/// Apply post-diff filters: pathspecs, max-depth, and pickaxe (`-S` / `-G`).
+fn filter_entries(odb: &Odb, entries: Vec<DiffEntry>, opts: &Options) -> Result<Vec<DiffEntry>> {
+    let mut filtered = filter_pathspecs(entries, &opts.pathspecs);
     if let Some(depth) = opts.max_depth {
-        filter_max_depth(filtered, depth, &opts.pathspecs)
-    } else {
-        filtered
+        filtered = filter_max_depth(filtered, depth, &opts.pathspecs);
     }
+    apply_pickaxe_filter(odb, filtered, opts)
+}
+
+/// `-G` / `-S` pickaxe filtering (matches `git diff-tree` / `git diff` semantics).
+fn apply_pickaxe_filter(
+    odb: &Odb,
+    entries: Vec<DiffEntry>,
+    opts: &Options,
+) -> Result<Vec<DiffEntry>> {
+    if let Some(ref pattern) = opts.pickaxe_grep {
+        let re =
+            Regex::new(pattern).with_context(|| format!("invalid pickaxe regex: {pattern}"))?;
+        let mut out = Vec::new();
+        for e in entries {
+            let (old, new) = read_blob_pair(odb, &e)?;
+            let mut keep = false;
+            for line in new.lines() {
+                if re.is_match(line) {
+                    keep = true;
+                    break;
+                }
+            }
+            if !keep {
+                for line in old.lines() {
+                    if re.is_match(line) {
+                        keep = true;
+                        break;
+                    }
+                }
+            }
+            if keep {
+                out.push(e);
+            }
+        }
+        return Ok(out);
+    }
+
+    if let Some(ref needle) = opts.pickaxe_string {
+        if opts.pickaxe_regex {
+            let re =
+                Regex::new(needle).with_context(|| format!("invalid pickaxe regex: {needle}"))?;
+            let mut out = Vec::new();
+            for e in entries {
+                let (old, new) = read_blob_pair(odb, &e)?;
+                let old_count = re.find_iter(&old).count();
+                let new_count = re.find_iter(&new).count();
+                let keep = if opts.pickaxe_all {
+                    old_count > 0 || new_count > 0
+                } else {
+                    old_count != new_count
+                };
+                if keep {
+                    out.push(e);
+                }
+            }
+            return Ok(out);
+        }
+
+        let mut out = Vec::new();
+        for e in entries {
+            let (old, new) = read_blob_pair(odb, &e)?;
+            let old_count = old.matches(needle.as_str()).count();
+            let new_count = new.matches(needle.as_str()).count();
+            let keep = if opts.pickaxe_all {
+                old_count > 0 || new_count > 0
+            } else {
+                old_count != new_count
+            };
+            if keep {
+                out.push(e);
+            }
+        }
+        return Ok(out);
+    }
+
+    Ok(entries)
 }
 
 fn filter_pathspecs(entries: Vec<DiffEntry>, pathspecs: &[String]) -> Vec<DiffEntry> {

--- a/grit/src/commands/merge.rs
+++ b/grit/src/commands/merge.rs
@@ -29,7 +29,7 @@ use grit_lib::write_tree::write_tree_from_index;
 use time::OffsetDateTime;
 
 use crate::commands::diff_index;
-use crate::explicit_exit::ExplicitExit;
+use crate::explicit_exit::{ExplicitExit, SilentNonZeroExit};
 
 /// Count distinct paths that have any unmerged index stage (matches `git merge` conflict scoring).
 fn unmerged_path_count(index: &Index) -> usize {
@@ -1508,7 +1508,7 @@ Aborting"
             let n = unmerged_path_count(&merge_result.index);
             return Err(anyhow::Error::new(StrategyTrialConflict(n)));
         }
-        std::process::exit(1);
+        return Err(anyhow::Error::new(SilentNonZeroExit { code: 1 }));
     }
 
     if args.squash {
@@ -2300,7 +2300,7 @@ fn do_octopus_merge(
                     eprintln!("fatal: merge program failed");
                 }
                 if exit_on_conflict {
-                    std::process::exit(2);
+                    return Err(anyhow::Error::new(SilentNonZeroExit { code: 2 }));
                 }
                 bail!("fatal: merge program failed");
             }
@@ -2390,7 +2390,7 @@ fn do_octopus_merge(
                 eprintln!("fatal: merge program failed");
             }
             if exit_on_conflict {
-                std::process::exit(2);
+                return Err(anyhow::Error::new(SilentNonZeroExit { code: 2 }));
             }
             bail!("fatal: merge program failed");
         }

--- a/logs/2026-04-09_t4017-diff-retval.md
+++ b/logs/2026-04-09_t4017-diff-retval.md
@@ -1,0 +1,18 @@
+# t4017-diff-retval
+
+## Summary
+
+Made `tests/t4017-diff-retval.sh` fully pass (38/38).
+
+## Changes
+
+- **`scripts/run-tests.sh`**: `unset -f git grit` before running tests so an exported shell `git () { ./grit "$@"; }` cannot override the harness `bin.*/git` wrapper (would break after `cd` into trash).
+- **`grit diff-tree`**: Implemented `-S` / `-G` pickaxe filtering (occurrence-count change for `-S`, line regex for `-G`) so `--exit-code` matches Git when the pickaxe does not select a change.
+- **`grit diff --check`**: Combined `--check` with `--exit-code` — exit 1 when diff is clean under check, 3 when whitespace/conflict check fails; conflict marker detection aligned with Git (`is_conflict_marker` + `conflict-marker-size` via `.gitattributes`).
+- **`grit merge`**: Replaced `std::process::exit(1|2)` on conflicts with `SilentNonZeroExit` so merge failures do not terminate the parent test shell.
+
+## Validation
+
+- `./scripts/run-tests.sh t4017-diff-retval.sh` → 38/38
+- `cargo test -p grit-lib --lib`
+- `cargo check -p grit-rs`

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -180,6 +180,9 @@ run_one() {
     fi
     output=$(
         cd "$TESTS_DIR" &&
+            # Cursor/agent shells often export `git () { ./grit "$@"; }`, which overrides the
+            # harness `git` wrapper and breaks once a test `cd`s into trash (./grit missing).
+            unset -f git grit 2>/dev/null || true &&
             env -u GIT_INDEX_FILE -u GIT_DIR -u GIT_WORK_TREE \
             EDITOR=: VISUAL=: LC_ALL=C LANG=C _prereq_DEFAULT_REPO_FORMAT=set GRIT_TEST_LIB_SUMMARY=1 GUST_BIN="$(pwd)/grit" \
             GIT_TEST_BUILTIN_HASH=sha1 \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t4017-diff-retval` now passes **38/38** in the harness.

## What changed

1. **`scripts/run-tests.sh`** — Clear exported shell functions named `git` / `grit` before running a test file. Cursor/agent environments sometimes define `git () { ./grit "$@"; }`, which overrides the harness `bin.*/git` wrapper and breaks once a test `cd`s into trash (no `./grit` there).

2. **`diff-tree`** — Parse and apply **pickaxe** options `-S` / `-G` (and `--pickaxe-regex` / `--pickaxe-all`) so `--exit-code` matches Git when a path changes but the pickaxe does not select that change (e.g. `-Snot-found`).

3. **`diff --check`** — Match Git’s exit codes with `--exit-code`: **1** when the diff is clean under the check, **3** when the check fails. Conflict marker detection now follows Git’s `is_conflict_marker` rules and honors **`conflict-marker-size`** from `.gitattributes`.

4. **`merge`** — On conflicts, return **`SilentNonZeroExit`** instead of `std::process::exit`, so a failed merge inside a test body does not kill the entire test shell (EXIT trap / FATAL).

## Validation

- `./scripts/run-tests.sh t4017-diff-retval.sh`
- `cargo test -p grit-lib --lib`
- `cargo check -p grit-rs`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f10424e-935d-4ebd-a48b-c054ae0c5778"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f10424e-935d-4ebd-a48b-c054ae0c5778"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

