### PR TITLE
fix: interactive rebase reword support (t3423-rebase-reword)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -256,7 +256,7 @@ commit → check it off → move on.
 - [x] `t3012-ls-files-dedup` ████████████████████ 3/3 (0 left) — git ls-files --deduplicate test
 - [x] `t3307-notes-man` ████████████████████ 3/3 (0 left) — Examples from the git-notes man page
 
-- [ ] `t3423-rebase-reword` ██████░░░░░░░░░░░░░░ 1/3 (2 left) — git rebase interactive with rewording
+- [x] `t3423-rebase-reword` ████████████████████ 3/3 (0 left) — git rebase interactive with rewording
 - [ ] `t3702-add-edit` ██████░░░░░░░░░░░░░░ 1/3 (2 left) — add -e basic tests
 - [ ] `t3450-history` ░░░░░░░░░░░░░░░░░░░░ 0/2 (2 left) — tests for git-history command
 - [x] `t3305-notes-fanout` ████████████████████ 7/7 (0 left) — Test that adding/removing many notes triggers automatic fanout restructuring

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -610,7 +610,7 @@ t3419-rebase-patch-id	t3	yes	8	8	0	true	ok	0
 t3420-rebase-autostash	t3	yes	54	36	18	false	ok	0
 t3421-rebase-topology-linear	t3	yes	63	39	24	false	ok	0
 t3422-rebase-incompatible-options	t3	yes	52	22	30	false	ok	0
-t3423-rebase-reword	t3	yes	3	1	2	false	ok	0
+t3423-rebase-reword	t3	yes	3	3	0	true	ok	0
 t3424-rebase-empty	t3	yes	19	2	17	false	ok	1
 t3425-rebase-topology-merges	t3	yes	13	1	12	false	ok	0
 t3426-rebase-submodule	t3	yes	29	10	19	false	ok	0
@@ -1076,7 +1076,7 @@ t6112-rev-list-filters-objects	t6	yes	54	38	16	false	ok	0
 t6113-rev-list-bitmap-filters	t6	yes	14	14	0	true	ok	0
 t6114-keep-packs	t6	yes	3	3	0	true	ok	0
 t6115-rev-list-du	t6	yes	17	17	0	true	ok	0
-t6120-describe	t6	yes	105	44	59	false	ok	0
+t6120-describe	t6	yes	103	44	59	false	ok	0
 t6120-name-rev	t6	yes	41	41	0	true	ok	0
 t6130-pathspec-noglob	t6	yes	21	8	13	false	ok	0
 t6131-pathspec-icase	t6	yes	9	1	8	false	ok	0
@@ -1113,13 +1113,13 @@ t6412-merge-large-rename	t6	yes	10	10	0	true	ok	0
 t6413-merge-crlf	t6	yes	3	2	1	false	ok	0
 t6414-merge-rename-nocruft	t6	yes	3	3	0	true	ok	0
 t6415-merge-dir-to-symlink	t6	yes	24	9	15	false	ok	0
-t6416-recursive-corner-cases	t6	yes	40	20	17	false	ok	3
+t6416-recursive-corner-cases	t6	yes	37	20	17	false	ok	3
 t6417-merge-ours-theirs	t6	yes	7	7	0	true	ok	0
 t6418-merge-text-auto	t6	yes	11	9	2	false	ok	0
 t6419-merge-ignorecase	t6	yes	0	0	0	false	ok	0
 t6421-merge-partial-clone	t6	yes	3	0	3	false	ok	0
 t6422-merge-rename-corner-cases	t6	yes	26	10	16	false	ok	0
-t6423-merge-rename-directories	t6	yes	82	29	51	false	ok	2
+t6423-merge-rename-directories	t6	yes	80	29	51	false	ok	2
 t6424-merge-unrelated-index-changes	t6	yes	19	18	1	false	ok	0
 t6425-merge-rename-delete	t6	yes	1	1	0	true	ok	0
 t6426-merge-skip-unneeded-updates	t6	yes	13	13	0	true	ok	0
@@ -1190,10 +1190,10 @@ t7107-reset-pathspec-file	t7	yes	11	1	10	false	ok	0
 t7110-reset-merge	t7	yes	21	9	12	false	ok	0
 t7110-reset-modes	t7	yes	20	20	0	true	ok	0
 t7111-reset-table	t7	yes	42	34	8	false	ok	0
