### PR TITLE
fix: t4057 combined diff paths and packed-refs listing

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -737,7 +737,7 @@ t4053-diff-no-index	t4	skip	41	0	0	false	ok	0
 t4054-diff-bogus-tree	t4	yes	14	14	0	true	ok	0
 t4055-diff-context	t4	yes	10	10	0	true	ok	0
 t4056-diff-order	t4	yes	23	10	13	false	ok	0
-t4057-diff-combined-paths	t4	yes	4	0	4	false	ok	0
+t4057-diff-combined-paths	t4	yes	4	4	0	true	ok	0
 t4058-diff-duplicates	t4	yes	16	16	0	true	ok	0
 t4059-diff-submodule-not-initialized	t4	yes	8	1	7	false	ok	0
 t4060-diff-submodule-option-diff-format	t4	yes	51	29	22	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T10:42:30+00:00" class="gen-time" title="2026-04-09 10:42 UTC">2026-04-09 10:42 UTC</time> · <a href="https://github.com/schacon/grit/commit/c0dd2fd56c0ca810cdf1d09d8ef194b602b9fe83" style="color:#58a6ff">c0dd2fd</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T11:28:07+00:00" class="gen-time" title="2026-04-09 11:28 UTC">2026-04-09 11:28 UTC</time> · <a href="https://github.com/schacon/grit/commit/da46a675dac4f9bacc5133b3eab91b4eec43a816" style="color:#58a6ff">da46a67</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -150,7 +150,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">34,603</div>
+      <div class="summary-big-val">34,607</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -164,7 +164,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,404 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>888 files fully passing</span>
+    <span>889 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -223,11 +223,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">97/178 files · 2 skipped · 2,790/3,853 tests</span>
+        <span class="group-meta">98/178 files · 2 skipped · 2,794/3,853 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.4%"></div></div>
-        <span class="group-pct pct-blue">72.4%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:72.5%"></div></div>
+        <span class="group-pct pct-blue">72.5%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T10:42:30+00:00" class="gen-time" title="2026-04-09 10:42 UTC">2026-04-09 10:42 UTC</time> · <a href="https://github.com/schacon/grit/commit/c0dd2fd56c0ca810cdf1d09d8ef194b602b9fe83" style="color:#58a6ff">c0dd2fd</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T11:28:07+00:00" class="gen-time" title="2026-04-09 11:28 UTC">2026-04-09 11:28 UTC</time> · <a href="https://github.com/schacon/grit/commit/da46a675dac4f9bacc5133b3eab91b4eec43a816" style="color:#58a6ff">da46a67</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,404</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">41,278</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">34,603</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">34,607</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">83.8%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -7527,14 +7527,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:43.5%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="4" data-passed="0">
+<tr class="" data-group="t4" data-tests="4" data-passed="4" data-full-pass="1">
   <td class="mono">t4057-diff-combined-paths</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">4</td>
-  <td class="right">0</td>
+  <td class="right">4</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="16" data-passed="16" data-full-pass="1">

--- a/grit-lib/src/refs.rs
+++ b/grit-lib/src/refs.rs
@@ -13,6 +13,7 @@
 //! When `extensions.refStorage = reftable`, the reftable backend is used
 //! instead.  The public API is the same; dispatch is handled internally.
 
+use std::collections::HashMap;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -719,23 +720,24 @@ pub fn list_refs(git_dir: &Path, prefix: &str) -> Result<Vec<(String, ObjectId)>
     if crate::reftable::is_reftable_repo(git_dir) {
         return crate::reftable::reftable_list_refs(git_dir, prefix);
     }
-    let mut results = Vec::new();
-    let base = git_dir.join(prefix);
-    collect_refs(&base, prefix, git_dir, &mut results)?;
-    collect_packed_refs(git_dir, prefix, &mut results)?;
+    // Merge packed + loose so **loose always wins** for the same ref name (matches Git and
+    // `resolve_ref`). Previously we concatenated packed then loose and never deduplicated the
+    // main git dir case, so `pack-refs` could leave stale packed lines that shadowed updates.
+    let mut by_name: HashMap<String, ObjectId> = HashMap::new();
 
-    // For worktrees, also collect refs from the common dir
     if let Some(cdir) = common_dir(git_dir) {
         if cdir != git_dir {
+            collect_packed_refs_into_map(&cdir, prefix, &mut by_name)?;
             let cbase = cdir.join(prefix);
-            collect_refs(&cbase, prefix, &cdir, &mut results)?;
-            collect_packed_refs(&cdir, prefix, &mut results)?;
-            // Deduplicate: worktree-local refs take priority
-            results.sort_by(|a, b| a.0.cmp(&b.0));
-            results.dedup_by(|b, a| a.0 == b.0);
+            collect_loose_refs_into_map(&cbase, prefix, &cdir, &mut by_name)?;
         }
     }
 
