### PR TITLE
fix(test): make t9832-unshelve exercise Grit via git wrapper

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1585,7 +1585,7 @@ t9829-git-p4-jobs	t9	skip	8	0	0	false	ok	0
 t9830-diff-stat-binary	t9	yes	38	38	0	true	ok	0
 t9830-git-p4-symlink-dir	t9	skip	2	0	0	false	ok	0
 t9831-git-p4-triggers	t9	skip	5	0	0	false	ok	0
-t9832-unshelve	t9	yes	0	0	0	false	ok	0
+t9832-unshelve	t9	yes	8	8	0	true	ok	0
 t9833-errors	t9	yes	0	0	0	false	ok	0
 t9834-git-p4-file-dir-bug	t9	skip	5	0	0	false	ok	0
 t9835-git-p4-metadata-encoding-python2	t9	skip	12	0	0	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T10:42:30+00:00" class="gen-time" title="2026-04-09 10:42 UTC">2026-04-09 10:42 UTC</time> · <a href="https://github.com/schacon/grit/commit/c0dd2fd56c0ca810cdf1d09d8ef194b602b9fe83" style="color:#58a6ff">c0dd2fd</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T11:01:35+00:00" class="gen-time" title="2026-04-09 11:01 UTC">2026-04-09 11:01 UTC</time> · <a href="https://github.com/schacon/grit/commit/da46a675dac4f9bacc5133b3eab91b4eec43a816" style="color:#58a6ff">da46a67</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,11 +150,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">34,603</div>
+      <div class="summary-big-val">34,611</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">41,278</div>
+      <div class="summary-big-val">41,286</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>888 files fully passing</span>
+    <span>889 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -278,7 +278,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t9</span>
         <span class="group-desc">Git tools</span>
-        <span class="group-meta">79/90 files · 127 skipped · 2,849/2,860 tests</span>
+        <span class="group-meta">80/90 files · 127 skipped · 2,857/2,868 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-green" style="width:99.6%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T10:42:30+00:00" class="gen-time" title="2026-04-09 10:42 UTC">2026-04-09 10:42 UTC</time> · <a href="https://github.com/schacon/grit/commit/c0dd2fd56c0ca810cdf1d09d8ef194b602b9fe83" style="color:#58a6ff">c0dd2fd</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T11:01:35+00:00" class="gen-time" title="2026-04-09 11:01 UTC">2026-04-09 11:01 UTC</time> · <a href="https://github.com/schacon/grit/commit/da46a675dac4f9bacc5133b3eab91b4eec43a816" style="color:#58a6ff">da46a67</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">41,278</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">34,603</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n" id="sum-tests">41,286</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">34,611</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">83.8%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -16007,14 +16007,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t9" data-tests="0" data-passed="0">
+<tr class="" data-group="t9" data-tests="8" data-passed="8" data-full-pass="1">
   <td class="mono">t9832-unshelve</td>
   <td>t9</td>
-  <td></td>
-  <td class="right">0</td>
-  <td class="right">0</td>
+  <td><span class="badge ok">full pass</span></td>
+  <td class="right">8</td>
+  <td class="right">8</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t9" data-tests="0" data-passed="0">

--- a/logs/2026-04-09-t9832-unshelve.md
+++ b/logs/2026-04-09-t9832-unshelve.md
@@ -1,0 +1,19 @@
+# t9832-unshelve
+
+## Issue
+
+`tests/t9832-unshelve.sh` exercised `git p4` via upstream `git/git-p4.py`, but the harness `git` wrapper delegated to `/usr/bin/git`, so Grit was never involved. `lib-git-p4.sh` also required a `PYTHON` prerequisite that the Gust `test-lib.sh` never set, so the file skipped entirely when `python3` existed but `PYTHON` was unset.
+
+## Fix
+
+- Set `PYTHON` when `NO_PYTHON` is unset and `python3` is on `PATH` (aligned with `git/t/test-lib.sh`).
+- Point the `git` / `grit` wrappers in `setup_trash` at `GUST_BIN` so subprocesses invoked as `git` run Grit.
+- Export `PYTHON_PATH` defaulting to `python3` for scripts that invoke `$PYTHON_PATH`.
+
+## Verification
+
+`PATH` must include Perforce `p4` and `p4d` (not bundled in the image). With binaries on `PATH`:
+
+`./scripts/run-tests.sh t9832-unshelve.sh` → 8/8 pass.
+
+Sanity: `./scripts/run-tests.sh t0000-basic.sh` → 92/92 pass.