-t7112-reset-submodule	t7	yes	82	24	52	false	ok	0
+t7112-reset-submodule	t7	yes	76	24	52	false	ok	0
 t7113-post-index-change-hook	t7	yes	4	1	3	false	ok	0
 t7201-co	t7	yes	46	17	29	false	ok	0
-t7300-clean	t7	yes	55	52	1	false	ok	2
+t7300-clean	t7	yes	53	52	1	false	ok	2
 t7301-clean-interactive	t7	yes	23	8	15	false	ok	0
 t7400-submodule-basic	t7	yes	124	51	73	false	ok	0
 t7401-submodule-summary	t7	yes	25	6	19	false	ok	0
@@ -1225,7 +1225,7 @@ t7501-commit-basic-functionality	t7	yes	77	49	28	false	ok	0
 t7502-commit-porcelain	t7	yes	82	31	51	false	ok	0
 t7503-pre-commit-and-diff-whitespace	t7	yes	22	21	1	false	ok	0
 t7503-pre-commit-and-pre-merge-commit-hooks	t7	yes	22	11	11	false	ok	0
-t7504-commit-msg-hook	t7	yes	30	21	8	false	ok	1
+t7504-commit-msg-hook	t7	yes	29	21	8	false	ok	1
 t7505-prepare-commit-msg	t7	yes	30	29	1	false	ok	0
 t7505-prepare-commit-msg-hook	t7	yes	23	7	16	false	ok	0
 t7506-status-submodule	t7	yes	40	6	34	false	ok	0
@@ -1275,7 +1275,7 @@ t7810-grep	t7	yes	263	222	41	false	ok	0
 t7811-grep-open	t7	yes	10	7	3	false	ok	0
 t7812-grep-icase-non-ascii	t7	yes	18	18	0	true	ok	0
 t7813-grep-icase-iso	t7	yes	2	2	0	true	ok	0
-t7814-grep-recurse-submodules	t7	yes	34	19	8	false	ok	7
+t7814-grep-recurse-submodules	t7	yes	27	19	8	false	ok	7
 t7815-grep-binary	t7	yes	22	20	2	false	ok	0
 t7816-grep-binary-pattern	t7	yes	145	145	0	true	ok	0
 t7817-grep-sparse-checkout	t7	yes	8	5	3	false	ok	0
@@ -1600,7 +1600,7 @@ t9880-config-file-option	t9	yes	32	32	0	true	ok	0
 t9890-init-object-format	t9	yes	31	31	0	true	ok	0
 t9900-branch-verbose-all	t9	yes	33	33	0	true	ok	0
 t9901-git-web--browse	t9	yes	5	5	0	true	ok	0
-t9902-completion	t9	yes	263	188	71	false	ok	3
+t9902-completion	t9	yes	259	188	71	false	ok	3
 t9903-bash-prompt	t9	yes	67	64	3	false	ok	0
 t9910-tag-pattern-glob	t9	yes	32	32	0	true	ok	0
 t9920-commit-tree-author-env	t9	yes	26	26	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78% of harness tests passing (35,200 / 45,139).">
+<meta property="og:description" content="78% of harness tests passing (35,202 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78% of harness tests passing (35,200 / 45,139).">
+<meta name="twitter:description" content="78% of harness tests passing (35,202 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T12:43:11+00:00" class="gen-time" title="2026-04-09 12:43 UTC">2026-04-09 12:43 UTC</time> · <a href="https://github.com/schacon/grit/commit/e4e8289a9970110f8f118ce35f756107db18ae87" style="color:#58a6ff">e4e8289</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T13:03:10+00:00" class="gen-time" title="2026-04-09 13:03 UTC">2026-04-09 13:03 UTC</time> · <a href="https://github.com/schacon/grit/commit/23c7475ff6234c021d787e61ed020fa4a358b658" style="color:#58a6ff">23c7475</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,11 +157,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,200</div>
+      <div class="summary-big-val">35,202</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">45,139</div>
+      <div class="summary-big-val">45,112</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>717 files fully passing</span>
+    <span>718 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -219,7 +219,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">51/141 files · 2 skipped · 3,919/5,369 tests</span>
+        <span class="group-meta">52/141 files · 2 skipped · 3,921/5,369 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:73.0%"></div></div>
@@ -252,22 +252,22 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t6</span>
         <span class="group-desc">Revision tree commands (e.g. merge-base)</span>
