### PR TITLE
fix: t4128-apply-root — apply --directory without double -p strip

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -474,7 +474,7 @@ commit → check it off → move on.
 - [ ] `t4067-diff-partial-clone` ░░░░░░░░░░░░░░░░░░░░ 0/9 (9 left) — behavior of diff when reading objects in a partial clone
 - [ ] `t4208-log-magic-pathspec` ██████████░░░░░░░░░░ 11/21 (10 left) — magic pathspec tests using git-log
 - [ ] `t4212-log-corrupt` ████░░░░░░░░░░░░░░░░ 3/13 (10 left) — git log with invalid commit headers
-- [ ] `t4128-apply-root` ███░░░░░░░░░░░░░░░░░ 2/12 (10 left) — apply same filename
+- [x] `t4128-apply-root` — apply same filename (`--directory` + `-p`: no double strip; normalize directory like Git)
 - [ ] `t4139-apply-escape` ███░░░░░░░░░░░░░░░░░ 2/12 (10 left) — paths written by git-apply cannot escape the working tree
 - [ ] `t4119-apply-config` █░░░░░░░░░░░░░░░░░░░ 1/11 (10 left) — git apply --whitespace=strip and configuration file.
 

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -798,7 +798,7 @@ t4124-apply-ws-rule	t4	yes	85	71	14	false	ok	0
 t4125-apply-ws-fuzz	t4	yes	4	2	2	false	ok	0
 t4126-apply-empty	t4	yes	8	7	1	false	ok	0
 t4127-apply-same-fn	t4	yes	7	7	0	true	ok	0
-t4128-apply-root	t4	yes	12	1	11	false	ok	0
+t4128-apply-root	t4	yes	12	12	0	true	ok	0
 t4129-apply-samemode	t4	yes	23	9	14	false	ok	0
 t4130-apply-criss-cross-rename	t4	yes	7	7	0	true	ok	0
 t4131-apply-fake-ancestor	t4	yes	3	3	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78% of harness tests passing (35,205 / 45,112).">
