### PR TITLE
fix: ls-tree -t shows prefix trees for missing pathspec paths (t3100)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -553,7 +553,7 @@ t3050-ls-files-unmerged	t3	yes	23	22	1	false	ok	0
 t3050-subprojects-fetch	t3	yes	4	3	1	false	ok	0
 t3060-ls-files-with-tree	t3	yes	8	8	0	true	ok	0
 t3070-wildmatch	t3	yes	1901	1901	0	true	ok	3
-t3100-ls-tree-restrict	t3	yes	14	13	1	false	ok	0
+t3100-ls-tree-restrict	t3	yes	14	14	0	true	ok	0
 t3101-ls-tree-dirname	t3	yes	19	18	1	false	ok	0
 t3102-ls-tree-wildcards	t3	yes	4	2	2	false	ok	0
 t3103-ls-tree-misc	t3	yes	10	10	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.2% of harness tests passing (35,289 / 45,112).">
+<meta property="og:description" content="78.2% of harness tests passing (35,290 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.2% of harness tests passing (35,289 / 45,112).">
+<meta name="twitter:description" content="78.2% of harness tests passing (35,290 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T15:06:57+00:00" class="gen-time" title="2026-04-09 15:06 UTC">2026-04-09 15:06 UTC</time> · <a href="https://github.com/schacon/grit/commit/c4ad2e9f44715e944bf5d633e8117c550d9c487c" style="color:#58a6ff">c4ad2e9</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T15:17:16+00:00" class="gen-time" title="2026-04-09 15:17 UTC">2026-04-09 15:17 UTC</time> · <a href="https://github.com/schacon/grit/commit/d453c985a004bbafaab0d0367914b362de89e59b" style="color:#58a6ff">d453c98</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,289</div>
+      <div class="summary-big-val">35,290</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>733 files fully passing</span>
+    <span>734 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -219,7 +219,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">52/141 files · 2 skipped · 3,923/5,369 tests</span>
+        <span class="group-meta">53/141 files · 2 skipped · 3,924/5,369 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:73.1%"></div></div>

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35289 of 45112 tests passing across 1405 harness files (78.2% pass rate).</desc>
+  <desc id="svg-desc">35290 of 45112 tests passing across 1405 harness files (78.2% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.2% pass rate · 35,289 / 45,112 tests · 1,405 files in scope · 733 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.2% pass rate · 35,290 / 45,112 tests · 1,405 files in scope · 734 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="547" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T15:06:57+00:00" class="gen-time" title="2026-04-09 15:06 UTC">2026-04-09 15:06 UTC</time> · <a href="https://github.com/schacon/grit/commit/c4ad2e9f44715e944bf5d633e8117c550d9c487c" style="color:#58a6ff">c4ad2e9</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T15:17:16+00:00" class="gen-time" title="2026-04-09 15:17 UTC">2026-04-09 15:17 UTC</time> · <a href="https://github.com/schacon/grit/commit/d453c985a004bbafaab0d0367914b362de89e59b" style="color:#58a6ff">d453c98</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,289</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,290</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -5687,14 +5687,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">3</td>
 </tr>
-<tr class="" data-group="t3" data-tests="14" data-passed="13">
+<tr class="" data-group="t3" data-tests="14" data-passed="14" data-full-pass="1">
   <td class="mono">t3100-ls-tree-restrict</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">14</td>
-  <td class="right">13</td>
+  <td class="right">14</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:92.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="19" data-passed="18">

--- a/grit/src/commands/ls_tree.rs
+++ b/grit/src/commands/ls_tree.rs
@@ -496,6 +496,12 @@ fn list_tree(
                         || (p.ends_with('/') && ps == full_name)
                 });
             if is_tree && is_ancestor && !args.recursive {
+                // Match Git's `read_tree` + `show_recursive`: with pathspecs we descend into prefix
+                // trees even without `-r`. `-t` then lists those intermediate trees (see t3100).
+                if args.show_trees {
+                    let display_name = make_cwd_relative(&full_name, cwd_prefix);
+                    print_entry(repo, entry, &display_name, args, out, term, quote_fully)?;
+                }
                 let sub_obj = repo.odb.read(&entry.oid)?;
                 list_tree(
                     repo,

--- a/logs/2026-04-09_ls-tree-t3100-t-flag-pathspec.md
+++ b/logs/2026-04-09_ls-tree-t3100-t-flag-pathspec.md
@@ -1,0 +1,14 @@
+# t3100-ls-tree-restrict
+
+## Issue
+
+`ls-tree -t` with a pathspec that names a missing path under an existing prefix (e.g. `path2/bak`) must still print intermediate trees walked while searching (Git: `show_recursive` + `LS_SHOW_TREES`). Grit descended but omitted the `path2` line.
+
+## Fix
+
+In `grit/src/commands/ls_tree.rs`, when descending into a tree for pathspec prefix matching without `-r`, emit the tree entry first if `--show-trees` (`-t`) is set.
+
+## Validation
+
+- `./scripts/run-tests.sh t3100-ls-tree-restrict.sh` → 14/14
+- `cargo check -p grit-rs`, `cargo test -p grit-lib --lib`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t3100-ls-tree-restrict` expected `git ls-tree -t $tree path2/bak` to print the `path2` tree when `path2/bak` does not exist. Git walks prefix trees while matching pathspecs and, with `-t`, emits those intermediate trees.

## Changes

- **`grit/src/commands/ls_tree.rs`**: When pathspec matching descends into a subdirectory without `-r`, print the tree entry first if `-t` is set (mirrors Git's `show_recursive` + `LS_SHOW_TREES`).
- **Harness**: `data/test-files.csv` and generated dashboards updated after `./scripts/run-tests.sh t3100-ls-tree-restrict.sh` (14/14).
- **Log**: `logs/2026-04-09_ls-tree-t3100-t-flag-pathspec.md`

## Validation

- `cargo check -p grit-rs`
- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t3100-ls-tree-restrict.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65def1ed-4609-42c6-9c7a-44a4ae861284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65def1ed-4609-42c6-9c7a-44a4ae861284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