-        <span class="group-meta">43/105 files · 3 skipped · 1,824/2,829 tests</span>
+        <span class="group-meta">43/105 files · 3 skipped · 1,824/2,822 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.5%"></div></div>
-        <span class="group-pct pct-blue">64.5%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.6%"></div></div>
+        <span class="group-pct pct-blue">64.6%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t7">
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">43/126 files · 11 skipped · 2,468/3,630 tests</span>
+        <span class="group-meta">43/126 files · 11 skipped · 2,468/3,614 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.0%"></div></div>
-        <span class="group-pct pct-blue">68.0%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.3%"></div></div>
+        <span class="group-pct pct-blue">68.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">
@@ -285,11 +285,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t9</span>
         <span class="group-desc">Git tools</span>
-        <span class="group-meta">74/90 files · 127 skipped · 2,770/2,864 tests</span>
+        <span class="group-meta">74/90 files · 127 skipped · 2,770/2,860 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:96.7%"></div></div>
-        <span class="group-pct pct-green">96.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:96.9%"></div></div>
+        <span class="group-pct pct-green">96.9%</span>
       </div>
     </a>
 

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35200 of 45139 tests passing across 1405 harness files (78% pass rate).</desc>
+  <desc id="svg-desc">35202 of 45112 tests passing across 1405 harness files (78% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78% pass rate · 35,200 / 45,139 tests · 1,405 files in scope · 717 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78% pass rate · 35,202 / 45,112 tests · 1,405 files in scope · 718 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="546" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T12:43:11+00:00" class="gen-time" title="2026-04-09 12:43 UTC">2026-04-09 12:43 UTC</time> · <a href="https://github.com/schacon/grit/commit/e4e8289a9970110f8f118ce35f756107db18ae87" style="color:#58a6ff">e4e8289</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T13:03:10+00:00" class="gen-time" title="2026-04-09 13:03 UTC">2026-04-09 13:03 UTC</time> · <a href="https://github.com/schacon/grit/commit/23c7475ff6234c021d787e61ed020fa4a358b658" style="color:#58a6ff">23c7475</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">45,139</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,200</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,202</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -6257,14 +6257,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:42.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="3" data-passed="1">
+<tr class="" data-group="t3" data-tests="3" data-passed="3" data-full-pass="1">
   <td class="mono">t3423-rebase-reword</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">3</td>
-  <td class="right">1</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:33.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="19" data-passed="2">
@@ -10917,14 +10917,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t6" data-tests="105" data-passed="44">
+<tr class="" data-group="t6" data-tests="103" data-passed="44">
   <td class="mono">t6120-describe</td>
   <td>t6</td>
   <td></td>
-  <td class="right">105</td>
+  <td class="right">103</td>
   <td class="right">44</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:41.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:42.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t6" data-tests="41" data-passed="41" data-full-pass="1">
@@ -11287,14 +11287,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:37.5%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t6" data-tests="40" data-passed="20">
+<tr class="" data-group="t6" data-tests="37" data-passed="20">
   <td class="mono">t6416-recursive-corner-cases</td>
   <td>t6</td>
   <td></td>
-  <td class="right">40</td>
+  <td class="right">37</td>
   <td class="right">20</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:54.1%"></div></div></td>
   <td class="right small">3</td>
 </tr>
 <tr class="" data-group="t6" data-tests="7" data-passed="7" data-full-pass="1">
@@ -11347,14 +11347,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:38.5%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t6" data-tests="82" data-passed="29">
+<tr class="" data-group="t6" data-tests="80" data-passed="29">
   <td class="mono">t6423-merge-rename-directories</td>
   <td>t6</td>
   <td></td>
-  <td class="right">82</td>
+  <td class="right">80</td>
   <td class="right">29</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:35.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:36.2%"></div></div></td>
   <td class="right small">2</td>
 </tr>
 <tr class="" data-group="t6" data-tests="19" data-passed="18">
@@ -12057,14 +12057,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:81.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="82" data-passed="24">
+<tr class="" data-group="t7" data-tests="76" data-passed="24">
   <td class="mono">t7112-reset-submodule</td>
   <td>t7</td>
   <td></td>
-  <td class="right">82</td>
+  <td class="right">76</td>
   <td class="right">24</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:29.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:31.6%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="4" data-passed="1">
@@ -12087,14 +12087,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:37.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="55" data-passed="52">
+<tr class="" data-group="t7" data-tests="53" data-passed="52">
   <td class="mono">t7300-clean</td>
   <td>t7</td>
   <td></td>
-  <td class="right">55</td>
+  <td class="right">53</td>
   <td class="right">52</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:94.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.1%"></div></div></td>
   <td class="right small">2</td>
 </tr>
 <tr class="" data-group="t7" data-tests="23" data-passed="8">
@@ -12407,14 +12407,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="30" data-passed="21">
+<tr class="" data-group="t7" data-tests="29" data-passed="21">
   <td class="mono">t7504-commit-msg-hook</td>
   <td>t7</td>
   <td></td>
-  <td class="right">30</td>
+  <td class="right">29</td>
   <td class="right">21</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:72.4%"></div></div></td>
   <td class="right small">1</td>
 </tr>
 <tr class="" data-group="t7" data-tests="30" data-passed="29">
@@ -12907,14 +12907,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="34" data-passed="19">
+<tr class="" data-group="t7" data-tests="27" data-passed="19">
   <td class="mono">t7814-grep-recurse-submodules</td>
   <td>t7</td>
   <td></td>
-  <td class="right">34</td>
+  <td class="right">27</td>
   <td class="right">19</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:55.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
   <td class="right small">7</td>
 </tr>
 <tr class="" data-group="t7" data-tests="22" data-passed="20">
@@ -16157,14 +16157,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t9" data-tests="263" data-passed="188">
+<tr class="" data-group="t9" data-tests="259" data-passed="188">
   <td class="mono">t9902-completion</td>
   <td>t9</td>
   <td></td>
-  <td class="right">263</td>
+  <td class="right">259</td>
   <td class="right">188</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:71.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:72.6%"></div></div></td>
   <td class="right small">3</td>
 </tr>
 <tr class="" data-group="t9" data-tests="67" data-passed="64">

--- a/grit/src/commands/rebase.rs
+++ b/grit/src/commands/rebase.rs
@@ -381,6 +381,7 @@ fn validate_compat_options(args: &Args) -> Result<()> {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum RebaseTodoCmd {
     Pick,
+    Reword,
     Fixup,
     Squash,
 }
@@ -389,6 +390,7 @@ impl RebaseTodoCmd {
     fn as_str(self) -> &'static str {
         match self {
             RebaseTodoCmd::Pick => "pick",
+            RebaseTodoCmd::Reword => "reword",
             RebaseTodoCmd::Fixup => "fixup",
             RebaseTodoCmd::Squash => "squash",
         }
@@ -397,6 +399,7 @@ impl RebaseTodoCmd {
     fn parse_word(word: &str) -> Option<Self> {
         match word {
             "pick" | "p" => Some(RebaseTodoCmd::Pick),
+            "reword" | "r" => Some(RebaseTodoCmd::Reword),
             "fixup" | "f" => Some(RebaseTodoCmd::Fixup),
             "squash" | "s" => Some(RebaseTodoCmd::Squash),
             _ => None,
@@ -1295,6 +1298,27 @@ fn run_shell_editor(editor: &str, path: &Path) -> Result<std::process::ExitStatu
     }
     .context("failed to run editor")?;
     Ok(status)
+}
+
+/// Opens `GIT_EDITOR` on `COMMIT_EDITMSG` for an interactive reword during `rebase -i`.
+///
+/// Matches Git's sequencer path: seed the file, run `prepare-commit-msg` with source `reword`,
+/// then invoke the commit editor. Returns the edited message text (before final cleanup).
+fn run_commit_editor_for_reword(
+    repo: &Repository,
+    git_dir: &Path,
+    template: &str,
+) -> Result<String> {
+    let editmsg = git_dir.join("COMMIT_EDITMSG");
+    fs::write(&editmsg, template)?;
+    run_prepare_commit_msg_hook(repo, &editmsg, "reword")?;
+    let config = ConfigSet::load(Some(git_dir), true)?;
+    let editor = git_editor_cmd(&config)?;
+    let status = run_shell_editor(&editor, &editmsg)?;
+    if !status.success() {
+        bail!("there was a problem with the editor");
+    }
+    fs::read_to_string(&editmsg).context("read COMMIT_EDITMSG after editor")
 }
 
 fn worktree_matches_head(repo: &Repository, git_dir: &Path) -> Result<bool> {
@@ -2396,9 +2420,11 @@ fn cherry_pick_for_rebase(
     let head_obj = repo.odb.read(&head_oid)?;
     let head_commit = parse_commit(&head_obj.data)?;
     let head_tree_oid = head_commit.tree;
+    let root_rebase = rb_dir.join("root").exists();
 
     // Already at the picked commit's parent tip — nothing to replay (matches Git's noop pick).
     // Fixup/squash must still run merge + message folding even when parent == HEAD.
+    // Reword still needs the commit editor even when the tree is already applied.
     if todo_cmd == RebaseTodoCmd::Pick {
         if let Some(p) = commit.parents.first() {
             if head_oid == *p {
@@ -2411,6 +2437,49 @@ fn cherry_pick_for_rebase(
                     checkout_merged_index(repo, wt, &old_index, &idx)?;
                 }
                 fs::write(git_dir.join("HEAD"), format!("{}\n", commit_oid.to_hex()))?;
+                return Ok(());
+            }
+        }
+    }
+    if todo_cmd == RebaseTodoCmd::Reword {
+        if let Some(p) = commit.parents.first() {
+            if head_oid == *p {
+                let old_index = load_index(repo)?;
+                let mut idx = Index::new();
+                idx.entries = tree_to_index_entries(repo, &commit_tree_oid, "")?;
+                idx.sort();
+                repo.write_index(&mut idx)?;
+                if let Some(wt) = &repo.work_tree {
+                    checkout_merged_index(repo, wt, &old_index, &idx)?;
+                }
+                let (template, _enc, _raw) = if root_rebase {
+                    let msg = message_for_root_replayed_commit(repo, &commit, true);
+                    (msg, commit.encoding.clone(), None)
+                } else {
+                    transcoded_replayed_message(&commit, &config)
+                };
+                let after_editor = run_commit_editor_for_reword(repo, git_dir, &template)?;
+                let cleaned =
+                    apply_commit_msg_cleanup(&after_editor, rebase_commit_msg_cleanup(&config));
+                let (message, encoding, raw_message) =
+                    finalize_message_for_commit_encoding(cleaned, &config);
+                let now = time::OffsetDateTime::now_utc();
+                let committer = resolve_identity(&config, "COMMITTER")?;
+                let commit_data = CommitData {
+                    tree: commit_tree_oid,
+                    parents: vec![head_oid],
+                    author: commit.author.clone(),
+                    committer: format_ident(&committer, now),
+                    author_raw: commit.author_raw.clone(),
+                    committer_raw: commit.committer_raw.clone(),
+                    encoding,
+                    message,
+                    raw_message,
+                };
+                let commit_bytes = serialize_commit(&commit_data);
+                let new_oid = repo.odb.write(ObjectKind::Commit, &commit_bytes)?;
+                fs::write(git_dir.join("HEAD"), format!("{}\n", new_oid.to_hex()))?;
+                append_rebase_rewrite_line(rb_dir, commit_oid, &new_oid)?;
                 return Ok(());
             }
         }
@@ -2462,11 +2531,15 @@ fn cherry_pick_for_rebase(
         }
     }
 
-    let root_rebase = rb_dir.join("root").exists();
-
     if has_conflicts {
         let _ = grit_lib::rerere::repo_rerere(repo, grit_lib::rerere::RerereAutoupdate::FromConfig);
-        fs::write(git_dir.join("MERGE_MSG"), &commit.message)?;
+        if todo_cmd == RebaseTodoCmd::Reword {
+            let (unicode, _enc, _raw) = transcoded_replayed_message(&commit, &config);
+            write_rebase_conflict_message(git_dir, &commit, &config)?;
+            fs::write(rb_dir.join("message"), unicode)?;
+        } else {
+            fs::write(git_dir.join("MERGE_MSG"), &commit.message)?;
+        }
         bail!("conflicts during cherry-pick of {}", commit_oid.to_hex());
     }
 
@@ -2560,20 +2633,34 @@ fn cherry_pick_for_rebase(
         return Ok(());
     }
 
-    // Create the rebased commit, preserving the original author (normal pick)
+    // Create the rebased commit, preserving the original author (normal pick / reword)
     let tree_oid = write_tree_from_index(&repo.odb, &merged_index, "")?;
 
     let now = time::OffsetDateTime::now_utc();
     let committer = resolve_identity(&config, "COMMITTER")?;
 
-    let (message, encoding, raw_message) = if root_rebase {
-        let msg = message_for_root_replayed_commit(repo, &commit, true);
-        (msg, commit.encoding.clone(), None)
+    let (message, encoding, raw_message) = if todo_cmd == RebaseTodoCmd::Reword {
+        let template = if root_rebase {
+            message_for_root_replayed_commit(repo, &commit, true)
+        } else {
+            let (unicode, _enc, _raw) = transcoded_replayed_message(&commit, &config);
+            unicode
+        };
+        let after_editor = run_commit_editor_for_reword(repo, git_dir, &template)?;
+        let cleaned = apply_commit_msg_cleanup(&after_editor, rebase_commit_msg_cleanup(&config));
+        finalize_message_for_commit_encoding(cleaned, &config)
     } else {
-        transcoded_replayed_message(&commit, &config)
+        let (msg_base, _enc_base, _raw_base) = if root_rebase {
+            let msg = message_for_root_replayed_commit(repo, &commit, true);
+            (msg, commit.encoding.clone(), None)
+        } else {
+            transcoded_replayed_message(&commit, &config)
+        };
+        let raw_msg = commit_message_after_prepare_hook(repo, git_dir, &msg_base, "message")?;
+        let message = apply_commit_msg_cleanup(&raw_msg, rebase_commit_msg_cleanup(&config));
+        finalize_message_for_commit_encoding(message, &config)
     };
-    let raw_msg = commit_message_after_prepare_hook(repo, git_dir, &message, "message")?;
-    let message = apply_commit_msg_cleanup(&raw_msg, rebase_commit_msg_cleanup(&config));
+
     let commit_data = CommitData {
         tree: tree_oid,
         parents: vec![head_oid],
@@ -2700,6 +2787,7 @@ fn read_current_rebase_todo_cmd(rb_dir: &Path) -> RebaseTodoCmd {
         return RebaseTodoCmd::Pick;
     };
     match s.trim() {
+        "reword" => RebaseTodoCmd::Reword,
         "fixup" => RebaseTodoCmd::Fixup,
         "squash" => RebaseTodoCmd::Squash,
         _ => RebaseTodoCmd::Pick,
@@ -2833,6 +2921,36 @@ fn do_continue() -> Result<()> {
             clear_squash_ctx(&rb_dir);
             oid
         }
+    } else if todo_cmd == RebaseTodoCmd::Reword {
+        let template = {
+            let rb_msg = rb_dir.join("message");
+            if rb_msg.exists() {
+                fs::read_to_string(&rb_msg)?
+            } else {
+                let (unicode, _enc, _raw) = transcoded_replayed_message(&original_commit, &config);
+                unicode
+            }
+        };
+        let after_editor = run_commit_editor_for_reword(&repo, git_dir, &template)?;
+        let cleaned = apply_commit_msg_cleanup(&after_editor, rebase_commit_msg_cleanup(&config));
+        let (message, encoding, raw_message) =
+            finalize_message_for_commit_encoding(cleaned, &config);
+        let tree_oid = write_tree_from_index(&repo.odb, &index, "")?;
+        let now = time::OffsetDateTime::now_utc();
+        let committer = resolve_identity(&config, "COMMITTER")?;
+        let commit_data = CommitData {
+            tree: tree_oid,
+            parents: vec![head_oid],
+            author: original_commit.author.clone(),
+            committer: format_ident(&committer, now),
+            author_raw: original_commit.author_raw.clone(),
+            committer_raw: original_commit.committer_raw.clone(),
+            encoding,
+            message,
+            raw_message,
+        };
+        let commit_bytes = serialize_commit(&commit_data);
+        repo.odb.write(ObjectKind::Commit, &commit_bytes)?
     } else {
         let (message, encoding, raw_message) =
             read_rebase_continue_message(git_dir, &original_commit, &config)?;

--- a/logs/2026-04-09_t3423-rebase-reword.md
+++ b/logs/2026-04-09_t3423-rebase-reword.md
@@ -1,0 +1,18 @@
+# t3423-rebase-reword
+
+## Symptom
+
+Harness showed 1/3: interactive todo lines with `reword` were dropped because `parse_todo_line_with_repo` only accepted pick/fixup/squash. First `pick` finished the rebase with one commit left on the todo. `FAKE_LINES="reword 2"` hit empty parsed todo → sequence editor failure.
+
+## Fix (grit/src/commands/rebase.rs)
+
+- Added `RebaseTodoCmd::Reword` and `reword`/`r` parsing in `parse_word`.
+- `run_commit_editor_for_reword`: seed `COMMIT_EDITMSG`, `prepare-commit-msg` with source `reword`, run `GIT_EDITOR`, non-zero exit → "there was a problem with the editor".
+- `cherry_pick_for_rebase`: restrict noop parent==HEAD fast path to `Pick` only; for `Reword` in that case still apply tree + editor + new commit. After merge, for `Reword` run editor instead of `prepare-commit-msg` with source `message`. On conflict for `Reword`, write `rebase-merge/message` (UTF-8 transcoded) plus `MERGE_MSG` via existing helper.
+- `read_current_rebase_todo_cmd` + `do_continue`: handle `Reword` using `rebase-merge/message` as editor template when present.
+
+## Validation
+
+- `cd tests && GUST_BIN=.../grit ./t3423-rebase-reword.sh -v` → 3/3
+- `./scripts/run-tests.sh t3423-rebase-reword.sh` → 3/3
+- `cargo test -p grit-lib --lib`, `cargo fmt`, `cargo check -p grit-rs`

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   294 |
-| In progress |     4 |
-| Remaining   |   471 |
+| Completed   |   307 |
+| In progress |     5 |
+| Remaining   |   457 |
 | **Total**   |   769 |
 
-Task lines in `PLAN.md`: 294 completed (`[x]`), 4 in progress (`[~]`), 471 remaining (`[ ]`).
+Task lines in `PLAN.md`: 307 completed (`[x]`), 5 in progress (`[~]`), 457 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t3423-rebase-reword` — 3/3 tests pass (`rebase -i`: parse `reword`/`r` in todo; run commit editor with `prepare-commit-msg` source `reword`; `rebase --continue` after conflict uses `rebase-merge/message` template; noop-fast-forward path restricted to `pick` only so `reword` still opens editor)
 - `t7011-skip-worktree-reading` — 15/15 tests pass (`update-index` skip-worktree no-op / `--remove` clears entry; `--remove` on missing untracked path is silent; `reset` preserves skip-worktree; `diff-index` skips worktree for skip-worktree; `commit` pathspec rejects skip-worktree)
 - `t3303-notes-subtrees` — 23/23 tests pass (`fast-import`: `data <<TERM` heredoc, `M … inline` blobs, `deleteall`; `log` notes map: concatenate duplicate commit paths like Git’s `combine_notes_concatenate`, skip identical blob payloads)
 - `t5323-pack-redundant` — 18/18 tests pass (`pack-redundant`: Git `minimize` algorithm, `--i-still-use-this` / stdin ignore / verbose + alt-odb; `clone --mirror` implies bare layout; `fsck` resolves relative `objects/info/alternates` against `objects/`)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements `reword` / `r` in interactive rebase so `tests/t3423-rebase-reword.sh` passes 3/3.

## Changes

- **`RebaseTodoCmd::Reword`**: parse `reword`/`r` in todo lines (previously dropped, which truncated the todo and finished the rebase early).
- **Commit message editing**: after a clean apply, run `prepare-commit-msg` with source `reword` on `COMMIT_EDITMSG`, then invoke `GIT_EDITOR` (matches Git sequencer behavior; tests use `FAKE_COMMIT_MESSAGE` on `COMMIT_EDITMSG`).
- **Conflicts**: for `reword`, save a UTF-8 template in `rebase-merge/message` (and keep `MERGE_MSG`); `rebase --continue` reads that template and opens the editor again.
- **Noop fast-forward**: the parent==HEAD shortcut applies only to **`pick`**, not `reword`, so reword still opens the editor when the tree is already satisfied.

## Validation

- `./scripts/run-tests.sh t3423-rebase-reword.sh` → 3/3
- `cargo test -p grit-lib --lib`
- `cargo check -p grit-rs`

Also updates `PLAN.md`, `progress.md`, harness CSV/dashboards, and adds `logs/2026-04-09_t3423-rebase-reword.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c04a5673-1a71-4ff4-aea1-2a414168e744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c04a5673-1a71-4ff4-aea1-2a414168e744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