+    collect_packed_refs_into_map(git_dir, prefix, &mut by_name)?;
+    let base = git_dir.join(prefix);
+    collect_loose_refs_into_map(&base, prefix, git_dir, &mut by_name)?;
+
+    let mut results: Vec<(String, ObjectId)> = by_name.into_iter().collect();
     results.sort_by(|a, b| a.0.cmp(&b.0));
     Ok(results)
 }
@@ -800,11 +802,11 @@ fn glob_match(pattern: &str, text: &str) -> bool {
     pi == pat.len()
 }
 
-fn collect_refs(
+fn collect_loose_refs_into_map(
     dir: &Path,
     prefix: &str,
-    git_dir: &Path,
-    out: &mut Vec<(String, ObjectId)>,
+    resolve_git_dir: &Path,
+    out: &mut HashMap<String, ObjectId>,
 ) -> Result<()> {
     let read = match fs::read_dir(dir) {
         Ok(r) => r,
@@ -818,17 +820,16 @@ fn collect_refs(
         let name_str = name.to_string_lossy();
         let refname = format!("{prefix}{name_str}");
         let path = entry.path();
-        // Follow symlinks: loose refs may be symlinks; `DirEntry::file_type` does not.
         let meta = match fs::metadata(&path) {
             Ok(m) => m,
             Err(_) => continue,
         };
 
         if meta.is_dir() {
-            collect_refs(&path, &format!("{refname}/"), git_dir, out)?;
+            collect_loose_refs_into_map(&path, &format!("{refname}/"), resolve_git_dir, out)?;
         } else if meta.is_file() {
-            if let Ok(oid) = resolve_ref(git_dir, &refname) {
-                out.push((refname, oid))
+            if let Ok(oid) = resolve_ref(resolve_git_dir, &refname) {
+                out.insert(refname, oid);
             }
         }
     }
@@ -867,10 +868,10 @@ pub fn resolve_at_n_branch(git_dir: &Path, spec: &str) -> Result<String> {
     )))
 }
 
-fn collect_packed_refs(
+fn collect_packed_refs_into_map(
     git_dir: &Path,
     prefix: &str,
-    out: &mut Vec<(String, ObjectId)>,
+    out: &mut HashMap<String, ObjectId>,
 ) -> Result<()> {
     let packed_path = git_dir.join("packed-refs");
     let content = match fs::read_to_string(&packed_path) {
@@ -890,7 +891,7 @@ fn collect_packed_refs(
             continue;
         }
         let oid: ObjectId = hash.parse()?;
-        out.push((refname.to_string(), oid));
+        out.insert(refname.to_string(), oid);
     }
     Ok(())
 }

--- a/grit/src/commands/diff.rs
+++ b/grit/src/commands/diff.rs
@@ -31,8 +31,8 @@ use grit_lib::diffstat::{terminal_columns, write_diffstat_block, DiffstatOptions
 use grit_lib::error::Error;
 use grit_lib::index::Index;
 use grit_lib::merge_diff::{
-    blob_text_for_diff_with_oid, diff_textconv_active, format_worktree_conflict_combined,
-    run_textconv,
+    blob_text_for_diff_with_oid, combined_diff_paths, diff_textconv_active,
+    format_worktree_conflict_combined, run_textconv,
 };
 use grit_lib::objects::{parse_commit, ObjectId, ObjectKind};
 use grit_lib::odb::Odb;
@@ -1134,6 +1134,7 @@ pub fn run(mut args: Args) -> Result<()> {
     // Expand A..B → A B (two-rev diff)
     // trailing_var_arg may capture flags like --name-only into args.
     // Move them back into the flags struct so they take effect.
+    let mut want_combined_diff = false;
     let mut extra_revs = Vec::new();
     let mut rev_idx = 0;
     while rev_idx < revs.len() {
@@ -1141,6 +1142,9 @@ pub fn run(mut args: Args) -> Result<()> {
         if r.starts_with("--") || r.starts_with("-") && r.len() > 1 {
             // Re-apply trailing flags
             match r.as_str() {
+                "-c" => {
+                    want_combined_diff = true;
+                }
                 "--name-only" => args.name_only = true,
                 "--name-status" => args.name_status = true,
                 "--numstat" => args.numstat = true,
@@ -1285,8 +1289,12 @@ pub fn run(mut args: Args) -> Result<()> {
                         args.find_renames = Some("50".to_owned());
                     }
                 }
-                s if s == "-C" || s == "-CC" || s.starts_with("--find-copies") => {
+                // `-CC` is copy detection; combined diff is spelled `--cc` only (Git).
+                s if s == "-C" || s.starts_with("--find-copies") => {
                     args.find_copies = Some("50".to_owned());
+                }
+                "--cc" => {
+                    want_combined_diff = true;
                 }
                 "--find-copies-harder" => {
                     args.find_copies_harder = true;
@@ -1402,40 +1410,84 @@ pub fn run(mut args: Args) -> Result<()> {
         (false, 0) => work_tree, // unstaged: index vs worktree
         (false, 1) => work_tree, // one rev: tree vs worktree
         (_, 2) => None,          // two revs: tree vs tree
+        (_, 3) if want_combined_diff && args.name_only && !args.cached => None,
         _ => None,
     };
 
-    let entries: Vec<DiffEntry> = match (args.cached, revs.len()) {
-        (true, 0) => {
-            // --cached with no revision: index vs HEAD
-            diff_index_to_tree(&repo.odb, &index, head_tree.as_ref())?
+    let entries: Vec<DiffEntry> = if want_combined_diff
+        && revs.len() == 3
+        && args.name_only
+        && !args.cached
+    {
+        let merge_oid = resolve_revision(&repo, &revs[0])
+            .with_context(|| format!("unknown revision: '{}'", revs[0]))?;
+        let p_a = resolve_revision(&repo, &revs[1])
+            .with_context(|| format!("unknown revision: '{}'", revs[1]))?;
+        let p_b = resolve_revision(&repo, &revs[2])
+            .with_context(|| format!("unknown revision: '{}'", revs[2]))?;
+        let merge_obj = repo
+            .odb
+            .read(&merge_oid)
+            .with_context(|| format!("reading object {merge_oid}"))?;
+        if merge_obj.kind != ObjectKind::Commit {
+            bail!("combined diff requires a merge commit");
         }
-        (true, 1) => {
-            // --cached with one revision: index vs that commit's tree
-            let tree_oid = commit_or_tree_oid(&repo, &revs[0])?;
-            diff_index_to_tree(&repo.odb, &index, Some(&tree_oid))?
+        let merge_commit = parse_commit(&merge_obj.data).context("parsing merge commit")?;
+        if merge_commit.parents.len() != 2 {
+            bail!("combined diff requires a merge commit with exactly two parents");
         }
-        (false, 0) => {
-            // No flags: unstaged changes (index vs worktree)
-            let wt = work_tree
-                .ok_or_else(|| anyhow::anyhow!("this operation must be run in a work tree"))?;
-            diff_index_to_worktree(&repo.odb, &index, wt)?
+        let parents_ok = merge_commit.parents == [p_a, p_b] || merge_commit.parents == [p_b, p_a];
+        if !parents_ok {
+            bail!("combined diff: revisions do not match merge parents");
         }
-        (false, 1) => {
-            // One revision: tree vs worktree
-            let tree_oid = commit_or_tree_oid(&repo, &revs[0])?;
-            let wt = work_tree
-                .ok_or_else(|| anyhow::anyhow!("this operation must be run in a work tree"))?;
-            diff_tree_to_worktree(&repo.odb, Some(&tree_oid), wt, &index)?
-        }
-        (_, 2) => {
-            // Two revisions: tree-to-tree diff
-            let tree1 = commit_or_tree_oid(&repo, &revs[0])?;
-            let tree2 = commit_or_tree_oid(&repo, &revs[1])?;
-            diff_trees(&repo.odb, Some(&tree1), Some(&tree2), "")?
-        }
-        _ => {
-            bail!("too many revisions");
+        let names = combined_diff_paths(&repo.odb, &merge_commit.tree, &[p_a, p_b]);
+        let z = zero_oid();
+        names
+            .into_iter()
+            .map(|p| DiffEntry {
+                status: DiffStatus::Modified,
+                old_path: Some(p.clone()),
+                new_path: Some(p),
+                old_mode: "100644".to_string(),
+                new_mode: "100644".to_string(),
+                old_oid: z,
+                new_oid: z,
+                score: None,
+            })
+            .collect()
+    } else {
+        match (args.cached, revs.len()) {
+            (true, 0) => {
+                // --cached with no revision: index vs HEAD
+                diff_index_to_tree(&repo.odb, &index, head_tree.as_ref())?
+            }
+            (true, 1) => {
+                // --cached with one revision: index vs that commit's tree
+                let tree_oid = commit_or_tree_oid(&repo, &revs[0])?;
+                diff_index_to_tree(&repo.odb, &index, Some(&tree_oid))?
+            }
+            (false, 0) => {
+                // No flags: unstaged changes (index vs worktree)
+                let wt = work_tree
+                    .ok_or_else(|| anyhow::anyhow!("this operation must be run in a work tree"))?;
+                diff_index_to_worktree(&repo.odb, &index, wt)?
+            }
+            (false, 1) => {
+                // One revision: tree vs worktree
+                let tree_oid = commit_or_tree_oid(&repo, &revs[0])?;
+                let wt = work_tree
+                    .ok_or_else(|| anyhow::anyhow!("this operation must be run in a work tree"))?;
+                diff_tree_to_worktree(&repo.odb, Some(&tree_oid), wt, &index)?
+            }
+            (_, 2) => {
+                // Two revisions: tree-to-tree diff
+                let tree1 = commit_or_tree_oid(&repo, &revs[0])?;
+                let tree2 = commit_or_tree_oid(&repo, &revs[1])?;
+                diff_trees(&repo.odb, Some(&tree1), Some(&tree2), "")?
+            }
+            _ => {
+                bail!("too many revisions");
+            }
         }
     };
 

--- a/grit/src/commands/gc.rs
+++ b/grit/src/commands/gc.rs
@@ -140,6 +140,7 @@ pub fn run(args: Args) -> Result<()> {
             all: true,
             prune: true,
             no_prune: false,
+            auto: false,
         })?;
     }
 
@@ -148,7 +149,12 @@ pub fn run(args: Args) -> Result<()> {
     if !args.no_prune {
         if let Some(expire) = gc_prune_expire_cli(&args, &cfg) {
             if quiet_effective {
-                trace_run_command_git_invocation(&["prune", "--expire", expire.as_str(), "--no-progress"]);
+                trace_run_command_git_invocation(&[
+                    "prune",
+                    "--expire",
+                    expire.as_str(),
+                    "--no-progress",
+                ]);
             } else {
                 trace_run_command_git_invocation(&["prune", "--expire", expire.as_str()]);
             }

--- a/grit/src/commands/pack_refs.rs
+++ b/grit/src/commands/pack_refs.rs
@@ -27,6 +27,10 @@ pub struct Args {
     /// Don't remove loose refs after packing.
     #[arg(long = "no-prune")]
     pub no_prune: bool,
+
+    /// Accepted for Git compatibility; `maintenance`/hooks may pass this. Ignored for now.
+    #[arg(long)]
+    pub auto: bool,
 }
 
 /// Run `grit pack-refs`.

--- a/grit/src/commands/refs.rs
+++ b/grit/src/commands/refs.rs
@@ -406,6 +406,7 @@ fn optimize_refs(_repo: &Repository) -> Result<()> {
         all: true,
         prune: false,
         no_prune: false,
+        auto: false,
     })
 }
 

--- a/scripts/run-upstream-tests.sh
+++ b/scripts/run-upstream-tests.sh
@@ -39,6 +39,15 @@ exec "\$GRIT" "\$@"
 WRAPPER
 chmod +x "$WORKDIR/git"
 
+# Upstream git/t/test-lib.sh prepends GIT_BUILD_DIR/bin-wrappers to PATH only when
+# bin-wrappers/git exists and is executable. Otherwise it sets with_dashes and
+# prepends GIT_BUILD_DIR to PATH — but this workdir has no top-level `git`
+# binary (only GIT-BUILD-OPTIONS), so every test sees `usage: git ...` from the
+# stub in git/t/git. Install the real wrapper as bin-wrappers/git.
+mkdir -p "$WORKDIR/bin-wrappers"
+cp "$WORKDIR/git" "$WORKDIR/bin-wrappers/git"
+chmod +x "$WORKDIR/bin-wrappers/git"
+
 # Create GIT-BUILD-OPTIONS
 cat > "$WORKDIR/GIT-BUILD-OPTIONS" <<EOF
 SHELL_PATH='/bin/sh'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Refs:** `list_refs` now merges packed and loose refs so **loose always wins** for the same name (matching `resolve_ref`). This fixes stale `packed-refs` lines shadowing branch updates after `pack-refs` prunes loose files—a regression that broke `HEAD` after `commit` when maintenance auto-packed refs, which aborted merges in `t4057`.
- **Diff:** Support `git diff -c` / `--cc` with three revisions (`HEAD`, `HEAD^`, `HEAD^2`) when combined with `--name-only`, using `combined_diff_paths` for the path intersection Git expects. `-CC` is no longer treated as copy detection (combined diff is `--cc` only).
- **pack-refs:** Accept `--auto` for compatibility (ignored for now).
- **Upstream runner:** Create `bin-wrappers/git` in the isolated workdir so `git/t/test-lib.sh` prepends a working wrapper to `PATH`.

## Validation

- `./scripts/run-tests.sh t4057-diff-combined-paths.sh` — 4/4
- `bash scripts/run-upstream-tests.sh t4057-diff-combined-paths` — 4/4
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-476f5da3-546c-4416-afec-c26c54f72126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-476f5da3-546c-4416-afec-c26c54f72126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

