### PR TITLE
fix: make t5506-remote-groups pass (local upload-pack fetch)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -923,7 +923,7 @@ t5502-quickfetch	t5	yes	7	2	5	false	ok	0
 t5503-tagfollow	t5	yes	12	6	6	false	ok	0
 t5504-fetch-receive-strict	t5	skip	29	0	0	false	ok	0
 t5505-remote	t5	yes	129	18	111	false	ok	1
-t5506-remote-groups	t5	yes	9	2	7	false	ok	0
+t5506-remote-groups	t5	yes	9	9	0	true	ok	0
 t5507-remote-environment	t5	yes	5	3	2	false	ok	0
 t5509-fetch-push-namespaces	t5	yes	15	4	11	false	ok	0
 t5510-fetch	t5	yes	215	35	180	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78% of harness tests passing (35,205 / 45,112).">
+<meta property="og:description" content="78.1% of harness tests passing (35,212 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78% of harness tests passing (35,205 / 45,112).">
+<meta name="twitter:description" content="78.1% of harness tests passing (35,212 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T12:58:52+00:00" class="gen-time" title="2026-04-09 12:58 UTC">2026-04-09 12:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/c9e26ba46f5a86c3328f4d62484968547c8560d9" style="color:#58a6ff">c9e26ba</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T14:12:02+00:00" class="gen-time" title="2026-04-09 14:12 UTC">2026-04-09 14:12 UTC</time> · <a href="https://github.com/schacon/grit/commit/999b424740b71e52cf30bf6fade3e1ef735f68bd" style="color:#58a6ff">999b424</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">78.0%</div>
+      <div class="summary-big-val pct-blue">78.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,205</div>
+      <div class="summary-big-val">35,212</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:78.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:78.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>719 files fully passing</span>
+    <span>720 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">23/167 files · 17 skipped · 1,478/4,139 tests</span>
+        <span class="group-meta">24/167 files · 17 skipped · 1,485/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:35.7%"></div></div>
-        <span class="group-pct pct-red">35.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:35.9%"></div></div>
+        <span class="group-pct pct-red">35.9%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35205 of 45112 tests passing across 1405 harness files (78% pass rate).</desc>
+  <desc id="svg-desc">35212 of 45112 tests passing across 1405 harness files (78.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78% pass rate · 35,205 / 45,112 tests · 1,405 files in scope · 719 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.1% pass rate · 35,212 / 45,112 tests · 1,405 files in scope · 720 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="546" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="547" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T12:58:52+00:00" class="gen-time" title="2026-04-09 12:58 UTC">2026-04-09 12:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/c9e26ba46f5a86c3328f4d62484968547c8560d9" style="color:#58a6ff">c9e26ba</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T14:12:02+00:00" class="gen-time" title="2026-04-09 14:12 UTC">2026-04-09 14:12 UTC</time> · <a href="https://github.com/schacon/grit/commit/999b424740b71e52cf30bf6fade3e1ef735f68bd" style="color:#58a6ff">999b424</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,205</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">78.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,212</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">78.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -9387,14 +9387,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:14.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t5" data-tests="9" data-passed="2">
+<tr class="" data-group="t5" data-tests="9" data-passed="9" data-full-pass="1">
   <td class="mono">t5506-remote-groups</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">9</td>
-  <td class="right">2</td>
+  <td class="right">9</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:22.2%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="5" data-passed="3">

--- a/grit/src/fetch_transport.rs
+++ b/grit/src/fetch_transport.rs
@@ -1,10 +1,11 @@
-//! Local fetch over `git-upload-pack` (protocol v0) with skipping negotiation.
+//! Local fetch over `grit upload-pack` with skipping negotiation (protocol v0/v1 ref ads, or v2
+//! capability preamble with ref names merged from the remote repository when needed).
 
 use std::cell::Cell;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::io::{Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
@@ -127,6 +128,40 @@ pub(crate) fn read_advertisement(
         }
     }
     Ok((out, head_symref))
+}
+
+/// When the child speaks protocol v2, [`read_advertisement`] only skips capability lines and never
+/// records ref advertisements. Merge `refs/heads/*` and `refs/tags/*` from the on-disk remote so
+/// [`collect_wants_for_upload_pack`] can request missing objects and the fetch command can update
+/// remote-tracking refs (t5506-remote-groups).
+fn merge_remote_refs_into_upload_pack_advertisement(
+    remote_repo_path: &Path,
+    advertised: &mut Vec<(String, ObjectId)>,
+) -> Result<()> {
+    // `remote_repo_path` is the repository root (bare) or work tree (non-bare); `list_refs` needs
+    // the git directory. `Repository::open` expects `.git` for normal repos.
+    let remote_git: PathBuf = {
+        let dot_git = remote_repo_path.join(".git");
+        if dot_git.is_dir() {
+            dot_git
+        } else {
+            remote_repo_path.to_path_buf()
+        }
+    };
+    if advertised.iter().any(|(n, _)| n.starts_with("refs/heads/")) {
+        return Ok(());
+    }
+    let mut by_name: HashMap<String, ObjectId> =
+        advertised.iter().map(|(n, o)| (n.clone(), *o)).collect();
+    for (n, o) in refs::list_refs(&remote_git, "refs/heads/")? {
+        by_name.insert(n, o);
+    }
+    for (n, o) in refs::list_refs(&remote_git, "refs/tags/")? {
+        by_name.insert(n, o);
+    }
+    *advertised = by_name.into_iter().collect();
+    advertised.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(())
 }
 
 pub(crate) fn collect_wants(
@@ -294,11 +329,10 @@ pub(crate) fn spawn_upload_pack(
     cmd_template: Option<&str>,
     repo_path: &Path,
 ) -> Result<std::process::Child> {
-    spawn_upload_pack_with_proto(
-        cmd_template,
-        repo_path,
-        protocol_wire::effective_client_protocol_version(),
-    )
+    // [`fetch_upload_pack_negotiate_pack_bytes_with_streams`] speaks protocol v0/v1 (want/have/done).
+    // If the server negotiates v2 from `GIT_PROTOCOL`, it treats our `want` lines as v2 capability
+    // extensions (`unknown capability 'want …'`). Force v0 on the child by clearing `GIT_PROTOCOL`.
+    spawn_upload_pack_with_proto(cmd_template, repo_path, 0)
 }
 
 pub(crate) fn drain_child_stdout_to_eof(r: &mut impl Read) -> std::io::Result<()> {
@@ -326,7 +360,9 @@ fn read_ack_round_with_negotiator(
             pkt_line::Packet::Data(ln) => {
                 trace_packet_fetch('<', ln.trim_end());
                 if ln.trim_end() == "NAK" {
-                    continue;
+                    // Upstream `upload-pack` often ends a have-window with `NAK` and no trailing
+                    // flush; waiting for `0000` would deadlock once the pipe fills.
+                    break;
                 }
                 let Some((ack_oid, kind)) = parse_ack(&ln) else {
                     break;
@@ -474,7 +510,10 @@ pub fn fetch_via_upload_pack_skipping(
     let mut stdin = child.stdin.take().context("upload-pack stdin")?;
     let mut stdout = child.stdout.take().context("upload-pack stdout")?;
 
-    let (advertised, head_symref) = read_advertisement(&mut stdout)?;
+    let (mut advertised, head_symref) = read_advertisement(&mut stdout)?;
+    if !has_cli_refspecs {
+        merge_remote_refs_into_upload_pack_advertisement(remote_repo_path, &mut advertised)?;
+    }
     let wants = compute_wants(&advertised)?;
     if wants.is_empty() {
         if !has_cli_refspecs && advertised.is_empty() {
@@ -542,7 +581,9 @@ pub fn fetch_via_upload_pack_skipping(
         bail!("upload-pack exited with {}", status);
     }
 
-    if pack_buf.len() < 12 || &pack_buf[0..4] != b"PACK" {
+    // When the client already has every wanted object, `pack-objects --thin` can stream an empty
+    // body (or only the 12-byte PACK header). That is still a successful fetch (ref updates only).
+    if !pack_buf.is_empty() && (pack_buf.len() < 12 || &pack_buf[0..4] != b"PACK") {
         bail!("did not receive a pack file from upload-pack");
     }
 
@@ -578,7 +619,7 @@ fn fetch_upload_pack_negotiate_pack_bytes(
         bail!("upload-pack exited with {}", status);
     }
 
-    if pack_buf.len() < 12 || &pack_buf[0..4] != b"PACK" {
+    if !pack_buf.is_empty() && (pack_buf.len() < 12 || &pack_buf[0..4] != b"PACK") {
         bail!("did not receive a pack file from upload-pack");
     }
 
@@ -914,7 +955,7 @@ pub fn fetch_via_git_protocol_skipping(
         &wants,
     )?;
 
-    if pack_buf.len() < 12 || &pack_buf[0..4] != b"PACK" {
+    if !pack_buf.is_empty() && (pack_buf.len() < 12 || &pack_buf[0..4] != b"PACK") {
         bail!("did not receive a pack file from upload-pack");
     }
 

--- a/logs/2026-04-09_t5506-remote-groups-fetch.md
+++ b/logs/2026-04-09_t5506-remote-groups-fetch.md
@@ -1,0 +1,16 @@
+# t5506-remote-groups
+
+## Problem
+
+`git remote update` / `git fetch` ran but `git log <remote>` failed: protocol v2 upload-pack advertisement was not parsed into ref names, so fetch updated no remote-tracking refs or updated refs without transferring objects.
+
+## Fix (grit `fetch_transport`)
+
+- Force spawned `upload-pack` to protocol v0 (clear `GIT_PROTOCOL`) so the client’s v0 `want`/`have` negotiation matches the server.
+- When the advertisement has no `refs/heads/*` lines, merge heads/tags from the remote’s `.git` directory before computing wants (covers any v2-style preamble).
+- End ACK rounds on `NAK` when no flush follows (avoids deadlock with grit `upload-pack`).
+- Treat empty or 12-byte PACK output as success after negotiation (thin pack with nothing new).
+
+## Verification
+
+`./scripts/run-tests.sh t5506-remote-groups.sh` — 9/9 pass.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t5506-remote-groups` failed because local `fetch`/`remote update` did not reliably populate remote-tracking refs and objects when negotiating with the child `upload-pack` process.

## Changes

- Spawn `upload-pack` with protocol **v0** (clear `GIT_PROTOCOL`) so the client’s v0 `want`/`have`/`done` flow matches the server instead of being misinterpreted as v2 capability lines.
- When the ref advertisement contains no `refs/heads/*` entries, **merge branch/tag OIDs from the remote repository’s git dir** before computing wants (so wants and ref updates stay aligned).
- **Stop reading the ACK round on `NAK`** when the server does not send a trailing flush (matches grit `upload-pack` behavior and avoids a full pipe deadlock).
- Treat **empty or 12-byte PACK** output as success after negotiation when the client already has all wanted objects (`pack-objects --thin` can emit no pack body).

## Testing

- `./scripts/run-tests.sh t5506-remote-groups.sh` → **9/9**
- `cargo test -p grit-lib --lib`

Note: `cargo clippy -p grit-rs -- -D warnings` still reports many pre-existing issues in the crate; this change does not address those.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1cc4c9c-d063-491f-ba05-ab1fdad01a98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1cc4c9c-d063-491f-ba05-ab1fdad01a98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

