### PR TITLE
fix: align rev-list --objects with Git for t6100

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1067,7 +1067,7 @@ t6040-tracking-info	t6	yes	44	35	9	false	ok	0
 t6041-bisect-submodule	t6	yes	14	6	8	false	ok	0
 t6050-replace	t6	skip	37	0	0	false	ok	0
 t6060-merge-index	t6	yes	7	7	0	true	ok	0
-t6100-rev-list-in-order	t6	yes	3	1	2	false	ok	0
+t6100-rev-list-in-order	t6	yes	3	3	0	true	ok	0
 t6101-rev-parse-parents	t6	yes	38	25	13	false	ok	0
 t6102-rev-list-unexpected-objects	t6	yes	22	21	1	false	ok	0
 t6110-rev-list-sparse	t6	yes	2	2	0	true	ok	0
@@ -1076,7 +1076,7 @@ t6112-rev-list-filters-objects	t6	yes	54	38	16	false	ok	0
 t6113-rev-list-bitmap-filters	t6	yes	14	14	0	true	ok	0
 t6114-keep-packs	t6	yes	3	3	0	true	ok	0
 t6115-rev-list-du	t6	yes	17	17	0	true	ok	0
-t6120-describe	t6	yes	105	44	59	false	ok	0
+t6120-describe	t6	yes	103	44	59	false	ok	0
 t6120-name-rev	t6	yes	41	41	0	true	ok	0
 t6130-pathspec-noglob	t6	yes	21	8	13	false	ok	0
 t6131-pathspec-icase	t6	yes	9	1	8	false	ok	0
@@ -1113,13 +1113,13 @@ t6412-merge-large-rename	t6	yes	10	10	0	true	ok	0
 t6413-merge-crlf	t6	yes	3	2	1	false	ok	0
 t6414-merge-rename-nocruft	t6	yes	3	3	0	true	ok	0
 t6415-merge-dir-to-symlink	t6	yes	24	9	15	false	ok	0
-t6416-recursive-corner-cases	t6	yes	40	20	17	false	ok	3
+t6416-recursive-corner-cases	t6	yes	37	20	17	false	ok	3
 t6417-merge-ours-theirs	t6	yes	7	7	0	true	ok	0
 t6418-merge-text-auto	t6	yes	11	9	2	false	ok	0
 t6419-merge-ignorecase	t6	yes	0	0	0	false	ok	0
 t6421-merge-partial-clone	t6	yes	3	0	3	false	ok	0
 t6422-merge-rename-corner-cases	t6	yes	26	10	16	false	ok	0
-t6423-merge-rename-directories	t6	yes	82	29	51	false	ok	2
+t6423-merge-rename-directories	t6	yes	80	29	51	false	ok	2
 t6424-merge-unrelated-index-changes	t6	yes	19	18	1	false	ok	0
 t6425-merge-rename-delete	t6	yes	1	1	0	true	ok	0
 t6426-merge-skip-unneeded-updates	t6	yes	13	13	0	true	ok	0
@@ -1190,10 +1190,10 @@ t7107-reset-pathspec-file	t7	yes	11	1	10	false	ok	0
 t7110-reset-merge	t7	yes	21	9	12	false	ok	0
 t7110-reset-modes	t7	yes	20	20	0	true	ok	0
 t7111-reset-table	t7	yes	42	34	8	false	ok	0
-t7112-reset-submodule	t7	yes	82	24	52	false	ok	0
+t7112-reset-submodule	t7	yes	76	24	52	false	ok	0
 t7113-post-index-change-hook	t7	yes	4	1	3	false	ok	0
 t7201-co	t7	yes	46	17	29	false	ok	0
-t7300-clean	t7	yes	55	52	1	false	ok	2
+t7300-clean	t7	yes	53	52	1	false	ok	2
 t7301-clean-interactive	t7	yes	23	8	15	false	ok	0
 t7400-submodule-basic	t7	yes	124	51	73	false	ok	0
 t7401-submodule-summary	t7	yes	25	6	19	false	ok	0
@@ -1225,7 +1225,7 @@ t7501-commit-basic-functionality	t7	yes	77	49	28	false	ok	0
 t7502-commit-porcelain	t7	yes	82	31	51	false	ok	0
 t7503-pre-commit-and-diff-whitespace	t7	yes	22	21	1	false	ok	0
 t7503-pre-commit-and-pre-merge-commit-hooks	t7	yes	22	11	11	false	ok	0
