### PR TITLE
fix: match git ident.c for empty user.name and GIT_*_NAME (t7518)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -56,7 +56,7 @@ t0092-diagnose	t0	yes	4	4	0	true	ok	0
 t0095-bloom	t0	yes	11	11	0	true	ok	0
 t0100-previous	t0	yes	6	6	0	true	ok	0
 t0101-at-syntax	t0	yes	8	8	0	true	ok	0
-t0110-environment	t0	yes	31	29	2	false	ok	0
+t0110-environment	t0	yes	31	31	0	true	ok	0
 t0120-dot-git-dir	t0	yes	32	32	0	true	ok	0
 t0130-sha1-validation	t0	yes	30	30	0	true	ok	0
 t0200-gettext-basic	t0	skip	16	0	0	false	ok	0
@@ -1241,7 +1241,7 @@ t7514-interpret-trailers-options	t7	yes	10	1	9	false	ok	0
 t7515-status-symlinks	t7	yes	3	1	2	false	ok	0
 t7516-commit-races	t7	yes	2	0	2	false	ok	0
 t7517-per-repo-email	t7	yes	16	16	0	true	ok	0
-t7518-ident-corner-cases	t7	yes	5	3	2	false	ok	0
+t7518-ident-corner-cases	t7	yes	5	5	0	true	ok	0
 t7519-status-fsmonitor	t7	yes	33	14	19	false	ok	0
 t7520-ignored-hook-warning	t7	yes	5	5	0	true	ok	0
 t7521-ignored-mode	t7	yes	12	12	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78% of harness tests passing (35,205 / 45,112).">
+<meta property="og:description" content="78% of harness tests passing (35,209 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78% of harness tests passing (35,205 / 45,112).">
+<meta name="twitter:description" content="78% of harness tests passing (35,209 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T12:58:52+00:00" class="gen-time" title="2026-04-09 12:58 UTC">2026-04-09 12:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/c9e26ba46f5a86c3328f4d62484968547c8560d9" style="color:#58a6ff">c9e26ba</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T13:24:22+00:00" class="gen-time" title="2026-04-09 13:24 UTC">2026-04-09 13:24 UTC</time> · <a href="https://github.com/schacon/grit/commit/999b424740b71e52cf30bf6fade3e1ef735f68bd" style="color:#58a6ff">999b424</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,205</div>
+      <div class="summary-big-val">35,209</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>719 files fully passing</span>
+    <span>721 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -186,11 +186,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t0</span>
         <span class="group-desc">Absolute basics and global stuff</span>
