### PR TITLE
fix: make t5602-clone-remote-exec pass (GIT_SSH argv for unresolved ssh clone)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -997,7 +997,7 @@ t5582-fetch-negative-refspec	t5	yes	16	9	7	false	ok	0
 t5583-push-branches	t5	yes	8	8	0	true	ok	0
 t5600-clone-fail-cleanup	t5	yes	14	11	3	false	ok	0
 t5601-clone	t5	yes	115	38	77	false	ok	0
-t5602-clone-remote-exec	t5	yes	3	1	2	false	ok	0
+t5602-clone-remote-exec	t5	yes	3	3	0	true	ok	0
 t5603-clone-dirname	t5	yes	47	1	46	false	ok	0
 t5604-clone-reference	t5	yes	34	22	12	false	ok	0
 t5605-clone-local	t5	yes	23	14	9	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.1% of harness tests passing (35,211 / 45,112).">
+<meta property="og:description" content="78.1% of harness tests passing (35,213 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.1% of harness tests passing (35,211 / 45,112).">
+<meta name="twitter:description" content="78.1% of harness tests passing (35,213 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T13:35:26+00:00" class="gen-time" title="2026-04-09 13:35 UTC">2026-04-09 13:35 UTC</time> · <a href="https://github.com/schacon/grit/commit/e77a8c04fc06ccd3ad1253e512a5889290d4b86f" style="color:#58a6ff">e77a8c0</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T13:57:23+00:00" class="gen-time" title="2026-04-09 13:57 UTC">2026-04-09 13:57 UTC</time> · <a href="https://github.com/schacon/grit/commit/1b2deb6d814ce62f9b7b0fab0b751f2cf7de238c" style="color:#58a6ff">1b2deb6</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,211</div>
+      <div class="summary-big-val">35,213</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>721 files fully passing</span>
+    <span>722 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">23/167 files · 17 skipped · 1,478/4,139 tests</span>
+        <span class="group-meta">24/167 files · 17 skipped · 1,480/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:35.7%"></div></div>
-        <span class="group-pct pct-red">35.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:35.8%"></div></div>
+        <span class="group-pct pct-red">35.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35211 of 45112 tests passing across 1405 harness files (78.1% pass rate).</desc>
+  <desc id="svg-desc">35213 of 45112 tests passing across 1405 harness files (78.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.1% pass rate · 35,211 / 45,112 tests · 1,405 files in scope · 721 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.1% pass rate · 35,213 / 45,112 tests · 1,405 files in scope · 722 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="547" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T13:35:26+00:00" class="gen-time" title="2026-04-09 13:35 UTC">2026-04-09 13:35 UTC</time> · <a href="https://github.com/schacon/grit/commit/e77a8c04fc06ccd3ad1253e512a5889290d4b86f" style="color:#58a6ff">e77a8c0</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T13:57:23+00:00" class="gen-time" title="2026-04-09 13:57 UTC">2026-04-09 13:57 UTC</time> · <a href="https://github.com/schacon/grit/commit/1b2deb6d814ce62f9b7b0fab0b751f2cf7de238c" style="color:#58a6ff">1b2deb6</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,211</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,213</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -10127,14 +10127,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:33.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="3" data-passed="1">
+<tr class="" data-group="t5" data-tests="3" data-passed="3" data-full-pass="1">
   <td class="mono">t5602-clone-remote-exec</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">3</td>
-  <td class="right">1</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:33.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="47" data-passed="1">

--- a/grit/src/commands/clone.rs
+++ b/grit/src/commands/clone.rs
@@ -2031,6 +2031,11 @@ fn is_ssh_url(url: &str) -> bool {
 fn run_ssh_clone(args: Args) -> Result<()> {
     let spec = crate::ssh_transport::parse_ssh_url(&args.repository)?;
     let Some(src_git_dir) = crate::ssh_transport::try_local_git_dir(&spec) else {
+        crate::ssh_transport::unresolved_ssh_clone_invoke_git_ssh(
+            &spec.host,
+            args.upload_pack.as_deref(),
+            &spec.path,
+        )?;
         bail!(
             "ssh: could not resolve '{}' to a local repository",
             args.repository

--- a/grit/src/ssh_transport.rs
+++ b/grit/src/ssh_transport.rs
@@ -1,10 +1,12 @@
 //! SSH URL parsing and local resolution for test harnesses (`GIT_SSH` wrappers).
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use grit_lib::repo::Repository;
+use std::ffi::OsString;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 
 /// Parsed SSH remote (scp-style `host:path` or `ssh://` / `git+ssh://`).
 #[derive(Debug, Clone)]
@@ -188,6 +190,67 @@ pub fn ssh_remote_repo_path_for_display(git_dir: &Path) -> PathBuf {
     } else {
         git_dir.to_path_buf()
     }
+}
+
+/// Shell-quote `s` with single quotes like Git's `sq_quote_buf` (`git/quote.c`).
+fn sq_quote_shell_arg(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('\'');
+    for ch in s.chars() {
+        match ch {
+            '\'' => out.push_str("'\\''"),
+            '!' => out.push_str("'\\!'"),
+            _ => out.push(ch),
+        }
+    }
+    out.push('\'');
+    out
+}
+
+/// When an SSH URL does not resolve to a local repository, match Git's behavior for
+/// `GIT_SSH` / `GIT_SSH_COMMAND` before reporting failure.
+///
+/// If `GIT_SSH_COMMAND` is set (non-empty), or `GIT_SSH` is unset/empty, returns `Ok(())` so the
+/// caller can emit the usual "could not resolve" error.
+///
+/// If `GIT_SSH` is set, runs the same argv Git uses for the initial probe:
+/// `GIT_SSH`, `host`, and one argument `upload-pack … '<path>'`, then exits with the child's status
+/// (see `git/connect.c` `git_connect` + `fill_ssh_args`). This records arguments for test wrappers
+/// such as in `t5602-clone-remote-exec.sh`.
+pub(crate) fn unresolved_ssh_clone_invoke_git_ssh(
+    host: &str,
+    upload_pack: Option<&str>,
+    remote_repo_path: &str,
+) -> Result<()> {
+    let ssh_cmd_set = std::env::var_os("GIT_SSH_COMMAND").is_some_and(|v| v != OsString::new());
+    if ssh_cmd_set {
+        return Ok(());
+    }
+
+    let ssh = match std::env::var("GIT_SSH") {
+        Ok(s) if !s.is_empty() => s,
+        _ => return Ok(()),
+    };
+
+    let quoted_path = sq_quote_shell_arg(remote_repo_path);
+    let remote_cmd = match upload_pack {
+        None => format!("git-upload-pack {quoted_path}"),
+        Some(p) => format!("{} {quoted_path}", p.trim()),
+    };
+
+    let status = Command::new(&ssh)
+        .arg(host)
+        .arg(&remote_cmd)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit())
+        .status()
+        .with_context(|| format!("failed to execute GIT_SSH '{ssh}'"))?;
+
+    if status.success() {
+        return Ok(());
+    }
+    std::process::exit(status.code().unwrap_or(1));
 }
 
 /// When `GIT_SSH` is Git's `test-fake-ssh` helper and `TRASH_DIRECTORY` is set, append one line to

--- a/logs/2026-04-09-t5602-clone-remote-exec.md
+++ b/logs/2026-04-09-t5602-clone-remote-exec.md
@@ -1,0 +1,15 @@
+# t5602-clone-remote-exec
+
+## Problem
+
+`clone` with scp-style SSH URLs (`host:/path`) and `GIT_SSH` set did not invoke the wrapper before failing when the path did not resolve to a local repo. Upstream test `t5602` expects `GIT_SSH` to receive argv matching Git: `host git-upload-pack '/path'` (or custom `-u` upload-pack).
+
+## Fix
+
+- `ssh_transport.rs`: `sq_quote_shell_arg` (Git `sq_quote_buf` semantics including `!`), `unresolved_ssh_clone_invoke_git_ssh` runs `GIT_SSH host "<upload-pack> '<path>'"` when URL is unresolved and `GIT_SSH_COMMAND` is unset; non-zero exit propagates; zero exit falls through to existing bail.
+- `clone.rs`: call the helper before `bail!` in `run_ssh_clone`.
+
+## Verification
+
+- `./scripts/run-tests.sh t5602-clone-remote-exec.sh` — 3/3 pass.
+- `cargo test -p grit-lib --lib` — pass.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t5602-clone-remote-exec` expects `git clone` with `GIT_SSH` set to invoke the wrapper with the same arguments as upstream Git before failing, when the SSH URL does not resolve to a local repository.

## Changes

- **`grit/src/ssh_transport.rs`**: Add Git-compatible single-quote shell quoting (`sq_quote_shell_arg`, including `!` handling per `git/quote.c`). Add `unresolved_ssh_clone_invoke_git_ssh` to run `GIT_SSH` with argv `[ssh, host, "git-upload-pack 'path'"` or the custom `--upload-pack` string when `GIT_SSH_COMMAND` is not set. If the child exits non-zero, propagate that exit code; if it exits zero, fall through to the existing resolution error.
- **`grit/src/commands/clone.rs`**: Call the helper from `run_ssh_clone` before bailing on unresolved URLs.

Harness run `./scripts/run-tests.sh t5602-clone-remote-exec.sh` is **3/3**. `cargo test -p grit-lib --lib` passes.

## Note

`cargo clippy -p grit-rs -- -D warnings` still reports pre-existing issues elsewhere in the workspace; this change does not add new clippy failures in the touched code paths.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0734ebea-0a65-4862-8cdf-0c6ccb76dfe4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0734ebea-0a65-4862-8cdf-0c6ccb76dfe4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

