### PR TITLE
fix: make t9833-errors pass (git-p4 + Perforce CLI)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ tests/expect
 tests/trash/
 scripts/subscripts/__pycache__
 tests/grit
+tests/bin.p4/
 tests/bin.*/
 tests/*.patch
 tests/before

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1586,7 +1586,7 @@ t9830-diff-stat-binary	t9	yes	38	38	0	true	ok	0
 t9830-git-p4-symlink-dir	t9	skip	2	0	0	false	ok	0
 t9831-git-p4-triggers	t9	skip	5	0	0	false	ok	0
 t9832-unshelve	t9	yes	0	0	0	false	ok	0
-t9833-errors	t9	yes	0	0	0	false	ok	0
+t9833-errors	t9	yes	4	4	0	true	ok	0
 t9834-git-p4-file-dir-bug	t9	skip	5	0	0	false	ok	0
 t9835-git-p4-metadata-encoding-python2	t9	skip	12	0	0	false	ok	0
 t9836-git-p4-metadata-encoding-python3	t9	skip	12	0	0	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T10:42:30+00:00" class="gen-time" title="2026-04-09 10:42 UTC">2026-04-09 10:42 UTC</time> · <a href="https://github.com/schacon/grit/commit/c0dd2fd56c0ca810cdf1d09d8ef194b602b9fe83" style="color:#58a6ff">c0dd2fd</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T11:08:01+00:00" class="gen-time" title="2026-04-09 11:08 UTC">2026-04-09 11:08 UTC</time> · <a href="https://github.com/schacon/grit/commit/da46a675dac4f9bacc5133b3eab91b4eec43a816" style="color:#58a6ff">da46a67</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,11 +150,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">34,603</div>
+      <div class="summary-big-val">34,607</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">41,278</div>
+      <div class="summary-big-val">41,282</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>888 files fully passing</span>
+    <span>889 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -278,7 +278,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t9</span>
         <span class="group-desc">Git tools</span>
-        <span class="group-meta">79/90 files · 127 skipped · 2,849/2,860 tests</span>
+        <span class="group-meta">80/90 files · 127 skipped · 2,853/2,864 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-green" style="width:99.6%"></div></div>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T10:42:30+00:00" class="gen-time" title="2026-04-09 10:42 UTC">2026-04-09 10:42 UTC</time> · <a href="https://github.com/schacon/grit/commit/c0dd2fd56c0ca810cdf1d09d8ef194b602b9fe83" style="color:#58a6ff">c0dd2fd</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T11:08:01+00:00" class="gen-time" title="2026-04-09 11:08 UTC">2026-04-09 11:08 UTC</time> · <a href="https://github.com/schacon/grit/commit/da46a675dac4f9bacc5133b3eab91b4eec43a816" style="color:#58a6ff">da46a67</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">41,278</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">34,603</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n" id="sum-tests">41,282</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">34,607</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">83.8%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -16017,14 +16017,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t9" data-tests="0" data-passed="0">
+<tr class="" data-group="t9" data-tests="4" data-passed="4" data-full-pass="1">
   <td class="mono">t9833-errors</td>
   <td>t9</td>
-  <td></td>
-  <td class="right">0</td>
-  <td class="right">0</td>
+  <td><span class="badge ok">full pass</span></td>
+  <td class="right">4</td>
+  <td class="right">4</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="row-skip" data-group="t9" data-tests="5" data-passed="0">

--- a/logs/2026-04-09_t9833-errors.md
+++ b/logs/2026-04-09_t9833-errors.md
@@ -1,0 +1,16 @@
+# t9833-errors
+
+## Problem
+
+`./scripts/run-tests.sh t9833-errors.sh` reported 0/0 tests: `lib-git-p4.sh` skipped because the harness never set the `PYTHON` prereq, and `p4`/`p4d` were not installed. `git p4` also had no `git-p4` helper on the harness `PATH`.
+
+## Changes
+
+- Added `tests/git-p4` shell wrapper that runs `git/git-p4.py` with `PYTHON_PATH` or `python3`.
+- `scripts/run-tests.sh`: download Perforce `p4`/`p4d` into `tests/bin.p4/` when missing (same URL as upstream CI), prepend to `PATH`.
+- `tests/lib-git-p4.sh`: require `python3` on PATH and set `PYTHON_PATH` instead of `test_have_prereq PYTHON`.
+- `.gitignore`: `tests/bin.p4/`.
+
+## Verification
+
+`./scripts/run-tests.sh t9833-errors.sh` → 4/4 pass.

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -73,6 +73,33 @@ rm -f "$TESTS_DIR/grit"
 cp "$BIN" "$TESTS_DIR/grit"
 chmod +x "$TESTS_DIR/grit"
 
+# Perforce p4/p4d for git-p4 tests (t9833, t9834, …). Prefer system install;
+# otherwise download Helix CLI binaries into tests/bin.p4/ (gitignored).
+P4_BIN_DIR="$TESTS_DIR/bin.p4"
+P4_URL_BASE="https://cdist2.perforce.com/perforce/r23.2/bin.linux26x86_64"
+ensure_p4_tools() {
+    if command -v p4 >/dev/null 2>&1 && command -v p4d >/dev/null 2>&1
+    then
+        return 0
+    fi
+    mkdir -p "$P4_BIN_DIR"
+    if [[ ! -x "$P4_BIN_DIR/p4" || ! -x "$P4_BIN_DIR/p4d" ]]
+    then
+        if command -v wget >/dev/null 2>&1
+        then
+            wget -q -O "$P4_BIN_DIR/p4" "$P4_URL_BASE/p4" &&
+                chmod a+x "$P4_BIN_DIR/p4" || rm -f "$P4_BIN_DIR/p4"
+            wget -q -O "$P4_BIN_DIR/p4d" "$P4_URL_BASE/p4d" &&
+                chmod a+x "$P4_BIN_DIR/p4d" || rm -f "$P4_BIN_DIR/p4d"
+        fi
+    fi
+    if [[ -x "$P4_BIN_DIR/p4" && -x "$P4_BIN_DIR/p4d" ]]
+    then
+        export PATH="$P4_BIN_DIR:$PATH"
+    fi
+}
+ensure_p4_tools
+
 mkdir -p "$DATA_DIR"
 python3 "$CATALOG"
 

--- a/tests/git-p4
+++ b/tests/git-p4
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Runs upstream git-p4.py with Python 3. Grit dispatches unknown `git p4` to
+# `git-p4` on PATH (see grit `find_git_external_helper`). `GIT_SOURCE_DIR` is
+# set by scripts/run-tests.sh to the repo's `git/` tree.
+set -e
+repo_git="${GIT_SOURCE_DIR:-}"
+if test -z "$repo_git"
+then
+	here=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+	repo_git=$(CDPATH= cd -- "$here/.." && pwd)/git
+fi
+_py="${PYTHON_PATH:-python3}"
+exec "$_py" "$repo_git/git-p4.py" "$@"

--- a/tests/lib-git-p4.sh
+++ b/tests/lib-git-p4.sh
@@ -21,11 +21,15 @@ then
 	skip_all='skipping git p4 tests, NO_P4_TESTS defined'
 	test_done
 fi
-if ! test_have_prereq PYTHON
+# Upstream uses the PYTHON lazy prereq from git/t/test-lib.sh; our harness does
+# not set it. Require python3 explicitly for git-p4.py.
+if ! command -v python3 >/dev/null 2>&1
 then
-	skip_all='skipping git p4 tests; python not available'
+	skip_all='skipping git p4 tests; python3 not available'
 	test_done
 fi
+PYTHON_PATH=$(command -v python3)
+export PYTHON_PATH
 ( p4 -h && p4d -h ) >/dev/null 2>&1 || {
 	skip_all='skipping git p4 tests; no p4 or p4d'
 	test_done


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t9833-errors` was effectively skipped (0 tests): the harness never defined the upstream `PYTHON` prereq, `p4`/`p4d` were absent, and grit had no `git-p4` helper on the test `PATH`.

## Changes

- **`tests/git-p4`**: wrapper that runs `git/git-p4.py` with `PYTHON_PATH` or `python3` (grit resolves `git p4` via `git-p4` on `PATH`).
- **`scripts/run-tests.sh`**: if `p4`/`p4d` are missing, download Helix binaries (same base URL as upstream Git CI) into `tests/bin.p4/` and prepend to `PATH`.
- **`tests/lib-git-p4.sh`**: require `python3` and export `PYTHON_PATH` instead of `test_have_prereq PYTHON`.
- **`.gitignore`**: ignore `tests/bin.p4/`.
- Refreshed **`data/test-files.csv`** and dashboards from a passing run.

## Verification

`./scripts/run-tests.sh t9833-errors.sh` → **4/4** pass.

## Note

Workspace `cargo clippy -D warnings` currently fails with many pre-existing `grit-lib` lints; `cargo check -p grit-rs` and `cargo test -p grit-lib --lib` pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb4da809-3a19-478d-81fc-f9493c030875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb4da809-3a19-478d-81fc-f9493c030875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