-t7504-commit-msg-hook	t7	yes	30	21	8	false	ok	1
+t7504-commit-msg-hook	t7	yes	29	21	8	false	ok	1
 t7505-prepare-commit-msg	t7	yes	30	29	1	false	ok	0
 t7505-prepare-commit-msg-hook	t7	yes	23	7	16	false	ok	0
 t7506-status-submodule	t7	yes	40	6	34	false	ok	0
@@ -1275,7 +1275,7 @@ t7810-grep	t7	yes	263	222	41	false	ok	0
 t7811-grep-open	t7	yes	10	7	3	false	ok	0
 t7812-grep-icase-non-ascii	t7	yes	18	18	0	true	ok	0
 t7813-grep-icase-iso	t7	yes	2	2	0	true	ok	0
-t7814-grep-recurse-submodules	t7	yes	34	19	8	false	ok	7
+t7814-grep-recurse-submodules	t7	yes	27	19	8	false	ok	7
 t7815-grep-binary	t7	yes	22	20	2	false	ok	0
 t7816-grep-binary-pattern	t7	yes	145	145	0	true	ok	0
 t7817-grep-sparse-checkout	t7	yes	8	5	3	false	ok	0
@@ -1600,7 +1600,7 @@ t9880-config-file-option	t9	yes	32	32	0	true	ok	0
 t9890-init-object-format	t9	yes	31	31	0	true	ok	0
 t9900-branch-verbose-all	t9	yes	33	33	0	true	ok	0
 t9901-git-web--browse	t9	yes	5	5	0	true	ok	0
-t9902-completion	t9	yes	263	188	71	false	ok	3
+t9902-completion	t9	yes	259	188	71	false	ok	3
 t9903-bash-prompt	t9	yes	67	64	3	false	ok	0
 t9910-tag-pattern-glob	t9	yes	32	32	0	true	ok	0
 t9920-commit-tree-author-env	t9	yes	26	26	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78% of harness tests passing (35,200 / 45,139).">
+<meta property="og:description" content="78% of harness tests passing (35,202 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78% of harness tests passing (35,200 / 45,139).">
+<meta name="twitter:description" content="78% of harness tests passing (35,202 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T12:43:11+00:00" class="gen-time" title="2026-04-09 12:43 UTC">2026-04-09 12:43 UTC</time> · <a href="https://github.com/schacon/grit/commit/e4e8289a9970110f8f118ce35f756107db18ae87" style="color:#58a6ff">e4e8289</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T13:30:17+00:00" class="gen-time" title="2026-04-09 13:30 UTC">2026-04-09 13:30 UTC</time> · <a href="https://github.com/schacon/grit/commit/23c7475ff6234c021d787e61ed020fa4a358b658" style="color:#58a6ff">23c7475</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,11 +157,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,200</div>
+      <div class="summary-big-val">35,202</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">45,139</div>
+      <div class="summary-big-val">45,112</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>717 files fully passing</span>
+    <span>718 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -252,22 +252,22 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t6</span>
         <span class="group-desc">Revision tree commands (e.g. merge-base)</span>
-        <span class="group-meta">43/105 files · 3 skipped · 1,824/2,829 tests</span>
+        <span class="group-meta">44/105 files · 3 skipped · 1,826/2,822 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.5%"></div></div>
-        <span class="group-pct pct-blue">64.5%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.7%"></div></div>
+        <span class="group-pct pct-blue">64.7%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t7">
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">43/126 files · 11 skipped · 2,468/3,630 tests</span>
+        <span class="group-meta">43/126 files · 11 skipped · 2,468/3,614 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.0%"></div></div>
-        <span class="group-pct pct-blue">68.0%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.3%"></div></div>
+        <span class="group-pct pct-blue">68.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">
@@ -285,11 +285,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t9</span>
         <span class="group-desc">Git tools</span>
