### PR TITLE
fix: rebase --whitespace=fix applies whitespace normalization

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -273,7 +273,7 @@ commit → check it off → move on.
 - [ ] `t3703-add-magic-pathspec` ██████░░░░░░░░░░░░░░ 2/6 (4 left) — magic pathspec tests using git-add
 - [ ] `t3601-rm-pathspec-file` ████░░░░░░░░░░░░░░░░ 1/5 (4 left) — rm --pathspec-from-file
 - [ ] `t3909-stash-pathspec-file` ████░░░░░░░░░░░░░░░░ 1/5 (4 left) — stash --pathspec-from-file
-- [ ] `t3417-rebase-whitespace-fix` ░░░░░░░░░░░░░░░░░░░░ 0/4 (4 left) — git rebase --whitespace=fix
+- [x] `t3417-rebase-whitespace-fix` ████████████████████ 4/4 (0 left) — git rebase --whitespace=fix
 
 - [ ] `t3433-rebase-across-mode-change` ░░░░░░░░░░░░░░░░░░░░ 0/4 (4 left) — git rebase across mode change
 - [ ] `t3040-subprojects-basic` ██████████░░░░░░░░░░ 6/11 (5 left) — Basic subproject functionality

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -604,7 +604,7 @@ t3412-rebase-root	t3	yes	25	25	0	true	ok	0
 t3413-rebase-hook	t3	yes	15	9	6	false	ok	0
 t3415-rebase-autosquash	t3	yes	28	23	5	false	ok	0
 t3416-rebase-onto-threedots	t3	yes	18	12	6	false	ok	0
-t3417-rebase-whitespace-fix	t3	yes	4	0	4	false	ok	0
+t3417-rebase-whitespace-fix	t3	yes	4	4	0	true	ok	0
 t3418-rebase-continue	t3	yes	30	6	24	false	ok	0
 t3419-rebase-patch-id	t3	yes	8	8	0	true	ok	0
 t3420-rebase-autostash	t3	yes	54	36	18	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78% of harness tests passing (35,205 / 45,112).">
