### PR TITLE
fix(rev-list): emit real parent OIDs for --parents with -n

### DIFF
--- a/grit/src/commands/rev_list.rs
+++ b/grit/src/commands/rev_list.rs
@@ -641,7 +641,6 @@ pub fn run(args: Args) -> Result<()> {
     };
 
     let graft_parents = load_graft_parents(&repo.git_dir);
-    let included_commits: HashSet<ObjectId> = result.commits.iter().copied().collect();
     let object_type_commit_oid_only = options.objects
         && matches!(&options.output_mode, OutputMode::OidOnly)
         && object_type_filter_commit_only(options.filter.as_ref());
@@ -677,12 +676,9 @@ pub fn run(args: Args) -> Result<()> {
                     if !no_commit_header && !is_oneline {
                         let mut header = format!("commit {prefix}{oid}");
                         if show_parents {
-                            let parents = visible_parents_for_output(
-                                &repo,
-                                *oid,
-                                &included_commits,
-                                &graft_parents,
-                            )?;
+                            // Match Git: parent lines come from the commit object (and grafts), not
+                            // from "visible" parents after narrowing the walk (e.g. `-n 1`).
+                            let parents = commit_parents_for_output(&repo, *oid, &graft_parents)?;
                             for parent in parents {
                                 header.push(' ');
                                 header.push_str(&parent.to_hex());
@@ -707,8 +703,9 @@ pub fn run(args: Args) -> Result<()> {
                     }
                 }
                 OutputMode::Parents => {
-                    let parents =
-                        visible_parents_for_output(&repo, *oid, &included_commits, &graft_parents)?;
+                    // Same as Git `rev-list --parents`: always emit stored parent OIDs, even when
+                    // those parents are outside the selected commit set (`-n`, etc.).
+                    let parents = commit_parents_for_output(&repo, *oid, &graft_parents)?;
                     if parents.is_empty() {
                         println!("{prefix}{oid}");
                     } else {
@@ -1177,48 +1174,4 @@ fn commit_parents_for_output(
     let object = repo.odb.read(&oid)?;
     let commit = parse_commit(&object.data)?;
     Ok(commit.parents)
-}
-
-fn collect_visible_parent(
-    repo: &Repository,
-    candidate: ObjectId,
-    included: &HashSet<ObjectId>,
-    graft_parents: &HashMap<ObjectId, Vec<ObjectId>>,
-    seen: &mut HashSet<ObjectId>,
-    out: &mut Vec<ObjectId>,
-) -> Result<()> {
-    if !seen.insert(candidate) {
-        return Ok(());
-    }
-    if included.contains(&candidate) {
-        out.push(candidate);
-        return Ok(());
-    }
-    let parents = commit_parents_for_output(repo, candidate, graft_parents)?;
-    for parent in parents {
-        collect_visible_parent(repo, parent, included, graft_parents, seen, out)?;
-    }
-    Ok(())
-}
-
-fn visible_parents_for_output(
-    repo: &Repository,
-    oid: ObjectId,
-    included: &HashSet<ObjectId>,
-    graft_parents: &HashMap<ObjectId, Vec<ObjectId>>,
-) -> Result<Vec<ObjectId>> {
-    let direct_parents = commit_parents_for_output(repo, oid, graft_parents)?;
-    let mut seen = HashSet::new();
-    let mut visible = Vec::new();
-    for parent in direct_parents {
-        collect_visible_parent(
-            repo,
-            parent,
-            included,
-            graft_parents,
-            &mut seen,
-            &mut visible,
-        )?;
-    }
-    Ok(visible)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`rev-list --parents` must print parent hashes from the commit object (and grafts), not only parents that appear in a truncated walk. With `-n 1` on a merge, the previous “visible parents” logic dropped both parents and broke **t6007-rev-list-cherry-pick-status**.

## Changes

- Use `commit_parents_for_output` for `OutputMode::Parents` and for `--pretty` headers when `--parents` is set.
- Remove unused `visible_parents_for_output` / `collect_visible_parent` helpers.

## Verification

- `cargo fmt --all`
- `cargo clippy --fix --allow-dirty -p grit-rs -- -D warnings`
- `cargo test -p grit-lib --lib` (152 tests)

Run `./scripts/run-tests.sh t6007-rev-list-cherry-pick-status.sh` to refresh harness CSV/dashboards if desired.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d86f2e92-53fb-417d-9098-c0a58e725a20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d86f2e92-53fb-417d-9098-c0a58e725a20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