+<meta property="og:description" content="78.1% of harness tests passing (35,216 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78% of harness tests passing (35,205 / 45,112).">
+<meta name="twitter:description" content="78.1% of harness tests passing (35,216 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T12:58:52+00:00" class="gen-time" title="2026-04-09 12:58 UTC">2026-04-09 12:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/c9e26ba46f5a86c3328f4d62484968547c8560d9" style="color:#58a6ff">c9e26ba</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T13:37:03+00:00" class="gen-time" title="2026-04-09 13:37 UTC">2026-04-09 13:37 UTC</time> · <a href="https://github.com/schacon/grit/commit/999b424740b71e52cf30bf6fade3e1ef735f68bd" style="color:#58a6ff">999b424</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">78.0%</div>
+      <div class="summary-big-val pct-blue">78.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,205</div>
+      <div class="summary-big-val">35,216</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:78.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:78.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>719 files fully passing</span>
+    <span>720 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -230,11 +230,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">68/178 files · 2 skipped · 2,668/4,437 tests</span>
+        <span class="group-meta">69/178 files · 2 skipped · 2,679/4,437 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.1%"></div></div>
-        <span class="group-pct pct-blue">60.1%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.4%"></div></div>
+        <span class="group-pct pct-blue">60.4%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35205 of 45112 tests passing across 1405 harness files (78% pass rate).</desc>
+  <desc id="svg-desc">35216 of 45112 tests passing across 1405 harness files (78.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78% pass rate · 35,205 / 45,112 tests · 1,405 files in scope · 719 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.1% pass rate · 35,216 / 45,112 tests · 1,405 files in scope · 720 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="546" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="547" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T12:58:52+00:00" class="gen-time" title="2026-04-09 12:58 UTC">2026-04-09 12:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/c9e26ba46f5a86c3328f4d62484968547c8560d9" style="color:#58a6ff">c9e26ba</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T13:37:03+00:00" class="gen-time" title="2026-04-09 13:37 UTC">2026-04-09 13:37 UTC</time> · <a href="https://github.com/schacon/grit/commit/999b424740b71e52cf30bf6fade3e1ef735f68bd" style="color:#58a6ff">999b424</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,205</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">78.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,216</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">78.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -8137,14 +8137,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="12" data-passed="1">
+<tr class="" data-group="t4" data-tests="12" data-passed="12" data-full-pass="1">
   <td class="mono">t4128-apply-root</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">12</td>
-  <td class="right">1</td>
+  <td class="right">12</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="23" data-passed="9">

--- a/grit/src/commands/apply.rs
+++ b/grit/src/commands/apply.rs
@@ -1627,7 +1627,7 @@ fn strip_components(path: &str, n: usize) -> String {
     remaining.to_string()
 }
 
-/// Strip `-p` prefix from a path the same way as [`adjust_path`] (without `--directory`).
+/// Strip `-p` prefix from a path (matches parsing-time strip, for validating headers).
 fn path_after_strip(path: &str, strip: usize) -> String {
     if path == "/dev/null" {
         return path.to_string();
@@ -1635,7 +1635,6 @@ fn path_after_strip(path: &str, strip: usize) -> String {
     strip_components(path, strip)
 }
 
-/// Apply -p and --directory transforms to a path.
 /// Create compact rename path: "dir/{old => new}" or "old => new".
 fn compact_rename_path(old: &str, new: &str) -> String {
     // Find common prefix
@@ -1688,16 +1687,29 @@ fn compact_rename_path(old: &str, new: &str) -> String {
     result
 }
 
-fn adjust_path(path: &str, strip: usize, directory: Option<&str>) -> String {
+/// Normalize `--directory` like Git (`strbuf_normalize_path` + trailing `/` when non-empty).
+fn normalize_apply_directory(raw: &str) -> Result<String> {
+    let normalized = crate::git_path::normalize_path_copy(raw)
+        .map_err(|_| anyhow::anyhow!("unable to normalize directory: '{raw}'"))?;
+    if normalized.is_empty() {
+        return Ok(String::new());
+    }
+    Ok(if normalized.ends_with('/') {
+        normalized
+    } else {
+        format!("{normalized}/")
+    })
+}
+
+/// Prepend normalized `--directory` to a path already adjusted for `-p` during parsing.
+fn adjust_path(path: &str, directory: Option<&str>) -> String {
     if path == "/dev/null" {
         return path.to_string();
     }
-    let stripped = strip_components(path, strip);
-    if let Some(dir) = directory {
-        format!("{dir}/{stripped}")
-    } else {
-        stripped
-    }
+    let Some(dir) = directory.filter(|d| !d.is_empty()) else {
+        return path.to_string();
+    };
+    format!("{dir}{path}")
 }
 
 fn symlink_prefix(path: &str, symlink_overlay: &HashMap<String, bool>) -> Option<String> {
@@ -1731,7 +1743,7 @@ fn verify_patch_paths_not_beyond_symlink(patches: &[FilePatch], args: &Args) -> 
 
     for fp in patches {
         if let Some(source) = fp.source_path() {
-            let source_adjusted = adjust_path(source, args.strip, args.directory.as_deref());
+            let source_adjusted = adjust_path(source, args.directory.as_deref());
             if !source_adjusted.is_empty() {
                 if let Some(prefix) = symlink_prefix(&source_adjusted, &symlink_overlay) {
                     let allow_delete_under_replaced_dir = fp.is_deleted
@@ -1747,7 +1759,7 @@ fn verify_patch_paths_not_beyond_symlink(patches: &[FilePatch], args: &Args) -> 
             }
         }
         if let Some(target) = fp.target_path() {
-            let target_adjusted = adjust_path(target, args.strip, args.directory.as_deref());
+            let target_adjusted = adjust_path(target, args.directory.as_deref());
             if !target_adjusted.is_empty() {
                 if let Some(prefix) = symlink_prefix(&target_adjusted, &symlink_overlay) {
                     let allow_delete_under_replaced_dir = fp.is_deleted
@@ -1765,11 +1777,11 @@ fn verify_patch_paths_not_beyond_symlink(patches: &[FilePatch], args: &Args) -> 
 
         let source_adjusted = fp
             .source_path()
-            .map(|p| adjust_path(p, args.strip, args.directory.as_deref()))
+            .map(|p| adjust_path(p, args.directory.as_deref()))
             .unwrap_or_default();
         let target_adjusted = fp
             .target_path()
-            .map(|p| adjust_path(p, args.strip, args.directory.as_deref()))
+            .map(|p| adjust_path(p, args.directory.as_deref()))
             .unwrap_or_default();
         let target_is_existing_dir =
             !target_adjusted.is_empty() && Path::new(&target_adjusted).is_dir();
@@ -1871,7 +1883,7 @@ fn assign_ws_rules(patches: &mut [FilePatch], args: &Args) {
             .target_path()
             .or_else(|| fp.effective_path())
             .unwrap_or("");
-        let adjusted = adjust_path(path_for_attr, args.strip, args.directory.as_deref());
+        let adjusted = adjust_path(path_for_attr, args.directory.as_deref());
         let fa = crlf::get_file_attrs(&rules, &adjusted, false, &config);
         let attr = match fa.whitespace.as_deref() {
             None => WhitespaceGitAttr::Unspecified,
@@ -2951,7 +2963,7 @@ fn write_reject_file(path: &Path, patch: &FilePatch, rejected_hunks: &[Hunk]) ->
 // Stat / numstat / summary output
 // ---------------------------------------------------------------------------
 
-fn show_stat(patches: &[FilePatch], strip: usize, directory: Option<&str>) {
+fn show_stat(patches: &[FilePatch], directory: Option<&str>) {
     let stdout = io::stdout();
     let mut out = stdout.lock();
 
@@ -2963,7 +2975,7 @@ fn show_stat(patches: &[FilePatch], strip: usize, directory: Option<&str>) {
     for fp in patches {
         let path = fp
             .effective_path()
-            .map(|p| adjust_path(p, strip, directory))
+            .map(|p| adjust_path(p, directory))
             .unwrap_or_else(|| "(unknown)".to_string());
         let (add, del) = count_hunk_changes(&fp.hunks);
         if path.len() > max_path_len {
@@ -2993,28 +3005,28 @@ fn show_stat(patches: &[FilePatch], strip: usize, directory: Option<&str>) {
     );
 }
 
-fn show_numstat(patches: &[FilePatch], strip: usize, directory: Option<&str>) {
+fn show_numstat(patches: &[FilePatch], directory: Option<&str>) {
     let stdout = io::stdout();
     let mut out = stdout.lock();
 
     for fp in patches {
         let path = fp
             .effective_path()
-            .map(|p| adjust_path(p, strip, directory))
+            .map(|p| adjust_path(p, directory))
             .unwrap_or_else(|| "(unknown)".to_string());
         let (add, del) = count_hunk_changes(&fp.hunks);
         let _ = writeln!(out, "{add}\t{del}\t{path}");
     }
 }
 
-fn show_summary(patches: &[FilePatch], strip: usize, directory: Option<&str>) {
+fn show_summary(patches: &[FilePatch], directory: Option<&str>) {
     let stdout = io::stdout();
     let mut out = stdout.lock();
 
     for fp in patches {
         let path = fp
             .effective_path()
-            .map(|p| adjust_path(p, strip, directory))
+            .map(|p| adjust_path(p, directory))
             .unwrap_or_else(|| "(unknown)".to_string());
 
         if fp.is_new {
@@ -3027,7 +3039,7 @@ fn show_summary(patches: &[FilePatch], strip: usize, directory: Option<&str>) {
             let old = fp
                 .old_path
                 .as_deref()
-                .map(|p| adjust_path(p, strip, directory))
+                .map(|p| adjust_path(p, directory))
                 .unwrap_or_else(|| "(unknown)".to_string());
             let kind = if fp.is_copy { "copy" } else { "rename" };
             let pct = fp.similarity_index.unwrap_or(100);
@@ -3081,7 +3093,12 @@ fn make_stat_bar(add: usize, del: usize, max_width: usize) -> String {
 // Main run
 // ---------------------------------------------------------------------------
 
-pub fn run(args: Args) -> Result<()> {
+pub fn run(mut args: Args) -> Result<()> {
+    if let Some(dir) = args.directory.take() {
+        let norm = normalize_apply_directory(&dir)?;
+        args.directory = if norm.is_empty() { None } else { Some(norm) };
+    }
+
     // Validate repository format if operating on the index or doing a check that requires it
     if args.cached || args.index || args.check {
         if let Some(git_dir) = crate::commands::config::resolve_git_dir_pub() {
@@ -3141,13 +3158,13 @@ pub fn run(args: Args) -> Result<()> {
     // Info-only modes unless explicitly overridden by --apply.
     let info_only = (args.stat || args.numstat || args.summary) && !args.apply;
     if args.stat {
-        show_stat(&patches, args.strip, args.directory.as_deref());
+        show_stat(&patches, args.directory.as_deref());
     }
     if args.numstat {
-        show_numstat(&patches, args.strip, args.directory.as_deref());
+        show_numstat(&patches, args.directory.as_deref());
     }
     if args.summary {
-        show_summary(&patches, args.strip, args.directory.as_deref());
+        show_summary(&patches, args.directory.as_deref());
     }
     if info_only {
         return Ok(());
@@ -3213,7 +3230,7 @@ fn build_fake_ancestor_file(patches: &[FilePatch], args: &Args, out_path: &Path)
         if raw_old_path == "/dev/null" {
             continue;
         }
-        let adjusted = adjust_path(raw_old_path, args.strip, args.directory.as_deref());
+        let adjusted = adjust_path(raw_old_path, args.directory.as_deref());
         if adjusted.is_empty() {
             continue;
         }
@@ -3340,7 +3357,7 @@ fn verify_worktree_gitlink_patch(
         let Some(target) = fp.target_path() else {
             return Ok(());
         };
-        let adjusted = adjust_path(target, args.strip, args.directory.as_deref());
+        let adjusted = adjust_path(target, args.directory.as_deref());
         let path = work_tree.join(&adjusted);
         if path.exists() && path.is_file() {
             // Replacing a tracked regular file (or symlink) with a submodule: the work tree must
@@ -3376,7 +3393,7 @@ fn verify_worktree_gitlink_patch(
         let Some(source) = fp.source_path() else {
             return Ok(());
         };
-        let adjusted = adjust_path(source, args.strip, args.directory.as_deref());
+        let adjusted = adjust_path(source, args.directory.as_deref());
         let path = work_tree.join(&adjusted);
         if !path.exists() {
             bail!("{}: does not exist", adjusted);
@@ -3401,7 +3418,7 @@ fn ensure_gitlink_placeholder_dirs(patches: &[FilePatch], args: &Args) -> Result
         let Some(path_str) = fp.target_path() else {
             continue;
         };
-        let adjusted = adjust_path(path_str, args.strip, args.directory.as_deref());
+        let adjusted = adjust_path(path_str, args.directory.as_deref());
         let path = PathBuf::from(&adjusted);
         if !path.exists() {
             fs::create_dir_all(&path)
@@ -3436,7 +3453,7 @@ fn verify_worktree_matches_index(patches: &[FilePatch], args: &Args) -> Result<(
     for fp in patches {
         if fp.is_new {
             if let Some(target) = fp.target_path() {
-                let adjusted = adjust_path(target, args.strip, args.directory.as_deref());
+                let adjusted = adjust_path(target, args.directory.as_deref());
                 if let Some(entry) = ctx.index.get(adjusted.as_bytes(), 0) {
                     let path = PathBuf::from(&adjusted);
                     if !path.exists() {
@@ -3459,7 +3476,7 @@ fn verify_worktree_matches_index(patches: &[FilePatch], args: &Args) -> Result<(
         let path_str = fp
             .source_path()
             .ok_or_else(|| anyhow::anyhow!("patch has no file path"))?;
-        let adjusted = adjust_path(path_str, args.strip, args.directory.as_deref());
+        let adjusted = adjust_path(path_str, args.directory.as_deref());
         let path = PathBuf::from(&adjusted);
 
         if !path.exists() {
@@ -3681,11 +3698,11 @@ fn precheck_worktree_patch_sequence(patches: &[FilePatch], args: &Args) -> Resul
 
     for fp in patches {
         if let Some(source) = fp.source_path() {
-            let adjusted = adjust_path(source, args.strip, args.directory.as_deref());
+            let adjusted = adjust_path(source, args.directory.as_deref());
             record_path_existence(&adjusted, &mut current_exists, &mut initial_exists);
         }
         if let Some(target) = fp.target_path() {
-            let adjusted = adjust_path(target, args.strip, args.directory.as_deref());
+            let adjusted = adjust_path(target, args.directory.as_deref());
             record_path_existence(&adjusted, &mut current_exists, &mut initial_exists);
         }
     }
@@ -3693,11 +3710,11 @@ fn precheck_worktree_patch_sequence(patches: &[FilePatch], args: &Args) -> Resul
     for fp in patches {
         let source_adjusted = fp
             .source_path()
-            .map(|p| adjust_path(p, args.strip, args.directory.as_deref()))
+            .map(|p| adjust_path(p, args.directory.as_deref()))
             .unwrap_or_default();
         let target_adjusted = fp
             .target_path()
-            .map(|p| adjust_path(p, args.strip, args.directory.as_deref()))
+            .map(|p| adjust_path(p, args.directory.as_deref()))
             .unwrap_or_default();
 
         let source_exists_now = current_exists
@@ -3798,8 +3815,8 @@ fn apply_to_worktree(
         let Some(target) = fp.target_path() else {
             continue;
         };
-        let source_adjusted = adjust_path(source, args.strip, args.directory.as_deref());
-        let target_adjusted = adjust_path(target, args.strip, args.directory.as_deref());
+        let source_adjusted = adjust_path(source, args.directory.as_deref());
+        let target_adjusted = adjust_path(target, args.directory.as_deref());
         if source_adjusted == target_adjusted || source_snapshots.contains_key(&source_adjusted) {
             continue;
         }
@@ -3818,7 +3835,7 @@ fn apply_to_worktree(
         let path_str = fp
             .target_path()
             .ok_or_else(|| anyhow::anyhow!("patch has no file path"))?;
-        let path_adjusted = adjust_path(path_str, args.strip, args.directory.as_deref());
+        let path_adjusted = adjust_path(path_str, args.directory.as_deref());
         let path = PathBuf::from(&path_adjusted);
 
         if fp.is_deleted {
@@ -3862,7 +3879,7 @@ fn apply_to_worktree(
         // for rename/copy patches where target may not exist yet).
         let source_adjusted = fp
             .source_path()
-            .map(|p| adjust_path(p, args.strip, args.directory.as_deref()))
+            .map(|p| adjust_path(p, args.directory.as_deref()))
             .unwrap_or_else(|| path_adjusted.clone());
         let read_path = PathBuf::from(&source_adjusted);
         let source_contains_target =
@@ -4072,11 +4089,11 @@ fn apply_to_index(
         let target_path_str = fp
             .target_path()
             .ok_or_else(|| anyhow::anyhow!("patch has no file path"))?;
-        let target_raw = adjust_path(target_path_str, args.strip, args.directory.as_deref());
+        let target_raw = adjust_path(target_path_str, args.directory.as_deref());
         let target_adjusted = format!("{cwd_prefix}{target_raw}");
         let source_adjusted = fp
             .source_path()
-            .map(|p| adjust_path(p, args.strip, args.directory.as_deref()))
+            .map(|p| adjust_path(p, args.directory.as_deref()))
             .map(|raw| format!("{cwd_prefix}{raw}"))
             .unwrap_or_else(|| target_adjusted.clone());
 
@@ -4295,7 +4312,7 @@ fn apply_intent_to_add_entries(patches: &[FilePatch], args: &Args) -> Result<()>
         let Some(target_path) = fp.target_path() else {
             continue;
         };
-        let target_raw = adjust_path(target_path, args.strip, args.directory.as_deref());
+        let target_raw = adjust_path(target_path, args.directory.as_deref());
         let target_adjusted = format!("{cwd_prefix}{target_raw}");
         if target_adjusted.is_empty() {
             continue;
@@ -4338,7 +4355,7 @@ fn check_patches(
         let path_str = fp
             .effective_path()
             .ok_or_else(|| anyhow::anyhow!("patch has no file path"))?;
-        let path_adjusted = adjust_path(path_str, args.strip, args.directory.as_deref());
+        let path_adjusted = adjust_path(path_str, args.directory.as_deref());
         let path = PathBuf::from(&path_adjusted);
 
         if fp.is_deleted {
@@ -4359,11 +4376,11 @@ fn check_patches(
 
         let read_path = fp
             .source_path()
-            .map(|p| PathBuf::from(adjust_path(p, args.strip, args.directory.as_deref())))
+            .map(|p| PathBuf::from(adjust_path(p, args.directory.as_deref())))
             .unwrap_or_else(|| path.clone());
         let source_adjusted = fp
             .source_path()
-            .map(|p| adjust_path(p, args.strip, args.directory.as_deref()))
+            .map(|p| adjust_path(p, args.directory.as_deref()))
             .unwrap_or_else(|| path_adjusted.clone());
         let old_content = match &crlf_ctx {
             Some(ctx) => {

--- a/logs/2026-04-09-t4128-apply-root.md
+++ b/logs/2026-04-09-t4128-apply-root.md
@@ -1,0 +1,15 @@
+# t4128-apply-root
+
+## Symptom
+
+All 11 non-setup tests failed: `git apply --directory=… -pN --index` looked for wrong paths (e.g. `some/sub/file` instead of `some/sub/dir/file`) because `-p` was applied twice—once during patch parsing and again in `adjust_path`.
+
+## Fix
+
+- `adjust_path`: only prepend `--directory` (normalized); do not call `strip_components` again.
+- `run`: normalize `--directory` with `git_path::normalize_path_copy` and ensure trailing `/` when non-empty (matches Git `apply_option_parse_directory`); reject leading `..` with `unable to normalize directory: '…'`.
+
+## Verification
+
+- `bash tests/t4128-apply-root.sh` (with `GUST_BIN`): 12/12 pass.
+- `cargo fmt`, `cargo check -p grit-rs`, `cargo clippy -p grit-rs --fix --allow-dirty`, `cargo test -p grit-lib --lib`.

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   294 |
+| Completed   |   295 |
 | In progress |     4 |
-| Remaining   |   471 |
+| Remaining   |   470 |
 | **Total**   |   769 |
 
-Task lines in `PLAN.md`: 294 completed (`[x]`), 4 in progress (`[~]`), 471 remaining (`[ ]`).
+Task lines in `PLAN.md`: 295 completed (`[x]`), 4 in progress (`[~]`), 470 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t4128-apply-root` — 12/12 tests pass (`apply --directory`: Git `normalize_path_copy` + trailing `/`; paths already stripped at parse time — do not strip again in `adjust_path`)
 - `t7011-skip-worktree-reading` — 15/15 tests pass (`update-index` skip-worktree no-op / `--remove` clears entry; `--remove` on missing untracked path is silent; `reset` preserves skip-worktree; `diff-index` skips worktree for skip-worktree; `commit` pathspec rejects skip-worktree)
 - `t3303-notes-subtrees` — 23/23 tests pass (`fast-import`: `data <<TERM` heredoc, `M … inline` blobs, `deleteall`; `log` notes map: concatenate duplicate commit paths like Git’s `combine_notes_concatenate`, skip identical blob payloads)
 - `t5323-pack-redundant` — 18/18 tests pass (`pack-redundant`: Git `minimize` algorithm, `--i-still-use-this` / stdin ignore / verbose + alt-odb; `clone --mirror` implies bare layout; `fsck` resolves relative `objects/info/alternates` against `objects/`)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`git apply` already applies `-p` while parsing `---`/`+++` paths. Grit was stripping again when prepending `--directory`, which broke `t4128-apply-root` (wrong paths like `some/sub/file` instead of `some/sub/dir/file`).

## Changes

- **`adjust_path`**: only prepends the normalized directory prefix; no second `strip_components`.
- **`run`**: normalizes `--directory` with `git_path::normalize_path_copy` (Git `strbuf_normalize_path`), adds a trailing `/` when non-empty, and fails with `unable to normalize directory: '…'` for values like `../foo` that escape the root.

## Verification

- `./scripts/run-tests.sh t4128-apply-root.sh` → 12/12
- `cargo fmt`, `cargo check -p grit-rs`, `cargo clippy -p grit-rs --fix --allow-dirty`, `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e7f4dda-e90e-4a50-bb52-1825d9e1ef05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e7f4dda-e90e-4a50-bb52-1825d9e1ef05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