+<meta property="og:description" content="78% of harness tests passing (35,209 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78% of harness tests passing (35,205 / 45,112).">
+<meta name="twitter:description" content="78% of harness tests passing (35,209 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T12:58:52+00:00" class="gen-time" title="2026-04-09 12:58 UTC">2026-04-09 12:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/c9e26ba46f5a86c3328f4d62484968547c8560d9" style="color:#58a6ff">c9e26ba</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T13:10:04+00:00" class="gen-time" title="2026-04-09 13:10 UTC">2026-04-09 13:10 UTC</time> · <a href="https://github.com/schacon/grit/commit/999b424740b71e52cf30bf6fade3e1ef735f68bd" style="color:#58a6ff">999b424</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,205</div>
+      <div class="summary-big-val">35,209</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>719 files fully passing</span>
+    <span>720 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -219,11 +219,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">51/141 files · 2 skipped · 3,919/5,369 tests</span>
+        <span class="group-meta">52/141 files · 2 skipped · 3,923/5,369 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:73.0%"></div></div>
-        <span class="group-pct pct-blue">73.0%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:73.1%"></div></div>
+        <span class="group-pct pct-blue">73.1%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35205 of 45112 tests passing across 1405 harness files (78% pass rate).</desc>
+  <desc id="svg-desc">35209 of 45112 tests passing across 1405 harness files (78% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78% pass rate · 35,205 / 45,112 tests · 1,405 files in scope · 719 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78% pass rate · 35,209 / 45,112 tests · 1,405 files in scope · 720 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="546" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T12:58:52+00:00" class="gen-time" title="2026-04-09 12:58 UTC">2026-04-09 12:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/c9e26ba46f5a86c3328f4d62484968547c8560d9" style="color:#58a6ff">c9e26ba</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T13:10:04+00:00" class="gen-time" title="2026-04-09 13:10 UTC">2026-04-09 13:10 UTC</time> · <a href="https://github.com/schacon/grit/commit/999b424740b71e52cf30bf6fade3e1ef735f68bd" style="color:#58a6ff">999b424</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,205</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,209</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -6197,14 +6197,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:66.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="4" data-passed="0">
+<tr class="" data-group="t3" data-tests="4" data-passed="4" data-full-pass="1">
   <td class="mono">t3417-rebase-whitespace-fix</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">4</td>
-  <td class="right">0</td>
+  <td class="right">4</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="30" data-passed="6">

--- a/grit/src/commands/rebase.rs
+++ b/grit/src/commands/rebase.rs
@@ -2396,6 +2396,8 @@ fn cherry_pick_for_rebase(
     let head_obj = repo.odb.read(&head_oid)?;
     let head_commit = parse_commit(&head_obj.data)?;
     let head_tree_oid = head_commit.tree;
+    let root_rebase = rb_dir.join("root").exists();
+    let ws_fix_rule = load_ws_fix_rule_from_rebase_state(git_dir);
 
     // Already at the picked commit's parent tip — nothing to replay (matches Git's noop pick).
     // Fixup/squash must still run merge + message folding even when parent == HEAD.
@@ -2406,11 +2408,45 @@ fn cherry_pick_for_rebase(
                 let mut idx = Index::new();
                 idx.entries = tree_to_index_entries(repo, &commit_tree_oid, "")?;
                 idx.sort();
+                if let Some(rule) = ws_fix_rule {
+                    apply_ws_fix_to_index(repo, &mut idx, rule)?;
+                }
                 repo.write_index(&mut idx)?;
                 if let Some(wt) = &repo.work_tree {
                     checkout_merged_index(repo, wt, &old_index, &idx)?;
                 }
-                fs::write(git_dir.join("HEAD"), format!("{}\n", commit_oid.to_hex()))?;
+                if ws_fix_rule.is_some() {
+                    let tree_oid = write_tree_from_index(&repo.odb, &idx, "")?;
+                    let now = time::OffsetDateTime::now_utc();
+                    let committer = resolve_identity(&config, "COMMITTER")?;
+                    let (message, encoding, raw_message) = if root_rebase {
+                        let msg = message_for_root_replayed_commit(repo, &commit, true);
+                        (msg, commit.encoding.clone(), None)
+                    } else {
+                        transcoded_replayed_message(&commit, &config)
+                    };
+                    let raw_msg =
+                        commit_message_after_prepare_hook(repo, git_dir, &message, "message")?;
+                    let message =
+                        apply_commit_msg_cleanup(&raw_msg, rebase_commit_msg_cleanup(&config));
+                    let commit_data = CommitData {
+                        tree: tree_oid,
+                        parents: vec![head_oid],
+                        author: commit.author.clone(),
+                        committer: format_ident(&committer, now),
+                        author_raw: commit.author_raw.clone(),
+                        committer_raw: commit.committer_raw.clone(),
+                        encoding,
+                        message,
+                        raw_message,
+                    };
+                    let commit_bytes = serialize_commit(&commit_data);
+                    let new_oid = repo.odb.write(ObjectKind::Commit, &commit_bytes)?;
+                    fs::write(git_dir.join("HEAD"), format!("{}\n", new_oid.to_hex()))?;
+                    append_rebase_rewrite_line(rb_dir, commit_oid, &new_oid)?;
+                } else {
+                    fs::write(git_dir.join("HEAD"), format!("{}\n", commit_oid.to_hex()))?;
+                }
                 return Ok(());
             }
         }
@@ -2422,7 +2458,6 @@ fn cherry_pick_for_rebase(
     }
 
     // Three-way merge: base=parent_tree, ours=HEAD_tree, theirs=commit_tree
-    let ws_fix_rule = load_ws_fix_rule_from_rebase_state(git_dir);
     let base_tree_oid = if ws_fix_rule.is_some() {
         // After an earlier replay, HEAD can differ from the picked commit's parent tree in the ODB
         // (e.g. `rebase --whitespace=fix`). Use the current tip tree as the merge base so the
@@ -2447,6 +2482,10 @@ fn cherry_pick_for_rebase(
     )?;
     let mut merged_index = merge_result.index;
 
+    if let Some(rule) = ws_fix_rule {
+        apply_ws_fix_to_index(repo, &mut merged_index, rule)?;
+    }
+
     let has_conflicts = merged_index.entries.iter().any(|e| e.stage() != 0)
         || !merge_result.conflict_files.is_empty();
 
@@ -2461,8 +2500,6 @@ fn cherry_pick_for_rebase(
             write_rebase_conflict_files(wt, &merge_result.conflict_files)?;
         }
     }
-
-    let root_rebase = rb_dir.join("root").exists();
 
     if has_conflicts {
         let _ = grit_lib::rerere::repo_rerere(repo, grit_lib::rerere::RerereAutoupdate::FromConfig);

--- a/logs/2026-04-09-t3417-rebase-whitespace-fix.md
+++ b/logs/2026-04-09-t3417-rebase-whitespace-fix.md
@@ -1,0 +1,5 @@
+# t3417-rebase-whitespace-fix
+
+- **Issue:** `apply_ws_fix_to_index` was defined but never called; noop rebase picks (`HEAD == parent`) reused the original commit OID without fixing blobs.
+- **Fix:** Load `ws_fix_rule` early; after `three_way_merge_with_content`, call `apply_ws_fix_to_index` before writing index/worktree. On noop pick with `--whitespace=fix|strip`, apply fix to the picked tree, write a new tree/commit, append `rewritten`, update HEAD.
+- **Verify:** `cargo build --release -p grit-rs`; `./scripts/run-tests.sh t3417-rebase-whitespace-fix.sh` → 4/4; `cargo test -p grit-lib --lib`.

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   294 |
-| In progress |     4 |
-| Remaining   |   471 |
+| Completed   |   308 |
+| In progress |     5 |
+| Remaining   |   456 |
 | **Total**   |   769 |
 
-Task lines in `PLAN.md`: 294 completed (`[x]`), 4 in progress (`[~]`), 471 remaining (`[ ]`).
+Task lines in `PLAN.md`: 308 completed (`[x]`), 5 in progress (`[~]`), 456 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t3417-rebase-whitespace-fix` — 4/4 tests pass (`rebase --whitespace=fix`: apply `fix_blob_bytes` to merged index after three-way merge; noop pick path rebuilds tree + commit when whitespace fix is active; harness CSV refreshed)
 - `t7011-skip-worktree-reading` — 15/15 tests pass (`update-index` skip-worktree no-op / `--remove` clears entry; `--remove` on missing untracked path is silent; `reset` preserves skip-worktree; `diff-index` skips worktree for skip-worktree; `commit` pathspec rejects skip-worktree)
 - `t3303-notes-subtrees` — 23/23 tests pass (`fast-import`: `data <<TERM` heredoc, `M … inline` blobs, `deleteall`; `log` notes map: concatenate duplicate commit paths like Git’s `combine_notes_concatenate`, skip identical blob payloads)
 - `t5323-pack-redundant` — 18/18 tests pass (`pack-redundant`: Git `minimize` algorithm, `--i-still-use-this` / stdin ignore / verbose + alt-odb; `clone --mirror` implies bare layout; `fsck` resolves relative `objects/info/alternates` against `objects/`)

--- a/test-results.md
+++ b/test-results.md
@@ -1,0 +1,6 @@
+# Test results
+
+**2026-04-09 (t3417 / rebase whitespace fix)**
+
+- `cargo test -p grit-lib --lib`: 147 passed
+- `./scripts/run-tests.sh t3417-rebase-whitespace-fix.sh`: 4/4 passed


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`rebase --whitespace=fix` stored `whitespace-action` and adjusted the merge base, but **`apply_ws_fix_to_index` was never invoked**, so blob contents stayed unfixed. The noop pick path also **reused the original commit OID** when `HEAD` already matched the picked commit's parent, so whitespace fixes never ran for those commits.

## Changes

- After a successful three-way merge during rebase, call `apply_ws_fix_to_index` when `whitespace-action` is `fix` or `strip` (using `core.whitespace` from config).
- On the noop pick fast path with whitespace fix active: apply fixes to the picked tree, write a new tree/commit, append `rewritten`, and update `HEAD`.

## Verification

- `t3417-rebase-whitespace-fix.sh`: 4/4
- `cargo test -p grit-lib --lib`: pass
- `cargo clippy -p grit-rs`: clean (with `--fix --allow-dirty`)

Also refreshed harness CSV/dashboards and marked `t3417` complete in `PLAN.md` / `progress.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33a03a43-7a19-4852-a6e1-7bef94bcd38b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33a03a43-7a19-4852-a6e1-7bef94bcd38b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

