### PR TITLE
fix: t6429 replay — disable inner merge directory renames

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1125,7 +1125,7 @@ t6425-merge-rename-delete	t6	yes	1	1	0	true	ok	0
 t6426-merge-skip-unneeded-updates	t6	yes	13	13	0	true	ok	0
 t6427-diff3-conflict-markers	t6	yes	9	9	0	true	ok	0
 t6428-merge-conflicts-sparse	t6	yes	2	2	0	true	ok	0
-t6429-merge-sequence-rename-caching	t6	yes	11	9	2	false	ok	0
+t6429-merge-sequence-rename-caching	t6	yes	11	11	0	true	ok	0
 t6430-merge-recursive	t6	yes	36	24	12	false	ok	0
 t6430-merge-strategy-option	t6	yes	6	6	0	true	ok	0
 t6431-merge-criscross	t6	yes	2	2	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.1% of harness tests passing (35,211 / 45,112).">
+<meta property="og:description" content="78.1% of harness tests passing (35,213 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.1% of harness tests passing (35,211 / 45,112).">
+<meta name="twitter:description" content="78.1% of harness tests passing (35,213 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T13:35:26+00:00" class="gen-time" title="2026-04-09 13:35 UTC">2026-04-09 13:35 UTC</time> · <a href="https://github.com/schacon/grit/commit/e77a8c04fc06ccd3ad1253e512a5889290d4b86f" style="color:#58a6ff">e77a8c0</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T15:13:52+00:00" class="gen-time" title="2026-04-09 15:13 UTC">2026-04-09 15:13 UTC</time> · <a href="https://github.com/schacon/grit/commit/1b2deb6d814ce62f9b7b0fab0b751f2cf7de238c" style="color:#58a6ff">1b2deb6</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,211</div>
+      <div class="summary-big-val">35,213</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>721 files fully passing</span>
+    <span>722 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -252,11 +252,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t6</span>
         <span class="group-desc">Revision tree commands (e.g. merge-base)</span>
-        <span class="group-meta">43/105 files · 3 skipped · 1,824/2,822 tests</span>
+        <span class="group-meta">44/105 files · 3 skipped · 1,826/2,822 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.6%"></div></div>
-        <span class="group-pct pct-blue">64.6%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.7%"></div></div>
+        <span class="group-pct pct-blue">64.7%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t7">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35211 of 45112 tests passing across 1405 harness files (78.1% pass rate).</desc>
+  <desc id="svg-desc">35213 of 45112 tests passing across 1405 harness files (78.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.1% pass rate · 35,211 / 45,112 tests · 1,405 files in scope · 721 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.1% pass rate · 35,213 / 45,112 tests · 1,405 files in scope · 722 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="547" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T13:35:26+00:00" class="gen-time" title="2026-04-09 13:35 UTC">2026-04-09 13:35 UTC</time> · <a href="https://github.com/schacon/grit/commit/e77a8c04fc06ccd3ad1253e512a5889290d4b86f" style="color:#58a6ff">e77a8c0</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T15:13:52+00:00" class="gen-time" title="2026-04-09 15:13 UTC">2026-04-09 15:13 UTC</time> · <a href="https://github.com/schacon/grit/commit/1b2deb6d814ce62f9b7b0fab0b751f2cf7de238c" style="color:#58a6ff">1b2deb6</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,211</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,213</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -11407,14 +11407,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t6" data-tests="11" data-passed="9">
+<tr class="" data-group="t6" data-tests="11" data-passed="11" data-full-pass="1">
   <td class="mono">t6429-merge-sequence-rename-caching</td>
   <td>t6</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">11</td>
-  <td class="right">9</td>
+  <td class="right">11</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:81.8%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t6" data-tests="36" data-passed="24">

--- a/grit/src/commands/replay.rs
+++ b/grit/src/commands/replay.rs
@@ -428,7 +428,12 @@ pub(crate) fn replay_commits_onto(
 ) -> Result<(ObjectId, HashMap<ObjectId, ObjectId>)> {
     let merge_renormalize = read_merge_renormalize(repo);
     let directory_renames = read_directory_renames(repo);
-    let merge_dir_mode = MergeDirectoryRenamesMode::FromConfig;
+    // `replay` already applies upstream/topic rename detection and cached renames before
+    // calling `merge_trees`. Running merge-ort directory rename handling again inside
+    // `merge_trees` can incorrectly relocate recreated paths (e.g. `olddir/unrelated` →
+    // `newdir/unrelated` in t6429 part 2). Match sequencer-style replay by disabling the
+    // inner directory-rename pass.
+    let merge_dir_mode = MergeDirectoryRenamesMode::Disabled;
     let rename_opts = MergeRenameOptions::from_config(repo);
 
     let mut replayed: HashMap<ObjectId, ObjectId> = HashMap::new();

--- a/logs/2026-04-09_t6429-merge-sequence-rename-caching.md
+++ b/logs/2026-04-09_t6429-merge-sequence-rename-caching.md
@@ -1,0 +1,6 @@
+## 2026-04-09 — t6429-merge-sequence-rename-caching
+
+- **Issue:** `t6429` failed test 5 (replay should stop on dir-rename conflict) and test 9 (`caching renames only on upstream side, part 2`) due to wrong tree after replay.
+- **Root cause:** `replay_commits_onto` pre-applies rename detection + cached upstream renames, then called `merge_trees` with `MergeDirectoryRenamesMode::FromConfig`. The inner merge-ort directory-rename pass ran again and could relocate paths such as a recreated `olddir/unrelated-file` into `newdir/`, and could miss conflicts Git expects when upstream vs topic disagree on directory renames.
+- **Fix:** Use `MergeDirectoryRenamesMode::Disabled` for `merge_trees_for_replay` so directory rename semantics come only from the replay-layer rename cache / `apply_directory_renames_to_ours_additions`, matching sequencer-style replay expectations in t6429.
+- **Validation:** `./scripts/run-tests.sh t6429-merge-sequence-rename-caching.sh` → **11/11**; `cargo test -p grit-lib --lib` passed.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`grit replay` already runs rename detection and applies cached upstream renames before calling the three-way tree merge. Passing `MergeDirectoryRenamesMode::FromConfig` into `merge_trees` ran merge-ort directory rename handling a second time, which:

- Misplaced recreated paths (e.g. `olddir/unrelated-file` ending up under `newdir/` in **t6429** part 2).
- Broke the expected **replay** failure / trace behavior in other **t6429** cases.

This change sets `MergeDirectoryRenamesMode::Disabled` for `merge_trees_for_replay` so directory-rename effects come only from the replay-layer logic, matching sequencer-style expectations.

## Testing

- `./scripts/run-tests.sh t6429-merge-sequence-rename-caching.sh` → **11/11**
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-869b1298-8182-4fe4-9aaf-6b86e8c943a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-869b1298-8182-4fe4-9aaf-6b86e8c943a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

