### PR TITLE
fix: make t4056-diff-order pass (diff order, merge --no-commit, log rotate/skip)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -737,7 +737,7 @@ t4052-stat-output	t4	yes	89	89	0	true	ok	0
 t4053-diff-no-index	t4	skip	41	0	0	false	ok	0
 t4054-diff-bogus-tree	t4	yes	14	14	0	true	ok	0
 t4055-diff-context	t4	yes	10	8	2	false	ok	0
-t4056-diff-order	t4	yes	23	10	13	false	ok	0
+t4056-diff-order	t4	yes	23	23	0	true	ok	0
 t4057-diff-combined-paths	t4	yes	4	0	4	false	ok	0
 t4058-diff-duplicates	t4	yes	16	8	8	false	ok	0
 t4059-diff-submodule-not-initialized	t4	yes	8	8	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.1% of harness tests passing (35,240 / 45,112).">
+<meta property="og:description" content="78.2% of harness tests passing (35,289 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.1% of harness tests passing (35,240 / 45,112).">
+<meta name="twitter:description" content="78.2% of harness tests passing (35,289 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T14:02:56+00:00" class="gen-time" title="2026-04-09 14:02 UTC">2026-04-09 14:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/e76e016793472595007208eec9693bdb6a4d41c2" style="color:#58a6ff">e76e016</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T15:06:57+00:00" class="gen-time" title="2026-04-09 15:06 UTC">2026-04-09 15:06 UTC</time> · <a href="https://github.com/schacon/grit/commit/c4ad2e9f44715e944bf5d633e8117c550d9c487c" style="color:#58a6ff">c4ad2e9</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">78.1%</div>
+      <div class="summary-big-val pct-blue">78.2%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,240</div>
+      <div class="summary-big-val">35,289</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:78.1%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:78.2%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>730 files fully passing</span>
+    <span>733 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -186,11 +186,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t0</span>
         <span class="group-desc">Absolute basics and global stuff</span>
