### PR TITLE
fix: make t7421-submodule-summary-add fully pass

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -811,7 +811,7 @@ commit → check it off → move on.
 - [ ] `t7615-diff-algo-with-mergy-operations` ████████░░░░░░░░░░░░ 3/7 (4 left) — git merge and other operations that rely on merge
 
 - [x] `t7402-submodule-rebase` — Test rebasing, stashing, etc. with submodules
-- [ ] `t7421-submodule-summary-add` ████░░░░░░░░░░░░░░░░ 1/5 (4 left) — Summary support for submodules, adding them using git submodule add
+- [x] `t7421-submodule-summary-add` — Summary support for submodules, adding them using git submodule add
 
 - [ ] `t7518-ident-corner-cases` ████░░░░░░░░░░░░░░░░ 1/5 (4 left) — corner cases in ident strings
 - [ ] `t7602-merge-octopus-many` ████░░░░░░░░░░░░░░░░ 1/5 (4 left) — git merge

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1212,7 +1212,7 @@ t7417-submodule-path-url	t7	yes	5	5	0	true	ok	0
 t7418-submodule-sparse-gitmodules	t7	yes	9	5	4	false	ok	0
 t7419-submodule-set-branch	t7	yes	9	9	0	true	ok	0
 t7420-submodule-set-url	t7	yes	3	2	1	false	ok	0
-t7421-submodule-summary-add	t7	yes	5	2	3	false	ok	0
+t7421-submodule-summary-add	t7	yes	5	5	0	true	ok	0
 t7422-submodule-output	t7	yes	18	8	10	false	ok	0
 t7423-submodule-symlinks	t7	yes	6	4	2	false	ok	0
 t7424-submodule-mixed-ref-formats	t7	skip	14	3	11	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.1% of harness tests passing (35,211 / 45,112).">
