### PR TITLE
fix: t6408 merge -s ours when fast-forward possible

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1106,7 +1106,7 @@ t6404-recursive-merge	t6	yes	6	4	2	false	ok	0
 t6405-merge-symlinks	t6	yes	7	7	0	true	ok	0
 t6406-merge-attr	t6	yes	13	12	1	false	ok	0
 t6407-merge-binary	t6	yes	3	3	0	true	ok	0
-t6408-merge-up-to-date	t6	yes	7	6	1	false	ok	0
+t6408-merge-up-to-date	t6	yes	7	7	0	true	ok	0
 t6409-merge-subtree	t6	yes	12	7	5	false	ok	0
 t6411-merge-filemode	t6	yes	19	17	2	false	ok	0
 t6412-merge-large-rename	t6	yes	10	10	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.1% of harness tests passing (35,211 / 45,112).">
+<meta property="og:description" content="78.1% of harness tests passing (35,212 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.1% of harness tests passing (35,211 / 45,112).">
+<meta name="twitter:description" content="78.1% of harness tests passing (35,212 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T13:35:26+00:00" class="gen-time" title="2026-04-09 13:35 UTC">2026-04-09 13:35 UTC</time> · <a href="https://github.com/schacon/grit/commit/e77a8c04fc06ccd3ad1253e512a5889290d4b86f" style="color:#58a6ff">e77a8c0</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T13:51:28+00:00" class="gen-time" title="2026-04-09 13:51 UTC">2026-04-09 13:51 UTC</time> · <a href="https://github.com/schacon/grit/commit/1b2deb6d814ce62f9b7b0fab0b751f2cf7de238c" style="color:#58a6ff">1b2deb6</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,211</div>
+      <div class="summary-big-val">35,212</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>721 files fully passing</span>
+    <span>722 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -252,11 +252,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t6</span>
         <span class="group-desc">Revision tree commands (e.g. merge-base)</span>
-        <span class="group-meta">43/105 files · 3 skipped · 1,824/2,822 tests</span>
+        <span class="group-meta">44/105 files · 3 skipped · 1,825/2,822 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.6%"></div></div>
-        <span class="group-pct pct-blue">64.6%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.7%"></div></div>
+        <span class="group-pct pct-blue">64.7%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t7">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35211 of 45112 tests passing across 1405 harness files (78.1% pass rate).</desc>
+  <desc id="svg-desc">35212 of 45112 tests passing across 1405 harness files (78.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.1% pass rate · 35,211 / 45,112 tests · 1,405 files in scope · 721 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.1% pass rate · 35,212 / 45,112 tests · 1,405 files in scope · 722 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="547" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T13:35:26+00:00" class="gen-time" title="2026-04-09 13:35 UTC">2026-04-09 13:35 UTC</time> · <a href="https://github.com/schacon/grit/commit/e77a8c04fc06ccd3ad1253e512a5889290d4b86f" style="color:#58a6ff">e77a8c0</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T13:51:28+00:00" class="gen-time" title="2026-04-09 13:51 UTC">2026-04-09 13:51 UTC</time> · <a href="https://github.com/schacon/grit/commit/1b2deb6d814ce62f9b7b0fab0b751f2cf7de238c" style="color:#58a6ff">1b2deb6</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,211</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,212</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -11217,14 +11217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t6" data-tests="7" data-passed="6">
+<tr class="" data-group="t6" data-tests="7" data-passed="7" data-full-pass="1">
   <td class="mono">t6408-merge-up-to-date</td>
   <td>t6</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">7</td>
-  <td class="right">6</td>
+  <td class="right">7</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:85.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t6" data-tests="12" data-passed="7">

--- a/grit/src/commands/merge.rs
+++ b/grit/src/commands/merge.rs
@@ -715,6 +715,12 @@ pub fn run(mut args: Args) -> Result<()> {
                 true,
             );
         }
+        // `-s ours` must not fast-forward to the other tip: Git records a merge commit whose
+        // tree matches ours (HEAD), even when a fast-forward to `merge_oid` exists (t6408).
+        if args.strategy.len() == 1 && args.strategy[0] == "ours" {
+            bail_if_index_tree_differs_from_head(&repo, head_oid, args.autostash)?;
+            return do_strategy_ours(&repo, &head, head_oid, merge_oid, &args);
+        }
         return do_fast_forward(&repo, &head, head_oid, merge_oid, &args);
     }
 

--- a/logs/2026-04-09_t6408-merge-up-to-date.md
+++ b/logs/2026-04-09_t6408-merge-up-to-date.md
@@ -1,0 +1,14 @@
+# t6408-merge-up-to-date
+
+## Problem
+
+`merge -s ours c1` with HEAD at `c0` (ancestor of `c1`) incorrectly fast-forwarded to `c1`, so `HEAD^{tree}` matched `c1` instead of staying on `c0`'s tree. Upstream Git records a merge commit with two parents whose tree is ours.
+
+## Fix
+
+In `merge.rs`, before `do_fast_forward` when `is_ancestor(head, merge_target)`, if the strategy is exactly `-s ours`, call `do_strategy_ours` (after the same index check as other merge paths) instead of fast-forwarding.
+
+## Verification
+
+- `cargo test -p grit-lib --lib`
+- `./scripts/run-tests.sh t6408-merge-up-to-date.sh` → 7/7 pass


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`merge -s ours` must not fast-forward to the other branch when HEAD is an ancestor of the merge target. Git records a merge commit with two parents whose tree stays on ours (HEAD); this matches upstream behavior exercised by `t6408-merge-up-to-date.sh`.

## Changes

- **merge.rs:** On the fast-forward path (`is_ancestor(head, merge)`), if strategy is exactly `ours`, call `do_strategy_ours` after the usual index/HEAD consistency check instead of `do_fast_forward`.
- **Harness:** Re-ran `./scripts/run-tests.sh t6408-merge-up-to-date.sh` (7/7); updated `data/test-files.csv` and generated dashboards.
- **Log:** `logs/2026-04-09_t6408-merge-up-to-date.md`

## Validation

- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t6408-merge-up-to-date.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0633def3-58d9-40d0-aaad-b0b369099ef2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0633def3-58d9-40d0-aaad-b0b369099ef2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

