### PR TITLE
feat: test-tool bundle-uri parse-key-values and parse-config (t5750)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -636,7 +636,7 @@ commit → check it off → move on.
 - [ ] `t5509-fetch-push-namespaces` ██░░░░░░░░░░░░░░░░░░ 2/15 (13 left) — fetch/push involving ref namespaces
 - [ ] `t5332-multi-pack-reuse` █░░░░░░░░░░░░░░░░░░░ 1/14 (13 left) — pack-objects multi-pack reuse
 - [ ] `t5574-fetch-output` █░░░░░░░░░░░░░░░░░░░ 1/14 (13 left) — git fetch output format
-- [ ] `t5750-bundle-uri-parse` ░░░░░░░░░░░░░░░░░░░░ 0/13 (13 left) — Test bundle-uri bundle_uri_parse_line()
+- [x] `t5750-bundle-uri-parse` ████████████████████ 13/13 (0 left) — Test bundle-uri bundle_uri_parse_line()
 - [ ] `t5303-pack-corruption-resilience` ████████████░░░░░░░░ 22/36 (14 left) — resilience to pack corruptions with redundant objects
 - [ ] `t5604-clone-reference` ███████████░░░░░░░░░ 20/34 (14 left) — test clone --reference
 - [ ] `t5533-push-cas` ███████░░░░░░░░░░░░░ 9/23 (14 left) — compare & swap push force/delete safety

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1027,7 +1027,7 @@ t5710-promisor-remote-capability	t5	yes	22	0	22	false	ok	0
 t5730-protocol-v2-bundle-uri-file	t5	yes	8	8	0	true	ok	0
 t5731-protocol-v2-bundle-uri-git	t5	yes	8	2	6	false	ok	0
 t5732-protocol-v2-bundle-uri-http	t5	yes	9	3	6	false	ok	0
-t5750-bundle-uri-parse	t5	yes	13	0	13	false	ok	0
+t5750-bundle-uri-parse	t5	yes	13	13	0	true	ok	0
 t5801-remote-helpers	t5	skip	35	0	0	false	ok	1
 t5802-connect-helper	t5	yes	8	2	6	false	ok	0
 t5810-proto-disable-local	t5	yes	54	53	1	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.1% of harness tests passing (35,211 / 45,112).">
