### PR TITLE
fix: make t5620-backfill fully pass

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -610,7 +610,7 @@ commit → check it off → move on.
 - [ ] `t5810-proto-disable-local` █████████████████░░░ 46/54 (8 left) — test disabling of local paths in clone/fetch
 - [ ] `t5545-push-options` ███████░░░░░░░░░░░░░ 5/13 (8 left) — pushing to a repository using push options
 - [ ] `t5322-pack-objects-sparse` █████░░░░░░░░░░░░░░░ 3/11 (8 left) — pack-objects object selection using sparse algorithm
-- [ ] `t5620-backfill` ████░░░░░░░░░░░░░░░░ 2/10 (8 left) — git backfill on partial clones
+- [x] `t5620-backfill` — git backfill on partial clones (10/10 harness)
 - [ ] `t5315-pack-objects-compression` ██░░░░░░░░░░░░░░░░░░ 1/9 (8 left) — pack-object compression configuration
 - [ ] `t5506-remote-groups` ██░░░░░░░░░░░░░░░░░░ 1/9 (8 left) — git remote group handling
 - [x] `t5900-repo-selection` — selecting remote repo in ambiguous cases (8/8)

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1015,7 +1015,7 @@ t5616-partial-clone	t5	yes	0	0	0	false	timeout	0
 t5617-clone-submodules-remote	t5	yes	9	2	7	false	ok	0
 t5618-alternate-refs	t5	yes	6	2	4	false	ok	0
 t5619-clone-local-ambiguous-transport	t5	yes	2	1	1	false	ok	0
-t5620-backfill	t5	yes	10	5	5	false	ok	0
+t5620-backfill	t5	yes	10	10	0	true	ok	0
 t5621-clone-revision	t5	yes	12	12	0	true	ok	0
 t5700-protocol-v1	t5	yes	24	24	0	true	ok	0
 t5701-git-serve	t5	yes	25	23	2	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78% of harness tests passing (35,205 / 45,112).">