-        <span class="group-meta">74/90 files · 127 skipped · 2,770/2,864 tests</span>
+        <span class="group-meta">74/90 files · 127 skipped · 2,770/2,860 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:96.7%"></div></div>
-        <span class="group-pct pct-green">96.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:96.9%"></div></div>
+        <span class="group-pct pct-green">96.9%</span>
       </div>
     </a>
 

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35200 of 45139 tests passing across 1405 harness files (78% pass rate).</desc>
+  <desc id="svg-desc">35202 of 45112 tests passing across 1405 harness files (78% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78% pass rate · 35,200 / 45,139 tests · 1,405 files in scope · 717 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78% pass rate · 35,202 / 45,112 tests · 1,405 files in scope · 718 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="546" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T12:43:11+00:00" class="gen-time" title="2026-04-09 12:43 UTC">2026-04-09 12:43 UTC</time> · <a href="https://github.com/schacon/grit/commit/e4e8289a9970110f8f118ce35f756107db18ae87" style="color:#58a6ff">e4e8289</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T13:30:17+00:00" class="gen-time" title="2026-04-09 13:30 UTC">2026-04-09 13:30 UTC</time> · <a href="https://github.com/schacon/grit/commit/23c7475ff6234c021d787e61ed020fa4a358b658" style="color:#58a6ff">23c7475</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">45,139</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,200</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,202</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -10827,14 +10827,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t6" data-tests="3" data-passed="1">
+<tr class="" data-group="t6" data-tests="3" data-passed="3" data-full-pass="1">
   <td class="mono">t6100-rev-list-in-order</td>
   <td>t6</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">3</td>
-  <td class="right">1</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:33.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t6" data-tests="38" data-passed="25">
@@ -10917,14 +10917,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t6" data-tests="105" data-passed="44">
+<tr class="" data-group="t6" data-tests="103" data-passed="44">
   <td class="mono">t6120-describe</td>
   <td>t6</td>
   <td></td>
-  <td class="right">105</td>
+  <td class="right">103</td>
   <td class="right">44</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:41.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:42.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t6" data-tests="41" data-passed="41" data-full-pass="1">
@@ -11287,14 +11287,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:37.5%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t6" data-tests="40" data-passed="20">
+<tr class="" data-group="t6" data-tests="37" data-passed="20">
   <td class="mono">t6416-recursive-corner-cases</td>
   <td>t6</td>
   <td></td>
-  <td class="right">40</td>
+  <td class="right">37</td>
   <td class="right">20</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:54.1%"></div></div></td>
   <td class="right small">3</td>
 </tr>
 <tr class="" data-group="t6" data-tests="7" data-passed="7" data-full-pass="1">
@@ -11347,14 +11347,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:38.5%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t6" data-tests="82" data-passed="29">
+<tr class="" data-group="t6" data-tests="80" data-passed="29">
   <td class="mono">t6423-merge-rename-directories</td>
   <td>t6</td>
   <td></td>
-  <td class="right">82</td>
+  <td class="right">80</td>
   <td class="right">29</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:35.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:36.2%"></div></div></td>
   <td class="right small">2</td>
 </tr>
 <tr class="" data-group="t6" data-tests="19" data-passed="18">
@@ -12057,14 +12057,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:81.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="82" data-passed="24">
+<tr class="" data-group="t7" data-tests="76" data-passed="24">
   <td class="mono">t7112-reset-submodule</td>
   <td>t7</td>
   <td></td>
-  <td class="right">82</td>
+  <td class="right">76</td>
   <td class="right">24</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:29.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:31.6%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="4" data-passed="1">
@@ -12087,14 +12087,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:37.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="55" data-passed="52">
+<tr class="" data-group="t7" data-tests="53" data-passed="52">
   <td class="mono">t7300-clean</td>
   <td>t7</td>
   <td></td>
-  <td class="right">55</td>
+  <td class="right">53</td>
   <td class="right">52</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:94.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.1%"></div></div></td>
   <td class="right small">2</td>
 </tr>
 <tr class="" data-group="t7" data-tests="23" data-passed="8">
@@ -12407,14 +12407,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="30" data-passed="21">
+<tr class="" data-group="t7" data-tests="29" data-passed="21">
   <td class="mono">t7504-commit-msg-hook</td>
   <td>t7</td>
   <td></td>
-  <td class="right">30</td>
+  <td class="right">29</td>
   <td class="right">21</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:72.4%"></div></div></td>
   <td class="right small">1</td>
 </tr>
 <tr class="" data-group="t7" data-tests="30" data-passed="29">
@@ -12907,14 +12907,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="34" data-passed="19">
+<tr class="" data-group="t7" data-tests="27" data-passed="19">
   <td class="mono">t7814-grep-recurse-submodules</td>
   <td>t7</td>
   <td></td>
-  <td class="right">34</td>
+  <td class="right">27</td>
   <td class="right">19</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:55.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
   <td class="right small">7</td>
 </tr>
 <tr class="" data-group="t7" data-tests="22" data-passed="20">
@@ -16157,14 +16157,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t9" data-tests="263" data-passed="188">
+<tr class="" data-group="t9" data-tests="259" data-passed="188">
   <td class="mono">t9902-completion</td>
   <td>t9</td>
   <td></td>
-  <td class="right">263</td>
+  <td class="right">259</td>
   <td class="right">188</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:71.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:72.6%"></div></div></td>
   <td class="right small">3</td>
 </tr>
 <tr class="" data-group="t9" data-tests="67" data-passed="64">

--- a/grit-lib/src/rev_list.rs
+++ b/grit-lib/src/rev_list.rs
@@ -2856,7 +2856,7 @@ fn collect_reachable_objects(
 /// the next commit, with global de-duplication of emitted object OIDs across the full walk.
 fn collect_reachable_objects_segmented(
     repo: &Repository,
-    graph: &mut CommitGraph<'_>,
+    _graph: &mut CommitGraph<'_>,
     commits: &[ObjectId],
     object_roots: &[RootObject],
     filter: Option<&ObjectFilter>,
@@ -2893,21 +2893,15 @@ fn collect_reachable_objects_segmented(
             Err(err) => return Err(err),
         };
         let mut tree_state = TreeWalkState::new(filter);
-        let parents = graph.parents_of(commit_oid)?;
-        let parent_union = union_parent_reachable_objects(
-            repo,
-            &parents,
-            missing_action,
-            &mut missing,
-            &mut missing_seen,
-        )?;
+        // Same as `collect_reachable_objects_in_commit_order`: Git lists objects in walk order with
+        // global OID de-duplication only (`emitted`), not parent-closure subtraction.
         collect_tree_objects_filtered(
             repo,
             commit.tree,
             "",
             0,
             false,
-            Some(&parent_union),
+            None,
             &mut tree_state,
             &mut emitted,
             &mut result,
@@ -3298,7 +3292,7 @@ fn collect_tree_objects_filtered(
 /// Returns (objects, omitted, per_commit_counts).
 fn collect_reachable_objects_in_commit_order(
     repo: &Repository,
-    graph: &mut CommitGraph<'_>,
+    _graph: &mut CommitGraph<'_>,
     commits: &[ObjectId],
     object_roots: &[RootObject],
     filter: Option<&ObjectFilter>,
@@ -3334,21 +3328,16 @@ fn collect_reachable_objects_in_commit_order(
             Err(err) => return Err(err),
         };
         let before = result.len();
-        let parents = graph.parents_of(commit_oid)?;
-        let parent_union = union_parent_reachable_objects(
-            repo,
-            &parents,
-            missing_action,
-            &mut missing,
-            &mut missing_seen,
-        )?;
+        // Match Git `rev-list --objects`: walk each commit's tree in full traversal order and rely
+        // on `emitted` for OID de-duplication. Do not subtract parent reachability here — that would
+        // skip blobs that still belong after this commit's tree line (t6100-rev-list-in-order).
         collect_tree_objects_filtered(
             repo,
             commit.tree,
             "",
             0,
             false,
-            Some(&parent_union),
+            None,
             &mut tree_state,
             &mut emitted,
             &mut result,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`git rev-list --objects` (including `--in-commit-order`) walks each commit’s tree in traversal order and deduplicates **only by object OID** across the whole walk. It does **not** omit blobs/trees that are also reachable from parents when they still appear in the current commit’s tree listing.

Grit was passing a parent-reachability set into `collect_tree_objects_filtered`, which skipped those entries and broke ordering vs upstream `git` (t6100-rev-list-in-order).

## Changes

- `collect_reachable_objects_in_commit_order` and `collect_reachable_objects_segmented`: pass `parent_union: None` and rely on `emitted` for global OID deduplication.
- Renamed unused `graph` parameter to `_graph` in the in-commit-order collector.
- Refreshed harness CSV/dashboards after `./scripts/run-tests.sh t6100-rev-list-in-order.sh` (3/3 pass).

## Validation

- `./scripts/run-tests.sh t6100-rev-list-in-order.sh`
- `cargo test -p grit-lib --lib`
- `cargo build --release -p grit-rs`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-975eaff5-4cab-4cdc-b736-4b7037af2dc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-975eaff5-4cab-4cdc-b736-4b7037af2dc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

