### PR TITLE
t12620: rev-parse ref resolution — full pass + harness refresh

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -317,7 +317,7 @@ t12580-log-oneline-all	t1	yes	31	28	3	false	ok	0
 t12590-log-format-tformat	t1	yes	33	32	1	false	ok	0
 t12600-rev-list-not-exclude	t1	yes	32	31	1	false	ok	0
 t12610-rev-list-all-branches	t1	yes	32	30	2	false	ok	0
-t12620-rev-parse-resolve-ref	t1	yes	32	31	1	false	ok	0
+t12620-rev-parse-resolve-ref	t1	yes	32	32	0	true	ok	0
 t12630-rev-parse-is-bare	t1	yes	33	32	1	false	ok	0
 t12640-config-list-show-origin	t1	yes	33	33	0	true	ok	0
 t12650-config-null-value	t1	yes	34	33	1	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.1% of harness tests passing (35,240 / 45,112).">
+<meta property="og:description" content="78.2% of harness tests passing (35,277 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.1% of harness tests passing (35,240 / 45,112).">
+<meta name="twitter:description" content="78.2% of harness tests passing (35,277 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T14:02:56+00:00" class="gen-time" title="2026-04-09 14:02 UTC">2026-04-09 14:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/e76e016793472595007208eec9693bdb6a4d41c2" style="color:#58a6ff">e76e016</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T14:09:04+00:00" class="gen-time" title="2026-04-09 14:09 UTC">2026-04-09 14:09 UTC</time> · <a href="https://github.com/schacon/grit/commit/c4ad2e9f44715e944bf5d633e8117c550d9c487c" style="color:#58a6ff">c4ad2e9</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">78.1%</div>
+      <div class="summary-big-val pct-blue">78.2%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,240</div>
+      <div class="summary-big-val">35,277</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:78.1%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:78.2%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>730 files fully passing</span>
+    <span>733 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -186,18 +186,18 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t0</span>
         <span class="group-desc">Absolute basics and global stuff</span>
-        <span class="group-meta">38/64 files · 21 skipped · 4,868/5,136 tests</span>
+        <span class="group-meta">39/64 files · 21 skipped · 4,884/5,136 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:94.8%"></div></div>
-        <span class="group-pct pct-green">94.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:95.1%"></div></div>
+        <span class="group-pct pct-green">95.1%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t1">
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">271/368 files · 8 skipped · 11,684/12,747 tests</span>
+        <span class="group-meta">272/368 files · 8 skipped · 11,685/12,747 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-green" style="width:91.7%"></div></div>
@@ -230,11 +230,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">70/178 files · 2 skipped · 2,683/4,437 tests</span>
+        <span class="group-meta">71/178 files · 2 skipped · 2,703/4,437 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.5%"></div></div>
-        <span class="group-pct pct-blue">60.5%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>
+        <span class="group-pct pct-blue">60.9%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35240 of 45112 tests passing across 1405 harness files (78.1% pass rate).</desc>
+  <desc id="svg-desc">35277 of 45112 tests passing across 1405 harness files (78.2% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.1% pass rate · 35,240 / 45,112 tests · 1,405 files in scope · 730 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.2% pass rate · 35,277 / 45,112 tests · 1,405 files in scope · 733 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="547" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T14:02:56+00:00" class="gen-time" title="2026-04-09 14:02 UTC">2026-04-09 14:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/e76e016793472595007208eec9693bdb6a4d41c2" style="color:#58a6ff">e76e016</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T14:09:04+00:00" class="gen-time" title="2026-04-09 14:09 UTC">2026-04-09 14:09 UTC</time> · <a href="https://github.com/schacon/grit/commit/c4ad2e9f44715e944bf5d633e8117c550d9c487c" style="color:#58a6ff">c4ad2e9</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,240</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">78.1%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,277</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">78.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -907,14 +907,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:97.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t0" data-tests="16" data-passed="0">
+<tr class="" data-group="t0" data-tests="16" data-passed="16" data-full-pass="1">
   <td class="mono">t0500-progress-display</td>
   <td>t0</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">16</td>
-  <td class="right">0</td>
+  <td class="right">16</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t0" data-tests="33" data-passed="12">
@@ -3327,14 +3327,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:93.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="32" data-passed="31">
+<tr class="" data-group="t1" data-tests="32" data-passed="32" data-full-pass="1">
   <td class="mono">t12620-rev-parse-resolve-ref</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">32</td>
-  <td class="right">31</td>
+  <td class="right">32</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:96.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="33" data-passed="32">
@@ -7477,14 +7477,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:28.6%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="27" data-passed="7">
+<tr class="" data-group="t4" data-tests="27" data-passed="27" data-full-pass="1">
   <td class="mono">t4051-diff-function-name</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">27</td>
-  <td class="right">7</td>
+  <td class="right">27</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:25.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="89" data-passed="89" data-full-pass="1">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t12620-rev-parse-resolve-ref.sh` passes **32/32** tests when run via `./scripts/run-tests.sh`.

This change updates `data/test-files.csv` and regenerated dashboards to record **fully passing** status for that file (was 31/32 in the previous CSV snapshot).

## Verification

```bash
./scripts/run-tests.sh t12620-rev-parse-resolve-ref.sh
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dfb27a66-9309-4b50-b8f8-3a9e8a44086f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dfb27a66-9309-4b50-b8f8-3a9e8a44086f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

