### PR TITLE
fix: pass t4064-diff-oidfind (log/diff-tree find-object, combined -c)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -745,7 +745,7 @@ t4060-diff-submodule-option-diff-format	t4	yes	51	29	22	false	ok	0
 t4061-diff-indent	t4	yes	33	2	31	false	ok	0
 t4062-diff-pickaxe	t4	yes	3	3	0	true	ok	0
 t4063-diff-blobs	t4	yes	18	3	15	false	ok	0
-t4064-diff-oidfind	t4	yes	10	6	4	false	ok	0
+t4064-diff-oidfind	t4	yes	10	10	0	true	ok	0
 t4065-diff-anchored	t4	yes	7	7	0	true	ok	0
 t4066-diff-emit-delay	t4	yes	2	2	0	true	ok	0
 t4067-diff-partial-clone	t4	yes	9	2	7	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78% of harness tests passing (35,205 / 45,112).">
+<meta property="og:description" content="78% of harness tests passing (35,209 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78% of harness tests passing (35,205 / 45,112).">
+<meta name="twitter:description" content="78% of harness tests passing (35,209 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T12:58:52+00:00" class="gen-time" title="2026-04-09 12:58 UTC">2026-04-09 12:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/c9e26ba46f5a86c3328f4d62484968547c8560d9" style="color:#58a6ff">c9e26ba</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T13:44:34+00:00" class="gen-time" title="2026-04-09 13:44 UTC">2026-04-09 13:44 UTC</time> · <a href="https://github.com/schacon/grit/commit/999b424740b71e52cf30bf6fade3e1ef735f68bd" style="color:#58a6ff">999b424</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,205</div>
+      <div class="summary-big-val">35,209</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>719 files fully passing</span>
+    <span>720 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -230,11 +230,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">68/178 files · 2 skipped · 2,668/4,437 tests</span>
+        <span class="group-meta">69/178 files · 2 skipped · 2,672/4,437 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.1%"></div></div>
-        <span class="group-pct pct-blue">60.1%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.2%"></div></div>
+        <span class="group-pct pct-blue">60.2%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35205 of 45112 tests passing across 1405 harness files (78% pass rate).</desc>
+  <desc id="svg-desc">35209 of 45112 tests passing across 1405 harness files (78% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78% pass rate · 35,205 / 45,112 tests · 1,405 files in scope · 719 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78% pass rate · 35,209 / 45,112 tests · 1,405 files in scope · 720 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="546" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T12:58:52+00:00" class="gen-time" title="2026-04-09 12:58 UTC">2026-04-09 12:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/c9e26ba46f5a86c3328f4d62484968547c8560d9" style="color:#58a6ff">c9e26ba</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T13:44:34+00:00" class="gen-time" title="2026-04-09 13:44 UTC">2026-04-09 13:44 UTC</time> · <a href="https://github.com/schacon/grit/commit/999b424740b71e52cf30bf6fade3e1ef735f68bd" style="color:#58a6ff">999b424</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,205</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,209</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -7607,14 +7607,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:16.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="10" data-passed="6">
+<tr class="" data-group="t4" data-tests="10" data-passed="10" data-full-pass="1">
   <td class="mono">t4064-diff-oidfind</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">10</td>
-  <td class="right">6</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:60.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="7" data-passed="7" data-full-pass="1">

--- a/grit-lib/src/combined_tree_diff.rs
+++ b/grit-lib/src/combined_tree_diff.rs
@@ -1,0 +1,420 @@
+//! Multi-parent combined tree diff (Git `diff_tree_paths` / `find_paths_multitree`).
+//!
+//! Implements the `D(T,P1...Pn)` walk from `tree-diff.c` for merge commits, producing
+//! per-path parent status letters used by `git diff-tree -c --name-status` and
+//! `--find-object` filtering (`combined_objfind` in `combine-diff.c`).
+
+use crate::diff::zero_oid;
+use crate::error::Result;
+use crate::objects::{parse_commit, parse_tree, tree_entry_cmp, ObjectId, ObjectKind, TreeEntry};
+use crate::odb::Odb;
+
+/// Per-parent coarse status in a combined diff (`A` / `M` / `D`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CombinedParentStatus {
+    /// Parent lacks the path; merge tree added it.
+    Added,
+    /// Parent has the path at the same name as the merge result.
+    Modified,
+    /// Path removed from merge (only in parents that had it at the min name).
+    Deleted,
+}
+
+/// One path in a combined diff: merge result tree vs each parent tree.
+#[derive(Debug, Clone)]
+pub struct CombinedDiffPath {
+    /// Path relative to repository root.
+    pub path: String,
+    /// Mode and OID on the merge result side (`0` / zero OID when deleted from merge).
+    pub merge_mode: u32,
+    pub merge_oid: ObjectId,
+    /// One slot per parent commit (same order as `parents` passed to [`combined_diff_paths_filtered`]).
+    pub parents: Vec<CombinedParentSide>,
+}
+
+/// One parent's contribution at a combined-diff path.
+#[derive(Debug, Clone)]
+pub struct CombinedParentSide {
+    pub mode: u32,
+    pub oid: ObjectId,
+    pub status: CombinedParentStatus,
+}
+
+/// Options for the multitree walk.
+#[derive(Debug, Clone)]
+#[derive(Default)]
+pub struct CombinedTreeDiffOptions {
+    /// Recurse into sub-trees (`diff_options.flags.recursive`).
+    pub recursive: bool,
+    /// Emit tree directory lines when recursing (`tree_in_recursive`, e.g. `--find-object`).
+    pub tree_in_recursive: bool,
+}
+
+
+fn is_tree_mode(mode: u32) -> bool {
+    (mode & 0o170000) == 0o040000
+}
+
+fn read_tree_entries(odb: &Odb, oid: Option<&ObjectId>) -> Result<Vec<TreeEntry>> {
+    let Some(oid) = oid else {
+        return Ok(Vec::new());
+    };
+    let obj = odb.read(oid)?;
+    if obj.kind != ObjectKind::Tree {
+        return Ok(Vec::new());
+    }
+    parse_tree(&obj.data)
+}
+
+fn tree_entry_pathcmp(a: Option<&TreeEntry>, b: Option<&TreeEntry>) -> std::cmp::Ordering {
+    match (a, b) {
+        (None, None) => std::cmp::Ordering::Equal,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (Some(e1), Some(e2)) => tree_entry_cmp(
+            &e1.name,
+            is_tree_mode(e1.mode),
+            &e2.name,
+            is_tree_mode(e2.mode),
+        ),
+    }
+}
+
+fn combined_matches_find_object(path: &CombinedDiffPath, find: Option<&ObjectId>) -> bool {
+    let Some(target) = find else {
+        return true;
+    };
+    if path.merge_oid == *target {
+        return true;
+    }
+    path.parents.iter().any(|p| p.oid == *target)
+}
+
+fn emit_combined_path(
+    path: String,
+    merge_entry: Option<&TreeEntry>,
+    tp: &[Vec<TreeEntry>],
+    tp_idx: &[usize],
+    parent_neq: &[bool],
+    find_object: Option<&ObjectId>,
+    out: &mut Vec<CombinedDiffPath>,
+) {
+    let nparent = tp.len();
+    let mut parents = Vec::with_capacity(nparent);
+
+    if let Some(te) = merge_entry {
+        for i in 0..nparent {
+            let tpi_valid = !parent_neq[i];
+            let (mode_i, oid_i, status) = if tpi_valid {
+                let e = &tp[i][tp_idx[i]];
+                (e.mode, e.oid, CombinedParentStatus::Modified)
+            } else {
+                (0u32, zero_oid(), CombinedParentStatus::Added)
+            };
+            parents.push(CombinedParentSide {
+                mode: mode_i,
+                oid: oid_i,
+                status,
+            });
+        }
+        let p = CombinedDiffPath {
+            path,
+            merge_mode: te.mode,
+            merge_oid: te.oid,
+            parents,
+        };
+        if combined_matches_find_object(&p, find_object) {
+            out.push(p);
+        }
+    } else {
+        for i in 0..nparent {
+            let tpi_valid = !parent_neq[i];
+            let (mode_i, oid_i, status) = if tpi_valid {
+                let e = &tp[i][tp_idx[i]];
+                (e.mode, e.oid, CombinedParentStatus::Deleted)
+            } else {
+                (0u32, zero_oid(), CombinedParentStatus::Added)
+            };
+            parents.push(CombinedParentSide {
+                mode: mode_i,
+                oid: oid_i,
+                status,
+            });
+        }
+        let p = CombinedDiffPath {
+            path,
+            merge_mode: 0,
+            merge_oid: zero_oid(),
+            parents,
+        };
+        if combined_matches_find_object(&p, find_object) {
+            out.push(p);
+        }
+    }
+}
+
+fn should_recurse_dir(_path: &str, opt: &CombinedTreeDiffOptions) -> bool {
+    opt.recursive
+}
+
+fn ll_diff_tree_paths(
+    odb: &Odb,
+    out: &mut Vec<CombinedDiffPath>,
+    base_path: &str,
+    opt: &CombinedTreeDiffOptions,
+    merge_oid: Option<&ObjectId>,
+    parents_oid: &[Option<ObjectId>],
+    find_object: Option<&ObjectId>,
+) -> Result<()> {
+    let nparent = parents_oid.len();
+    let t_entries = read_tree_entries(odb, merge_oid)?;
+    let mut tp_entries: Vec<Vec<TreeEntry>> = Vec::with_capacity(nparent);
+    for po in parents_oid {
+        tp_entries.push(read_tree_entries(odb, po.as_ref())?);
+    }
+
+    let mut ti = 0usize;
+    let mut tp_idx = vec![0usize; nparent];
+
+    loop {
+        let t_cur = t_entries.get(ti);
+
+        if t_cur.is_none() && (0..nparent).all(|i| tp_idx[i] >= tp_entries[i].len()) {
+            break;
+        }
+
+        let mut imin = 0usize;
+        if nparent > 0 {
+            for i in 1..nparent {
+                let e_imin = tp_entries[imin].get(tp_idx[imin]);
+                let e_i = tp_entries[i].get(tp_idx[i]);
+                if tree_entry_pathcmp(e_i, e_imin) == std::cmp::Ordering::Less {
+                    imin = i;
+                }
+            }
+        }
+
+        let mut parent_neq = vec![false; nparent];
+        for i in 0..nparent {
+            let e_imin = tp_entries[imin].get(tp_idx[imin]);
+            let e_i = tp_entries[i].get(tp_idx[i]);
+            parent_neq[i] = tree_entry_pathcmp(e_i, e_imin) != std::cmp::Ordering::Equal;
+        }
+        for i in 0..imin {
+            parent_neq[i] = true;
+        }
+
+        let p_min = tp_entries[imin].get(tp_idx[imin]);
+
+        let cmp = tree_entry_pathcmp(t_cur, p_min);
+
+        if cmp == std::cmp::Ordering::Equal {
+            let te = t_cur.expect("cmp Equal implies t_cur");
+            let mut skip_emit = true;
+            for i in 0..nparent {
+                if parent_neq[i] {
+                    continue;
+                }
+                let Some(pe) = tp_entries[i].get(tp_idx[i]) else {
+                    skip_emit = false;
+                    break;
+                };
+                if pe.oid != te.oid || pe.mode != te.mode {
+                    skip_emit = false;
+                    break;
+                }
+            }
+
+            if !skip_emit {
+                let name = std::str::from_utf8(&te.name).unwrap_or("");
+                let full_path = if base_path.is_empty() {
+                    name.to_string()
+                } else {
+                    format!("{base_path}/{name}")
+                };
+
+                let isdir = is_tree_mode(te.mode);
+                let mut do_emit = true;
+                if isdir
+                    && should_recurse_dir(&full_path, opt) {
+                        do_emit = opt.tree_in_recursive;
+                    }
+
+                if do_emit {
+                    emit_combined_path(
+                        full_path.clone(),
+                        Some(te),
+                        &tp_entries,
+                        &tp_idx,
+                        &parent_neq,
+                        find_object,
+                        out,
+                    );
+                }
+
+                if isdir && should_recurse_dir(&full_path, opt) {
+                    let merge_child = te.oid;
+                    let mut child_parent_opts = vec![None; nparent];
+                    for i in 0..nparent {
+                        if parent_neq[i] {
+                            continue;
+                        }
+                        if let Some(pe) = tp_entries[i].get(tp_idx[i]) {
+                            if tree_entry_cmp(
+                                &pe.name,
+                                is_tree_mode(pe.mode),
+                                &te.name,
+                                is_tree_mode(te.mode),
+                            ) == std::cmp::Ordering::Equal
+                            {
+                                child_parent_opts[i] = Some(pe.oid);
+                            }
+                        }
+                    }
+                    ll_diff_tree_paths(
+                        odb,
+                        out,
+                        &full_path,
+                        opt,
+                        Some(&merge_child),
+                        &child_parent_opts,
+                        find_object,
+                    )?;
+                }
+            }
+
+            ti += 1;
+            for i in 0..nparent {
+                if !parent_neq[i] {
+                    tp_idx[i] += 1;
+                }
+            }
+        } else if cmp == std::cmp::Ordering::Less {
+            let te = t_cur.expect("cmp Less implies t_cur");
+            let name = std::str::from_utf8(&te.name).unwrap_or("");
+            let full_path = if base_path.is_empty() {
+                name.to_string()
+            } else {
+                format!("{base_path}/{name}")
+            };
+            let isdir = is_tree_mode(te.mode);
+            let mut do_emit = true;
+            if isdir && should_recurse_dir(&full_path, opt) {
+                do_emit = opt.tree_in_recursive;
+            }
+            if do_emit {
+                let all_parents_absent: Vec<bool> = vec![true; nparent];
+                emit_combined_path(
+                    full_path.clone(),
+                    Some(te),
+                    &tp_entries,
+                    &tp_idx,
+                    &all_parents_absent,
+                    find_object,
+                    out,
+                );
+            }
+            if isdir && should_recurse_dir(&full_path, opt) {
+                let merge_child = te.oid;
+                let child_parent_opts = vec![None; nparent];
+                ll_diff_tree_paths(
+                    odb,
+                    out,
+                    &full_path,
+                    opt,
+                    Some(&merge_child),
+                    &child_parent_opts,
+                    find_object,
+                )?;
+            }
+            ti += 1;
+        } else {
+            let skip_emit_tp = (0..nparent).all(|i| parent_neq[i]);
+            if !skip_emit_tp {
+                let pe = p_min.expect("cmp Greater implies p_min");
+                let name = std::str::from_utf8(&pe.name).unwrap_or("");
+                let full_path = if base_path.is_empty() {
+                    name.to_string()
+                } else {
+                    format!("{base_path}/{name}")
+                };
+                let isdir = is_tree_mode(pe.mode);
+                let mut do_emit = true;
+                if isdir && should_recurse_dir(&full_path, opt) {
+                    do_emit = opt.tree_in_recursive;
+                }
+                if do_emit {
+                    emit_combined_path(
+                        full_path.clone(),
+                        None,
+                        &tp_entries,
+                        &tp_idx,
+                        &parent_neq,
+                        find_object,
+                        out,
+                    );
+                }
+                if isdir && should_recurse_dir(&full_path, opt) {
+                    let mut child_parent_opts = vec![None; nparent];
+                    for i in 0..nparent {
+                        if !parent_neq[i] {
+                            if let Some(e) = tp_entries[i].get(tp_idx[i]) {
+                                child_parent_opts[i] = Some(e.oid);
+                            }
+                        }
+                    }
+                    ll_diff_tree_paths(
+                        odb,
+                        out,
+                        &full_path,
+                        opt,
+                        None,
+                        &child_parent_opts,
+                        find_object,
+                    )?;
+                }
+            }
+            for i in 0..nparent {
+                if !parent_neq[i] {
+                    tp_idx[i] += 1;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Build combined-diff paths for a merge commit's tree against each parent's tree.
+pub fn combined_diff_paths_filtered(
+    odb: &Odb,
+    commit_tree: &ObjectId,
+    parents: &[ObjectId],
+    walk: &CombinedTreeDiffOptions,
+    find_object: Option<&ObjectId>,
+) -> Result<Vec<CombinedDiffPath>> {
+    if parents.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut parent_trees = Vec::with_capacity(parents.len());
+    for p in parents {
+        let obj = odb.read(p)?;
+        if obj.kind != ObjectKind::Commit {
+            return Ok(Vec::new());
+        }
+        let c = parse_commit(&obj.data)?;
+        parent_trees.push(Some(c.tree));
+    }
+    let parent_opts: Vec<Option<ObjectId>> = parent_trees;
+    let mut out = Vec::new();
+    ll_diff_tree_paths(
+        odb,
+        &mut out,
+        "",
+        walk,
+        Some(commit_tree),
+        &parent_opts,
+        find_object,
+    )?;
+    Ok(out)
+}

--- a/grit-lib/src/lib.rs
+++ b/grit-lib/src/lib.rs
@@ -17,6 +17,7 @@
 
 pub mod attributes;
 pub mod check_ref_format;
+pub mod combined_tree_diff;
 pub mod commit_encoding;
 pub mod commit_pretty;
 pub mod commit_trailers;

--- a/grit/src/commands/diff_tree.rs
+++ b/grit/src/commands/diff_tree.rs
@@ -9,6 +9,9 @@
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use encoding_rs::Encoding;
+use grit_lib::combined_tree_diff::{
+    combined_diff_paths_filtered, CombinedDiffPath, CombinedParentStatus, CombinedTreeDiffOptions,
+};
 use grit_lib::config::ConfigSet;
 use grit_lib::diff::{
     count_changes, detect_renames, diff_trees, diff_trees_show_tree_entries, format_raw,
@@ -130,6 +133,8 @@ struct Options {
     pickaxe_all: bool,
     /// Submodule diff format (`log` shows one-line summaries for gitlinks, like Git's `diff --submodule=log`).
     submodule_mode: Option<String>,
+    /// Object id spec for `--find-object` (resolved against the repo before the walk).
+    find_object: Option<String>,
 }
 
 impl Default for Options {
@@ -171,6 +176,7 @@ impl Default for Options {
             pickaxe_regex: false,
             pickaxe_all: false,
             submodule_mode: None,
+            find_object: None,
         }
     }
 }
@@ -321,9 +327,22 @@ fn parse_options(argv: &[String]) -> Result<Options> {
                         }
                     }
                 }
+                _ if arg.starts_with("--find-object=") => {
+                    opts.find_object = Some(arg["--find-object=".len()..].to_string());
+                }
+                "--find-object" => {
+                    i += 1;
+                    let next = argv
+                        .get(i)
+                        .ok_or_else(|| anyhow::anyhow!("`--find-object` requires a value"))?;
+                    opts.find_object = Some(next.clone());
+                }
+                _ if arg.starts_with("--format=") => {
+                    let val = &arg["--format=".len()..];
+                    opts.pretty = Some(format!("format:{val}"));
+                }
                 _ if arg.starts_with("--diff-filter=")
                     || arg.starts_with("--diff-merges=")
-                    || arg.starts_with("--format=")
                     || arg.starts_with("-O")
                     || arg.starts_with("--relative") =>
                 {
@@ -448,7 +467,7 @@ fn run_two_trees(repo: &Repository, opts: &Options, out: &mut impl Write) -> Res
         validate_tree_depth_limit(&repo.odb, tree_oid, 0, max_tree_depth)?;
     }
     let entries = diff_with_opts(&repo.odb, old_tree, new_tree, opts)?;
-    let filtered = filter_entries(&repo.odb, entries, opts)?;
+    let filtered = filter_entries(&repo.odb, &repo, entries, opts)?;
     let has_diff = !filtered.is_empty();
     if !opts.quiet {
         print_diff(
@@ -481,7 +500,7 @@ fn run_one_commit(repo: &Repository, opts: &Options, out: &mut impl Write) -> Re
             if commit.parents.is_empty() {
                 if opts.root {
                     let entries = diff_with_opts(&repo.odb, None, Some(&commit.tree), opts)?;
-                    let filtered = filter_entries(&repo.odb, entries, opts)?;
+                    let filtered = filter_entries(&repo.odb, &repo, entries, opts)?;
                     has_diff = !filtered.is_empty();
                     if !opts.quiet && (has_diff || opts.pretty.is_some()) {
                         write_commit_header(out, &oid, &obj.data, opts)?;
@@ -516,6 +535,39 @@ fn run_one_commit(repo: &Repository, opts: &Options, out: &mut impl Write) -> Re
                 if !opts.quiet && (hd || opts.pretty.is_some()) {
                     write_commit_header(out, &oid, &obj.data, opts)?;
                     out.write_all(&buf)?;
+                }
+            } else if commit.parents.len() > 1
+                && opts.combined_patch
+                && matches!(
+                    opts.format,
+                    OutputFormat::NameStatus | OutputFormat::NameOnly
+                )
+            {
+                let find_oid = if let Some(ref spec) = opts.find_object {
+                    Some(
+                        resolve_revision(repo, spec)
+                            .with_context(|| format!("unable to resolve '{spec}'"))?,
+                    )
+                } else {
+                    None
+                };
+                let walk = CombinedTreeDiffOptions {
+                    recursive: opts.recursive,
+                    tree_in_recursive: find_oid.is_some(),
+                };
+                let paths = combined_diff_paths_filtered(
+                    &repo.odb,
+                    &commit.tree,
+                    &commit.parents,
+                    &walk,
+                    find_oid.as_ref(),
+                )?;
+                has_diff = !paths.is_empty();
+                if !opts.quiet && (has_diff || opts.pretty.is_some()) {
+                    write_commit_header(out, &oid, &obj.data, opts)?;
+                    if has_diff {
+                        print_combined_paths(out, &paths, opts)?;
+                    }
                 }
             } else if commit.parents.len() > 1
                 && opts.combined_patch
@@ -558,7 +610,7 @@ fn run_one_commit(repo: &Repository, opts: &Options, out: &mut impl Write) -> Re
                 let parent_tree = commit_tree(&repo.odb, &commit.parents[0])?;
                 let entries =
                     diff_with_opts(&repo.odb, Some(&parent_tree), Some(&commit.tree), opts)?;
-                let filtered = filter_entries(&repo.odb, entries, opts)?;
+                let filtered = filter_entries(&repo.odb, &repo, entries, opts)?;
                 has_diff = !filtered.is_empty();
                 if !opts.quiet && (has_diff || opts.pretty.is_some()) {
                     write_commit_header(out, &oid, &obj.data, opts)?;
@@ -704,7 +756,7 @@ fn process_stdin_commit(
     } else if parent_oids.is_empty() {
         if opts.root {
             let entries = diff_with_opts(&repo.odb, None, Some(&commit.tree), opts)?;
-            let filtered = filter_entries(&repo.odb, entries, opts)?;
+            let filtered = filter_entries(&repo.odb, &repo, entries, opts)?;
             let hd = !filtered.is_empty();
             if !opts.quiet {
                 print_diff(
@@ -724,7 +776,7 @@ fn process_stdin_commit(
     } else {
         let parent_tree = commit_tree(&repo.odb, &parent_oids[0])?;
         let entries = diff_with_opts(&repo.odb, Some(&parent_tree), Some(&commit.tree), opts)?;
-        let filtered = filter_entries(&repo.odb, entries, opts)?;
+        let filtered = filter_entries(&repo.odb, &repo, entries, opts)?;
         let hd = !filtered.is_empty();
         if !opts.quiet {
             print_diff(
@@ -769,7 +821,7 @@ fn process_stdin_two_trees(
         (Some(oid1), Some(&oid2))
     };
     let entries = diff_with_opts(&repo.odb, old_side, new_side, opts)?;
-    let filtered = filter_entries(&repo.odb, entries, opts)?;
+    let filtered = filter_entries(&repo.odb, &repo, entries, opts)?;
     let has_diff = !filtered.is_empty();
     if !opts.quiet {
         print_diff(
@@ -1302,6 +1354,35 @@ fn print_submodule_log_for_entry(
     Ok(())
 }
 
+/// Print combined merge paths (`-c` / `--cc` with `--name-status` / `--name-only`).
+fn print_combined_paths(
+    out: &mut impl Write,
+    paths: &[CombinedDiffPath],
+    opts: &Options,
+) -> Result<()> {
+    for p in paths {
+        match opts.format {
+            OutputFormat::NameOnly => {
+                writeln!(out, "{}", p.path)?;
+            }
+            OutputFormat::NameStatus => {
+                let letters: String = p
+                    .parents
+                    .iter()
+                    .map(|side| match side.status {
+                        CombinedParentStatus::Added => 'A',
+                        CombinedParentStatus::Modified => 'M',
+                        CombinedParentStatus::Deleted => 'D',
+                    })
+                    .collect();
+                writeln!(out, "{letters}\t{}", p.path)?;
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
 /// Print the diff entries according to `opts.format`.
 fn print_diff(
     out: &mut impl Write,
@@ -1773,6 +1854,7 @@ fn write_commit_header(
             if template == "%s" {
                 let first_line = commit.message.lines().next().unwrap_or("");
                 writeln!(out, "{first_line}")?;
+                writeln!(out)?;
                 return Ok(false);
             }
         }
@@ -1954,12 +2036,36 @@ fn read_blob_pair(odb: &Odb, entry: &DiffEntry) -> Result<(String, String)> {
 }
 
 /// Apply post-diff filters: pathspecs, max-depth, and pickaxe (`-S` / `-G`).
-fn filter_entries(odb: &Odb, entries: Vec<DiffEntry>, opts: &Options) -> Result<Vec<DiffEntry>> {
+fn filter_entries(
+    odb: &Odb,
+    repo: &Repository,
+    entries: Vec<DiffEntry>,
+    opts: &Options,
+) -> Result<Vec<DiffEntry>> {
     let mut filtered = filter_pathspecs(entries, &opts.pathspecs);
     if let Some(depth) = opts.max_depth {
         filtered = filter_max_depth(filtered, depth, &opts.pathspecs);
     }
-    apply_pickaxe_filter(odb, filtered, opts)
+    let filtered = apply_pickaxe_filter(odb, filtered, opts)?;
+    apply_find_object_filter(repo, filtered, opts)
+}
+
+/// Keep entries whose old or new blob OID matches `--find-object` (non-combined diffs).
+fn apply_find_object_filter(
+    repo: &Repository,
+    entries: Vec<DiffEntry>,
+    opts: &Options,
+) -> Result<Vec<DiffEntry>> {
+    let Some(ref spec) = opts.find_object else {
+        return Ok(entries);
+    };
+    let oid =
+        resolve_revision(repo, spec).with_context(|| format!("unable to resolve '{spec}'"))?;
+    let filtered: Vec<DiffEntry> = entries
+        .into_iter()
+        .filter(|e| e.old_oid == oid || e.new_oid == oid)
+        .collect();
+    Ok(filtered)
 }
 
 /// Keep only diff entries that match `-G` / `-S` pickaxe rules (same semantics as `git diff`).

--- a/grit/src/commands/log.rs
+++ b/grit/src/commands/log.rs
@@ -6,10 +6,12 @@
 use crate::explicit_exit::ExplicitExit;
 use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
+use grit_lib::combined_tree_diff::{combined_diff_paths_filtered, CombinedTreeDiffOptions};
 use grit_lib::config::ConfigSet;
 use grit_lib::crlf::{get_file_attrs, load_gitattributes, DiffAttr};
 use grit_lib::diff::{
-    count_changes, diff_trees, format_raw, unified_diff, zero_oid, DiffEntry, DiffStatus,
+    count_changes, diff_trees, diff_trees_show_tree_entries, format_raw, unified_diff, zero_oid,
+    DiffEntry, DiffStatus,
 };
 use grit_lib::diffstat::{terminal_columns, write_diffstat_block, DiffstatOptions, FileStatInput};
 use grit_lib::git_date::parse::parse_date_basic;
@@ -492,6 +494,10 @@ pub struct Args {
     /// Show tree objects in diff.
     #[arg(long = "show-trees")]
     pub show_trees: bool,
+
+    /// Recurse into trees in diffs (`-t`, same as `git log -t`).
+    #[arg(short = 't', hide = true)]
+    pub recurse_trees: bool,
 
     /// Generate diff with N lines of context.
     #[arg(short = 'U', long = "unified", value_name = "N")]
@@ -2746,6 +2752,7 @@ pub fn run(mut args: Args) -> Result<()> {
     } else {
         None
     };
+    let find_object_tree_recursive = args.show_trees || args.recurse_trees;
     let since_str = args.since_as_filter.as_ref().or(args.since.as_ref());
     let since_threshold = since_str.and_then(|s| parse_date_to_epoch(s));
     let until_threshold = args.until.as_ref().and_then(|s| parse_date_to_epoch(s));
@@ -2813,6 +2820,7 @@ pub fn run(mut args: Args) -> Result<()> {
                 &args,
                 diff_filter_str,
                 find_oid,
+                find_object_tree_recursive,
                 decoration_map_for_simplify,
                 since_threshold,
                 until_threshold,
@@ -2931,7 +2939,13 @@ pub fn run(mut args: Args) -> Result<()> {
             commits
                 .into_iter()
                 .filter(|(_oid, info)| {
-                    commit_has_object(&repo.odb, info, &find_oid_buf).unwrap_or_default()
+                    commit_has_object(
+                        &repo.odb,
+                        info,
+                        &find_oid_buf,
+                        args.show_trees || args.recurse_trees,
+                    )
+                    .unwrap_or_default()
                 })
                 .collect::<Vec<_>>()
         } else {
@@ -4769,6 +4783,7 @@ fn commit_passes_post_walk_filters(
     args: &Args,
     diff_filter: Option<&str>,
     find_oid: Option<ObjectId>,
+    find_object_tree_recursive: bool,
     decorations: Option<&std::collections::HashMap<String, Vec<String>>>,
     since_threshold: Option<i64>,
     until_threshold: Option<i64>,
@@ -4803,7 +4818,7 @@ fn commit_passes_post_walk_filters(
         let has = if args.remerge_diff && info.parents.len() == 2 {
             commit_has_remerge_object(repo, info, &fo).unwrap_or_default()
         } else {
-            commit_has_object(odb, info, &fo).unwrap_or_default()
+            commit_has_object(odb, info, &fo, find_object_tree_recursive).unwrap_or_default()
         };
         if !has {
             return Ok(false);
@@ -6952,7 +6967,25 @@ fn commit_has_remerge_object(
 }
 
 /// Check whether a commit's diff introduces or removes a specific object.
-fn commit_has_object(odb: &Odb, info: &CommitInfo, target: &ObjectId) -> Result<bool> {
+///
+/// When `tree_in_recursive` is true, tree directory lines are included in the diff (Git
+/// `tree_in_recursive` / `log -t`), which is required for `--find-object` on tree OIDs.
+fn commit_has_object(
+    odb: &Odb,
+    info: &CommitInfo,
+    target: &ObjectId,
+    tree_in_recursive: bool,
+) -> Result<bool> {
+    if info.parents.len() > 1 {
+        let walk = CombinedTreeDiffOptions {
+            recursive: true,
+            tree_in_recursive,
+        };
+        let paths =
+            combined_diff_paths_filtered(odb, &info.tree, &info.parents, &walk, Some(target))?;
+        return Ok(!paths.is_empty());
+    }
+
     let parent_tree = if let Some(parent) = info.parents.first() {
         let pobj = odb.read(parent)?;
         let pc = parse_commit(&pobj.data)?;
@@ -6961,7 +6994,11 @@ fn commit_has_object(odb: &Odb, info: &CommitInfo, target: &ObjectId) -> Result<
         None
     };
 
-    let entries = diff_trees(odb, parent_tree.as_ref(), Some(&info.tree), "")?;
+    let entries = if tree_in_recursive {
+        diff_trees_show_tree_entries(odb, parent_tree.as_ref(), Some(&info.tree), "")?
+    } else {
+        diff_trees(odb, parent_tree.as_ref(), Some(&info.tree), "")?
+    };
     for entry in &entries {
         if entry.old_oid == *target || entry.new_oid == *target {
             return Ok(true);

--- a/grit/src/commands/reflog.rs
+++ b/grit/src/commands/reflog.rs
@@ -354,6 +354,7 @@ fn run_show(args: ShowArgs) -> Result<()> {
         pathspecs: args.pathspecs,
         break_rewrites: None,
         show_trees: false,
+        recurse_trees: false,
         unified: None,
         line_range: Vec::new(),
         show_parents: false,

--- a/logs/2026-04-09_t4064-diff-oidfind.md
+++ b/logs/2026-04-09_t4064-diff-oidfind.md
@@ -1,0 +1,14 @@
+## Task: t4064-diff-oidfind (2026-04-09)
+
+### Symptom
+Harness reported 6/10: `log -t --find-object` for tree OID, and `diff-tree -c --find-object --format=%s --name-status` on merges failed.
+
+### Changes
+- **grit-lib** `combined_tree_diff.rs`: multitree combined path walk (Git `diff_tree_paths`) with optional `--find-object` filtering.
+- **grit** `diff_tree.rs`: parse `--find-object`, `--format=%s`; combined `-c` + `--name-status` / `--name-only`; find-object filter for normal diffs; `%s` header + blank line before diff lines.
+- **grit** `log.rs`: hidden `-t` (`recurse_trees`); `commit_has_object` uses `diff_trees_show_tree_entries` when `-t`/`--show-trees`, and combined multitree walk for merges with `--find-object`.
+- **grit** `reflog.rs`: `Args { recurse_trees: false }` for struct init.
+
+### Validation
+- `cargo fmt`, `cargo clippy --fix --allow-dirty`, `cargo test -p grit-lib --lib`
+- `./scripts/run-tests.sh t4064-diff-oidfind.sh` → 10/10


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes `tests/t4064-diff-oidfind.sh` pass (10/10) by aligning `log` and `diff-tree` with Git’s `--find-object` and combined merge diff behavior.

## Changes

- **`grit-lib`**: New `combined_tree_diff` module implementing the multitree combined path walk (equivalent to Git’s `find_paths_multitree` / `diff_tree_paths`), with optional OID filtering matching `combined_objfind`.
- **`grit diff-tree`**: Parses `--find-object` and `--format=%s`; for merge commits with `-c` and `--name-status` / `--name-only`, emits combined per-parent status letters (`AM`, `MA`, …); applies find-object filtering to normal (first-parent) diffs; `%s` format prints subject plus a blank line before diff lines.
- **`grit log`**: Hidden `-t` flag (Git compatibility: recursive diff with `tree_in_recursive`); `commit_has_object` uses `diff_trees_show_tree_entries` when `-t` or `--show-trees` is set, and uses the combined multitree walk for merge commits when `--find-object` is used.
- **Harness**: `./scripts/run-tests.sh t4064-diff-oidfind.sh` refreshed `data/test-files.csv` and dashboards.

## Validation

- `cargo fmt`, `cargo clippy --fix --allow-dirty`
- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t4064-diff-oidfind.sh` → 10/10
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d129373d-621c-4740-9301-edab6157b8d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d129373d-621c-4740-9301-edab6157b8d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

