### PR TITLE
fix: status --porcelain v1 omits ## without -b (t7515)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1238,7 +1238,7 @@ t7512-status-help	t7	yes	47	8	39	false	ok	0
 t7513-interpret-trailers	t7	yes	99	99	0	true	ok	0
 t7514-commit-patch	t7	yes	3	1	2	false	ok	0
 t7514-interpret-trailers-options	t7	yes	10	1	9	false	ok	0
-t7515-status-symlinks	t7	yes	3	1	2	false	ok	0
+t7515-status-symlinks	t7	yes	3	3	0	true	ok	0
 t7516-commit-races	t7	yes	2	0	2	false	ok	0
 t7517-per-repo-email	t7	yes	16	16	0	true	ok	0
 t7518-ident-corner-cases	t7	yes	5	3	2	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78% of harness tests passing (35,205 / 45,112).">
+<meta property="og:description" content="78% of harness tests passing (35,207 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78% of harness tests passing (35,205 / 45,112).">
+<meta name="twitter:description" content="78% of harness tests passing (35,207 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T12:58:52+00:00" class="gen-time" title="2026-04-09 12:58 UTC">2026-04-09 12:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/c9e26ba46f5a86c3328f4d62484968547c8560d9" style="color:#58a6ff">c9e26ba</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T13:12:04+00:00" class="gen-time" title="2026-04-09 13:12 UTC">2026-04-09 13:12 UTC</time> · <a href="https://github.com/schacon/grit/commit/999b424740b71e52cf30bf6fade3e1ef735f68bd" style="color:#58a6ff">999b424</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,205</div>
+      <div class="summary-big-val">35,207</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>719 files fully passing</span>
+    <span>720 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -263,7 +263,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">43/126 files · 11 skipped · 2,468/3,614 tests</span>
+        <span class="group-meta">44/126 files · 11 skipped · 2,470/3,614 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.3%"></div></div>

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35205 of 45112 tests passing across 1405 harness files (78% pass rate).</desc>
+  <desc id="svg-desc">35207 of 45112 tests passing across 1405 harness files (78% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78% pass rate · 35,205 / 45,112 tests · 1,405 files in scope · 719 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78% pass rate · 35,207 / 45,112 tests · 1,405 files in scope · 720 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="546" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T12:58:52+00:00" class="gen-time" title="2026-04-09 12:58 UTC">2026-04-09 12:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/c9e26ba46f5a86c3328f4d62484968547c8560d9" style="color:#58a6ff">c9e26ba</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T13:12:04+00:00" class="gen-time" title="2026-04-09 13:12 UTC">2026-04-09 13:12 UTC</time> · <a href="https://github.com/schacon/grit/commit/999b424740b71e52cf30bf6fade3e1ef735f68bd" style="color:#58a6ff">999b424</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,205</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,207</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -12537,14 +12537,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:10.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="3" data-passed="1">
+<tr class="" data-group="t7" data-tests="3" data-passed="3" data-full-pass="1">
   <td class="mono">t7515-status-symlinks</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">3</td>
-  <td class="right">1</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:33.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="2" data-passed="0">

--- a/grit/src/commands/status.rs
+++ b/grit/src/commands/status.rs
@@ -189,8 +189,6 @@ fn relative_path(parent: &str, name: &str) -> String {
 
 /// Run the `status` command.
 pub fn run(mut args: Args) -> Result<()> {
-    // Whether the user passed `--porcelain` (before `-z` may synthesize it).
-    let explicit_porcelain = args.porcelain.is_some();
     // -z implies porcelain
     if args.null_terminated && args.porcelain.is_none() {
         args.porcelain = Some("v1".to_string());
@@ -338,19 +336,6 @@ pub fn run(mut args: Args) -> Result<()> {
     // Untracked and ignored files
     let show_all_untracked = untracked_mode == "all";
     let hide_untracked = untracked_mode == "no";
-
-    // Porcelain v1: Git omits the `##` branch line when `--untracked-files=no` (e.g.
-    // `status --porcelain -uno`). Grit still defaults to showing `##` for plain `--porcelain`
-    // so clean repos and mixed outputs match our status tests (t12570). `-b` / `--branch`
-    // always forces the header.
-    if explicit_porcelain
-        && args.porcelain.as_deref() == Some("v1")
-        && !args.no_branch
-        && !args.branch
-        && !hide_untracked
-    {
-        args.branch = true;
-    }
 
     let (untracked, ignored_files) = if !hide_untracked {
         collect_untracked_and_ignored(&repo, &index, work_tree, ignored_mode, show_all_untracked)?

--- a/logs/2026-04-09_t7515-status-symlinks.md
+++ b/logs/2026-04-09_t7515-status-symlinks.md
@@ -1,0 +1,14 @@
+# t7515-status-symlinks
+
+## Problem
+
+`t7515-status-symlinks.sh` compared `git status --porcelain` to expected output without a `##` branch line. Grit forced `args.branch = true` for explicit `--porcelain=v1` whenever untracked files were shown, so porcelain always started with `## master`, diverging from upstream Git.
+
+## Fix
+
+Removed the block in `grit/src/commands/status.rs` that set `args.branch = true` for that case. Plain `status --porcelain` now omits the `##` line unless `-b` / `--branch` (or `status.branch` for non-porcelain) is used, matching `/usr/bin/git` 2.43.
+
+## Verification
+
+- `GUST_BIN=target/release/grit sh tests/t7515-status-symlinks.sh -v -i` — 3/3
+- `./scripts/run-tests.sh t7515-status-symlinks.sh` — updates CSV/dashboards


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Upstream `git status --porcelain` does not emit the `##` branch line unless `-b` / `--branch` is used. Grit was forcing the branch header whenever porcelain v1 was requested and untracked files were shown, which made `t7515-status-symlinks` fail (expected output is only `?? symlink` / path lines).

## Changes

- Remove the override in `grit/src/commands/status.rs` that set `args.branch = true` for that case.
- Refresh harness results for `t7515-status-symlinks` (`data/test-files.csv`, dashboards).
- Add `logs/2026-04-09_t7515-status-symlinks.md`.

## Verification

- `./scripts/run-tests.sh t7515-status-symlinks.sh` — 3/3
- `cargo fmt`, `cargo check -p grit-rs`, `cargo clippy --fix --allow-dirty -p grit-rs`, `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32e76b55-cc62-4404-a055-c6e8cf43b256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32e76b55-cc62-4404-a055-c6e8cf43b256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

