### PR TITLE
fix: t12630 rev-parse HEAD fails in empty bare repo

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -318,7 +318,7 @@ t12590-log-format-tformat	t1	yes	33	32	1	false	ok	0
 t12600-rev-list-not-exclude	t1	yes	32	31	1	false	ok	0
 t12610-rev-list-all-branches	t1	yes	32	30	2	false	ok	0
 t12620-rev-parse-resolve-ref	t1	yes	32	31	1	false	ok	0
-t12630-rev-parse-is-bare	t1	yes	33	32	1	false	ok	0
+t12630-rev-parse-is-bare	t1	yes	33	33	0	true	ok	0
 t12640-config-list-show-origin	t1	yes	33	33	0	true	ok	0
 t12650-config-null-value	t1	yes	34	33	1	false	ok	0
 t12660-init-shared-perm	t1	yes	37	34	3	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.1% of harness tests passing (35,212 / 45,112).">
+<meta property="og:description" content="78.1% of harness tests passing (35,231 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.1% of harness tests passing (35,212 / 45,112).">
+<meta name="twitter:description" content="78.1% of harness tests passing (35,231 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T13:51:28+00:00" class="gen-time" title="2026-04-09 13:51 UTC">2026-04-09 13:51 UTC</time> · <a href="https://github.com/schacon/grit/commit/1b2deb6d814ce62f9b7b0fab0b751f2cf7de238c" style="color:#58a6ff">1b2deb6</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T14:05:34+00:00" class="gen-time" title="2026-04-09 14:05 UTC">2026-04-09 14:05 UTC</time> · <a href="https://github.com/schacon/grit/commit/e21f56e868c440bbf8e0cd98724990dbb13d8b57" style="color:#58a6ff">e21f56e</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,212</div>
+      <div class="summary-big-val">35,231</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>722 files fully passing</span>
+    <span>726 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -197,7 +197,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">271/368 files · 8 skipped · 11,684/12,747 tests</span>
+        <span class="group-meta">272/368 files · 8 skipped · 11,685/12,747 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-green" style="width:91.7%"></div></div>
@@ -230,22 +230,22 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">68/178 files · 2 skipped · 2,668/4,437 tests</span>
+        <span class="group-meta">70/178 files · 2 skipped · 2,683/4,437 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.1%"></div></div>
-        <span class="group-pct pct-blue">60.1%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.5%"></div></div>
+        <span class="group-pct pct-blue">60.5%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">23/167 files · 17 skipped · 1,478/4,139 tests</span>
+        <span class="group-meta">24/167 files · 17 skipped · 1,481/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:35.7%"></div></div>
-        <span class="group-pct pct-red">35.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:35.8%"></div></div>
+        <span class="group-pct pct-red">35.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35212 of 45112 tests passing across 1405 harness files (78.1% pass rate).</desc>
+  <desc id="svg-desc">35231 of 45112 tests passing across 1405 harness files (78.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.1% pass rate · 35,212 / 45,112 tests · 1,405 files in scope · 722 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.1% pass rate · 35,231 / 45,112 tests · 1,405 files in scope · 726 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="547" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T13:51:28+00:00" class="gen-time" title="2026-04-09 13:51 UTC">2026-04-09 13:51 UTC</time> · <a href="https://github.com/schacon/grit/commit/1b2deb6d814ce62f9b7b0fab0b751f2cf7de238c" style="color:#58a6ff">1b2deb6</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T14:05:34+00:00" class="gen-time" title="2026-04-09 14:05 UTC">2026-04-09 14:05 UTC</time> · <a href="https://github.com/schacon/grit/commit/e21f56e868c440bbf8e0cd98724990dbb13d8b57" style="color:#58a6ff">e21f56e</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,212</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,231</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -2037,14 +2037,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="7" data-passed="3">
+<tr class="" data-group="t1" data-tests="7" data-passed="7" data-full-pass="1">
   <td class="mono">t1090-sparse-checkout-scope</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">7</td>
-  <td class="right">3</td>
+  <td class="right">7</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:42.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
@@ -3337,14 +3337,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:96.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="33" data-passed="32">
+<tr class="" data-group="t1" data-tests="33" data-passed="33" data-full-pass="1">
   <td class="mono">t12630-rev-parse-is-bare</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">33</td>
-  <td class="right">32</td>
+  <td class="right">33</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:97.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="33" data-passed="33" data-full-pass="1">
@@ -3457,14 +3457,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:97.1%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="36" data-passed="36" data-full-pass="1">
+<tr class="" data-group="t1" data-tests="36" data-passed="32">
   <td class="mono">t12770-for-each-ref-perl-format</td>
   <td>t1</td>
-  <td><span class="badge ok">full pass</span></td>
+  <td></td>
   <td class="right">36</td>
-  <td class="right">36</td>
+  <td class="right">32</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:88.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="36" data-passed="35">
@@ -7607,14 +7607,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:16.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="10" data-passed="6">
+<tr class="" data-group="t4" data-tests="10" data-passed="10" data-full-pass="1">
   <td class="mono">t4064-diff-oidfind</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">10</td>
-  <td class="right">6</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:60.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="7" data-passed="7" data-full-pass="1">
@@ -8137,14 +8137,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="12" data-passed="1">
+<tr class="" data-group="t4" data-tests="12" data-passed="12" data-full-pass="1">
   <td class="mono">t4128-apply-root</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">12</td>
-  <td class="right">1</td>
+  <td class="right">12</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="23" data-passed="9">
@@ -9017,14 +9017,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="9" data-passed="6">
+<tr class="" data-group="t5" data-tests="9" data-passed="4">
   <td class="mono">t5318-pack-objects-revs-exclude</td>
   <td>t5</td>
   <td></td>
   <td class="right">9</td>
-  <td class="right">6</td>
+  <td class="right">4</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:66.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:44.4%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="98" data-passed="20">
@@ -10307,14 +10307,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="10" data-passed="5">
+<tr class="" data-group="t5" data-tests="10" data-passed="10" data-full-pass="1">
   <td class="mono">t5620-backfill</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">10</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="12" data-passed="12" data-full-pass="1">

--- a/grit/src/commands/rev_parse.rs
+++ b/grit/src/commands/rev_parse.rs
@@ -932,23 +932,6 @@ Use 'git <command> -- <path>...' to specify paths that do not exist locally."
                 // Use ONLY the per-action flag (not global, to support mixed usage)
                 let use_symbolic = *rev_symbolic_full_name;
 
-                // When `HEAD` is symbolic but the branch tip does not exist yet (empty bare repo,
-                // orphan checkout), Git prints the literal `HEAD` unless `--short` is used
-                // (`rev-parse` exits 128 with no stdout for `--short HEAD` in that state; t9903).
-                if rev == "HEAD"
-                    && short_len.is_none()
-                    && !abbrev_ref
-                    && !use_symbolic
-                    && current.is_bare()
-                    && matches!(
-                        refs::read_symbolic_ref(&current.git_dir, "HEAD"),
-                        Ok(Some(ref target)) if refs::resolve_ref(&current.git_dir, target).is_err()
-                    )
-                {
-                    println!("HEAD");
-                    continue;
-                }
-
                 if abbrev_ref {
                     // --abbrev-ref: resolve to symbolic name and abbreviate
                     if let Some(full) = symbolic_full_name(current, rev) {

--- a/logs/2026-04-09_t12630-rev-parse-is-bare.md
+++ b/logs/2026-04-09_t12630-rev-parse-is-bare.md
@@ -1,0 +1,14 @@
+# t12630-rev-parse-is-bare
+
+## Issue
+
+Harness failed at "bare: HEAD not valid without commits": `grit rev-parse HEAD` printed `HEAD` and exited 0 in an empty bare repo.
+
+## Fix
+
+Removed the `rev_parse` special case that echoed literal `HEAD` when bare and the symref target had no OID. Resolution now fails like `git rev-parse --verify HEAD`, matching t12630 and t13330 (orphan branch).
+
+## Verification
+
+- `./scripts/run-tests.sh t12630-rev-parse-is-bare.sh` → 33/33
+- `cargo test -p grit-lib --lib` → pass


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t12630-rev-parse-is-bare` expected `grit rev-parse HEAD` to **fail** in a bare repository with no commits. Grit had a special case that printed the literal string `HEAD` and exited 0 (mimicking plain `git rev-parse HEAD` on some Git versions).

## Change

- Removed that bare-repo shortcut in `grit rev-parse` so unresolvable `HEAD` follows the normal error path (aligned with `git rev-parse --verify HEAD` and with `t13330` orphan expectations).

## Testing

- `./scripts/run-tests.sh t12630-rev-parse-is-bare.sh` — 33/33
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2dca0457-0d51-4dc1-927c-d093c7747482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2dca0457-0d51-4dc1-927c-d093c7747482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