+<meta property="og:description" content="78.1% of harness tests passing (35,210 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78% of harness tests passing (35,205 / 45,112).">
+<meta name="twitter:description" content="78.1% of harness tests passing (35,210 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T12:58:52+00:00" class="gen-time" title="2026-04-09 12:58 UTC">2026-04-09 12:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/c9e26ba46f5a86c3328f4d62484968547c8560d9" style="color:#58a6ff">c9e26ba</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T13:39:08+00:00" class="gen-time" title="2026-04-09 13:39 UTC">2026-04-09 13:39 UTC</time> · <a href="https://github.com/schacon/grit/commit/999b424740b71e52cf30bf6fade3e1ef735f68bd" style="color:#58a6ff">999b424</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">78.0%</div>
+      <div class="summary-big-val pct-blue">78.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,205</div>
+      <div class="summary-big-val">35,210</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:78.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:78.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>719 files fully passing</span>
+    <span>720 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">23/167 files · 17 skipped · 1,478/4,139 tests</span>
+        <span class="group-meta">24/167 files · 17 skipped · 1,483/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:35.7%"></div></div>
-        <span class="group-pct pct-red">35.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:35.8%"></div></div>
+        <span class="group-pct pct-red">35.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35205 of 45112 tests passing across 1405 harness files (78% pass rate).</desc>
+  <desc id="svg-desc">35210 of 45112 tests passing across 1405 harness files (78.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78% pass rate · 35,205 / 45,112 tests · 1,405 files in scope · 719 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.1% pass rate · 35,210 / 45,112 tests · 1,405 files in scope · 720 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="546" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="547" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T12:58:52+00:00" class="gen-time" title="2026-04-09 12:58 UTC">2026-04-09 12:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/c9e26ba46f5a86c3328f4d62484968547c8560d9" style="color:#58a6ff">c9e26ba</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T13:39:08+00:00" class="gen-time" title="2026-04-09 13:39 UTC">2026-04-09 13:39 UTC</time> · <a href="https://github.com/schacon/grit/commit/999b424740b71e52cf30bf6fade3e1ef735f68bd" style="color:#58a6ff">999b424</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,205</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">78.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,210</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">78.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -10307,14 +10307,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="10" data-passed="5">
+<tr class="" data-group="t5" data-tests="10" data-passed="10" data-full-pass="1">
   <td class="mono">t5620-backfill</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">10</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="12" data-passed="12" data-full-pass="1">

--- a/grit-lib/src/sparse_checkout.rs
+++ b/grit-lib/src/sparse_checkout.rs
@@ -606,10 +606,24 @@ fn path_in_expanded_cone(path: &str, lines: &[String]) -> bool {
     let Some((parents, recursive)) = parse_expanded_cone_parent_recursive(lines) else {
         return false;
     };
-    let path = path.trim_start_matches('/').trim_end_matches('/');
+    let raw = path.trim_start_matches('/');
+    let is_directory_path = raw.ends_with('/');
+    let path = raw.trim_end_matches('/');
 
     if !path.contains('/') {
-        return true;
+        // Top-level: files are always in-cone (`/*`). Directories are in-cone only when
+        // they lead into an expanded parent/recursive rule (Git uses dtype when matching).
+        // Callers pass directories with a trailing slash (e.g. `a/`); files have none.
+        if !is_directory_path {
+            return true;
+        }
+        if parents.is_empty() && recursive.is_empty() {
+            return false;
+        }
+        return parents.iter().any(|p| p == path)
+            || recursive
+                .iter()
+                .any(|r| r == path || r.starts_with(&format!("{path}/")));
     }
 
     for r in &recursive {
@@ -904,4 +918,30 @@ pub fn path_matches_sparse_patterns(path: &str, patterns: &[String], cone_mode: 
     }
 
     included
+}
+
+#[cfg(test)]
+mod path_in_expanded_cone_tests {
+    use super::path_in_sparse_checkout_patterns;
+
+    #[test]
+    fn root_only_cone_includes_files_not_top_level_dirs() {
+        let lines = vec!["/*".to_string(), "!/*/".to_string()];
+        assert!(path_in_sparse_checkout_patterns("file.1.txt", &lines, true));
+        assert!(!path_in_sparse_checkout_patterns("a/", &lines, true));
+        assert!(!path_in_sparse_checkout_patterns("d/", &lines, true));
+    }
+
+    #[test]
+    fn expanded_cone_with_d_includes_d_tree_not_sibling_a() {
+        let lines = vec![
+            "/*".to_string(),
+            "!/*/".to_string(),
+            "/d/".to_string(),
+        ];
+        assert!(path_in_sparse_checkout_patterns("file.1.txt", &lines, true));
+        assert!(path_in_sparse_checkout_patterns("d/", &lines, true));
+        assert!(!path_in_sparse_checkout_patterns("a/", &lines, true));
+        assert!(path_in_sparse_checkout_patterns("d/e/file.1.txt", &lines, true));
+    }
 }

--- a/grit/src/commands/checkout.rs
+++ b/grit/src/commands/checkout.rs
@@ -3855,6 +3855,9 @@ fn checkout_index_to_worktree(
         if entry.stage() != 0 {
             continue;
         }
+        if entry.skip_worktree() {
+            continue;
+        }
 
         // Skip gitlink (submodule) entries — their OIDs reference commits
         // in the submodule's object store, not blobs in ours.

--- a/grit/src/commands/clone.rs
+++ b/grit/src/commands/clone.rs
@@ -3932,11 +3932,15 @@ fn setup_remote_tracking_head(
     Ok(())
 }
 
-/// Build `.git/index` from `HEAD` when missing (e.g. `clone --no-checkout` before sparse-checkout).
+/// Build `.git/index` from `HEAD` when missing or empty (e.g. `clone --no-checkout` before
+/// `sparse-checkout set`).
 pub(crate) fn ensure_index_from_head_if_missing(repo: &Repository) -> Result<()> {
     let index_path = repo.index_path();
     if index_path.exists() {
-        return Ok(());
+        let idx = repo.load_index_at(&index_path).unwrap_or_default();
+        if !idx.entries.is_empty() {
+            return Ok(());
+        }
     }
     let head_content = fs::read_to_string(repo.git_dir.join("HEAD")).context("reading HEAD")?;
     let head = head_content.trim();

--- a/grit/src/commands/promisor_hydrate.rs
+++ b/grit/src/commands/promisor_hydrate.rs
@@ -135,6 +135,14 @@ pub(crate) fn try_lazy_fetch_promisor_object(repo: &Repository, oid: ObjectId) -
     for (remote_name, src) in list_promisor_remotes(&config, &repo.git_dir)? {
         match &src {
             PromisorSource::Local(odb) => {
+                if let Ok(obj) = odb.read(&oid) {
+                    repo.odb.write(obj.kind, &obj.data).with_context(|| {
+                        format!("writing lazy-fetched object from {remote_name}")
+                    })?;
+                    if repo.odb.exists_local(&oid) {
+                        return Ok(());
+                    }
+                }
                 let remote_git_dir = odb
                     .objects_dir()
                     .parent()

--- a/grit/src/commands/sparse_checkout.rs
+++ b/grit/src/commands/sparse_checkout.rs
@@ -7,6 +7,7 @@
 use anyhow::{bail, Context, Result};
 use clap::{Args as ClapArgs, Subcommand};
 use grit_lib::config::{ConfigFile, ConfigScope};
+use grit_lib::error::Error as GritError;
 use grit_lib::ignore::path_in_sparse_checkout as path_in_sparse_checkout_lines;
 use grit_lib::index::MODE_TREE;
 use grit_lib::objects::parse_commit;
@@ -412,10 +413,10 @@ fn cmd_set(repo: &Repository, args: &SetArgs) -> Result<()> {
                 let body = ws.to_sparse_checkout_file();
                 write_sparse_file(repo, &body)?;
                 let patterns = read_sparse_patterns(repo)?;
-                apply_sparse_patterns(repo, &patterns, true)?;
                 crate::commands::promisor_hydrate::hydrate_sparse_patterns_after_sparse_checkout_update(
                     repo, &patterns, true,
                 )?;
+                apply_sparse_patterns(repo, &patterns, true)?;
             } else {
                 let mut lines = lines;
                 if lines.is_empty() {
@@ -424,10 +425,10 @@ fn cmd_set(repo: &Repository, args: &SetArgs) -> Result<()> {
                 let body: String = lines.iter().map(|l| format!("{l}\n")).collect();
                 write_sparse_file(repo, &body)?;
                 let patterns = read_sparse_patterns(repo)?;
-                apply_sparse_patterns(repo, &patterns, false)?;
                 crate::commands::promisor_hydrate::hydrate_sparse_patterns_after_sparse_checkout_update(
                     repo, &patterns, false,
                 )?;
+                apply_sparse_patterns(repo, &patterns, false)?;
             }
             Ok(())
         } else {
@@ -468,10 +469,10 @@ fn cmd_set(repo: &Repository, args: &SetArgs) -> Result<()> {
             }
             let patterns = read_sparse_patterns(repo)?;
             let apply_cone = cone && !file_only_cone;
-            apply_sparse_patterns(repo, &patterns, apply_cone)?;
             crate::commands::promisor_hydrate::hydrate_sparse_patterns_after_sparse_checkout_update(
                 repo, &patterns, apply_cone,
             )?;
+            apply_sparse_patterns(repo, &patterns, apply_cone)?;
             Ok(())
         }
     })();
@@ -562,10 +563,10 @@ fn cmd_add(repo: &Repository, args: &AddArgs) -> Result<()> {
             write_sparse_file(repo, &body)?;
         }
         let patterns = read_sparse_patterns(repo)?;
-        apply_sparse_patterns(repo, &patterns, cone)?;
         crate::commands::promisor_hydrate::hydrate_sparse_patterns_after_sparse_checkout_update(
             repo, &patterns, cone,
         )?;
+        apply_sparse_patterns(repo, &patterns, cone)?;
         Ok(())
     })();
     release_sparse_lock(repo);
@@ -603,10 +604,10 @@ fn cmd_reapply(repo: &Repository, args: &ReapplyArgs) -> Result<()> {
         .and_then(|v| v.parse::<bool>().ok())
         .unwrap_or(true);
     let patterns = read_sparse_patterns(repo)?;
-    apply_sparse_patterns(repo, &patterns, cone)?;
     crate::commands::promisor_hydrate::hydrate_sparse_patterns_after_sparse_checkout_update(
         repo, &patterns, cone,
     )?;
+    apply_sparse_patterns(repo, &patterns, cone)?;
     Ok(())
 }
 
@@ -1086,6 +1087,12 @@ fn apply_sparse_patterns(repo: &Repository, patterns: &[String], cone_mode: bool
 
     let index_path = repo.index_path();
     let mut index = repo.load_index_at(&index_path).context("reading index")?;
+    if index.entries.is_empty() {
+        crate::commands::clone::ensure_index_from_head_if_missing(repo)?;
+        index = repo
+            .load_index_at(&index_path)
+            .context("reading index after building from HEAD")?;
+    }
 
     if index.version < 3 {
         index.version = 3;
@@ -1122,8 +1129,23 @@ fn apply_sparse_patterns(repo: &Repository, patterns: &[String], cone_mode: bool
                     if let Some(parent) = full_path.parent() {
                         let _ = fs::create_dir_all(parent);
                     }
-                    if let Ok(obj) = repo.odb.read(&entry.oid) {
-                        let _ = fs::write(&full_path, &obj.data);
+                    let blob_data = match repo.odb.read(&entry.oid) {
+                        Ok(obj) => Some(obj.data),
+                        Err(GritError::ObjectNotFound(_)) => {
+                            if crate::commands::promisor_hydrate::try_lazy_fetch_promisor_object(
+                                repo, entry.oid,
+                            )
+                            .is_ok()
+                            {
+                                repo.odb.read(&entry.oid).ok().map(|o| o.data)
+                            } else {
+                                None
+                            }
+                        }
+                        Err(_) => None,
+                    };
+                    if let Some(data) = blob_data {
+                        let _ = fs::write(&full_path, &data);
                     }
                 }
             }

--- a/logs/2026-04-09_t5620-backfill.md
+++ b/logs/2026-04-09_t5620-backfill.md
@@ -1,0 +1,24 @@
+# t5620-backfill — full pass
+
+## Summary
+
+Made `tests/t5620-backfill.sh` 10/10: sparse backfill path-walk counts, non-cone partial clone + sparse-checkout + checkout, HTTP backfill.
+
+## Changes
+
+1. **`grit-lib` `path_in_expanded_cone`**: Distinguish directory paths (trailing `/`) for single-segment paths. Root-only expanded cone (`/*`, `!/*/`) includes top-level files, excludes top-level directories unless they appear in parent/recursive cone lines. Fixes path-walk over-count and wrong subtree inclusion for `backfill --sparse`.
+
+2. **`grit` `promisor_hydrate::try_lazy_fetch_promisor_object`**: For `PromisorSource::Local`, try `odb.read` + `write` into the clone before upload-pack (avoids bogus capability errors for single-OID fetch).
+
+3. **`sparse_checkout`**: Run `hydrate_sparse_patterns_after_sparse_checkout_update` before `apply_sparse_patterns` so blobs exist when materializing files. If index is empty, call `ensure_index_from_head_if_missing` (clone `--no-checkout` can leave an empty index). Promisor lazy-fetch when clearing `skip_worktree` and writing files.
+
+4. **`clone::ensure_index_from_head_if_missing`**: Also repopulate when index file exists but has zero entries.
+
+5. **`checkout` `checkout_index_to_worktree`**: Skip entries with `skip_worktree` set so sparse checkout does not read every blob.
+
+6. **Tests**: Two unit tests in `grit-lib/src/sparse_checkout.rs` for expanded-cone root / `d` inclusion.
+
+## Verification
+
+- `cargo fmt`, `cargo clippy --fix --allow-dirty`, `cargo test -p grit-lib --lib`
+- `./scripts/run-tests.sh --timeout 120 t5620-backfill.sh` → 10/10

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   294 |
-| In progress |     4 |
-| Remaining   |   471 |
+| Completed   |   308 |
+| In progress |     5 |
+| Remaining   |   456 |
 | **Total**   |   769 |
 
-Task lines in `PLAN.md`: 294 completed (`[x]`), 4 in progress (`[~]`), 471 remaining (`[ ]`).
+Task lines in `PLAN.md`: 308 completed (`[x]`), 5 in progress (`[~]`), 456 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t5620-backfill` — 10/10 tests pass (expanded-cone path matching: top-level dirs excluded unless in cone; `sparse-checkout` hydrates before apply + empty-index rebuild from HEAD; promisor lazy-fetch reads local ODB first; checkout skips `skip_worktree` paths)
 - `t7011-skip-worktree-reading` — 15/15 tests pass (`update-index` skip-worktree no-op / `--remove` clears entry; `--remove` on missing untracked path is silent; `reset` preserves skip-worktree; `diff-index` skips worktree for skip-worktree; `commit` pathspec rejects skip-worktree)
 - `t3303-notes-subtrees` — 23/23 tests pass (`fast-import`: `data <<TERM` heredoc, `M … inline` blobs, `deleteall`; `log` notes map: concatenate duplicate commit paths like Git’s `combine_notes_concatenate`, skip identical blob payloads)
 - `t5323-pack-redundant` — 18/18 tests pass (`pack-redundant`: Git `minimize` algorithm, `--i-still-use-this` / stdin ignore / verbose + alt-odb; `clone --mirror` implies bare layout; `fsck` resolves relative `objects/info/alternates` against `objects/`)


### PR DESCRIPTION
- Expanded-cone path matching: exclude top-level dirs for root-only cone
- Sparse-checkout: hydrate promisor blobs before apply; rebuild empty index from HEAD
- Promisor lazy-fetch: copy from local remote ODB before upload-pack
- Checkout: skip skip_worktree entries when syncing worktree to index