### PR TITLE
t5310-pack-bitmaps: verify full pass, refresh dashboards

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -686,7 +686,7 @@ commit → check it off → move on.
 - [ ] `t5516-fetch-push` █░░░░░░░░░░░░░░░░░░░ 7/124 (117 left) — Basic fetch/push functionality.
 
 - [ ] `t5411-proc-receive-hook` ██████████░░░░░░░░░░ 193/354 (161 left) — Test proc-receive hook
-- [~] `t5310-pack-bitmaps` ███████████░░░░░░░░░ 127/236 (109 left) — exercise basic bitmap functionality (fast-import bulk + name-hash; pack bitmap I/O still missing)
+- [x] `t5310-pack-bitmaps` ████████████████████ 236/236 (0 left) — exercise basic bitmap functionality
 - [ ] `t5327-multi-pack-bitmaps-rev` ░░░░░░░░░░░░░░░░░░░░ 14/314 (300 left) — exercise basic multi-pack bitmap functionality (.rev files)
 - [ ] `t5326-multi-pack-bitmaps` █░░░░░░░░░░░░░░░░░░░ 29/357 (328 left) — exercise basic multi-pack bitmap functionality
 - [ ] `t5500-fetch-pack` █░░░░░░░░░░░░░░░░░░░ 29/378 (349 left) — Testing multi_ack pack fetching

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -876,7 +876,7 @@ t5306-pack-nobase	t5	yes	4	4	0	true	ok	0
 t5307-pack-missing-commit	t5	yes	5	5	0	true	ok	0
 t5308-pack-detect-duplicates	t5	yes	6	6	0	true	ok	0
 t5309-pack-delta-cycles	t5	yes	7	7	0	true	ok	0
-t5310-pack-bitmaps	t5	yes	236	23	213	false	ok	0
+t5310-pack-bitmaps	t5	yes	236	236	0	true	ok	0
 t5311-pack-bitmaps-shallow	t5	yes	6	6	0	true	ok	0
 t5312-prune-corruption	t5	yes	11	5	6	false	ok	0
 t5313-pack-bounds-checks	t5	yes	9	2	7	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,16 +141,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T10:42:30+00:00" class="gen-time" title="2026-04-09 10:42 UTC">2026-04-09 10:42 UTC</time> · <a href="https://github.com/schacon/grit/commit/c0dd2fd56c0ca810cdf1d09d8ef194b602b9fe83" style="color:#58a6ff">c0dd2fd</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T10:56:27+00:00" class="gen-time" title="2026-04-09 10:56 UTC">2026-04-09 10:56 UTC</time> · <a href="https://github.com/schacon/grit/commit/da46a675dac4f9bacc5133b3eab91b4eec43a816" style="color:#58a6ff">da46a67</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-green">83.8%</div>
+      <div class="summary-big-val pct-green">84.3%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">34,603</div>
+      <div class="summary-big-val">34,816</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -159,12 +159,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:83.8%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:84.3%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>888 files fully passing</span>
+    <span>889 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -234,11 +234,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">67/167 files · 17 skipped · 2,052/3,949 tests</span>
+        <span class="group-meta">68/167 files · 17 skipped · 2,265/3,949 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:52.0%"></div></div>
-        <span class="group-pct pct-orange">52.0%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:57.4%"></div></div>
+        <span class="group-pct pct-orange">57.4%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T10:42:30+00:00" class="gen-time" title="2026-04-09 10:42 UTC">2026-04-09 10:42 UTC</time> · <a href="https://github.com/schacon/grit/commit/c0dd2fd56c0ca810cdf1d09d8ef194b602b9fe83" style="color:#58a6ff">c0dd2fd</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T10:56:27+00:00" class="gen-time" title="2026-04-09 10:56 UTC">2026-04-09 10:56 UTC</time> · <a href="https://github.com/schacon/grit/commit/da46a675dac4f9bacc5133b3eab91b4eec43a816" style="color:#58a6ff">da46a67</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">41,278</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">34,603</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">83.8%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">34,816</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">84.3%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -8917,14 +8917,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="236" data-passed="23">
+<tr class="" data-group="t5" data-tests="236" data-passed="236" data-full-pass="1">
   <td class="mono">t5310-pack-bitmaps</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">236</td>
-  <td class="right">23</td>
+  <td class="right">236</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:9.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="6" data-passed="6" data-full-pass="1">

--- a/logs/2026-04-09-t5310-pack-bitmaps-complete.md
+++ b/logs/2026-04-09-t5310-pack-bitmaps-complete.md
@@ -1,0 +1,11 @@
+# t5310-pack-bitmaps — verified full pass
+
+## Session
+
+- Ran `./scripts/run-tests.sh --timeout 900 t5310-pack-bitmaps.sh`: **236/236** pass.
+- `cargo test -p grit-lib --lib`: pass (147 tests).
+- Refreshed `data/test-files.csv` and dashboards via harness; updated `PLAN.md` / `progress.md` to mark task complete.
+
+## Note
+
+Implementation was already on branch `cursor/t5310-pack-bitmaps-tests-6c57`; this commit records harness/dashboard + plan state after verification.

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   294 |
-| In progress |     4 |
-| Remaining   |   471 |
+| Completed   |   295 |
+| In progress |     3 |
+| Remaining   |   470 |
 | **Total**   |   769 |
 
-Task lines in `PLAN.md`: 294 completed (`[x]`), 4 in progress (`[~]`), 471 remaining (`[ ]`).
+Task lines in `PLAN.md`: 295 completed (`[x]`), 3 in progress (`[~]`), 470 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t5310-pack-bitmaps` — 236/236 tests pass (pack bitmaps, repack, pack-objects bitmap paths, `rev-list --test-bitmap`, name-hash stability; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t7011-skip-worktree-reading` — 15/15 tests pass (`update-index` skip-worktree no-op / `--remove` clears entry; `--remove` on missing untracked path is silent; `reset` preserves skip-worktree; `diff-index` skips worktree for skip-worktree; `commit` pathspec rejects skip-worktree)
 - `t3303-notes-subtrees` — 23/23 tests pass (`fast-import`: `data <<TERM` heredoc, `M … inline` blobs, `deleteall`; `log` notes map: concatenate duplicate commit paths like Git’s `combine_notes_concatenate`, skip identical blob payloads)
 - `t5323-pack-redundant` — 18/18 tests pass (`pack-redundant`: Git `minimize` algorithm, `--i-still-use-this` / stdin ignore / verbose + alt-odb; `clone --mirror` implies bare layout; `fsck` resolves relative `objects/info/alternates` against `objects/`)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t5310-pack-bitmaps.sh` passes **236/236** tests on the harness (`./scripts/run-tests.sh --timeout 900 t5310-pack-bitmaps.sh`). This change records that state: refreshed `data/test-files.csv` and generated dashboards, and marked the task complete in `PLAN.md` / `progress.md`.

## Validation

- `./scripts/run-tests.sh --timeout 900 t5310-pack-bitmaps.sh`
- `cargo test -p grit-lib --lib`

## Notes

Bitmap/pack behavior is already implemented on this branch; this commit is documentation and harness metadata after verification.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d5b0996d-b4f0-4390-a31c-bdf64ea8abcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d5b0996d-b4f0-4390-a31c-bdf64ea8abcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

