### PR TITLE
fix: diff-index -p matches Git when index and worktree both differ from HEAD

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1486,7 +1486,7 @@ t9210-scalar	t9	skip	22	16	6	false	ok	0
 t9211-scalar-clone	t9	skip	14	10	4	false	ok	0
 t9220-diff-tree-pathspec	t9	yes	30	30	0	true	ok	0
 t9230-diff-index-modes	t9	yes	38	38	0	true	ok	0
-t9231-diff-index-patch	t9	yes	11	10	1	false	ok	0
+t9231-diff-index-patch	t9	yes	11	11	0	true	ok	0
 t9240-diff-files-deleted	t9	yes	34	33	1	false	ok	0
 t9250-status-short-branch	t9	yes	33	33	0	true	ok	0
 t9260-log-oneline-format	t9	yes	33	32	1	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.1% of harness tests passing (35,240 / 45,112).">
+<meta property="og:description" content="78.2% of harness tests passing (35,277 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.1% of harness tests passing (35,240 / 45,112).">
+<meta name="twitter:description" content="78.2% of harness tests passing (35,277 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T14:02:56+00:00" class="gen-time" title="2026-04-09 14:02 UTC">2026-04-09 14:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/e76e016793472595007208eec9693bdb6a4d41c2" style="color:#58a6ff">e76e016</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T14:57:31+00:00" class="gen-time" title="2026-04-09 14:57 UTC">2026-04-09 14:57 UTC</time> · <a href="https://github.com/schacon/grit/commit/c4ad2e9f44715e944bf5d633e8117c550d9c487c" style="color:#58a6ff">c4ad2e9</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">78.1%</div>
+      <div class="summary-big-val pct-blue">78.2%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,240</div>
+      <div class="summary-big-val">35,277</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:78.1%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:78.2%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>730 files fully passing</span>
+    <span>733 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -186,11 +186,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t0</span>
         <span class="group-desc">Absolute basics and global stuff</span>
-        <span class="group-meta">38/64 files · 21 skipped · 4,868/5,136 tests</span>
+        <span class="group-meta">39/64 files · 21 skipped · 4,884/5,136 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:94.8%"></div></div>
-        <span class="group-pct pct-green">94.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:95.1%"></div></div>
+        <span class="group-pct pct-green">95.1%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t1">
@@ -230,11 +230,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">70/178 files · 2 skipped · 2,683/4,437 tests</span>
+        <span class="group-meta">71/178 files · 2 skipped · 2,703/4,437 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.5%"></div></div>
-        <span class="group-pct pct-blue">60.5%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>
+        <span class="group-pct pct-blue">60.9%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">
@@ -285,7 +285,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t9</span>
         <span class="group-desc">Git tools</span>