-        <span class="group-meta">37/64 files · 21 skipped · 4,866/5,136 tests</span>
+        <span class="group-meta">38/64 files · 21 skipped · 4,868/5,136 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:94.7%"></div></div>
-        <span class="group-pct pct-green">94.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:94.8%"></div></div>
+        <span class="group-pct pct-green">94.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t1">
@@ -263,7 +263,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">43/126 files · 11 skipped · 2,468/3,614 tests</span>
+        <span class="group-meta">44/126 files · 11 skipped · 2,470/3,614 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.3%"></div></div>

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35205 of 45112 tests passing across 1405 harness files (78% pass rate).</desc>
+  <desc id="svg-desc">35209 of 45112 tests passing across 1405 harness files (78% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78% pass rate · 35,205 / 45,112 tests · 1,405 files in scope · 719 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78% pass rate · 35,209 / 45,112 tests · 1,405 files in scope · 721 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="546" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T12:58:52+00:00" class="gen-time" title="2026-04-09 12:58 UTC">2026-04-09 12:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/c9e26ba46f5a86c3328f4d62484968547c8560d9" style="color:#58a6ff">c9e26ba</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T13:24:22+00:00" class="gen-time" title="2026-04-09 13:24 UTC">2026-04-09 13:24 UTC</time> · <a href="https://github.com/schacon/grit/commit/999b424740b71e52cf30bf6fade3e1ef735f68bd" style="color:#58a6ff">999b424</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,205</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,209</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -717,14 +717,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t0" data-tests="31" data-passed="29">
+<tr class="" data-group="t0" data-tests="31" data-passed="31" data-full-pass="1">
   <td class="mono">t0110-environment</td>
   <td>t0</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">31</td>
-  <td class="right">29</td>
+  <td class="right">31</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:93.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t0" data-tests="32" data-passed="32" data-full-pass="1">
@@ -12567,14 +12567,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="5" data-passed="3">
+<tr class="" data-group="t7" data-tests="5" data-passed="5" data-full-pass="1">
   <td class="mono">t7518-ident-corner-cases</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">5</td>
-  <td class="right">3</td>
+  <td class="right">5</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:60.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="33" data-passed="14">

--- a/grit-lib/src/ident_config.rs
+++ b/grit-lib/src/ident_config.rs
@@ -1,0 +1,55 @@
+//! Default identity values from config and the system (Git `ident.c`).
+
+use crate::config::ConfigSet;
+
+/// Git `ident_default_name()` for this merged config: `user.name` if that key was ever set
+/// (including to `""`), otherwise the passwd short name (Unix) or `USER` / `"unknown"`.
+#[must_use]
+pub fn ident_default_name(config: &ConfigSet) -> String {
+    if config.get_last_entry("user.name").is_some() {
+        config
+            .get("user.name")
+            .map(|s| s.trim().to_owned())
+            .unwrap_or_default()
+    } else {
+        passwd_short_username()
+    }
+}
+
+#[cfg(unix)]
+fn passwd_short_username() -> String {
+    // SAFETY: `getpwuid_r` writes through `buf` for the duration of the call; `pwd` is stack-local.
+    let uid = unsafe { libc::getuid() };
+    let mut pwd: libc::passwd = unsafe { std::mem::zeroed() };
+    let mut result: *mut libc::passwd = std::ptr::null_mut();
+    let mut buf = vec![0u8; 16_384];
+    let rv = unsafe {
+        libc::getpwuid_r(
+            uid,
+            &mut pwd,
+            buf.as_mut_ptr().cast(),
+            buf.len(),
+            &mut result,
+        )
+    };
+    if rv != 0 || result.is_null() {
+        return std::env::var("USER")
+            .or_else(|_| std::env::var("USERNAME"))
+            .unwrap_or_else(|_| "unknown".to_owned());
+    }
+    let name_ptr = pwd.pw_name;
+    if name_ptr.is_null() {
+        return std::env::var("USER")
+            .or_else(|_| std::env::var("USERNAME"))
+            .unwrap_or_else(|_| "unknown".to_owned());
+    }
+    let cstr = unsafe { std::ffi::CStr::from_ptr(name_ptr) };
+    cstr.to_string_lossy().into_owned()
+}
+
+#[cfg(not(unix))]
+fn passwd_short_username() -> String {
+    std::env::var("USER")
+        .or_else(|_| std::env::var("USERNAME"))
+        .unwrap_or_else(|_| "unknown".to_owned())
+}

--- a/grit-lib/src/lib.rs
+++ b/grit-lib/src/lib.rs
@@ -37,6 +37,7 @@ pub mod git_date;
 pub mod gitmodules;
 pub mod hooks;
 pub mod ident;
+pub mod ident_config;
 pub mod ignore;
 pub mod index;
 pub mod index_name_hash_lazy;

--- a/grit/src/commands/am.rs
+++ b/grit/src/commands/am.rs
@@ -3574,9 +3574,24 @@ fn resolve_identity(config: &ConfigSet, kind: &str) -> Result<(String, String)> 
     let name_var = format!("GIT_{kind}_NAME");
     let email_var = format!("GIT_{kind}_EMAIL");
 
-    let name = crate::ident::read_git_identity_name_from_env(&name_var)
-        .or_else(|| config.get("user.name"))
-        .unwrap_or_else(|| "Unknown".to_owned());
+    let mut name = match crate::ident::read_git_identity_name_env(&name_var) {
+        crate::ident::GitIdentityNameEnv::Set(s) => s,
+        crate::ident::GitIdentityNameEnv::Unset => {
+            if let Some(v) = config.get("user.name") {
+                let t = v.trim();
+                if !t.is_empty() {
+                    t.to_owned()
+                } else {
+                    crate::ident::ident_default_name(config)
+                }
+            } else {
+                crate::ident::ident_default_name(config)
+            }
+        }
+    };
+    if name.trim().is_empty() {
+        name = "Unknown".to_owned();
+    }
     let email = std::env::var(&email_var)
         .ok()
         .or_else(|| config.get("user.email"))

--- a/grit/src/commands/cherry_pick.rs
+++ b/grit/src/commands/cherry_pick.rs
@@ -1506,9 +1506,24 @@ fn create_cherry_pick_commit(
 }
 
 fn committer_name_email(config: &ConfigSet) -> (String, String) {
-    let name = crate::ident::read_git_identity_name_from_env("GIT_COMMITTER_NAME")
-        .or_else(|| config.get("user.name"))
-        .unwrap_or_else(|| "Unknown".to_owned());
+    let mut name = match crate::ident::read_git_identity_name_env("GIT_COMMITTER_NAME") {
+        crate::ident::GitIdentityNameEnv::Set(s) => s,
+        crate::ident::GitIdentityNameEnv::Unset => {
+            if let Some(v) = config.get("user.name") {
+                let t = v.trim();
+                if !t.is_empty() {
+                    t.to_owned()
+                } else {
+                    crate::ident::ident_default_name(config)
+                }
+            } else {
+                crate::ident::ident_default_name(config)
+            }
+        }
+    };
+    if name.trim().is_empty() {
+        name = "Unknown".to_owned();
+    }
     let email = std::env::var("GIT_COMMITTER_EMAIL")
         .ok()
         .or_else(|| config.get("user.email"))
@@ -1533,9 +1548,24 @@ fn resolve_committer_ident(config: &ConfigSet, now: time::OffsetDateTime) -> Res
 
 fn append_signoff(msg: &str, git_dir: &Path) -> Result<String> {
     let config = ConfigSet::load(Some(git_dir), true)?;
-    let name = crate::ident::read_git_identity_name_from_env("GIT_COMMITTER_NAME")
-        .or_else(|| config.get("user.name"))
-        .unwrap_or_else(|| "Unknown".to_owned());
+    let mut name = match crate::ident::read_git_identity_name_env("GIT_COMMITTER_NAME") {
+        crate::ident::GitIdentityNameEnv::Set(s) => s,
+        crate::ident::GitIdentityNameEnv::Unset => {
+            if let Some(v) = config.get("user.name") {
+                let t = v.trim();
+                if !t.is_empty() {
+                    t.to_owned()
+                } else {
+                    crate::ident::ident_default_name(&config)
+                }
+            } else {
+                crate::ident::ident_default_name(&config)
+            }
+        }
+    };
+    if name.trim().is_empty() {
+        name = "Unknown".to_owned();
+    }
     let email = std::env::var("GIT_COMMITTER_EMAIL")
         .ok()
         .or_else(|| config.get("user.email"))

--- a/grit/src/commands/commit.rs
+++ b/grit/src/commands/commit.rs
@@ -2471,7 +2471,6 @@ fn resolve_author(
     }
 
     let name = resolve_name(config, IdentRole::Author)?;
-    validate_ident_name(&name, "author")?;
 
     let email = resolve_email(config, IdentRole::Author)?;
 
@@ -2492,7 +2491,6 @@ fn resolve_author(
 /// Resolve the committer identity from env and config.
 fn resolve_committer(config: &ConfigSet, now: OffsetDateTime) -> Result<String> {
     let name = resolve_name(config, IdentRole::Committer)?;
-    validate_ident_name(&name, "committer")?;
 
     let email = resolve_email(config, IdentRole::Committer)?;
 

--- a/grit/src/commands/commit_tree.rs
+++ b/grit/src/commands/commit_tree.rs
@@ -14,11 +14,12 @@ use std::io::Read;
 use time::format_description::well_known::Rfc3339;
 use time::{format_description, OffsetDateTime, PrimitiveDateTime, UtcOffset};
 
+use grit_lib::config::ConfigSet;
 use grit_lib::objects::{serialize_commit, CommitData, ObjectId, ObjectKind};
 use grit_lib::repo::Repository;
 use grit_lib::rev_parse::{resolve_revision_for_commit_tree_tree, resolve_revision_for_range_end};
 
-use crate::ident::read_git_identity_name_from_env;
+use crate::ident::{read_git_identity_name_env, GitIdentityNameEnv};
 
 /// Arguments for `grit commit-tree`.
 #[derive(Debug, ClapArgs)]
@@ -46,6 +47,7 @@ pub struct Args {
 /// Run `grit commit-tree`.
 pub fn run(args: Args) -> Result<()> {
     let repo = Repository::discover(None).context("not a git repository")?;
+    let config = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
 
     let tree_oid = resolve_revision_for_commit_tree_tree(&repo, &args.tree)
         .with_context(|| format!("not a valid object name: '{}'", args.tree))?;
@@ -72,8 +74,8 @@ pub fn run(args: Args) -> Result<()> {
     let now_unix = current_unix_timestamp();
     let tz_str = local_tz_string();
 
-    let author = build_identity("AUTHOR", &now_unix, &tz_str)?;
-    let committer = build_identity("COMMITTER", &now_unix, &tz_str)?;
+    let author = build_identity("AUTHOR", &config, &now_unix, &tz_str)?;
+    let committer = build_identity("COMMITTER", &config, &now_unix, &tz_str)?;
 
     let commit_data = CommitData {
         tree: tree_oid,
@@ -119,14 +121,35 @@ fn build_message(args: &Args) -> Result<String> {
 }
 
 /// Build a `"Name <email> <timestamp> <tz>"` identity string.
-fn build_identity(prefix: &str, now_unix: &str, tz_str: &str) -> Result<String> {
+fn build_identity(
+    prefix: &str,
+    config: &ConfigSet,
+    now_unix: &str,
+    tz_str: &str,
+) -> Result<String> {
     let name_key = format!("GIT_{prefix}_NAME");
     let email_key = format!("GIT_{prefix}_EMAIL");
     let date_key = format!("GIT_{prefix}_DATE");
 
-    let name = read_git_identity_name_from_env(&name_key)
-        .or_else(|| read_git_identity_name_from_env("GIT_AUTHOR_NAME"))
-        .unwrap_or_else(|| "Unknown".to_owned());
+    let name = if prefix == "COMMITTER" {
+        match read_git_identity_name_env(&name_key) {
+            GitIdentityNameEnv::Set(s) => s,
+            GitIdentityNameEnv::Unset => match read_git_identity_name_env("GIT_AUTHOR_NAME") {
+                GitIdentityNameEnv::Set(s) => s,
+                GitIdentityNameEnv::Unset => crate::ident::ident_default_name(config),
+            },
+        }
+    } else {
+        match read_git_identity_name_env(&name_key) {
+            GitIdentityNameEnv::Set(s) => s,
+            GitIdentityNameEnv::Unset => crate::ident::ident_default_name(config),
+        }
+    };
+    let name = if name.trim().is_empty() {
+        "Unknown".to_owned()
+    } else {
+        name
+    };
     let email = env::var(&email_key)
         .or_else(|_| env::var("GIT_AUTHOR_EMAIL"))
         .unwrap_or_else(|_| "unknown@unknown".to_owned());

--- a/grit/src/commands/format_patch.rs
+++ b/grit/src/commands/format_patch.rs
@@ -22,7 +22,7 @@ use std::io::{self, Write};
 use std::path::PathBuf;
 
 use crate::git_commit_encoding::commit_message_unicode_for_display;
-use crate::ident::read_git_identity_name_from_env;
+use crate::ident::{read_git_identity_name_env, GitIdentityNameEnv};
 
 /// Arguments for `grit format-patch`.
 #[derive(Debug, ClapArgs)]
@@ -927,16 +927,18 @@ fn format_cover_letter(
 
 /// Get the signoff identity, preferring GIT_COMMITTER_NAME/EMAIL env vars.
 fn get_signoff_identity(committer_ident: &str) -> (String, String) {
-    let env_name = read_git_identity_name_from_env("GIT_COMMITTER_NAME");
     let env_email = std::env::var("GIT_COMMITTER_EMAIL").ok();
 
-    let name = env_name.unwrap_or_else(|| {
-        if let Some(bracket) = committer_ident.find('<') {
-            committer_ident[..bracket].trim().to_string()
-        } else {
-            "Unknown".to_string()
+    let name = match read_git_identity_name_env("GIT_COMMITTER_NAME") {
+        GitIdentityNameEnv::Set(s) if !s.is_empty() => s,
+        _ => {
+            if let Some(bracket) = committer_ident.find('<') {
+                committer_ident[..bracket].trim().to_string()
+            } else {
+                "Unknown".to_string()
+            }
         }
-    });
+    };
     let email = env_email.unwrap_or_else(|| {
         extract_email(committer_ident)
             .unwrap_or("unknown")

--- a/grit/src/commands/revert.rs
+++ b/grit/src/commands/revert.rs
@@ -1195,9 +1195,24 @@ fn resolve_identity(config: &ConfigSet, kind: &str) -> Result<(String, String)> 
     let name_var = format!("GIT_{kind}_NAME");
     let email_var = format!("GIT_{kind}_EMAIL");
 
-    let name = crate::ident::read_git_identity_name_from_env(&name_var)
-        .or_else(|| config.get("user.name"))
-        .unwrap_or_else(|| "Unknown".to_owned());
+    let mut name = match crate::ident::read_git_identity_name_env(&name_var) {
+        crate::ident::GitIdentityNameEnv::Set(s) => s,
+        crate::ident::GitIdentityNameEnv::Unset => {
+            if let Some(v) = config.get("user.name") {
+                let t = v.trim();
+                if !t.is_empty() {
+                    t.to_owned()
+                } else {
+                    crate::ident::ident_default_name(config)
+                }
+            } else {
+                crate::ident::ident_default_name(config)
+            }
+        }
+    };
+    if name.trim().is_empty() {
+        name = "Unknown".to_owned();
+    }
     let email = std::env::var(&email_var)
         .ok()
         .or_else(|| config.get("user.email"))

--- a/grit/src/ident.rs
+++ b/grit/src/ident.rs
@@ -6,15 +6,26 @@
 use anyhow::{bail, Result};
 use grit_lib::config::ConfigSet;
 
-/// Read `GIT_AUTHOR_NAME` / `GIT_COMMITTER_NAME` from the environment.
+pub use grit_lib::ident_config::ident_default_name;
+
+/// Whether `GIT_AUTHOR_NAME` / `GIT_COMMITTER_NAME` is unset vs set (possibly empty).
 ///
-/// Shell scripts may `export` these with ISO-8859-1 bytes (see upstream `t3901`).
-/// Rust's [`std::env::var`] rejects non-UTF-8 sequences; Git accepts arbitrary bytes
-/// in the name field and stores them according to `i18n.commitEncoding`. We decode
-/// invalid UTF-8 as Latin-1 to match Git's behavior for test fixtures.
+/// Git treats a set-but-empty value as an explicit override: it must not fall through
+/// to `user.name` or passwd/GECOS fallback (`t7518-ident-corner-cases`).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum GitIdentityNameEnv {
+    /// Variable is not present in the environment.
+    Unset,
+    /// Present after trimming whitespace (may be `""`).
+    Set(String),
+}
+
+/// Read a `GIT_*_NAME` variable like Git's `getenv`: unset vs set, preserving explicit empty.
 #[must_use]
-pub fn read_git_identity_name_from_env(key: &str) -> Option<String> {
-    let os = std::env::var_os(key)?;
+pub fn read_git_identity_name_env(key: &str) -> GitIdentityNameEnv {
+    let Some(os) = std::env::var_os(key) else {
+        return GitIdentityNameEnv::Unset;
+    };
     #[cfg(unix)]
     {
         use std::os::unix::ffi::OsStrExt;
@@ -24,18 +35,31 @@ pub fn read_git_identity_name_from_env(key: &str) -> Option<String> {
         } else {
             crate::git_commit_encoding::decode_bytes(Some("ISO8859-1"), bytes)
         };
-        let t = s.trim();
-        if t.is_empty() {
-            None
-        } else {
-            Some(t.to_owned())
-        }
+        GitIdentityNameEnv::Set(s.trim().to_owned())
     }
     #[cfg(not(unix))]
     {
-        os.to_str()
-            .map(|s| s.trim().to_owned())
-            .filter(|s| !s.is_empty())
+        let s = os.to_str().map(|t| t.trim().to_owned()).unwrap_or_default();
+        GitIdentityNameEnv::Set(s)
+    }
+}
+
+/// Read `GIT_AUTHOR_NAME` / `GIT_COMMITTER_NAME` from the environment.
+///
+/// Shell scripts may `export` these with ISO-8859-1 bytes (see upstream `t3901`).
+/// Rust's [`std::env::var`] rejects non-UTF-8 sequences; Git accepts arbitrary bytes
+/// in the name field and stores them according to `i18n.commitEncoding`. We decode
+/// invalid UTF-8 as Latin-1 to match Git's behavior for test fixtures.
+///
+/// Returns [`None`] when the variable is unset or set to whitespace only. A set-but-empty
+/// value (after trim) is still [`None`] here; use [`read_git_identity_name_env`] when the
+/// distinction matters.
+#[must_use]
+pub fn read_git_identity_name_from_env(key: &str) -> Option<String> {
+    match read_git_identity_name_env(key) {
+        GitIdentityNameEnv::Unset => None,
+        GitIdentityNameEnv::Set(s) if s.is_empty() => None,
+        GitIdentityNameEnv::Set(s) => Some(s),
     }
 }
 
@@ -101,6 +125,35 @@ fn config_mail_given(config: &ConfigSet) -> bool {
         }
     }
     false
+}
+
+fn ident_env_hint(role: IdentRole) {
+    eprintln!("{}", role.missing_email_hint());
+    eprintln!(
+        "\n*** Please tell me who you are.\n\n\
+Run\n\n\
+  git config --global user.email \"you@example.com\"\n\
+  git config --global user.name \"Your Name\"\n\n\
+to set your account's default identity.\n\
+Omit --global to set the identity only in this repository.\n"
+    );
+}
+
+/// True if `name` contains at least one character Git does not treat as `crud`
+/// (`ident.c` `has_non_crud`).
+fn ident_name_has_non_crud(name: &str) -> bool {
+    name.chars().any(|c| {
+        let o = c as u32;
+        !(o <= 32
+            || c == ','
+            || c == ':'
+            || c == ';'
+            || c == '<'
+            || c == '>'
+            || c == '"'
+            || c == '\\'
+            || c == '\'')
+    })
 }
 
 fn synthetic_email() -> String {
@@ -179,59 +232,96 @@ pub fn resolve_email_lenient(config: &ConfigSet, role: IdentRole) -> String {
 /// Name from env and config without erroring (for `git var -l`).
 #[must_use]
 pub fn peek_name(config: &ConfigSet, role: IdentRole) -> Option<String> {
-    if let Some(v) = read_git_identity_name_from_env(role.env_name_key()) {
-        return Some(v);
-    }
-    if let Some(v) = config.get(role.config_name_key()) {
-        let t = v.trim();
-        if !t.is_empty() {
-            return Some(t.to_owned());
+    match read_git_identity_name_env(role.env_name_key()) {
+        GitIdentityNameEnv::Set(s) => {
+            if s.is_empty() {
+                None
+            } else {
+                Some(s)
+            }
+        }
+        GitIdentityNameEnv::Unset => {
+            if let Some(v) = config.get(role.config_name_key()) {
+                let t = v.trim();
+                if !t.is_empty() {
+                    return Some(t.to_owned());
+                }
+            }
+            let d = ident_default_name(config);
+            if d.is_empty() {
+                None
+            } else {
+                Some(d)
+            }
         }
     }
-    config
-        .get("user.name")
-        .map(|s| s.trim().to_owned())
-        .filter(|s| !s.is_empty())
 }
 
 /// Resolve name for a role when creating commits.
 pub fn resolve_name(config: &ConfigSet, role: IdentRole) -> Result<String> {
-    if let Some(n) = peek_name(config, role) {
-        return Ok(n);
+    let email = resolve_email_inner(config, role, true)?;
+
+    let name: String = match read_git_identity_name_env(role.env_name_key()) {
+        GitIdentityNameEnv::Set(s) => s,
+        GitIdentityNameEnv::Unset => {
+            if let Some(v) = config.get(role.config_name_key()) {
+                let t = v.trim();
+                if !t.is_empty() {
+                    t.to_owned()
+                } else {
+                    ident_default_name(config)
+                }
+            } else {
+                ident_default_name(config)
+            }
+        }
+    };
+
+    if name.is_empty() {
+        ident_env_hint(role);
+        bail!("empty ident name (for <{email}>) not allowed");
     }
 
-    match role {
-        IdentRole::Author => {
-            eprintln!("Author identity unknown");
-            bail!(
-                "Author identity unknown\n\n\
-Please tell me who you are.\n\n\
-Run\n\n\
-  git config user.email \"you@example.com\"\n\
-  git config user.name \"Your Name\""
-            );
-        }
-        IdentRole::Committer => Ok("Unknown".to_owned()),
+    if !ident_name_has_non_crud(&name) {
+        bail!("invalid ident name: '{}'", name);
     }
+
+    Ok(name)
 }
 
 /// Committer name/email for reflog and other non-strict contexts: never errors; always has an email.
 pub fn resolve_loose_committer_parts(config: &ConfigSet) -> (String, String) {
-    let name = read_git_identity_name_from_env("GIT_COMMITTER_NAME")
-        .or_else(|| read_git_identity_name_from_env("GIT_AUTHOR_NAME"))
-        .or_else(|| {
-            config
-                .get("committer.name")
-                .map(|s| s.trim().to_owned())
-                .filter(|s| !s.is_empty())
-        })
-        .or_else(|| {
-            config
-                .get("user.name")
-                .map(|s| s.trim().to_owned())
-                .filter(|s| !s.is_empty())
-        })
-        .unwrap_or_else(|| "Unknown".to_owned());
+    let name = match read_git_identity_name_env("GIT_COMMITTER_NAME") {
+        GitIdentityNameEnv::Set(s) => {
+            if s.is_empty() {
+                None
+            } else {
+                Some(s)
+            }
+        }
+        GitIdentityNameEnv::Unset => read_git_identity_name_from_env("GIT_AUTHOR_NAME"),
+    }
+    .or_else(|| {
+        config
+            .get("committer.name")
+            .map(|s| s.trim().to_owned())
+            .filter(|s| !s.is_empty())
+    })
+    .or_else(|| {
+        config
+            .get("user.name")
+            .map(|s| s.trim().to_owned())
+            .filter(|s| !s.is_empty())
+    })
+    .or_else(|| {
+        let d = ident_default_name(config);
+        if d.is_empty() {
+            None
+        } else {
+            Some(d)
+        }
+    })
+    .unwrap_or_else(|| "Unknown".to_owned());
 
     let email = std::env::var("GIT_COMMITTER_EMAIL")
         .ok()

--- a/logs/2026-04-09_t7518-ident-corner-cases.md
+++ b/logs/2026-04-09_t7518-ident-corner-cases.md
@@ -1,0 +1,24 @@
+# t7518 ident corner cases
+
+## Goal
+
+Make `t7518-ident-corner-cases.sh` pass (5/5).
+
+## Root cause
+
+Harness exports `GIT_AUTHOR_NAME` / `GIT_COMMITTER_NAME` from `test-lib.sh`. Tests that `sane_unset` author name and use `git -c user.name=` expect Git’s `ident.c` behavior: an explicit empty `user.name` makes the default name empty (no `$USER` fallback), so commit fails with `empty ident name` and the role-specific hint.
+
+Grit previously treated empty env as “unset” and fell back to `USER`, so `git -c user.name= commit` succeeded.
+
+## Changes
+
+- `grit-lib/src/ident_config.rs`: `ident_default_name` using `getpwuid_r` on Unix (matches Git passwd short name); empty `user.name` key yields `""`.
+- `grit/src/ident.rs`: `GitIdentityNameEnv`, `read_git_identity_name_env`, `resolve_name` aligned with `fmt_ident` (resolve email first, empty name + crud checks, hints).
+- Call sites: `commit_tree`, `revert`, `am`, `cherry_pick`, `format_patch` use env set/unset distinction and `ident_default_name`.
+- `tests/t0110-environment.sh`: last case expected wrong behavior vs real Git; updated to `test_must_fail` + grep (now 31/31).
+
+## Validation
+
+- `sh tests/t7518-ident-corner-cases.sh -v`
+- `cargo test -p grit-lib --lib`
+- `./scripts/run-tests.sh t7518-ident-corner-cases.sh t0110-environment.sh`

--- a/tests/t0110-environment.sh
+++ b/tests/t0110-environment.sh
@@ -316,16 +316,15 @@ test_expect_success 'GIT_COMMITTER_NAME with special characters' '
 # Edge: empty author name
 # ===========================================================================
 
-test_expect_success 'empty GIT_AUTHOR_NAME is accepted' '
+test_expect_success 'empty GIT_AUTHOR_NAME is rejected (matches git ident.c)' '
 	cd repo &&
 	echo "empty-author" >empty-author.txt &&
 	git add empty-author.txt &&
-	GIT_AUTHOR_NAME="" \
-	GIT_AUTHOR_EMAIL="empty@example.com" \
-	git commit -m "empty author name" &&
-	git log -n 1 --format="%ae" >actual &&
-	echo "empty@example.com" >expect &&
-	test_cmp expect actual
+	test_must_fail env GIT_AUTHOR_NAME="" \
+		GIT_AUTHOR_EMAIL="empty@example.com" \
+		git commit -m "empty author name" 2>err &&
+	test_grep "empty ident name" err &&
+	test_grep "Author identity unknown" err
 '
 
 test_done


### PR DESCRIPTION
- Add ident_default_name in grit-lib (passwd short name when user.name unset)
- Distinguish unset vs empty GIT_AUTHOR_NAME / GIT_COMMITTER_NAME
- resolve_name: resolve email first, then empty-name and crud validation like fmt_ident
- Update commit_tree, revert, am, cherry_pick, format_patch fallbacks
- Fix t0110 empty GIT_AUTHOR_NAME expectation to match real git