### PR TITLE
t4119-apply-config: full pass + harness refresh

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -788,7 +788,7 @@ t4115-apply-symlink	t4	yes	8	2	6	false	ok	0
 t4116-apply-reverse	t4	yes	7	6	1	false	ok	0
 t4117-apply-reject	t4	yes	8	2	6	false	ok	0
 t4118-apply-empty-context	t4	yes	3	3	0	true	ok	0
-t4119-apply-config	t4	yes	11	2	9	false	ok	0
+t4119-apply-config	t4	yes	11	11	0	true	ok	0
 t4120-apply-popt	t4	yes	12	12	0	true	ok	0
 t4121-apply-diffs	t4	yes	2	2	0	true	ok	0
 t4122-apply-symlink-inside	t4	yes	7	3	4	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,16 +141,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T10:42:30+00:00" class="gen-time" title="2026-04-09 10:42 UTC">2026-04-09 10:42 UTC</time> · <a href="https://github.com/schacon/grit/commit/c0dd2fd56c0ca810cdf1d09d8ef194b602b9fe83" style="color:#58a6ff">c0dd2fd</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T10:55:19+00:00" class="gen-time" title="2026-04-09 10:55 UTC">2026-04-09 10:55 UTC</time> · <a href="https://github.com/schacon/grit/commit/da46a675dac4f9bacc5133b3eab91b4eec43a816" style="color:#58a6ff">da46a67</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-green">83.8%</div>
+      <div class="summary-big-val pct-green">83.9%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">34,603</div>
+      <div class="summary-big-val">34,612</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -159,12 +159,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:83.8%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:83.9%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>888 files fully passing</span>
+    <span>889 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -223,11 +223,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">97/178 files · 2 skipped · 2,790/3,853 tests</span>
+        <span class="group-meta">98/178 files · 2 skipped · 2,799/3,853 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.4%"></div></div>
-        <span class="group-pct pct-blue">72.4%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.6%"></div></div>
+        <span class="group-pct pct-blue">72.6%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T10:42:30+00:00" class="gen-time" title="2026-04-09 10:42 UTC">2026-04-09 10:42 UTC</time> · <a href="https://github.com/schacon/grit/commit/c0dd2fd56c0ca810cdf1d09d8ef194b602b9fe83" style="color:#58a6ff">c0dd2fd</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T10:55:19+00:00" class="gen-time" title="2026-04-09 10:55 UTC">2026-04-09 10:55 UTC</time> · <a href="https://github.com/schacon/grit/commit/da46a675dac4f9bacc5133b3eab91b4eec43a816" style="color:#58a6ff">da46a67</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">41,278</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">34,603</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">83.8%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">34,612</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">83.9%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -8037,14 +8037,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="11" data-passed="2">
+<tr class="" data-group="t4" data-tests="11" data-passed="11" data-full-pass="1">
   <td class="mono">t4119-apply-config</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">11</td>
-  <td class="right">2</td>
+  <td class="right">11</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:18.2%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="12" data-passed="12" data-full-pass="1">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t4119-apply-config.sh` passes all 11 tests on this branch. The implementation already honors `apply.whitespace` from config (see `grit/src/commands/apply.rs`: `config_whitespace_fix`, `resolve_apply_whitespace_mode`).

This change refresifies harness artifacts after `./scripts/run-tests.sh t4119-apply-config.sh`:

- `data/test-files.csv` — 11/11 passed, `fully_passing=true`
- `docs/index.html`, `docs/testfiles.html` — regenerated dashboards

## Verification

```bash
./scripts/run-tests.sh t4119-apply-config.sh
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-287d05ec-9f67-472b-81d2-cdecb099b237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-287d05ec-9f67-472b-81d2-cdecb099b237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