-        <span class="group-meta">74/90 files · 127 skipped · 2,770/2,860 tests</span>
+        <span class="group-meta">75/90 files · 127 skipped · 2,771/2,860 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-green" style="width:96.9%"></div></div>

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35240 of 45112 tests passing across 1405 harness files (78.1% pass rate).</desc>
+  <desc id="svg-desc">35277 of 45112 tests passing across 1405 harness files (78.2% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.1% pass rate · 35,240 / 45,112 tests · 1,405 files in scope · 730 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.2% pass rate · 35,277 / 45,112 tests · 1,405 files in scope · 733 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="547" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T14:02:56+00:00" class="gen-time" title="2026-04-09 14:02 UTC">2026-04-09 14:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/e76e016793472595007208eec9693bdb6a4d41c2" style="color:#58a6ff">e76e016</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T14:57:31+00:00" class="gen-time" title="2026-04-09 14:57 UTC">2026-04-09 14:57 UTC</time> · <a href="https://github.com/schacon/grit/commit/c4ad2e9f44715e944bf5d633e8117c550d9c487c" style="color:#58a6ff">c4ad2e9</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,240</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">78.1%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,277</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">78.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -907,14 +907,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:97.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t0" data-tests="16" data-passed="0">
+<tr class="" data-group="t0" data-tests="16" data-passed="16" data-full-pass="1">
   <td class="mono">t0500-progress-display</td>
   <td>t0</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">16</td>
-  <td class="right">0</td>
+  <td class="right">16</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t0" data-tests="33" data-passed="12">
@@ -7477,14 +7477,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:28.6%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="27" data-passed="7">
+<tr class="" data-group="t4" data-tests="27" data-passed="27" data-full-pass="1">
   <td class="mono">t4051-diff-function-name</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">27</td>
-  <td class="right">7</td>
+  <td class="right">27</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:25.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="89" data-passed="89" data-full-pass="1">
@@ -15017,14 +15017,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t9" data-tests="11" data-passed="10">
+<tr class="" data-group="t9" data-tests="11" data-passed="11" data-full-pass="1">
   <td class="mono">t9231-diff-index-patch</td>
   <td>t9</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">11</td>
-  <td class="right">10</td>
+  <td class="right">11</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t9" data-tests="34" data-passed="33">

--- a/grit/src/commands/diff_index.rs
+++ b/grit/src/commands/diff_index.rs
@@ -789,6 +789,34 @@ fn collect_tree_entries(
     Ok(())
 }
 
+/// Returns true when the work tree at `path` matches `index_snapshot` (stat cache or content hash).
+fn worktree_matches_index_snapshot(
+    repo: &Repository,
+    work_tree: &Path,
+    path: &str,
+    index_snapshot: Snapshot,
+    index_entries: &BTreeMap<&[u8], &IndexEntry>,
+) -> Result<bool> {
+    if index_snapshot.mode == MODE_GITLINK {
+        return Ok(true);
+    }
+    let abs = work_tree.join(path);
+    let meta = match fs::symlink_metadata(&abs) {
+        Ok(m) => m,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(e) => return Err(e.into()),
+    };
+    if let Some(ie) = index_entries.get(path.as_bytes()) {
+        if stat_matches(ie, &meta) {
+            return Ok(true);
+        }
+    }
+    let Some(wt_snapshot) = read_worktree_snapshot_from_meta(repo, &abs, &meta)? else {
+        return Ok(false);
+    };
+    Ok(wt_snapshot == index_snapshot)
+}
+
 fn diff_tree_vs_index(
     tree_map: &BTreeMap<String, Snapshot>,
     index_map: &BTreeMap<String, Snapshot>,
@@ -850,6 +878,42 @@ fn diff_tree_vs_worktree(
     let mut merged = BTreeMap::new();
     for change in diff_tree_vs_index(tree_map, index_map) {
         merged.insert(change.path.clone(), change);
+    }
+
+    // Git `diff-index` without `--cached` compares the tree to the **working tree** for patch/raw
+    // purposes, while still classifying tree↔index conflicts. When the index differs from the tree,
+    // the recorded "new" side is the index blob if the work tree still matches the index; if the
+    // work tree has diverged further, the new side is the work tree (placeholder zero OID in raw,
+    // content read from disk for `-p`). See t9231-diff-index-patch and `git diff-index -p HEAD`.
+    for change in merged.values_mut() {
+        if !matches!(change.status, 'A' | 'M') {
+            continue;
+        }
+        let Some(index_snapshot) = change.new else {
+            continue;
+        };
+        if index_snapshot.mode == MODE_GITLINK {
+            continue;
+        }
+        let path = change.path.as_str();
+        if worktree_matches_index_snapshot(repo, work_tree, path, index_snapshot, &index_entries)? {
+            continue;
+        }
+        let abs = work_tree.join(path);
+        let meta = match fs::symlink_metadata(&abs) {
+            Ok(m) => m,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                continue;
+            }
+            Err(e) => return Err(e.into()),
+        };
+        let Some(wt_snapshot) = read_worktree_snapshot_from_meta(repo, &abs, &meta)? else {
+            continue;
+        };
+        change.new = Some(Snapshot {
+            mode: wt_snapshot.mode,
+            oid: zero_oid(),
+        });
     }
 
     for (path, index_snapshot) in index_map {

--- a/logs/2026-04-09-diff-index-uncached-worktree.md
+++ b/logs/2026-04-09-diff-index-uncached-worktree.md
@@ -1,0 +1,15 @@
+# diff-index uncached: tree vs working tree when index differs
+
+## Problem
+
+`t9231-diff-index-patch` failed on `diff-index -p HEAD` after staging changes then modifying the work tree again. Grit emitted `diff --git` with no `---`/`+++` hunk because the diff compared HEAD to the **index** blob only.
+
+## Fix
+
+In `diff_tree_vs_worktree`, after merging tree↔index changes, adjust `A`/`M` entries when the index differs from the tree: if the work tree still matches the index (stat cache or content hash), keep the index snapshot as the "new" side; otherwise replace the new side with a work-tree placeholder (zero OID, mode from disk) so `-p` reads file content from the work tree, matching Git.
+
+## Validation
+
+- `./scripts/run-tests.sh t9231-diff-index-patch.sh` → 11/11
+- `sh tests/t1501-work-tree.sh` → 39/39 (sanity)
+- `cargo test -p grit-lib --lib` → pass


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Uncached `diff-index` was treating paths where the index already differged from `HEAD` as if the comparison stopped at the index. Git instead compares the tree to the **working tree** for patch output when the work tree has moved past the index.

## Changes

- After merging tree↔index changes in `diff_tree_vs_worktree`, post-process `A`/`M` entries: if the work tree still matches the index (stat cache or hashed content), keep the index blob as the "new" side; otherwise use a work-tree placeholder (zero OID) so `-p` reads from disk.
- Refreshed harness row and dashboards for `t9231-diff-index-patch` (11/11).

## Testing

- `./scripts/run-tests.sh t9231-diff-index-patch.sh`
- `cargo test -p grit-lib --lib`
- Sanity: `sh tests/t1501-work-tree.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3532a7e-26bb-4f7f-be91-ace7a0f997b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3532a7e-26bb-4f7f-be91-ace7a0f997b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

