### PR TITLE
fix: pack-objects --revs resolves packed branch refs

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -662,6 +662,7 @@ commit → check it off → move on.
 - [ ] `t5511-refspec` ██████████░░░░░░░░░░ 24/47 (23 left) — refspec parsing
 - [ ] `t5551-http-fetch-smart` ███████░░░░░░░░░░░░░ 13/37 (24 left) — test smart fetching over http via http-backend ($HTTP_PROTO)
 - [x] `t5317-pack-objects-filter-objects` — git pack-objects using object filtering (33/33)
+- [x] `t5318-pack-objects-revs-exclude` — pack-objects `--revs` with `^ref` exclusion and `--stdin-packs` (9/9)
 - [ ] `t5304-prune` █████░░░░░░░░░░░░░░░ 8/32 (24 left) — prune
 - [ ] `t5531-deep-submodule-push` ███░░░░░░░░░░░░░░░░░ 5/29 (24 left) — test push with submodules
 - [ ] `t5548-push-porcelain` ░░░░░░░░░░░░░░░░░░░░ 1/25 (24 left) — Test git push porcelain output

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -886,7 +886,7 @@ t5315-pack-objects-compression	t5	yes	9	1	8	false	ok	0
 t5316-pack-delta-depth	t5	yes	5	3	2	false	ok	0
 t5317-pack-objects-filter-objects	t5	yes	33	19	14	false	ok	0
 t5318-commit-graph	t5	skip	85	0	0	false	ok	0
-t5318-pack-objects-revs-exclude	t5	yes	9	6	3	false	ok	0
+t5318-pack-objects-revs-exclude	t5	yes	9	9	0	true	ok	0
 t5319-multi-pack-index	t5	yes	98	20	78	false	ok	0
 t5320-delta-islands	t5	yes	15	2	13	false	ok	0
 t5321-pack-large-objects	t5	yes	2	0	2	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78% of harness tests passing (35,205 / 45,112).">
+<meta property="og:description" content="78% of harness tests passing (35,208 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78% of harness tests passing (35,205 / 45,112).">
+<meta name="twitter:description" content="78% of harness tests passing (35,208 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T12:58:52+00:00" class="gen-time" title="2026-04-09 12:58 UTC">2026-04-09 12:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/c9e26ba46f5a86c3328f4d62484968547c8560d9" style="color:#58a6ff">c9e26ba</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T13:21:22+00:00" class="gen-time" title="2026-04-09 13:21 UTC">2026-04-09 13:21 UTC</time> · <a href="https://github.com/schacon/grit/commit/999b424740b71e52cf30bf6fade3e1ef735f68bd" style="color:#58a6ff">999b424</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,205</div>
+      <div class="summary-big-val">35,208</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>719 files fully passing</span>
+    <span>720 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">23/167 files · 17 skipped · 1,478/4,139 tests</span>
+        <span class="group-meta">24/167 files · 17 skipped · 1,481/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:35.7%"></div></div>
-        <span class="group-pct pct-red">35.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:35.8%"></div></div>
+        <span class="group-pct pct-red">35.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35205 of 45112 tests passing across 1405 harness files (78% pass rate).</desc>
+  <desc id="svg-desc">35208 of 45112 tests passing across 1405 harness files (78% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78% pass rate · 35,205 / 45,112 tests · 1,405 files in scope · 719 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78% pass rate · 35,208 / 45,112 tests · 1,405 files in scope · 720 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="546" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T12:58:52+00:00" class="gen-time" title="2026-04-09 12:58 UTC">2026-04-09 12:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/c9e26ba46f5a86c3328f4d62484968547c8560d9" style="color:#58a6ff">c9e26ba</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T13:21:22+00:00" class="gen-time" title="2026-04-09 13:21 UTC">2026-04-09 13:21 UTC</time> · <a href="https://github.com/schacon/grit/commit/999b424740b71e52cf30bf6fade3e1ef735f68bd" style="color:#58a6ff">999b424</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,205</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,208</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -9017,14 +9017,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="9" data-passed="6">
+<tr class="" data-group="t5" data-tests="9" data-passed="9" data-full-pass="1">
   <td class="mono">t5318-pack-objects-revs-exclude</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">9</td>
-  <td class="right">6</td>
+  <td class="right">9</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:66.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="98" data-passed="20">

--- a/grit/src/commands/pack_objects.rs
+++ b/grit/src/commands/pack_objects.rs
@@ -22,6 +22,7 @@ use grit_lib::objects::{parse_tree, ObjectId, ObjectKind};
 use grit_lib::odb::Odb;
 use grit_lib::promisor::{promisor_pack_object_ids, repo_treats_promisor_packs};
 use grit_lib::repo::Repository;
+use grit_lib::rev_parse::resolve_revision;
 use std::collections::HashMap;
 use std::path::Path;
 use std::process::{Command, Stdio};
@@ -739,7 +740,8 @@ fn collect_oids(repo: &Repository, args: &Args) -> Result<PackObjectList> {
                 let oid = if let Ok(oid) = ObjectId::from_hex(trimmed) {
                     oid
                 } else {
-                    resolve_ref(repo, trimmed)?
+                    resolve_revision(repo, trimmed)
+                        .with_context(|| format!("cannot resolve ref '{trimmed}'"))?
                 };
                 have_roots.insert(oid);
                 continue;
@@ -748,14 +750,16 @@ fn collect_oids(repo: &Repository, args: &Args) -> Result<PackObjectList> {
                 let oid = if let Ok(oid) = ObjectId::from_hex(neg_ref) {
                     oid
                 } else {
-                    resolve_ref(repo, neg_ref)?
+                    resolve_revision(repo, neg_ref)
+                        .with_context(|| format!("cannot resolve ref '{neg_ref}'"))?
                 };
                 walk_reachable(repo, &oid, &mut exclude)?;
             } else {
                 let oid = if let Ok(oid) = ObjectId::from_hex(trimmed) {
                     oid
                 } else {
-                    resolve_ref(repo, trimmed)?
+                    resolve_revision(repo, trimmed)
+                        .with_context(|| format!("cannot resolve ref '{trimmed}'"))?
                 };
                 walk_reachable(repo, &oid, &mut oids)?;
             }
@@ -962,38 +966,6 @@ fn collect_all_loose(odb: &Odb, oids: &mut BTreeSet<ObjectId>) -> Result<()> {
         }
     }
     Ok(())
-}
-
-/// Resolve a ref name to an ObjectId.
-fn resolve_ref(repo: &Repository, refname: &str) -> Result<ObjectId> {
-    // Check refs/heads/, refs/tags/, and direct.
-    let candidates = [
-        repo.git_dir.join(refname),
-        repo.git_dir.join("refs/heads").join(refname),
-        repo.git_dir.join("refs/tags").join(refname),
-    ];
-    for path in &candidates {
-        if path.is_file() {
-            let content = std::fs::read_to_string(path)?;
-            let trimmed = content.trim();
-            if let Some(target) = trimmed.strip_prefix("ref: ") {
-                return resolve_ref(repo, target);
-            }
-            return ObjectId::from_hex(trimmed)
-                .map_err(|e| anyhow::anyhow!("cannot resolve ref '{refname}': {e}"));
-        }
-    }
-    // Try HEAD.
-    if refname == "HEAD" {
-        let head = std::fs::read_to_string(repo.git_dir.join("HEAD"))?;
-        let trimmed = head.trim();
-        if trimmed.starts_with("ref: ") {
-            return resolve_ref(repo, &trimmed[5..]);
-        }
-        return ObjectId::from_hex(trimmed)
-            .map_err(|e| anyhow::anyhow!("cannot resolve HEAD: {e}"));
-    }
-    bail!("cannot resolve ref '{refname}'")
 }
 
 /// Walk reachable objects from a commit/tree/tag/blob OID.