+<meta property="og:description" content="78.1% of harness tests passing (35,212 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.1% of harness tests passing (35,211 / 45,112).">
+<meta name="twitter:description" content="78.1% of harness tests passing (35,212 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T13:35:26+00:00" class="gen-time" title="2026-04-09 13:35 UTC">2026-04-09 13:35 UTC</time> · <a href="https://github.com/schacon/grit/commit/e77a8c04fc06ccd3ad1253e512a5889290d4b86f" style="color:#58a6ff">e77a8c0</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T15:03:13+00:00" class="gen-time" title="2026-04-09 15:03 UTC">2026-04-09 15:03 UTC</time> · <a href="https://github.com/schacon/grit/commit/901940dd69b8520127f0395f3537b41c32b82df4" style="color:#58a6ff">901940d</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,211</div>
+      <div class="summary-big-val">35,212</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>721 files fully passing</span>
+    <span>722 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,7 +241,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">23/167 files · 17 skipped · 1,478/4,139 tests</span>
+        <span class="group-meta">23/167 files · 17 skipped · 1,476/4,139 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-red" style="width:35.7%"></div></div>
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">44/126 files · 11 skipped · 2,470/3,614 tests</span>
+        <span class="group-meta">45/126 files · 11 skipped · 2,473/3,614 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.3%"></div></div>
-        <span class="group-pct pct-blue">68.3%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.4%"></div></div>
+        <span class="group-pct pct-blue">68.4%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35211 of 45112 tests passing across 1405 harness files (78.1% pass rate).</desc>
+  <desc id="svg-desc">35212 of 45112 tests passing across 1405 harness files (78.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.1% pass rate · 35,211 / 45,112 tests · 1,405 files in scope · 721 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.1% pass rate · 35,212 / 45,112 tests · 1,405 files in scope · 722 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="547" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T13:35:26+00:00" class="gen-time" title="2026-04-09 13:35 UTC">2026-04-09 13:35 UTC</time> · <a href="https://github.com/schacon/grit/commit/e77a8c04fc06ccd3ad1253e512a5889290d4b86f" style="color:#58a6ff">e77a8c0</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T15:03:13+00:00" class="gen-time" title="2026-04-09 15:03 UTC">2026-04-09 15:03 UTC</time> · <a href="https://github.com/schacon/grit/commit/901940dd69b8520127f0395f3537b41c32b82df4" style="color:#58a6ff">901940d</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,211</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,212</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -2037,14 +2037,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="7" data-passed="3">
+<tr class="" data-group="t1" data-tests="7" data-passed="7" data-full-pass="1">
   <td class="mono">t1090-sparse-checkout-scope</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">7</td>
-  <td class="right">3</td>
+  <td class="right">7</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:42.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
@@ -3457,14 +3457,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:97.1%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="36" data-passed="36" data-full-pass="1">
+<tr class="" data-group="t1" data-tests="36" data-passed="32">
   <td class="mono">t12770-for-each-ref-perl-format</td>
   <td>t1</td>
-  <td><span class="badge ok">full pass</span></td>
+  <td></td>
   <td class="right">36</td>
-  <td class="right">36</td>
+  <td class="right">32</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:88.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="36" data-passed="35">
@@ -9017,14 +9017,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="9" data-passed="6">
+<tr class="" data-group="t5" data-tests="9" data-passed="4">
   <td class="mono">t5318-pack-objects-revs-exclude</td>
   <td>t5</td>
   <td></td>
   <td class="right">9</td>
-  <td class="right">6</td>
+  <td class="right">4</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:66.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:44.4%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="98" data-passed="20">
@@ -12277,14 +12277,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:66.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="5" data-passed="2">
+<tr class="" data-group="t7" data-tests="5" data-passed="5" data-full-pass="1">
   <td class="mono">t7421-submodule-summary-add</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">5</td>
-  <td class="right">2</td>
+  <td class="right">5</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:40.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="18" data-passed="8">

--- a/grit/src/commands/_submodule_run_update_inner.rs.inc
+++ b/grit/src/commands/_submodule_run_update_inner.rs.inc
@@ -243,18 +243,29 @@ fn run_update_inner(args: &UpdateArgs, discover_base: Option<PathBuf>) -> Result
             }
         } else {
             let checkout_oid = if args.remote {
-                let mut fetch_cmd = grit_subprocess(&grit_bin);
-                fetch_cmd
-                    .args(["fetch", "origin"])
-                    .current_dir(&sub_path)
-                    .env_remove("GIT_DIR")
-                    .env_remove("GIT_WORK_TREE");
-                if args.quiet {
-                    fetch_cmd.arg("--quiet");
-                }
-                let fetch_status = fetch_cmd.status().context("failed to fetch in submodule")?;
-                if !fetch_status.success() {
-                    bail!("failed to fetch in submodule '{}'", m.name);
+                let nested_cfg_path = if sub_path.join(".git").is_file() {
+                    modules_dir.join("config")
+                } else {
+                    sub_path.join(".git").join("config")
+                };
+                let nested_content = fs::read_to_string(&nested_cfg_path)?;
+                let nested_cfg = ConfigFile::parse(&nested_cfg_path, &nested_content, ConfigScope::Local)?;
+                let used_local_fetch =
+                    submodule_fetch_origin_local_path(&sub_path, &nested_cfg, args.quiet)?;
+                if !used_local_fetch {
+                    let mut fetch_cmd = grit_subprocess(&grit_bin);
+                    fetch_cmd
+                        .args(["fetch", "origin"])
+                        .current_dir(&sub_path)
+                        .env_remove("GIT_DIR")
+                        .env_remove("GIT_WORK_TREE");
+                    if args.quiet {
+                        fetch_cmd.arg("--quiet");
+                    }
+                    let fetch_status = fetch_cmd.status().context("failed to fetch in submodule")?;
+                    if !fetch_status.success() {
+                        bail!("failed to fetch in submodule '{}'", m.name);
+                    }
                 }
 
                 let explicit_branch = {
@@ -394,6 +405,10 @@ fn run_update_inner(args: &UpdateArgs, discover_base: Option<PathBuf>) -> Result
             }
 
             refresh_gitlink_index_stat(&repo, &m.path)?;
+
+            if args.remote {
+                stage_gitlink_in_super_index(&repo, &m.path, &checkout_oid)?;
+            }
 
             if matches!(effective.as_str(), "" | "checkout") || args.remote {
                 println!(

--- a/grit/src/commands/fetch.rs
+++ b/grit/src/commands/fetch.rs
@@ -1946,7 +1946,7 @@ pub fn copy_objects_for_pull(src_git_dir: &Path, dst_git_dir: &Path) -> Result<(
 ///
 /// Used for local `fetch` so the destination does not receive unrelated objects from the
 /// source object database (matching Git's behavior and keeping negotiation tests faithful).
-fn copy_reachable_objects(
+pub(crate) fn copy_reachable_objects(
     src_git_dir: &Path,
     dst_git_dir: &Path,
     roots: &[ObjectId],

--- a/grit/src/commands/submodule.rs
+++ b/grit/src/commands/submodule.rs
@@ -203,6 +203,7 @@ fn run_with_top_opts(top: SubmoduleTopOpts, args: Args) -> Result<()> {
         }
         Some(SubmoduleCommand::Summary(mut a)) => {
             a.quiet |= top.quiet;
+            a.cached |= top.cached;
             run_summary(&a, a.quiet)
         }
         Some(SubmoduleCommand::SetBranch(mut a)) => {
@@ -216,11 +217,14 @@ fn run_with_top_opts(top: SubmoduleTopOpts, args: Args) -> Result<()> {
     }
 }
 use grit_lib::config::{ConfigFile, ConfigScope};
+use grit_lib::diff::{diff_index_to_tree, DiffEntry, DiffStatus};
 use grit_lib::error::Error as LibError;
 use grit_lib::index::MODE_GITLINK;
-use grit_lib::objects::{parse_commit, parse_tree, ObjectKind};
+use grit_lib::objects::{parse_commit, parse_tree, ObjectId, ObjectKind};
+use grit_lib::pathspec::matches_pathspec;
+use grit_lib::refs;
 use grit_lib::repo::Repository;
-use grit_lib::rev_parse;
+use grit_lib::rev_parse::{self, resolve_revision};
 use grit_lib::state::resolve_head;
 use grit_lib::submodule_gitdir::submodule_modules_git_dir;
 use std::collections::BTreeMap;
@@ -587,9 +591,25 @@ pub struct SummaryArgs {
     #[arg(short = 'q', long = "quiet")]
     pub quiet: bool,
 
-    /// Restrict to specific submodule paths.
-    #[arg(value_name = "PATH")]
-    pub paths: Vec<String>,
+    /// Compare the index to the given commit instead of the submodule working tree HEAD.
+    #[arg(long)]
+    pub cached: bool,
+
+    /// Compare the index gitlink to the submodule HEAD (instead of index vs commit tree).
+    #[arg(long)]
+    pub files: bool,
+
+    /// Limit how many commits `log` shows for each submodule (`-n`; Git `--summary-limit`).
+    #[arg(short = 'n', long = "summary-limit")]
+    pub summary_limit: Option<i32>,
+
+    /// Optional commit to compare against, then pathspecs after `--`.
+    #[arg(
+        trailing_var_arg = true,
+        allow_hyphen_values = true,
+        value_name = "ARGS"
+    )]
+    pub rest: Vec<String>,
 }
 
 #[derive(Debug, ClapArgs)]
@@ -655,6 +675,35 @@ pub(crate) fn update_after_superproject_merge(init: bool, recursive: bool) -> Re
         reference: vec![],
         no_recommend_shallow: false,
     })
+}
+
+/// Stage the given commit OID as the gitlink for `rel_path` in the superproject index.
+///
+/// Used by `submodule update --remote` so the superproject records the fetched submodule tip
+/// (matches Git; required for `git commit <path>` after `--remote`).
+fn stage_gitlink_in_super_index(
+    repo: &Repository,
+    rel_path: &str,
+    new_oid_hex: &str,
+) -> Result<()> {
+    let new_oid = ObjectId::from_hex(new_oid_hex.trim())
+        .with_context(|| format!("invalid submodule OID '{new_oid_hex}' for path '{rel_path}'"))?;
+    let index_path = repo.index_path();
+    let mut index = repo.load_index_at(&index_path)?;
+    let path_bytes = rel_path.as_bytes().to_vec();
+    let Some(entry) = index
+        .entries
+        .iter_mut()
+        .find(|e| e.stage() == 0 && e.path == path_bytes)
+    else {
+        return Ok(());
+    };
+    if entry.mode != MODE_GITLINK {
+        return Ok(());
+    }
+    entry.oid = new_oid;
+    repo.write_index_at(&index_path, &mut index)?;
+    Ok(())
 }
 
 /// Refresh cached stat data for a gitlink in the superproject index after checkout.
@@ -1515,6 +1564,105 @@ fn read_head_from_file(head_file: &Path) -> Option<String> {
 
 fn default_initial_branch_name() -> String {
     std::env::var("GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME").unwrap_or_else(|_| "main".to_string())
+}
+
+/// When `remote.origin.url` points at a local repository, emulate `git fetch origin` by copying
+/// objects and updating `refs/remotes/origin/*` without `upload-pack` (avoids protocol v2 client
+/// limitations for submodule `--remote`).
+///
+/// Returns `Ok(true)` when the fast path ran, `Ok(false)` when the URL is not a local repo path.
+fn submodule_fetch_origin_local_path(
+    sub_path: &Path,
+    local_cfg: &ConfigFile,
+    quiet: bool,
+) -> Result<bool> {
+    let Some(sub_git_dir) = resolve_submodule_git_dir(sub_path) else {
+        return Ok(false);
+    };
+    let Some(url) = config_last_value(local_cfg, "remote.origin.url") else {
+        return Ok(false);
+    };
+    let url = url.trim();
+    if url.is_empty() {
+        return Ok(false);
+    }
+    if url.starts_with("ext::") || url.starts_with("http://") || url.starts_with("https://") {
+        return Ok(false);
+    }
+    if url.starts_with("git://") {
+        return Ok(false);
+    }
+    if crate::ssh_transport::is_configured_ssh_url(url) {
+        return Ok(false);
+    }
+
+    let mut remote_path = if let Some(stripped) = url.strip_prefix("file://") {
+        PathBuf::from(stripped)
+    } else {
+        PathBuf::from(url)
+    };
+    if remote_path.is_relative() {
+        remote_path = sub_path.join(&remote_path);
+    }
+    let remote_path = remote_path.canonicalize().unwrap_or(remote_path);
+    let remote_repo = match Repository::open(&remote_path, None)
+        .or_else(|_| Repository::discover(Some(&remote_path)))
+    {
+        Ok(r) => r,
+        Err(_) => return Ok(false),
+    };
+    let remote_git = remote_repo.git_dir.as_path();
+
+    let heads = refs::list_refs(remote_git, "refs/heads/")?;
+    if heads.is_empty() {
+        return Ok(false);
+    }
+
+    if !quiet {
+        eprintln!("From {}", remote_path.display());
+    }
+
+    let mut roots: Vec<ObjectId> = Vec::new();
+    for (refname, oid) in &heads {
+        let short = refname
+            .strip_prefix("refs/heads/")
+            .unwrap_or(refname.as_str());
+        let local_ref = format!("refs/remotes/origin/{short}");
+        let old_hex = refs::resolve_ref(&sub_git_dir, &local_ref)
+            .map(|o| o.to_hex())
+            .unwrap_or_else(|_| "0".repeat(40));
+        refs::write_ref(&sub_git_dir, &local_ref, oid)?;
+        roots.push(*oid);
+        if !quiet {
+            let branch = short;
+            eprintln!(
+                "   {}..{}  {}     -> origin/{}",
+                &old_hex[..7.min(old_hex.len())],
+                &oid.to_hex()[..7],
+                branch,
+                branch
+            );
+        }
+    }
+    roots.sort_by_key(|o| o.to_hex());
+    roots.dedup();
+
+    if let Ok(head) = resolve_head(remote_git) {
+        match head {
+            grit_lib::state::HeadState::Branch { short_name, .. } => {
+                let sym = format!("refs/remotes/origin/{short_name}");
+                if refs::resolve_ref(&sub_git_dir, &sym).is_ok() {
+                    let _ =
+                        refs::write_symbolic_ref(&sub_git_dir, "refs/remotes/origin/HEAD", &sym);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    crate::commands::fetch::copy_reachable_objects(remote_git, &sub_git_dir, &roots)?;
+
+    Ok(true)
 }
 
 fn superproject_head_short_branch(repo: &Repository) -> Option<String> {
@@ -2457,26 +2605,313 @@ fn pathdiff_relative(from: &Path, to: &Path) -> String {
     result.to_string_lossy().into_owned()
 }
 
-fn run_summary(_args: &SummaryArgs, _quiet: bool) -> Result<()> {
-    // Summary is a complex feature — for now, output a basic summary.
+fn parse_mode_octal(mode: &str) -> u32 {
+    u32::from_str_radix(mode.trim(), 8).unwrap_or(0)
+}
+
+fn mode_is_gitlink(mode: &str) -> bool {
+    parse_mode_octal(mode) == MODE_GITLINK
+}
+
+fn short_oid_in_submodule(grit_bin: &Path, sub_path: &Path, committish: &str) -> Option<String> {
+    let spec = format!("{committish}^0");
+    let out = grit_subprocess(grit_bin)
+        .args(["rev-parse", "-q", "--short", &spec, "--"])
+        .current_dir(sub_path)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout);
+    let line = s.lines().next().unwrap_or("").trim();
+    if line.is_empty() {
+        None
+    } else {
+        Some(line.to_string())
+    }
+}
+
+fn submodule_rev_list_count(grit_bin: &Path, sub_path: &Path, range: &str) -> Result<i32> {
+    let out = grit_subprocess(grit_bin)
+        .args(["rev-list", "--first-parent", "--count", range, "--"])
+        .current_dir(sub_path)
+        .output()
+        .context("rev-list --count in submodule")?;
+    if !out.status.success() {
+        return Ok(-1);
+    }
+    let n = String::from_utf8_lossy(&out.stdout)
+        .trim()
+        .parse::<i32>()
+        .unwrap_or(-1);
+    Ok(n)
+}
+
+fn submodule_log_first_parent(
+    grit_bin: &Path,
+    sub_path: &Path,
+    src_abbrev: &str,
+    dst_abbrev: &str,
+    summary_limit: i32,
+) -> Result<()> {
+    let range = format!("{src_abbrev}...{dst_abbrev}");
+    let mut cmd = grit_subprocess(grit_bin);
+    cmd.current_dir(sub_path);
+    cmd.arg("log");
+    if summary_limit > 0 {
+        cmd.arg(format!("-{summary_limit}"));
+    }
+    cmd.args(["--pretty=  %m %s", "--first-parent", &range, "--"]);
+    let st = cmd.status().context("submodule log for summary")?;
+    if !st.success() {
+        bail!("submodule log failed");
+    }
+    Ok(())
+}
+
+fn submodule_log_one(
+    grit_bin: &Path,
+    sub_path: &Path,
+    dst_abbrev: &str,
+    prefix: char,
+) -> Result<()> {
+    let pretty = format!("  {} %s", prefix);
+    let st = grit_subprocess(grit_bin)
+        .args(["log", "--pretty", &pretty, "-1", dst_abbrev, "--"])
+        .current_dir(sub_path)
+        .status()
+        .context("submodule log -1 for summary")?;
+    if !st.success() {
+        bail!("submodule log -1 failed");
+    }
+    Ok(())
+}
+
+fn resolve_summary_base_tree(repo: &Repository, commit_spec: &str) -> Result<Option<ObjectId>> {
+    match resolve_revision(repo, commit_spec) {
+        Ok(oid) => {
+            let obj = repo.odb.read(&oid).context("read summary base commit")?;
+            let commit = parse_commit(&obj.data).context("parse summary base commit")?;
+            Ok(Some(commit.tree))
+        }
+        Err(e) => {
+            if commit_spec == "HEAD" {
+                Ok(None)
+            } else {
+                return Err(e).context("could not resolve summary base revision");
+            }
+        }
+    }
+}
+
+fn summary_display_path(entry: &DiffEntry) -> &str {
+    entry.old_path.as_deref().unwrap_or_else(|| entry.path())
+}
+
+fn pathspec_selected(pathspecs: &[String], sm_path: &str) -> bool {
+    if pathspecs.is_empty() {
+        return true;
+    }
+    pathspecs.iter().any(|spec| matches_pathspec(spec, sm_path))
+}
+
+/// Working tree directory for a submodule given the path Git uses in the summary diff (often the
+/// old path after `git mv`).
+fn submodule_work_tree_for_summary(work_tree: &Path, logical_path: &str) -> PathBuf {
+    let direct = work_tree.join(logical_path);
+    if direct.join(".git").exists() {
+        return direct;
+    }
+    let Ok(modules) = parse_gitmodules(work_tree) else {
+        return direct;
+    };
+    if let Some(m) = modules
+        .iter()
+        .find(|m| m.path == logical_path || m.name == logical_path)
+    {
+        let relocated = work_tree.join(&m.path);
+        if relocated.join(".git").exists() {
+            return relocated;
+        }
+    }
+    direct
+}
+
+fn run_summary(args: &SummaryArgs, _quiet: bool) -> Result<()> {
+    if args.summary_limit == Some(0) {
+        return Ok(());
+    }
+    let summary_limit = args.summary_limit.unwrap_or(-1);
+
     let repo = Repository::discover(None).context("not a git repository")?;
     let work_tree = repo.work_tree.as_ref().context("bare repository")?;
-    let modules = parse_gitmodules(work_tree)?;
+    let grit_bin = grit_exe::grit_executable();
+
+    let mut commit_spec = "HEAD";
+    let pathspecs: Vec<String> = if let Some(p) = args.rest.iter().position(|x| x.as_str() == "--")
+    {
+        let head_tokens = &args.rest[..p];
+        let tail = args.rest[p + 1..].to_vec();
+        if head_tokens.is_empty() {
+            tail
+        } else if resolve_revision(&repo, &head_tokens[0]).is_ok() {
+            commit_spec = head_tokens[0].as_str();
+            let mut ps: Vec<String> = head_tokens[1..].to_vec();
+            ps.extend(tail);
+            ps
+        } else {
+            let mut ps = head_tokens.to_vec();
+            ps.extend(tail);
+            ps
+        }
+    } else if args.rest.is_empty() {
+        vec![]
+    } else if resolve_revision(&repo, &args.rest[0]).is_ok() {
+        commit_spec = args.rest[0].as_str();
+        args.rest[1..].to_vec()
+    } else {
+        args.rest.clone()
+    };
+
+    let base_tree_oid = resolve_summary_base_tree(&repo, commit_spec)?;
+    let index = repo
+        .load_index()
+        .context("load index for submodule summary")?;
+
+    let entries: Vec<DiffEntry> = if args.files {
+        if args.cached {
+            bail!("options '--cached' and '--files' cannot be used together");
+        }
+        let mut out = Vec::new();
+        let modules = parse_gitmodules_with_repo(work_tree, Some(&repo))?;
+        for m in &modules {
+            let path_bytes = m.path.as_bytes();
+            let Some(ie) = index.get(path_bytes, 0) else {
+                continue;
+            };
+            if ie.mode != MODE_GITLINK {
+                continue;
+            }
+            let sub_path = work_tree.join(&m.path);
+            let dst_oid = if let Some(h) = grit_lib::diff::read_submodule_head_oid(&sub_path) {
+                h
+            } else {
+                ObjectId::zero()
+            };
+            if ie.oid == dst_oid {
+                continue;
+            }
+            out.push(DiffEntry {
+                status: DiffStatus::Modified,
+                old_path: Some(m.path.clone()),
+                new_path: Some(m.path.clone()),
+                old_mode: format!("{:o}", MODE_GITLINK),
+                new_mode: format!("{:o}", MODE_GITLINK),
+                old_oid: ie.oid,
+                new_oid: dst_oid,
+                score: None,
+            });
+        }
+        out.sort_by(|a, b| a.path().cmp(b.path()));
+        out
+    } else {
+        diff_index_to_tree(&repo.odb, &index, base_tree_oid.as_ref())?
+    };
 
     let stdout = io::stdout();
     let mut out = stdout.lock();
 
-    for m in &modules {
-        let sub_path = work_tree.join(&m.path);
-        let recorded = read_submodule_commit(&repo, &m.path)?;
-        let oid = recorded.as_deref().unwrap_or("0000000");
-        let short_oid = &oid[..oid.len().min(7)];
-
-        if sub_path.exists() {
-            writeln!(out, "* {} {}:", m.path, short_oid)?;
-        } else {
-            writeln!(out, "* {} {} (not checked out):", m.path, short_oid)?;
+    for e in &entries {
+        if !mode_is_gitlink(&e.old_mode) && !mode_is_gitlink(&e.new_mode) {
+            continue;
         }
+        let sm_path = summary_display_path(e);
+        if !pathspec_selected(&pathspecs, sm_path) {
+            continue;
+        }
+
+        let sub_path = submodule_work_tree_for_summary(work_tree, sm_path);
+        if !args.cached && !sub_path.join(".git").exists() {
+            continue;
+        }
+
+        let oid_src = e.old_oid;
+        let mut oid_dst = e.new_oid;
+        if !args.cached && oid_dst.is_zero() && mode_is_gitlink(&e.new_mode) {
+            if let Some(h) = grit_lib::diff::read_submodule_head_oid(&sub_path) {
+                oid_dst = h;
+            }
+        }
+
+        let src_gitlink = mode_is_gitlink(&e.old_mode);
+        let dst_gitlink = mode_is_gitlink(&e.new_mode);
+
+        let src_hex = oid_src.to_hex();
+        let dst_hex = oid_dst.to_hex();
+        let src_abbrev = short_oid_in_submodule(&grit_bin, &sub_path, &src_hex)
+            .unwrap_or_else(|| src_hex.chars().take(7).collect());
+        let dst_abbrev = short_oid_in_submodule(&grit_bin, &sub_path, &dst_hex)
+            .unwrap_or_else(|| dst_hex.chars().take(7).collect());
+
+        if e.status == DiffStatus::TypeChanged {
+            if dst_gitlink && !src_gitlink {
+                writeln!(
+                    out,
+                    "* {} {}(blob)->{}(submodule)",
+                    sm_path, src_abbrev, dst_abbrev
+                )?;
+            } else if src_gitlink && !dst_gitlink {
+                writeln!(
+                    out,
+                    "* {} {}(submodule)->{}(blob)",
+                    sm_path, src_abbrev, dst_abbrev
+                )?;
+            } else {
+                writeln!(out, "* {} {}...{}", sm_path, src_abbrev, dst_abbrev)?;
+            }
+            writeln!(out)?;
+            continue;
+        }
+
+        let total_commits = if !src_abbrev.is_empty() && !dst_abbrev.is_empty() {
+            if src_gitlink && dst_gitlink {
+                submodule_rev_list_count(
+                    &grit_bin,
+                    &sub_path,
+                    &format!("{src_abbrev}...{dst_abbrev}"),
+                )?
+            } else {
+                submodule_rev_list_count(&grit_bin, &sub_path, &dst_abbrev)?
+            }
+        } else {
+            -1
+        };
+
+        write!(out, "* {} {}...{}", sm_path, src_abbrev, dst_abbrev)?;
+        if total_commits < 0 {
+            writeln!(out, ":")?;
+        } else {
+            writeln!(out, " ({total_commits}):")?;
+        }
+        out.flush()?;
+
+        if total_commits > 0 {
+            if src_gitlink && dst_gitlink {
+                submodule_log_first_parent(
+                    &grit_bin,
+                    &sub_path,
+                    &src_abbrev,
+                    &dst_abbrev,
+                    summary_limit,
+                )?;
+            } else if dst_gitlink {
+                submodule_log_one(&grit_bin, &sub_path, &dst_abbrev, '>')?;
+            } else {
+                submodule_log_one(&grit_bin, &sub_path, &src_abbrev, '<')?;
+            }
+        }
+        writeln!(out)?;
     }
 
     Ok(())

--- a/grit/src/fetch_transport.rs
+++ b/grit/src/fetch_transport.rs
@@ -486,7 +486,10 @@ pub fn fetch_via_upload_pack_skipping(
             }
             return Ok((Vec::new(), Vec::new(), head_symref, None));
         }
-        // Empty repo / unborn default branch: nothing to transfer.
+        // No pack to transfer (local already has all objects), but when the remote advertised
+        // refs we must still return those heads/tags so `git fetch` can update
+        // `refs/remotes/<remote>/*` to match the remote repository (Git behavior; submodule
+        // `update --remote` depends on this).
         if !has_cli_refspecs {
             drop(stdin);
             let _ = drain_child_stdout_to_eof(&mut stdout);

--- a/grit/src/protocol_wire.rs
+++ b/grit/src/protocol_wire.rs
@@ -65,7 +65,19 @@ pub fn server_protocol_version_from_git_protocol_env() -> u8 {
     best
 }
 
+fn strip_protocol_version_entries(s: &str) -> String {
+    s.split(':')
+        .filter(|p| !p.trim_start().starts_with("version="))
+        .filter(|p| !p.is_empty())
+        .collect::<Vec<_>>()
+        .join(":")
+}
+
 /// When spawning `upload-pack` / `receive-pack`, merge `GIT_PROTOCOL` so the server negotiates v1/v2.
+///
+/// Any existing `version=N` entries are removed before appending `version={client_wants}` so a
+/// parent process cannot pin v2 when the child explicitly uses `protocol.version=1` (e.g.
+/// `submodule update --remote` local fetch).
 pub fn merge_git_protocol_env_for_child(cmd: &mut Command, client_wants: u8) {
     if client_wants == 0 {
         return;
@@ -73,10 +85,11 @@ pub fn merge_git_protocol_env_for_child(cmd: &mut Command, client_wants: u8) {
     let entry = format!("version={client_wants}");
     let merged = match std::env::var("GIT_PROTOCOL") {
         Ok(existing) if !existing.is_empty() => {
-            if existing.split(':').any(|p| p == entry.as_str()) {
-                existing
+            let base = strip_protocol_version_entries(existing.trim());
+            if base.is_empty() {
+                entry
             } else {
-                format!("{existing}:{entry}")
+                format!("{base}:{entry}")
             }
         }
         _ => entry,

--- a/logs/2026-04-09_t7421-submodule-summary-add.md
+++ b/logs/2026-04-09_t7421-submodule-summary-add.md
@@ -1,0 +1,21 @@
+# t7421-submodule-summary-add
+
+## Outcome
+
+All 5 tests in `tests/t7421-submodule-summary-add.sh` pass.
+
+## Changes
+
+1. **`git submodule summary`** — Implemented Git-style summary: diff index vs base commit tree for gitlinks, pathspec filtering, deinit skip (no `.git` in work tree), relocated submodule path via `.gitmodules`, `rev-list`/`log` in submodule, flush before child log to avoid stdout interleaving, first-line-only `rev-parse --short` (trailing `--`).
+
+2. **`submodule update --remote`** — Local `remote.origin.url` fast path: copy reachable objects from source repo into submodule git dir and update `refs/remotes/origin/*` without upload-pack (fixes stale remote-tracking refs when protocol v2 advertises no refs to the v0 client). Falls back to `grit fetch origin` for non-local URLs.
+
+3. **Index** — After remote checkout, stage updated gitlink in superproject index (`stage_gitlink_in_super_index`) so `git commit <path>` works.
+
+4. **`SummaryArgs`** — Extended for `--cached`, `--files`, `-n` / `--summary-limit`, and trailing `[commit] [--] [paths…]`; top-level `--cached` merges into summary.
+
+5. **`copy_reachable_objects`** — `pub(crate)` for reuse from submodule fetch.
+
+6. **`fetch_via_upload_pack_skipping`** — When wants are empty but refs were advertised, still return heads/tags so `git fetch` can update remote-tracking refs (kept for non-submodule cases).
+
+7. **`merge_git_protocol_env_for_child`** — Strip existing `version=` entries from `GIT_PROTOCOL` before appending client version (avoids `version=1:version=2` overriding).

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   308 |
+| Completed   |   309 |
 | In progress |     5 |
-| Remaining   |   456 |
+| Remaining   |   455 |
 | **Total**   |   769 |
 
-Task lines in `PLAN.md`: 308 completed (`[x]`), 5 in progress (`[~]`), 456 remaining (`[ ]`).
+Task lines in `PLAN.md`: 309 completed (`[x]`), 5 in progress (`[~]`), 455 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t7421-submodule-summary-add` — 5/5 tests pass (`submodule summary`: index↔commit gitlink diff, pathspecs + renamed paths, `rev-parse` first line for abbrev; `submodule update --remote`: local URL fast path updates `refs/remotes/origin/*` + copies objects, stages gitlink in super index)
 - `t3423-rebase-reword` — 3/3 tests pass (`rebase -i`: parse `reword`/`r` in todo; run commit editor with `prepare-commit-msg` source `reword`; `rebase --continue` after conflict uses `rebase-merge/message` template; noop-fast-forward path restricted to `pick` only so `reword` still opens editor)
 - `t3417-rebase-whitespace-fix` — 4/4 tests pass (`rebase --whitespace=fix`: apply `fix_blob_bytes` to merged index after three-way merge; noop pick path rebuilds tree + commit when whitespace fix is active; harness CSV refreshed)
 - `t7011-skip-worktree-reading` — 15/15 tests pass (`update-index` skip-worktree no-op / `--remove` clears entry; `--remove` on missing untracked path is silent; `reset` preserves skip-worktree; `diff-index` skips worktree for skip-worktree; `commit` pathspec rejects skip-worktree)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **`git submodule summary`**: Implements Git-style behavior (index vs base commit tree for gitlinks, pathspecs, deinit skip, relocated paths after `git mv`, submodule `rev-list`/`log`, stdout flush before child log, first line only from `rev-parse --short`).
- **`submodule update --remote`**: Fast path when `remote.origin.url` is a local repo—updates `refs/remotes/origin/*`, copies reachable objects, avoids broken upload-pack v2 ref advertisement for this case. Stages the new gitlink in the superproject index after checkout.
- **Supporting**: `copy_reachable_objects` is `pub(crate)` for reuse; empty-want upload-pack fetch still returns advertised heads; `GIT_PROTOCOL` merge strips conflicting `version=` entries.

## Testing

- `./scripts/run-tests.sh t7421-submodule-summary-add.sh` — **5/5**
- `cargo test -p grit-lib --lib`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9afee29c-6d48-452b-9ae5-756131987fda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9afee29c-6d48-452b-9ae5-756131987fda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

