### PR TITLE
Verify t2002-checkout-cache-u (checkout-index -u)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -186,6 +186,7 @@ commit → check it off → move on.
 - [x] `t2018-checkout-branch` ████████████████████ 25/25 (0 left) — checkout
 - [x] `t2006-checkout-index-basic` ████████████████████ 9/9 (0 left) — basic checkout-index tests
 - [x] `t2030-checkout-index-basic` ████████████████████ 27/27 (0 left) — checkout-index --all/--force/--prefix/--temp/--stdin
+- [x] `t2002-checkout-cache-u` ████████████████████ 3/3 (0 left) — checkout-index -u refreshes cached stat after checkout
 
 - [x] `t2019-checkout-ambiguous-ref` ████████████████████ 9/9 (0 left) — checkout handling of ambiguous (branch/tag) refs
 - [ ] `t2206-add-submodule-ignored` ██████████░░░░░░░░░░ 4/8 (4 left) — git add respects submodule ignore=all and explicit pathspec

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -460,7 +460,7 @@ t1800-ls-remote	t1	yes	24	22	2	false	ok	0
 t1900-repo-info	t1	yes	37	37	0	true	ok	0
 t1901-repo-structure	t1	yes	4	4	0	true	ok	0
 t2000-conflict-when-checking-files-out	t2	yes	14	13	1	false	ok	0
-t2002-checkout-cache-u	t2	yes	3	2	1	false	ok	0
+t2002-checkout-cache-u	t2	yes	3	3	0	true	ok	0
 t2003-checkout-cache-mkdir	t2	yes	10	10	0	true	ok	0
 t2004-checkout-cache-temp	t2	yes	23	23	0	true	ok	0
 t2005-checkout-index-symlinks	t2	yes	3	3	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T10:42:30+00:00" class="gen-time" title="2026-04-09 10:42 UTC">2026-04-09 10:42 UTC</time> · <a href="https://github.com/schacon/grit/commit/c0dd2fd56c0ca810cdf1d09d8ef194b602b9fe83" style="color:#58a6ff">c0dd2fd</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T10:55:54+00:00" class="gen-time" title="2026-04-09 10:55 UTC">2026-04-09 10:55 UTC</time> · <a href="https://github.com/schacon/grit/commit/da46a675dac4f9bacc5133b3eab91b4eec43a816" style="color:#58a6ff">da46a67</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">34,603</div>
+      <div class="summary-big-val">34,604</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>888 files fully passing</span>
+    <span>889 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -201,11 +201,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t2</span>
         <span class="group-desc">Basic commands concerning the working tree</span>
-        <span class="group-meta">34/61 files · 9 skipped · 644/872 tests</span>
+        <span class="group-meta">35/61 files · 9 skipped · 645/872 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:73.9%"></div></div>
-        <span class="group-pct pct-blue">73.9%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:74.0%"></div></div>
+        <span class="group-pct pct-blue">74.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t3">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T10:42:30+00:00" class="gen-time" title="2026-04-09 10:42 UTC">2026-04-09 10:42 UTC</time> · <a href="https://github.com/schacon/grit/commit/c0dd2fd56c0ca810cdf1d09d8ef194b602b9fe83" style="color:#58a6ff">c0dd2fd</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T10:55:54+00:00" class="gen-time" title="2026-04-09 10:55 UTC">2026-04-09 10:55 UTC</time> · <a href="https://github.com/schacon/grit/commit/da46a675dac4f9bacc5133b3eab91b4eec43a816" style="color:#58a6ff">da46a67</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">41,278</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">34,603</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">34,604</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">83.8%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -4757,14 +4757,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:92.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t2" data-tests="3" data-passed="2">
+<tr class="" data-group="t2" data-tests="3" data-passed="3" data-full-pass="1">
   <td class="mono">t2002-checkout-cache-u</td>
   <td>t2</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">3</td>
-  <td class="right">2</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:66.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t2" data-tests="10" data-passed="10" data-full-pass="1">

