### PR TITLE
chore: refresh t4206-log-follow-harder-copies harness (7/7)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -825,7 +825,7 @@ t4204-log-follow	t4	yes	5	5	0	true	ok	0
 t4204-patch-id	t4	yes	26	26	0	true	ok	0
 t4205-log-pretty-formats	t4	yes	123	35	88	false	ok	2
 t4206-log-follow	t4	yes	26	26	0	true	ok	0
-t4206-log-follow-harder-copies	t4	yes	7	3	4	false	ok	0
+t4206-log-follow-harder-copies	t4	yes	7	7	0	true	ok	0
 t4207-log-decoration	t4	yes	23	23	0	true	ok	0
 t4207-log-decoration-colors	t4	yes	4	4	0	true	ok	0
 t4208-diff-pathspec-magic	t4	yes	22	21	1	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T10:42:30+00:00" class="gen-time" title="2026-04-09 10:42 UTC">2026-04-09 10:42 UTC</time> · <a href="https://github.com/schacon/grit/commit/c0dd2fd56c0ca810cdf1d09d8ef194b602b9fe83" style="color:#58a6ff">c0dd2fd</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T10:56:38+00:00" class="gen-time" title="2026-04-09 10:56 UTC">2026-04-09 10:56 UTC</time> · <a href="https://github.com/schacon/grit/commit/da46a675dac4f9bacc5133b3eab91b4eec43a816" style="color:#58a6ff">da46a67</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">34,603</div>
+      <div class="summary-big-val">34,607</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>888 files fully passing</span>
+    <span>889 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -223,11 +223,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">97/178 files · 2 skipped · 2,790/3,853 tests</span>
+        <span class="group-meta">98/178 files · 2 skipped · 2,794/3,853 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.4%"></div></div>
-        <span class="group-pct pct-blue">72.4%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.5%"></div></div>
+        <span class="group-pct pct-blue">72.5%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T10:42:30+00:00" class="gen-time" title="2026-04-09 10:42 UTC">2026-04-09 10:42 UTC</time> · <a href="https://github.com/schacon/grit/commit/c0dd2fd56c0ca810cdf1d09d8ef194b602b9fe83" style="color:#58a6ff">c0dd2fd</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T10:56:38+00:00" class="gen-time" title="2026-04-09 10:56 UTC">2026-04-09 10:56 UTC</time> · <a href="https://github.com/schacon/grit/commit/da46a675dac4f9bacc5133b3eab91b4eec43a816" style="color:#58a6ff">da46a67</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">41,278</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">34,603</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">34,607</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">83.8%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -8407,14 +8407,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="7" data-passed="3">
+<tr class="" data-group="t4" data-tests="7" data-passed="7" data-full-pass="1">
   <td class="mono">t4206-log-follow-harder-copies</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">7</td>
-  <td class="right">3</td>
+  <td class="right">7</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:42.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="23" data-passed="23" data-full-pass="1">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`tests/t4206-log-follow-harder-copies.sh` already passes **7/7** against current `grit`. The repo’s `data/test-files.csv` row was stale (3/7). This change refreshes the harness row and regenerated dashboards after `./scripts/run-tests.sh t4206-log-follow-harder-copies.sh`.

## Verification

- `cargo build --release -p grit-rs`
- `./scripts/run-tests.sh t4206-log-follow-harder-copies.sh` → 7/7
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-339b887a-5676-4a64-a906-e918785ada46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-339b887a-5676-4a64-a906-e918785ada46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