--- a/tests/test-lib.sh
+++ b/tests/test-lib.sh
@@ -145,16 +145,16 @@ setup_trash () {
 	mkdir -p "$TRASH_DIRECTORY"
 	# BIN_DIRECTORY is outside the working tree so git clean -x cannot remove it
 	mkdir -p "$BIN_DIRECTORY"
-	# Write a 'git' wrapper script that calls grit
+	# Write a 'git' wrapper script that calls grit (GUST_BIN)
 	cat >"$BIN_DIRECTORY/git" <<EOF
 #!/bin/sh
-exec /usr/bin/git "\$@"
+exec "$GUST_BIN" "\$@"
 EOF
 	chmod +x "$BIN_DIRECTORY/git"
 	# Also write a 'grit' wrapper
 	cat >"$BIN_DIRECTORY/grit" <<EOF
 #!/bin/sh
-exec /usr/bin/git "\$@"
+exec "$GUST_BIN" "\$@"
 EOF
 	chmod +x "$BIN_DIRECTORY/grit"
 	# Write a 'test-tool' wrapper for shell tests invoking it directly
@@ -953,6 +953,9 @@ test_set_prereq () {
 # Grit implements the traditional loose-ref + packed-refs layout (not reftable).
 test_set_prereq REFFILES
 
+# git-p4 and other Python-assisted tests (matches git/t/test-lib.sh: NO_PYTHON).
+test -z "$NO_PYTHON" && command -v python3 >/dev/null 2>&1 && test_set_prereq PYTHON
+
 # Lazy prerequisites (git/t0000 nested-lazy): script runs in a temp dir under trash.
 lazily_testable_prereq=
 lazily_tested_prereq=
@@ -982,6 +985,9 @@ export TAR
 
 PERL_PATH=${PERL_PATH:-$(command -v perl 2>/dev/null || echo /usr/bin/perl)}
 export PERL_PATH
+
+PYTHON_PATH=${PYTHON_PATH:-$(command -v python3 2>/dev/null || echo python3)}
+export PYTHON_PATH
 
 # test_set_port VAR — assign a random port (or use existing value)
 test_set_port () {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t9832-unshelve` runs `git p4` (upstream `git/git-p4.py`). The harness previously pointed the `git` wrapper at `/usr/bin/git`, so the suite never touched Grit. `lib-git-p4.sh` also required a `PYTHON` prerequisite that Gust `test-lib.sh` never set, so the file could skip even when `python3` was available.

## Changes

- Set the `PYTHON` prerequisite when `NO_PYTHON` is unset and `python3` exists (same idea as upstream `git/t/test-lib.sh`).
- Wire `setup_trash` `git` / `grit` wrappers to `GUST_BIN` so `git p4` subprocesses run through grit.
- Export `PYTHON_PATH` (default `python3`) for scripts that call `$PYTHON_PATH`.
- Refreshed harness CSV/dashboards from `./scripts/run-tests.sh t9832-unshelve.sh`.

## Testing

- `./scripts/run-tests.sh t9832-unshelve.sh` — **8/8** (requires `p4` and `p4d` on `PATH`; Perforce Helix binaries from their distribution).
- `./scripts/run-tests.sh t0000-basic.sh` — **92/92** sanity check.

## Note

CI/agents must install Perforce client + server binaries if these tests should run; without them, `lib-git-p4.sh` still skips the whole file as before.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6665c91e-a32e-40ab-b88d-f62f903dde1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6665c91e-a32e-40ab-b88d-f62f903dde1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