-        <span class="group-meta">38/64 files · 21 skipped · 4,868/5,136 tests</span>
+        <span class="group-meta">39/64 files · 21 skipped · 4,884/5,136 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:94.8%"></div></div>
-        <span class="group-pct pct-green">94.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:95.1%"></div></div>
+        <span class="group-pct pct-green">95.1%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t1">
@@ -230,11 +230,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">70/178 files · 2 skipped · 2,683/4,437 tests</span>
+        <span class="group-meta">72/178 files · 2 skipped · 2,716/4,437 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.5%"></div></div>
-        <span class="group-pct pct-blue">60.5%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:61.2%"></div></div>
+        <span class="group-pct pct-blue">61.2%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35240 of 45112 tests passing across 1405 harness files (78.1% pass rate).</desc>
+  <desc id="svg-desc">35289 of 45112 tests passing across 1405 harness files (78.2% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.1% pass rate · 35,240 / 45,112 tests · 1,405 files in scope · 730 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.2% pass rate · 35,289 / 45,112 tests · 1,405 files in scope · 733 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="547" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T14:02:56+00:00" class="gen-time" title="2026-04-09 14:02 UTC">2026-04-09 14:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/e76e016793472595007208eec9693bdb6a4d41c2" style="color:#58a6ff">e76e016</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T15:06:57+00:00" class="gen-time" title="2026-04-09 15:06 UTC">2026-04-09 15:06 UTC</time> · <a href="https://github.com/schacon/grit/commit/c4ad2e9f44715e944bf5d633e8117c550d9c487c" style="color:#58a6ff">c4ad2e9</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,240</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">78.1%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,289</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">78.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -907,14 +907,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:97.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t0" data-tests="16" data-passed="0">
+<tr class="" data-group="t0" data-tests="16" data-passed="16" data-full-pass="1">
   <td class="mono">t0500-progress-display</td>
   <td>t0</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">16</td>
-  <td class="right">0</td>
+  <td class="right">16</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t0" data-tests="33" data-passed="12">
@@ -7477,14 +7477,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:28.6%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="27" data-passed="7">
+<tr class="" data-group="t4" data-tests="27" data-passed="27" data-full-pass="1">
   <td class="mono">t4051-diff-function-name</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">27</td>
-  <td class="right">7</td>
+  <td class="right">27</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:25.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="89" data-passed="89" data-full-pass="1">
@@ -7527,14 +7527,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:80.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="23" data-passed="10">
+<tr class="" data-group="t4" data-tests="23" data-passed="23" data-full-pass="1">
   <td class="mono">t4056-diff-order</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">23</td>
-  <td class="right">10</td>
+  <td class="right">23</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:43.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="4" data-passed="0">

--- a/grit-lib/src/merge_diff.rs
+++ b/grit-lib/src/merge_diff.rs
@@ -12,7 +12,7 @@ use tempfile::NamedTempFile;
 use crate::config::ConfigSet;
 use crate::crlf::{get_file_attrs, load_gitattributes, DiffAttr, FileAttrs};
 use crate::diff::{diff_trees, DiffStatus};
-use crate::objects::{parse_commit, ObjectId};
+use crate::objects::{parse_commit, parse_tree, ObjectId, ObjectKind};
 use crate::odb::Odb;
 use crate::textconv_cache::{read_textconv_cache, write_textconv_cache};
 
@@ -44,8 +44,77 @@ pub fn combined_diff_paths(odb: &Odb, commit_tree: &ObjectId, parents: &[ObjectI
     for s in &per_parent[1..] {
         common = common.intersection(s).cloned().collect();
     }
-    let mut out: Vec<String> = common.into_iter().collect();
-    out.sort();
+    if common.is_empty() {
+        return Vec::new();
+    }
+    paths_in_tree_order(odb, commit_tree, "", &common)
+}
+
+/// All blob paths in `tree_oid`, depth-first in Git tree entry order (for `diff` / `log`
+/// `--rotate-to` / `--skip-to`).
+#[must_use]
+pub fn all_blob_paths_in_tree_order(odb: &Odb, tree_oid: &ObjectId) -> Vec<String> {
+    all_blob_paths_dfs(odb, tree_oid, "")
+}
+
+fn all_blob_paths_dfs(odb: &Odb, tree_oid: &ObjectId, prefix: &str) -> Vec<String> {
+    let Ok(obj) = odb.read(tree_oid) else {
+        return Vec::new();
+    };
+    if obj.kind != ObjectKind::Tree {
+        return Vec::new();
+    }
+    let Ok(entries) = parse_tree(&obj.data) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for e in entries {
+        let name = String::from_utf8_lossy(&e.name);
+        let path = if prefix.is_empty() {
+            name.into_owned()
+        } else {
+            format!("{prefix}/{name}")
+        };
+        if e.mode == 0o040000 {
+            out.extend(all_blob_paths_dfs(odb, &e.oid, &path));
+        } else {
+            out.push(path);
+        }
+    }
+    out
+}
+
+/// List paths under `prefix` that appear in `want`, following merge-tree entry order (Git
+/// `traverse_trees` order), not lexicographic sorting.
+fn paths_in_tree_order(
+    odb: &Odb,
+    tree_oid: &ObjectId,
+    prefix: &str,
+    want: &std::collections::HashSet<String>,
+) -> Vec<String> {
+    let Ok(obj) = odb.read(tree_oid) else {
+        return Vec::new();
+    };
+    if obj.kind != ObjectKind::Tree {
+        return Vec::new();
+    }
+    let Ok(entries) = parse_tree(&obj.data) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for e in entries {
+        let name = String::from_utf8_lossy(&e.name);
+        let path = if prefix.is_empty() {
+            name.into_owned()
+        } else {
+            format!("{prefix}/{name}")
+        };
+        if e.mode == 0o040000 {
+            out.extend(paths_in_tree_order(odb, &e.oid, &path, want));
+        } else if want.contains(&path) {
+            out.push(path);
+        }
+    }
     out
 }
 

--- a/grit/src/commands/diff.rs
+++ b/grit/src/commands/diff.rs
@@ -12,6 +12,7 @@
 //! Exit codes: `--exit-code` / `--quiet` return exit code 1 if there are
 //! differences.
 
+use crate::explicit_exit::ExplicitExit;
 use crate::pathspec::resolve_pathspec;
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
@@ -813,6 +814,10 @@ pub struct Args {
     #[arg(long = "line-prefix", value_name = "PREFIX")]
     pub line_prefix: Option<String>,
 
+    /// Redirect diff output to a file (default stdout).
+    #[arg(long = "output", value_name = "file")]
+    pub output_path: Option<PathBuf>,
+
     /// Disable rename detection (must not be abbreviated).
     #[arg(long = "no-renames")]
     pub no_renames: bool,
@@ -1033,9 +1038,19 @@ pub fn run(mut args: Args) -> Result<()> {
     }
 
     let repo = Repository::discover(None).context("not a git repository")?;
-    let quote_path_fully = grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true)
-        .unwrap_or_default()
-        .quote_path_fully();
+    let diff_config_early = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+    if args.order_file.is_none() {
+        if let Some(p) = diff_config_early
+            .get("diff.orderfile")
+            .or_else(|| diff_config_early.get("diff.orderFile"))
+        {
+            let t = p.trim();
+            if !t.is_empty() {
+                args.order_file = Some(t.to_owned());
+            }
+        }
+    }
+    let quote_path_fully = diff_config_early.quote_path_fully();
 
     let patch_context = if let Some(u) = args.unified {
         u
@@ -1247,7 +1262,12 @@ pub fn run(mut args: Args) -> Result<()> {
                     args.color_moved = Some("default".to_owned());
                 }
                 s if s.starts_with("-O") && s.len() > 2 => {
-                    args.order_file = Some(s[2..].to_string());
+                    let path = s[2..].to_string();
+                    if path == "/dev/null" {
+                        args.order_file = None;
+                    } else {
+                        args.order_file = Some(path);
+                    }
                 }
                 "--no-prefix" => {
                     args.no_prefix = true;
@@ -1370,6 +1390,9 @@ pub fn run(mut args: Args) -> Result<()> {
         rev_idx += 1;
     }
     revs = extra_revs;
+    if revs.len() == 3 && args.name_only && !args.cached {
+        want_combined_diff = true;
+    }
 
     let mut _symmetric = false;
     if revs.len() == 1 {
@@ -1763,10 +1786,13 @@ pub fn run(mut args: Args) -> Result<()> {
 
     // Apply orderfile sorting if specified
     let entries = if let Some(ref order_path) = args.order_file {
-        apply_orderfile(entries, order_path)
+        apply_orderfile(entries, order_path, &cwd)?
     } else {
         entries
     };
+
+    let entries =
+        apply_rotate_skip_entries(entries, args.rotate_to.as_deref(), args.skip_to.as_deref())?;
 
     // Apply -R: reverse the diff (swap old and new sides)
     let mut entries = if args.reverse {
@@ -1878,12 +1904,33 @@ pub fn run(mut args: Args) -> Result<()> {
     let use_color = match args.color.as_deref() {
         Some("always") => true,
         Some("never") => false,
-        Some("auto") | None => io::stdout().is_terminal(),
+        Some("auto") | None => {
+            if args.output_path.is_some() {
+                false
+            } else {
+                io::stdout().is_terminal()
+            }
+        }
         Some(_) => false,
     };
 
-    let stdout = io::stdout();
-    let mut out = stdout.lock();
+    let mut out: Box<dyn Write> = if let Some(ref p) = args.output_path {
+        let resolved = if p.is_absolute() {
+            p.clone()
+        } else {
+            cwd.join(p)
+        };
+        Box::new(
+            std::fs::OpenOptions::new()
+                .create(true)
+                .truncate(true)
+                .write(true)
+                .open(&resolved)
+                .with_context(|| format!("failed to open output file {}", resolved.display()))?,
+        )
+    } else {
+        Box::new(io::stdout())
+    };
 
     let word_diff = args.word_diff.is_some() || args.color_words;
 
@@ -2839,22 +2886,23 @@ fn run_no_index_dirs(args: Args, dir_a: &Path, dir_b: &Path) -> Result<()> {
 /// The orderfile contains one pattern per line. Files matching the first
 /// pattern come first, then files matching the second, etc. Files not
 /// matching any pattern come last in their original order.
+///
+/// `cwd` is used to resolve relative orderfile paths (matches `git diff -O`).
 /// Apply an orderfile to sort diff entries (public for use by other commands like log).
-pub fn apply_orderfile_entries(entries: Vec<DiffEntry>, order_path: &str) -> Vec<DiffEntry> {
-    apply_orderfile(entries, order_path)
+pub fn apply_orderfile_entries(
+    entries: Vec<DiffEntry>,
+    order_path: &str,
+    cwd: &Path,
+) -> Result<Vec<DiffEntry>> {
+    apply_orderfile(entries, order_path, cwd)
 }
 
-fn apply_orderfile(mut entries: Vec<DiffEntry>, order_path: &str) -> Vec<DiffEntry> {
-    let patterns: Vec<String> = match std::fs::read_to_string(order_path) {
-        Ok(content) => content
-            .lines()
-            .map(|l| l.trim().to_string())
-            .filter(|l| !l.is_empty() && !l.starts_with('#'))
-            .collect(),
-        Err(_) => return entries,
-    };
-
-    // Assign a sort key to each entry based on which pattern it matches first
+fn apply_orderfile(
+    mut entries: Vec<DiffEntry>,
+    order_path: &str,
+    cwd: &Path,
+) -> Result<Vec<DiffEntry>> {
+    let patterns = read_orderfile_patterns(order_path, cwd)?;
     let sort_key = |entry: &DiffEntry| -> usize {
         let path = entry
             .new_path
@@ -2867,11 +2915,171 @@ fn apply_orderfile(mut entries: Vec<DiffEntry>, order_path: &str) -> Vec<DiffEnt
                 return i;
             }
         }
-        patterns.len() // unmatched files go last
+        patterns.len()
     };
-
     entries.sort_by_key(|e| sort_key(e));
-    entries
+    Ok(entries)
+}
+
+fn read_orderfile_patterns(order_path: &str, cwd: &Path) -> Result<Vec<String>> {
+    let path = Path::new(order_path);
+    let resolved = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    };
+    let _meta = std::fs::metadata(&resolved).map_err(|e| {
+        anyhow::Error::new(ExplicitExit {
+            code: 128,
+            message: format!("could not read orderfile {order_path}: {e}"),
+        })
+    })?;
+    let mut f = std::fs::File::open(&resolved).map_err(|e| {
+        anyhow::Error::new(ExplicitExit {
+            code: 128,
+            message: format!("could not read orderfile {order_path}: {e}"),
+        })
+    })?;
+    let mut content = String::new();
+    std::io::Read::read_to_string(&mut f, &mut content).map_err(|e| {
+        anyhow::Error::new(ExplicitExit {
+            code: 128,
+            message: format!("could not read orderfile {order_path}: {e}"),
+        })
+    })?;
+    Ok(content
+        .lines()
+        .map(|l| l.trim().to_string())
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .collect())
+}
+
+/// Reorder diff entries for `git diff` `--rotate-to` / `--skip-to` (changed paths only).
+pub fn apply_rotate_skip_entries(
+    mut entries: Vec<DiffEntry>,
+    rotate_to: Option<&str>,
+    skip_to: Option<&str>,
+) -> Result<Vec<DiffEntry>> {
+    let Some(needle) = rotate_to.or(skip_to) else {
+        return Ok(entries);
+    };
+    let needle = needle.trim();
+    if needle.is_empty() {
+        return Ok(entries);
+    }
+    let idx = entries
+        .iter()
+        .position(|e| e.path() == needle)
+        .ok_or_else(|| {
+            anyhow::Error::new(ExplicitExit {
+                code: 128,
+                message: format!("fatal: No such path '{needle}' in the diff"),
+            })
+        })?;
+    if rotate_to.is_some() {
+        entries.rotate_left(idx);
+    }
+    if let Some(skip) = skip_to.filter(|s| !s.trim().is_empty()) {
+        let pos = entries
+            .iter()
+            .position(|e| e.path() == skip)
+            .ok_or_else(|| {
+                anyhow::Error::new(ExplicitExit {
+                    code: 128,
+                    message: format!("fatal: No such path '{skip}' in the diff"),
+                })
+            })?;
+        entries.drain(..pos);
+    }
+    Ok(entries)
+}
+
+/// `git log` rotate/skip: reorder using the **commit tree** path order (all blobs), then keep only
+/// paths present in `entries` — matches Git's `diff --rotate-to` with history walks.
+pub fn apply_rotate_skip_log_entries(
+    odb: &Odb,
+    commit_tree: &ObjectId,
+    entries: Vec<DiffEntry>,
+    rotate_to: Option<&str>,
+    skip_to: Option<&str>,
+) -> Result<Vec<DiffEntry>> {
+    let tree_paths = grit_lib::merge_diff::all_blob_paths_in_tree_order(odb, commit_tree);
+    apply_rotate_skip_ordered_paths(&tree_paths, entries, rotate_to, skip_to)
+}
+
+fn apply_rotate_skip_ordered_paths(
+    tree_paths: &[String],
+    entries: Vec<DiffEntry>,
+    rotate_to: Option<&str>,
+    skip_to: Option<&str>,
+) -> Result<Vec<DiffEntry>> {
+    let rotate = rotate_to.and_then(|s| {
+        let t = s.trim();
+        (!t.is_empty()).then_some(t)
+    });
+    let skip = skip_to.and_then(|s| {
+        let t = s.trim();
+        (!t.is_empty()).then_some(t)
+    });
+    if rotate.is_none() && skip.is_none() {
+        return Ok(entries);
+    }
+
+    use std::collections::HashMap;
+    let mut by_path: HashMap<String, DiffEntry> = HashMap::new();
+    for e in entries {
+        by_path.insert(e.path().to_string(), e);
+    }
+
+    // `git log --skip-to`: only list changed paths from the skip point onward (unmodified paths
+    // in the tree-order suffix are omitted). `--rotate-to` still lists every changed file in order.
+    if rotate.is_none() {
+        let Some(skip_path) = skip else {
+            return Ok(by_path.into_values().collect());
+        };
+        let idx = tree_paths
+            .iter()
+            .position(|p| p == skip_path)
+            .ok_or_else(|| {
+                anyhow::Error::new(ExplicitExit {
+                    code: 128,
+                    message: format!("fatal: No such path '{skip_path}' in the diff"),
+                })
+            })?;
+        let mut out = Vec::new();
+        for p in tree_paths.iter().skip(idx) {
+            if let Some(e) = by_path.remove(p) {
+                out.push(e);
+            }
+        }
+        return Ok(out);
+    }
+
+    let needle = rotate.expect("rotate set when reaching this branch");
+    let idx = tree_paths.iter().position(|p| p == needle).ok_or_else(|| {
+        anyhow::Error::new(ExplicitExit {
+            code: 128,
+            message: format!("fatal: No such path '{needle}' in the diff"),
+        })
+    })?;
+    let mut order: Vec<String> = tree_paths.to_vec();
+    order.rotate_left(idx);
+    if let Some(skip_path) = skip {
+        let pos = order.iter().position(|p| p == skip_path).ok_or_else(|| {
+            anyhow::Error::new(ExplicitExit {
+                code: 128,
+                message: format!("fatal: No such path '{skip_path}' in the diff"),
+            })
+        })?;
+        order.drain(..pos);
+    }
+    let mut out = Vec::new();
+    for p in order {
+        if let Some(e) = by_path.remove(&p) {
+            out.push(e);
+        }
+    }
+    Ok(out)
 }
 
 /// Check if an orderfile pattern matches a path.

--- a/grit/src/commands/format_patch.rs
+++ b/grit/src/commands/format_patch.rs
@@ -986,7 +986,8 @@ fn format_single_patch(
     let diff_entries_raw = diff_trees(odb, parent_tree_oid.as_ref(), Some(&commit.tree), "")
         .context("computing diff")?;
     let diff_entries = if let Some(ref order_path) = opts.order_file {
-        crate::commands::diff::apply_orderfile_entries(diff_entries_raw, order_path)
+        let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+        crate::commands::diff::apply_orderfile_entries(diff_entries_raw, order_path, &cwd)?
     } else {
         diff_entries_raw
     };

--- a/grit/src/commands/log.rs
+++ b/grit/src/commands/log.rs
@@ -441,6 +441,14 @@ pub struct Args {
     #[arg(short = 'O', value_name = "orderfile")]
     pub order_file: Option<String>,
 
+    /// Rotate diff output to start at the named path.
+    #[arg(long = "rotate-to", value_name = "path")]
+    pub rotate_to: Option<String>,
+
+    /// Skip diff output until the named path.
+    #[arg(long = "skip-to", value_name = "path")]
+    pub skip_to: Option<String>,
+
     /// Show full object hashes in diff output.
     #[arg(long = "full-index")]
     pub full_index: bool,
@@ -6321,6 +6329,8 @@ fn write_commit_diff(
     let show_patch = log_wants_patch_hunks(args, info, git_dir)?;
     let separate = merge_diff_is_separate(args, is_merge, git_dir)?;
 
+    let log_cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+
     if separate {
         for (i, parent_oid) in info.parents.iter().enumerate() {
             let mut entries = compute_commit_diff_against_parent(odb, info, i)?;
@@ -6328,8 +6338,16 @@ fn write_commit_diff(
                 continue;
             }
             if let Some(ref order_path) = args.order_file {
-                entries = crate::commands::diff::apply_orderfile_entries(entries, order_path);
+                entries =
+                    crate::commands::diff::apply_orderfile_entries(entries, order_path, &log_cwd)?;
             }
+            entries = crate::commands::diff::apply_rotate_skip_log_entries(
+                odb,
+                &info.tree,
+                entries,
+                args.rotate_to.as_deref(),
+                args.skip_to.as_deref(),
+            )?;
             // First parent: the main `format_commit` was already printed; only extra headers
             // repeat the commit with `(from <parent>)` for parents 2+ (matches Git).
             if i > 0 {
@@ -6370,11 +6388,31 @@ fn write_commit_diff(
     }
 
     if let Some(ref order_path) = args.order_file {
-        entries = crate::commands::diff::apply_orderfile_entries(entries, order_path);
+        entries = crate::commands::diff::apply_orderfile_entries(entries, order_path, &log_cwd)?;
     }
 
-    let combined_entries = if merge_diff_is_combined_style(args, is_merge, git_dir)? {
+    let combined_style = merge_diff_is_combined_style(args, is_merge, git_dir)?;
+    let mut combined_entries = if combined_style {
         compute_combined_diff_entries(odb, info)?
+    } else {
+        entries.clone()
+    };
+
+    entries = crate::commands::diff::apply_rotate_skip_log_entries(
+        odb,
+        &info.tree,
+        entries,
+        args.rotate_to.as_deref(),
+        args.skip_to.as_deref(),
+    )?;
+    combined_entries = if combined_style {
+        crate::commands::diff::apply_rotate_skip_log_entries(
+            odb,
+            &info.tree,
+            combined_entries,
+            args.rotate_to.as_deref(),
+            args.skip_to.as_deref(),
+        )?
     } else {
         entries.clone()
     };

--- a/grit/src/commands/merge.rs
+++ b/grit/src/commands/merge.rs
@@ -2744,6 +2744,20 @@ fn do_strategy_ours(
     let author = resolve_ident(&config, "author", now)?;
     let committer = resolve_ident(&config, "committer", now)?;
 
+    if args.no_commit {
+        fs::write(
+            repo.git_dir.join("MERGE_HEAD"),
+            format!("{}\n", merge_oid.to_hex()),
+        )?;
+        fs::write(repo.git_dir.join("MERGE_MSG"), &msg)?;
+        fs::write(repo.git_dir.join("MERGE_MODE"), "no-ff\n")?;
+        if !args.quiet {
+            eprintln!("Automatic merge went well; stopped before committing as requested");
+        }
+        run_post_merge_hook(repo, false);
+        return Ok(());
+    }
+
     let commit_data = CommitData {
         tree: tree_oid,
         parents: vec![head_oid, merge_oid],

--- a/grit/src/commands/reflog.rs
+++ b/grit/src/commands/reflog.rs
@@ -345,6 +345,8 @@ fn run_show(args: ShowArgs) -> Result<()> {
         shortstat: false,
         bisect: false,
         order_file: None,
+        rotate_to: None,
+        skip_to: None,
         full_index: false,
         binary: false,
         since_as_filter: None,

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -3381,6 +3381,17 @@ fn preprocess_diff_args(rest: &[String]) -> Vec<String> {
     let word_diff_modes = ["plain", "color", "porcelain", "none"];
     while i < rest.len() {
         let arg = &rest[i];
+        // Clap parses glued `-O../path` incorrectly (treats `--output` as a revision when the
+        // orderfile path starts with `.` / `..`). Split into `-O` and the path (matches `git diff -O`).
+        if arg.len() > 2 && arg.starts_with("-O") && !arg.starts_with("-O=") {
+            let rest_o = &arg[2..];
+            if !rest_o.is_empty() && !rest_o.starts_with('-') {
+                result.push("-O".to_owned());
+                result.push(rest_o.to_owned());
+                i += 1;
+                continue;
+            }
+        }
         if arg == "-X" {
             if i + 1 < rest.len() && !rest[i + 1].starts_with('-') {
                 result.push(format!("--dirstat={}", rest[i + 1]));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This makes `tests/t4056-diff-order.sh` pass all 23 cases.

### Merge

- **`merge -s ours --no-commit`** now leaves `MERGE_HEAD` / `MERGE_MSG` / `MERGE_MODE` instead of committing immediately, so a follow-up `commit` records a real two-parent merge. That unblocks `HEAD^2` and three-revision combine diffs used by the test.

### Diff / orderfile

- **`combined_diff_paths`** lists paths in **merge-tree traversal order** (not lexicographic sort).
- **`git diff` with three revisions** and `--name-only` uses the combine-diff path set when appropriate.
- **`diff.orderfile` / `diff.orderFile`** from config is applied when `-O` is not given.
- **Missing / unreadable orderfiles** exit 128 with Git-style messages; **FIFO** orderfiles are read via `File::open` + `read_to_string`.
- **`-O/dev/null`** clears a configured orderfile (matches Git).
- **`--output`** writes diff output to a path resolved relative to the current working directory.
- **`--rotate-to` / `--skip-to`** reorder **changed** paths only (diff semantics).

### Log

- **`--rotate-to` / `--skip-to`** use **full tree path order** for placement; **`--skip-to`** only emits raw/name lines for **changed** paths from the skip point onward (matches Git).

### CLI

- **`preprocess_diff_args`**: split glued **`-O../path`** into `-O` and the path so clap does not mis-parse **`--output`** as a revision when the orderfile starts with `.` or `..`.

### Also

- **`apply_orderfile_entries`** now takes a **`cwd`** and returns **`Result`** (call sites updated: `format-patch`, `log`).

## Validation

- `cargo fmt`, `cargo clippy -p grit-rs -p grit-lib --fix --allow-dirty`
- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t4056-diff-order.sh` → 23/23
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8604b405-cbe5-4372-8665-68b9434803bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8604b405-cbe5-4372-8665-68b9434803bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