--- a/logs/2026-04-09_t5318-pack-objects-revs-exclude.md
+++ b/logs/2026-04-09_t5318-pack-objects-revs-exclude.md
@@ -1,0 +1,18 @@
+# t5318-pack-objects-revs-exclude
+
+## Symptom
+
+Harness showed 5/9 passing. Failures were `pack-objects --revs` and `verify-pack` after the test checked out `master` again.
+
+## Root cause
+
+After branch switches, Git runs `pack-refs`: branch tips live only in `packed-refs`, with no loose files under `.git/refs/heads/`. `pack-objects --revs` used a local resolver that only read loose ref files, so `HEAD` → `refs/heads/master` failed with "cannot resolve ref".
+
+## Fix
+
+Use `grit_lib::rev_parse::resolve_revision` for non-hex stdin lines in the `--revs` path (same DWIM as `git rev-parse`). Removed the redundant `resolve_ref` helper from `pack_objects.rs`.
+
+## Verification
+
+- `./scripts/run-tests.sh t5318-pack-objects-revs-exclude.sh` → 9/9
+- `cargo test -p grit-lib --lib`

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   294 |
+| Completed   |   295 |
 | In progress |     4 |
-| Remaining   |   471 |
+| Remaining   |   470 |
 | **Total**   |   769 |
 
-Task lines in `PLAN.md`: 294 completed (`[x]`), 4 in progress (`[~]`), 471 remaining (`[ ]`).
+Task lines in `PLAN.md`: 295 completed (`[x]`), 4 in progress (`[~]`), 470 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t5318-pack-objects-revs-exclude` — 9/9 tests pass (`pack-objects --revs` resolves branch names via `rev_parse::resolve_revision` so packed refs work after `pack-refs`; `^master` exclusion and `--stdin-packs`; harness CSV/dashboards refreshed)
 - `t7011-skip-worktree-reading` — 15/15 tests pass (`update-index` skip-worktree no-op / `--remove` clears entry; `--remove` on missing untracked path is silent; `reset` preserves skip-worktree; `diff-index` skips worktree for skip-worktree; `commit` pathspec rejects skip-worktree)
 - `t3303-notes-subtrees` — 23/23 tests pass (`fast-import`: `data <<TERM` heredoc, `M … inline` blobs, `deleteall`; `log` notes map: concatenate duplicate commit paths like Git’s `combine_notes_concatenate`, skip identical blob payloads)
 - `t5323-pack-redundant` — 18/18 tests pass (`pack-redundant`: Git `minimize` algorithm, `--i-still-use-this` / stdin ignore / verbose + alt-odb; `clone --mirror` implies bare layout; `fsck` resolves relative `objects/info/alternates` against `objects/`)

--- a/test-results.md
+++ b/test-results.md
@@ -1,0 +1,3 @@
+# Test results (agent run)
+
+**2026-04-09:** `cargo test -p grit-lib --lib` — 147 passed. `./scripts/run-tests.sh t5318-pack-objects-revs-exclude.sh` — 9/9 passed.


### PR DESCRIPTION
pack-objects --revs read only loose files under .git/refs, so after pack-refs (e.g. checkout master in t5318) HEAD could not be resolved. Use rev_parse::resolve_revision for ref names so packed-refs and DWIM match Git.

Verified: ./scripts/run-tests.sh t5318-pack-objects-revs-exclude.sh (9/9); cargo test -p grit-lib --lib.