+<meta property="og:description" content="78.1% of harness tests passing (35,224 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.1% of harness tests passing (35,211 / 45,112).">
+<meta name="twitter:description" content="78.1% of harness tests passing (35,224 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T13:35:26+00:00" class="gen-time" title="2026-04-09 13:35 UTC">2026-04-09 13:35 UTC</time> · <a href="https://github.com/schacon/grit/commit/e77a8c04fc06ccd3ad1253e512a5889290d4b86f" style="color:#58a6ff">e77a8c0</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T14:01:24+00:00" class="gen-time" title="2026-04-09 14:01 UTC">2026-04-09 14:01 UTC</time> · <a href="https://github.com/schacon/grit/commit/1b2deb6d814ce62f9b7b0fab0b751f2cf7de238c" style="color:#58a6ff">1b2deb6</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,211</div>
+      <div class="summary-big-val">35,224</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>721 files fully passing</span>
+    <span>722 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">23/167 files · 17 skipped · 1,478/4,139 tests</span>
+        <span class="group-meta">24/167 files · 17 skipped · 1,491/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:35.7%"></div></div>
-        <span class="group-pct pct-red">35.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:36.0%"></div></div>
+        <span class="group-pct pct-red">36.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35211 of 45112 tests passing across 1405 harness files (78.1% pass rate).</desc>
+  <desc id="svg-desc">35224 of 45112 tests passing across 1405 harness files (78.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.1% pass rate · 35,211 / 45,112 tests · 1,405 files in scope · 721 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.1% pass rate · 35,224 / 45,112 tests · 1,405 files in scope · 722 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="547" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T13:35:26+00:00" class="gen-time" title="2026-04-09 13:35 UTC">2026-04-09 13:35 UTC</time> · <a href="https://github.com/schacon/grit/commit/e77a8c04fc06ccd3ad1253e512a5889290d4b86f" style="color:#58a6ff">e77a8c0</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T14:01:24+00:00" class="gen-time" title="2026-04-09 14:01 UTC">2026-04-09 14:01 UTC</time> · <a href="https://github.com/schacon/grit/commit/1b2deb6d814ce62f9b7b0fab0b751f2cf7de238c" style="color:#58a6ff">1b2deb6</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,211</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,224</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -10427,14 +10427,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:33.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="13" data-passed="0">
+<tr class="" data-group="t5" data-tests="13" data-passed="13" data-full-pass="1">
   <td class="mono">t5750-bundle-uri-parse</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">13</td>
-  <td class="right">0</td>
+  <td class="right">13</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="row-skip" data-group="t5" data-tests="35" data-passed="0">

--- a/grit/src/bundle_uri_test_tool.rs
+++ b/grit/src/bundle_uri_test_tool.rs
@@ -1,0 +1,514 @@
+//! `test-tool bundle-uri parse-key-values` / `parse-config` — matches Git's `bundle-uri.c`
+//! and `t/helper/test-bundle-uri.c` for `t5750-bundle-uri-parse.sh`.
+
+use std::collections::HashMap;
+use std::fs;
+use std::io::{BufRead, Write};
+use std::path::Path;
+
+use anyhow::{bail, Result};
+
+use crate::git_path;
+
+/// Prototype base URI used by the Git test helper (`test-bundle-uri.c`).
+const TEST_BASE_URI: &str = "<uri>";
+
+#[derive(Debug, Clone)]
+struct RemoteBundleInfo {
+    id: String,
+    uri: Option<String>,
+    creation_token: Option<u64>,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+enum BundleMode {
+    #[default]
+    All,
+    Any,
+    None,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+enum BundleHeuristic {
+    #[default]
+    None,
+    CreationToken,
+}
+
+#[derive(Debug)]
+struct BundleList {
+    base_uri: Option<String>,
+    mode: BundleMode,
+    version: i32,
+    heuristic: BundleHeuristic,
+    bundles: HashMap<String, RemoteBundleInfo>,
+}
+
+impl BundleList {
+    fn new() -> Self {
+        Self {
+            base_uri: None,
+            mode: BundleMode::All,
+            version: 1,
+            heuristic: BundleHeuristic::None,
+            bundles: HashMap::new(),
+        }
+    }
+}
+
+fn heuristic_name(h: BundleHeuristic) -> Option<&'static str> {
+    match h {
+        BundleHeuristic::CreationToken => Some("creationToken"),
+        BundleHeuristic::None => None,
+    }
+}
+
+/// Split `bundle.<subsection?>.<subkey>` the same way as Git `parse_config_key(..., "bundle", ...)`.
+fn parse_bundle_key(full_key: &str) -> Option<(Option<String>, String)> {
+    let rest = full_key.strip_prefix("bundle.")?;
+    if rest.is_empty() {
+        return None;
+    }
+    match rest.rsplit_once('.') {
+        Some((subsection, subkey)) if !subsection.is_empty() && !subkey.is_empty() => {
+            Some((Some(subsection.to_string()), subkey.to_string()))
+        }
+        _ => Some((None, rest.to_string())),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BundleUpdateOutcome {
+    Ok,
+    Ignored,
+    DuplicateUri,
+}
+
+fn bundle_list_update(key: &str, value: &str, list: &mut BundleList) -> BundleUpdateOutcome {
+    let Some((subsection, subkey)) = parse_bundle_key(key) else {
+        return BundleUpdateOutcome::Ignored;
+    };
+    let subkey_lc = subkey.to_ascii_lowercase();
+
+    if subsection.is_none() {
+        match subkey_lc.as_str() {
+            "version" => {
+                if let Ok(v) = value.parse::<i32>() {
+                    if v == 1 {
+                        list.version = v;
+                        return BundleUpdateOutcome::Ok;
+                    }
+                }
+                BundleUpdateOutcome::Ignored
+            }
+            "mode" => {
+                if value == "all" {
+                    list.mode = BundleMode::All;
+                    BundleUpdateOutcome::Ok
+                } else if value == "any" {
+                    list.mode = BundleMode::Any;
+                    BundleUpdateOutcome::Ok
+                } else {
+                    BundleUpdateOutcome::Ignored
+                }
+            }
+            "heuristic" => {
+                if value.eq_ignore_ascii_case("creationtoken") {
+                    list.heuristic = BundleHeuristic::CreationToken;
+                    BundleUpdateOutcome::Ok
+                } else {
+                    BundleUpdateOutcome::Ignored
+                }
+            }
+            _ => BundleUpdateOutcome::Ignored,
+        }
+    } else {
+        let Some(id) = subsection else {
+            return BundleUpdateOutcome::Ignored;
+        };
+        let entry = list
+            .bundles
+            .entry(id.clone())
+            .or_insert_with(|| RemoteBundleInfo {
+                id,
+                uri: None,
+                creation_token: None,
+            });
+
+        if subkey_lc == "uri" {
+            if entry.uri.is_some() {
+                return BundleUpdateOutcome::DuplicateUri;
+            }
+            let base = list.base_uri.as_deref().unwrap_or(TEST_BASE_URI);
+            let resolved = match git_path::relative_url(base, value, None) {
+                Ok(u) => u,
+                Err(()) => {
+                    eprintln!("fatal: cannot strip one component off url '{base}'");
+                    std::process::exit(128);
+                }
+            };
+            entry.uri = Some(resolved);
+            BundleUpdateOutcome::Ok
+        } else if subkey_lc == "creationtoken" {
+            match value.parse::<u64>() {
+                Ok(t) => {
+                    entry.creation_token = Some(t);
+                    BundleUpdateOutcome::Ok
+                }
+                Err(_) => {
+                    eprintln!(
+                        "warning: could not parse bundle list key creationToken with value '{value}'"
+                    );
+                    BundleUpdateOutcome::Ok
+                }
+            }
+        } else {
+            BundleUpdateOutcome::Ignored
+        }
+    }
+}
+
+fn print_bundle_list(list: &BundleList) -> Result<()> {
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    let mode_str = match list.mode {
+        BundleMode::All => "all",
+        BundleMode::Any => "any",
+        BundleMode::None => "<unknown>",
+    };
+    writeln!(out, "[bundle]")?;
+    writeln!(out, "\tversion = {}", list.version)?;
+    writeln!(out, "\tmode = {mode_str}")?;
+    if let Some(name) = heuristic_name(list.heuristic) {
+        writeln!(out, "\theuristic = {name}")?;
+    }
+
+    let mut ids: Vec<_> = list.bundles.keys().cloned().collect();
+    ids.sort();
+    for id in ids {
+        let info = list.bundles.get(&id).expect("key must exist");
+        writeln!(out, "[bundle \"{id}\"]")?;
+        if let Some(ref u) = info.uri {
+            writeln!(out, "\turi = {u}")?;
+        } else {
+            writeln!(out, "\t# uri = (missing)")?;
+        }
+        if let Some(t) = info.creation_token {
+            if t != 0 {
+                writeln!(out, "\tcreationToken = {t}")?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// `bundle_uri_parse_line` + error handling like Git `test-bundle-uri.c`.
+pub(crate) fn parse_key_values_file(path: &str) -> Result<i32> {
+    let mut list = BundleList::new();
+    list.base_uri = Some(TEST_BASE_URI.to_string());
+
+    let file = fs::File::open(path).map_err(|e| anyhow::anyhow!("failed to open '{path}': {e}"))?;
+    let reader = std::io::BufReader::new(file);
+    let mut err = 0i32;
+
+    for line in reader.lines() {
+        let line = line?;
+        if bundle_uri_parse_line(&mut list, &line).is_err() {
+            err = 1;
+            eprintln!("error: bad line: '{line}'");
+        }
+    }
+
+    print_bundle_list(&list)?;
+    Ok(err)
+}
+
+fn bundle_uri_parse_line(list: &mut BundleList, line: &str) -> Result<(), ()> {
+    if line.is_empty() {
+        eprintln!("error: bundle-uri: got an empty line");
+        return Err(());
+    }
+    let Some(eq) = line.find('=') else {
+        eprintln!("error: bundle-uri: line is not of the form 'key=value'");
+        return Err(());
+    };
+    if eq == 0 || eq + 1 >= line.len() {
+        eprintln!("error: bundle-uri: line has empty key or value");
+        return Err(());
+    }
+    let key = &line[..eq];
+    let value = &line[eq + 1..];
+    match bundle_list_update(key, value, list) {
+        BundleUpdateOutcome::DuplicateUri => Err(()),
+        _ => Ok(()),
+    }
+}
+
+#[derive(Default, Clone)]
+struct IniParserState {
+    section_bundle: bool,
+    subsection: Option<String>,
+}
+
+/// Validate a config line like Git's core scanner: first content character on an entry line must
+/// be alphabetic; `key = value` must have non-empty trimmed key and value.
+///
+/// Returns `false` when the line is invalid (after printing the same message as Git's config
+/// parser).
+fn validate_git_config_entry_line(raw: &str, line_no: usize, path: &Path) -> bool {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed.starts_with('#') || trimmed.starts_with(';') {
+        return true;
+    }
+    if trimmed.starts_with('[') {
+        return true;
+    }
+    let bytes = trimmed.as_bytes();
+    let mut i = 0usize;
+    while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+        i += 1;
+    }
+    if i >= bytes.len() {
+        return true;
+    }
+    if !bytes[i].is_ascii_alphabetic() {
+        eprintln!(
+            "error: bad config line {} in file {}",
+            line_no,
+            path.display()
+        );
+        return false;
+    }
+    let Some(eq_pos) = trimmed.find('=') else {
+        eprintln!(
+            "error: bad config line {} in file {}",
+            line_no,
+            path.display()
+        );
+        return false;
+    };
+    let key_part = trimmed[..eq_pos].trim();
+    let value_part = strip_inline_comment_config(trimmed[eq_pos + 1..].trim());
+    if key_part.is_empty() || value_part.trim().is_empty() {
+        eprintln!(
+            "error: bad config line {} in file {}",
+            line_no,
+            path.display()
+        );
+        return false;
+    }
+    true
+}
+
+/// Strip `#` / `;` comments not inside double quotes (Git config semantics, simplified).
+fn strip_inline_comment_config(s: &str) -> &str {
+    let mut in_quote = false;
+    let mut chars = s.char_indices().peekable();
+    while let Some((i, ch)) = chars.next() {
+        match ch {
+            '"' => in_quote = !in_quote,
+            '#' | ';' if !in_quote => return &s[..i],
+            _ => {}
+        }
+    }
+    s
+}
+
+/// Build `bundle.full.key` from current ini section and raw variable name.
+fn make_config_key(state: &IniParserState, raw_var: &str) -> Option<String> {
+    if !state.section_bundle {
+        return None;
+    }
+    let var = raw_var.trim();
+    let var_lc = var.to_ascii_lowercase();
+    match &state.subsection {
+        None => Some(format!("bundle.{var_lc}")),
+        Some(sub) => Some(format!("bundle.{sub}.{var_lc}")),
+    }
+}
+
+pub(crate) fn parse_config_file(uri_param: &str, path: &str) -> Result<i32> {
+    let path = Path::new(path);
+    let content = fs::read_to_string(path)
+        .map_err(|e| anyhow::anyhow!("failed to open '{}': {e}", path.display()))?;
+
+    let mut list = BundleList::new();
+    list.base_uri = Some(if uri_param == TEST_BASE_URI {
+        TEST_BASE_URI.to_string()
+    } else {
+        let mut b = uri_param.to_string();
+        if !b.ends_with('/') {
+            if let Some(pos) = b.rfind('/') {
+                b.truncate(pos + 1);
+            } else {
+                b.clear();
+            }
+        }
+        b
+    });
+
+    let mut err = 0i32;
+    let mut state = IniParserState::default();
+    let raw_lines: Vec<&str> = content.lines().collect();
+    let mut idx = 0usize;
+
+    while idx < raw_lines.len() {
+        let line_no = idx + 1;
+        let line = raw_lines[idx].strip_suffix('\r').unwrap_or(raw_lines[idx]);
+        idx += 1;
+
+        if line.trim().starts_with('#') || line.trim().starts_with(';') {
+            continue;
+        }
+
+        // Continuation lines (backslash at end of value portion)
+        let mut logical = line.to_string();
+        while line_continues(&logical) && idx < raw_lines.len() {
+            let t = logical.trim_end();
+            logical = format!("{}{}", &t[..t.len() - 1], raw_lines[idx].trim_start());
+            idx += 1;
+        }
+
+        let trimmed = logical.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        if trimmed.starts_with('[') {
+            if let Some(s) = parse_section_header(trimmed) {
+                state = s;
+            } else {
+                state = IniParserState::default();
+            }
+            continue;
+        }
+
+        if !validate_git_config_entry_line(&logical, line_no, path) {
+            err = 1;
+            continue;
+        }
+
+        let Some(eq) = trimmed.find('=') else {
+            continue;
+        };
+        let raw_name = trimmed[..eq].trim();
+        let raw_value = strip_inline_comment_config(trimmed[eq + 1..].trim());
+        let value = unescape_config_value(raw_value.trim());
+
+        let Some(full_key) = make_config_key(&state, raw_name) else {
+            continue;
+        };
+
+        match bundle_list_update(&full_key, &value, &mut list) {
+            BundleUpdateOutcome::DuplicateUri => {
+                err = 1;
+                eprintln!("error: bad line: '{trimmed}'");
+            }
+            _ => {}
+        }
+    }
+
+    if list.mode == BundleMode::None {
+        eprintln!("warning: bundle list at '{}' has no mode", uri_param);
+        err = 1;
+    }
+
+    for (id, info) in &list.bundles {
+        if info.uri.is_none() {
+            eprintln!("error: bundle list at '{uri_param}': bundle '{id}' has no uri");
+            err = 1;
+        }
+    }
+
+    print_bundle_list(&list)?;
+    Ok(err)
+}
+
+fn line_continues(line: &str) -> bool {
+    let trimmed = line.trim();
+    if trimmed.is_empty() || trimmed.starts_with('#') || trimmed.starts_with(';') {
+        return false;
+    }
+    let Some(pos) = trimmed.find('=') else {
+        return false;
+    };
+    let value_part = &trimmed[pos + 1..];
+    let mut in_quote = false;
+    let mut escaped = false;
+    let mut in_comment = false;
+    let mut last_bs = false;
+    for ch in value_part.chars() {
+        if in_comment {
+            last_bs = false;
+            continue;
+        }
+        match ch {
+            '"' if !escaped => in_quote = !in_quote,
+            '\\' if !escaped => {
+                escaped = true;
+                last_bs = true;
+                continue;
+            }
+            '#' | ';' if !in_quote && !escaped => in_comment = true,
+            _ => {}
+        }
+        escaped = false;
+        last_bs = false;
+    }
+    last_bs && !in_comment
+}
+
+fn unescape_config_value(s: &str) -> String {
+    if !s.contains('\\') {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\\' {
+            if let Some(&n) = chars.peek() {
+                if n == '\n' {
+                    chars.next();
+                    continue;
+                }
+                out.push(chars.next().unwrap());
+                continue;
+            }
+        }
+        out.push(ch);
+    }
+    out
+}
+
+fn parse_section_header(line: &str) -> Option<IniParserState> {
+    let t = line.trim();
+    let end = t.find(']')?;
+    let inside = t.get(1..end)?.trim();
+    if inside == "bundle" {
+        return Some(IniParserState {
+            section_bundle: true,
+            subsection: None,
+        });
+    }
+    // `[bundle "subsection"]` — subsection may contain escapes.
+    let prefix = "bundle \"";
+    if inside.starts_with(prefix) && inside.ends_with('"') {
+        let quoted = &inside[prefix.len()..inside.len() - 1];
+        let mut unescaped = String::new();
+        let mut ch = quoted.chars().peekable();
+        while let Some(c) = ch.next() {
+            if c == '\\' {
+                if let Some(n) = ch.next() {
+                    unescaped.push(n);
+                }
+            } else {
+                unescaped.push(c);
+            }
+        }
+        return Some(IniParserState {
+            section_bundle: true,
+            subsection: Some(unescaped),
+        });
+    }
+    None
+}

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -16,6 +16,7 @@ use std::path::{Path, PathBuf};
 mod alias;
 mod branch_tracking;
 mod bundle_uri;
+mod bundle_uri_test_tool;
 mod commands;
 mod dotfile;
 mod explicit_exit;
@@ -4556,6 +4557,23 @@ pub(crate) fn dispatch(subcmd: &str, rest: &[String], opts: &GlobalOpts) -> Resu
                             .with_context(|| "could not get the bundle-uri list")?;
                             crate::http_bundle_uri::print_bundle_list_from_pairs(&pairs);
                             Ok(())
+                        }
+                        "parse-key-values" => {
+                            let path = rest.get(2).map(|s| s.as_str()).unwrap_or("");
+                            if path.is_empty() {
+                                bail!("usage: test-tool bundle-uri parse-key-values <input>");
+                            }
+                            let code = crate::bundle_uri_test_tool::parse_key_values_file(path)?;
+                            std::process::exit(code);
+                        }
+                        "parse-config" => {
+                            let path = rest.get(2).map(|s| s.as_str()).unwrap_or("");
+                            if path.is_empty() {
+                                bail!("usage: test-tool bundle-uri parse-config <input>");
+                            }
+                            let code =
+                                crate::bundle_uri_test_tool::parse_config_file("<uri>", path)?;
+                            std::process::exit(code);
                         }
                         other => bail!("test-tool bundle-uri: unknown subcommand '{other}'"),
                     }

--- a/logs/2026-04-09_t5750-bundle-uri-parse.md
+++ b/logs/2026-04-09_t5750-bundle-uri-parse.md
@@ -1,0 +1,25 @@
+# t5750-bundle-uri-parse
+
+## Goal
+
+Make `tests/t5750-bundle-uri-parse.sh` pass (13 cases) by implementing Git-compatible
+`test-tool bundle-uri parse-key-values` and `parse-config`.
+
+## Changes
+
+- Added `grit/src/bundle_uri_test_tool.rs`: bundle list state, `bundle_list_update` matching
+  `git/bundle-uri.c` key rules, `relative_url` via `git_path::relative_url`, config-file scan
+  with Git-style bad-line validation for empty key/value, fatal on “strip one component” like Git.
+- Wired `parse-key-values` and `parse-config` in `grit/src/main.rs` `test-tool bundle-uri` dispatch
+  (exit code from parse errors).
+
+## Verification
+
+- `cargo fmt`, `cargo clippy -p grit-rs --fix --allow-dirty`
+- `cargo test -p grit-lib --lib`
+- `./scripts/run-tests.sh t5750-bundle-uri-parse.sh` → 13/13
+
+## Notes
+
+`parse-config` uses base URI `<uri>` unchanged when passed that literal (matches
+`test-bundle-uri.c`), so relative URI resolution matches Git’s test expectations.

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   308 |
+| Completed   |   309 |
 | In progress |     5 |
-| Remaining   |   456 |
+| Remaining   |   455 |
 | **Total**   |   769 |
 
-Task lines in `PLAN.md`: 308 completed (`[x]`), 5 in progress (`[~]`), 456 remaining (`[ ]`).
+Task lines in `PLAN.md`: 309 completed (`[x]`), 5 in progress (`[~]`), 455 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t5750-bundle-uri-parse` — 13/13 tests pass (`test-tool bundle-uri parse-key-values` / `parse-config`: Git `bundle-uri.c` semantics, `git_path::relative_url`, stderr messages; harness CSV/dashboards refreshed)
 - `t3423-rebase-reword` — 3/3 tests pass (`rebase -i`: parse `reword`/`r` in todo; run commit editor with `prepare-commit-msg` source `reword`; `rebase --continue` after conflict uses `rebase-merge/message` template; noop-fast-forward path restricted to `pick` only so `reword` still opens editor)
 - `t3417-rebase-whitespace-fix` — 4/4 tests pass (`rebase --whitespace=fix`: apply `fix_blob_bytes` to merged index after three-way merge; noop pick path rebuilds tree + commit when whitespace fix is active; harness CSV refreshed)
 - `t7011-skip-worktree-reading` — 15/15 tests pass (`update-index` skip-worktree no-op / `--remove` clears entry; `--remove` on missing untracked path is silent; `reset` preserves skip-worktree; `diff-index` skips worktree for skip-worktree; `commit` pathspec rejects skip-worktree)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements `test-tool bundle-uri parse-key-values` and `parse-config` to match Git's `bundle-uri.c` / `t/helper/test-bundle-uri.c` behavior so `t5750-bundle-uri-parse` passes (13/13).

## Details

- New module `grit/src/bundle_uri_test_tool.rs`: bundle list state, `bundle_list_update` (version/mode/heuristic, per-bundle `uri` with `git_path::relative_url`, `creationToken` parse + warning on bogus), duplicate-uri handling, empty-line / empty key-value errors, fatal message for `relative_url` strip failure.
- Config path: Git-style validation for bad lines (alphabetic first char, non-empty key and value), section parsing for `[bundle]` / `[bundle "id"]`, base URI `<uri>` preserved when literal (matches the C test helper).
- `main.rs`: wire subcommands; non-zero exit on parse errors.

## Verification

- `cargo fmt`, `cargo clippy -p grit-rs --fix --allow-dirty`
- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t5750-bundle-uri-parse.sh`

Also updates `PLAN.md`, `progress.md`, harness `data/test-files.csv`, and generated dashboards.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d32936ad-2387-43ff-8330-36f0328ef80c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d32936ad-2387-43ff-8330-36f0328ef80c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