--- a/grit/src/commands/gc.rs
+++ b/grit/src/commands/gc.rs
@@ -148,7 +148,12 @@ pub fn run(args: Args) -> Result<()> {
     if !args.no_prune {
         if let Some(expire) = gc_prune_expire_cli(&args, &cfg) {
             if quiet_effective {
-                trace_run_command_git_invocation(&["prune", "--expire", expire.as_str(), "--no-progress"]);
+                trace_run_command_git_invocation(&[
+                    "prune",
+                    "--expire",
+                    expire.as_str(),
+                    "--no-progress",
+                ]);
             } else {
                 trace_run_command_git_invocation(&["prune", "--expire", expire.as_str()]);
             }

--- a/logs/2026-04-09_t2002-checkout-cache-u.md
+++ b/logs/2026-04-09_t2002-checkout-cache-u.md
@@ -1,0 +1,5 @@
+# t2002-checkout-cache-u
+
+- Fast-forwarded branch to `origin/main` (da46a675).
+- `./scripts/run-tests.sh t2002-checkout-cache-u.sh`: **3/3** passing.
+- No Rust changes required: `grit checkout-index -u` already updates cached stat fields after checkout (`checkout_index.rs`: `args.update_stat` → `refresh_stat_for_entry`).

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   294 |
+| Completed   |   295 |
 | In progress |     4 |
-| Remaining   |   471 |
+| Remaining   |   470 |
 | **Total**   |   769 |
 
-Task lines in `PLAN.md`: 294 completed (`[x]`), 4 in progress (`[~]`), 471 remaining (`[ ]`).
+Task lines in `PLAN.md`: 295 completed (`[x]`), 4 in progress (`[~]`), 470 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t2002-checkout-cache-u` — 3/3 tests pass (`checkout-index -u` updates index stat from working tree after checkout; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t7011-skip-worktree-reading` — 15/15 tests pass (`update-index` skip-worktree no-op / `--remove` clears entry; `--remove` on missing untracked path is silent; `reset` preserves skip-worktree; `diff-index` skips worktree for skip-worktree; `commit` pathspec rejects skip-worktree)
 - `t3303-notes-subtrees` — 23/23 tests pass (`fast-import`: `data <<TERM` heredoc, `M … inline` blobs, `deleteall`; `log` notes map: concatenate duplicate commit paths like Git’s `combine_notes_concatenate`, skip identical blob payloads)
 - `t5323-pack-redundant` — 18/18 tests pass (`pack-redundant`: Git `minimize` algorithm, `--i-still-use-this` / stdin ignore / verbose + alt-odb; `clone --mirror` implies bare layout; `fsck` resolves relative `objects/info/alternates` against `objects/`)

--- a/test-results.md
+++ b/test-results.md
@@ -2,6 +2,7 @@
 
 **Updated:** 2026-04-09
 
+- `./scripts/run-tests.sh t2002-checkout-cache-u.sh`: 3/3 passing (`checkout-index -u` stat refresh; harness CSV/dashboards refreshed).
 - `./scripts/run-tests.sh t3303-notes-subtrees.sh`: 23/23 passing (`fast-import` heredoc `data`, `M … inline`, `deleteall`; `log` notes map merges duplicate paths like Git).
 - `./scripts/run-tests.sh t0040-parse-options.sh`: 94/94 passing (`test-tool parse-options*` / `parse-subcommand`: intermingled argv + NODASH `+`, selective usage append, negated-option error names, I/O flush before exit, nested `--git-completion-helper`; harness `test_run_` no longer uses `$(printf ...)` around bodies with backticks).
 - `./scripts/run-tests.sh t9003-help-autocorrect.sh`: 10/10 passing (`help.autocorrect` + unknown-command flow aligned with Git; harness CSV/dashboards refreshed).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t2002-checkout-cache-u` already passes against current `main` (3/3). `grit checkout-index -u` refreshes cached stat data after checkout via `refresh_stat_for_entry` in `grit/src/commands/checkout_index.rs`.

## Changes

- Fast-forwarded this branch to `origin/main` and re-ran `./scripts/run-tests.sh t2002-checkout-cache-u.sh` (3/3).
- Updated `data/test-files.csv`, dashboards, `PLAN.md`, `progress.md`, `test-results.md`, and added `logs/2026-04-09_t2002-checkout-cache-u.md`.
- Small `rustfmt` wrap in `grit/src/commands/gc.rs` so `cargo fmt --check` is clean on this branch.

## Testing

- `./scripts/run-tests.sh t2002-checkout-cache-u.sh`
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04c127ca-7dd7-41f6-8024-3bd1ccab03af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04c127ca-7dd7-41f6-8024-3bd1ccab03af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

