### PR TITLE
fix: cherry-pick/revert conflict handling and sequencer (t3507)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T12:58:52+00:00" class="gen-time" title="2026-04-09 12:58 UTC">2026-04-09 12:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/c9e26ba46f5a86c3328f4d62484968547c8560d9" style="color:#58a6ff">c9e26ba</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T13:04:23+00:00" class="gen-time" title="2026-04-09 13:04 UTC">2026-04-09 13:04 UTC</time> · <a href="https://github.com/schacon/grit/commit/999b424740b71e52cf30bf6fade3e1ef735f68bd" style="color:#58a6ff">999b424</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,7 +100,7 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T12:58:52+00:00" class="gen-time" title="2026-04-09 12:58 UTC">2026-04-09 12:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/c9e26ba46f5a86c3328f4d62484968547c8560d9" style="color:#58a6ff">c9e26ba</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T13:04:23+00:00" class="gen-time" title="2026-04-09 13:04 UTC">2026-04-09 13:04 UTC</time> · <a href="https://github.com/schacon/grit/commit/999b424740b71e52cf30bf6fade3e1ef735f68bd" style="color:#58a6ff">999b424</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>

--- a/grit-lib/examples/cherry_pick.rs
+++ b/grit-lib/examples/cherry_pick.rs
@@ -137,7 +137,9 @@ fn main() -> grit_lib::error::Result<()> {
         theirs_tree,
         MergeFavor::default(),
         WhitespaceMergeOptions::default(),
-        "HEAD",
+        "parent of picked commit",
+        "picked",
+        grit_lib::merge_file::ConflictStyle::Merge,
     )?;
 
     if !merged.conflict_content.is_empty() {

--- a/grit-lib/src/merge_trees.rs
+++ b/grit-lib/src/merge_trees.rs
@@ -8,7 +8,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 use crate::diff::{detect_renames, diff_trees, DiffStatus};
 use crate::index::{Index, IndexEntry};
-use crate::merge_file::{merge, MergeFavor, MergeInput};
+use crate::merge_file::{merge, ConflictStyle, MergeFavor, MergeInput};
 use crate::objects::{parse_tree, ObjectId, ObjectKind};
 use crate::odb::Odb;
 use crate::repo::Repository;
@@ -42,7 +42,9 @@ pub struct WhitespaceMergeOptions {
 /// - `ours_tree` — current branch tree (HEAD during pick/revert).
 /// - `theirs_tree` — tree being applied (picked commit for cherry-pick, parent of reverted commit for revert).
 /// - `favor` / `ws` — merge strategy favour and whitespace options for textual merges.
-/// - `label_base` — label for the merge conflict "base" side in markers.
+/// - `label_base` — label for the merge conflict "base" side in diff3 markers.
+/// - `label_theirs` — label for the `>>>>>>>` side (Git uses commit summaries, not paths).
+/// - `conflict_style` — `merge` vs `diff3` conflict markers.
 ///
 /// # Errors
 ///
@@ -55,6 +57,8 @@ pub fn merge_trees_three_way(
     favor: MergeFavor,
     ws: WhitespaceMergeOptions,
     label_base: &str,
+    label_theirs: &str,
+    conflict_style: ConflictStyle,
 ) -> crate::error::Result<TreeMergeOutput> {
     let odb = &repo.odb;
     let base = tree_to_map(tree_to_index_entries(repo, &base_tree, "")?);
@@ -105,6 +109,8 @@ pub fn merge_trees_three_way(
         favor,
         ws,
         label_base,
+        label_theirs,
+        conflict_style,
     )
 }
 
@@ -142,6 +148,8 @@ fn three_way_on_aligned_paths(
     favor: MergeFavor,
     ws: WhitespaceMergeOptions,
     label_base: &str,
+    label_theirs: &str,
+    conflict_style: ConflictStyle,
 ) -> crate::error::Result<TreeMergeOutput> {
     let mut out = Index::new();
     let mut conflict_content = BTreeMap::new();
@@ -188,6 +196,8 @@ fn three_way_on_aligned_paths(
             favor,
             ws,
             label_base,
+            label_theirs,
+            conflict_style,
         )?;
     }
 
@@ -216,6 +226,8 @@ fn three_way_on_aligned_paths(
             favor,
             ws,
             label_base,
+            label_theirs,
+            conflict_style,
         )?;
     }
 
@@ -237,6 +249,8 @@ fn three_way_on_aligned_paths(
             favor,
             ws,
             label_base,
+            label_theirs,
+            conflict_style,
         )?;
     }
 
@@ -264,6 +278,8 @@ fn merge_one_path(
     favor: MergeFavor,
     ws: WhitespaceMergeOptions,
     label_base: &str,
+    label_theirs: &str,
+    conflict_style: ConflictStyle,
 ) -> crate::error::Result<()> {
     match (b, o, t) {
         (_, Some(oe), Some(te)) if same_blob(oe, te) => {
@@ -320,6 +336,8 @@ fn merge_one_path(
                 favor,
                 ws,
                 label_base,
+                label_theirs,
+                conflict_style,
             )?;
         }
         (None, Some(oe), None) => {
@@ -386,6 +404,8 @@ fn content_merge_or_conflict(
     favor: MergeFavor,
     ws: WhitespaceMergeOptions,
     label_base: &str,
+    label_theirs: &str,
+    conflict_style: ConflictStyle,
 ) -> crate::error::Result<()> {
     if base.mode == 0o160000 || ours.mode == 0o160000 || theirs.mode == 0o160000 {
         stage_entry(index, path, base, 1);
@@ -427,15 +447,20 @@ fn content_merge_or_conflict(
     }
 
     let path_label = String::from_utf8_lossy(path);
+    let theirs_label = if label_theirs.is_empty() {
+        path_label.as_ref()
+    } else {
+        label_theirs
+    };
     let input = MergeInput {
         base: &base_obj.data,
         ours: &ours_obj.data,
         theirs: &theirs_obj.data,
         label_ours: "HEAD",
         label_base,
-        label_theirs: path_label.as_ref(),
+        label_theirs: theirs_label,
         favor,
-        style: Default::default(),
+        style: conflict_style,
         marker_size: 7,
         diff_algorithm: None,
         ignore_all_space: ws.ignore_all_space,

--- a/grit/src/commands/cherry_pick.rs
+++ b/grit/src/commands/cherry_pick.rs
@@ -17,8 +17,9 @@ use grit_lib::commit_trailers::{
     format_signoff_line,
 };
 use grit_lib::config::ConfigSet;
+use grit_lib::diff::diff_index_to_worktree;
 use grit_lib::index::{Index, IndexEntry, MODE_EXECUTABLE, MODE_SYMLINK};
-use grit_lib::merge_file::{merge, MergeFavor, MergeInput};
+use grit_lib::merge_file::{merge, ConflictStyle, MergeFavor, MergeInput};
 use grit_lib::merge_trees::{merge_trees_three_way, WhitespaceMergeOptions};
 use grit_lib::objects::{
     parse_commit, parse_tree, serialize_commit, CommitData, ObjectId, ObjectKind,
@@ -162,9 +163,14 @@ fn verify_pick_flags_not_with_operation(args: &Args, operation: &str) {
     }
 }
 
+use super::merge::{
+    bail_if_resolve_index_not_clean_vs_head, cleanup_message, merge_touched_paths,
+    staged_dirty_paths_vs_head,
+};
 use super::sequencer::{
-    rollback_is_safe, sequencer_is_pick_sequence, sequencer_is_revert_sequence,
-    strip_first_sequencer_todo_line, write_abort_safety_file,
+    append_merge_msg_conflict_footer, rollback_is_safe, sequencer_is_pick_sequence,
+    sequencer_is_revert_sequence, strip_first_sequencer_todo_line, unmerged_paths,
+    write_abort_safety_file,
 };
 
 /// Result of a three-way merge: the index plus any conflict content for working tree.
@@ -268,6 +274,10 @@ pub struct Args {
     /// Unsupported on cherry-pick (revert-only); accepted to print upstream usage.
     #[arg(long = "reference", hide = true)]
     pub reference: bool,
+
+    /// Message cleanup mode (matches `git cherry-pick --cleanup`; used for conflict `MERGE_MSG`).
+    #[arg(long = "cleanup", value_name = "MODE", hide = true)]
+    pub cleanup: Option<String>,
 }
 
 /// Run the `cherry-pick` command.
@@ -466,7 +476,14 @@ fn run_commit_sequence(
             }
             Err(e) => {
                 let err_msg = format!("{e}");
+                if err_msg.contains("CHERRY_PICK_DIRTY_GENERIC") {
+                    eprintln!("fatal: cherry-pick failed");
+                    std::process::exit(128);
+                }
                 if err_msg.contains("CONFLICT_EXIT") {
+                    if std::env::var_os("GIT_CHERRY_PICK_HELP").is_some() {
+                        std::process::exit(1);
+                    }
                     if oids.len() > 1 {
                         save_sequencer_state(git_dir, &orig_head_oid, remaining, args)?;
                         write_abort_safety_file(git_dir)?;
@@ -761,6 +778,31 @@ fn cherry_pick_one_commit(repo: &Repository, commit_oid: ObjectId, args: &Args) 
         head_tree_oid
     };
 
+    let config = ConfigSet::load(Some(git_dir), true)?;
+
+    if let (Some(head_oid), Some(wt)) = (head_oid_opt.as_ref(), repo.work_tree.as_deref()) {
+        error_if_cherry_pick_would_clobber_worktree(
+            repo,
+            git_dir,
+            *head_oid,
+            parent_tree_oid,
+            ours_tree_oid,
+            commit_tree_oid,
+            wt,
+        )?;
+    }
+
+    if let Some(head_oid) = head_oid_opt.as_ref() {
+        if !args.no_commit
+            && args
+                .strategy
+                .as_deref()
+                .is_some_and(|s| s.eq_ignore_ascii_case("resolve"))
+        {
+            bail_if_resolve_index_not_clean_vs_head(repo, *head_oid, false)?;
+        }
+    }
+
     let (favor, ws_opts) = parse_strategy_options(&args.strategy_option);
     let ws_merge = WhitespaceMergeOptions {
         ignore_all_space: ws_opts.ignore_all_space,
@@ -768,6 +810,16 @@ fn cherry_pick_one_commit(repo: &Repository, commit_oid: ObjectId, args: &Args) 
         ignore_space_at_eol: ws_opts.ignore_space_at_eol,
         ignore_cr_at_eol: ws_opts.ignore_cr_at_eol,
     };
+    let short_oid = &commit_oid.to_hex()[..7];
+    let subject = commit.message.lines().next().unwrap_or("");
+    let label_theirs = format!("{short_oid} ({subject})");
+    let label_base = format!("parent of {short_oid} ({subject})");
+
+    let conflict_style = match config.get("merge.conflictstyle").as_deref() {
+        Some("diff3") | Some("zdiff3") => ConflictStyle::Diff3,
+        _ => ConflictStyle::Merge,
+    };
+
     let merged = merge_trees_three_way(
         repo,
         parent_tree_oid,
@@ -775,7 +827,9 @@ fn cherry_pick_one_commit(repo: &Repository, commit_oid: ObjectId, args: &Args) 
         commit_tree_oid,
         favor,
         ws_merge,
-        "parent of picked commit",
+        label_base.as_str(),
+        label_theirs.as_str(),
+        conflict_style,
     )?;
     let mut merge_result = MergeResult {
         index: merged.index,
@@ -843,7 +897,6 @@ fn cherry_pick_one_commit(repo: &Repository, commit_oid: ObjectId, args: &Args) 
     )?;
 
     // Build the cherry-pick message (Git: `sequencer.c` + `commit.cleanup` when `-x`).
-    let config = ConfigSet::load(Some(git_dir), true)?;
     let (cname, cemail) = committer_name_email(&config);
     let mut msg = finalize_cherry_pick_message(
         &cherry_pick_source_message(&commit),
@@ -860,21 +913,52 @@ fn cherry_pick_one_commit(repo: &Repository, commit_oid: ObjectId, args: &Args) 
     // the opts from the sequencer), not by a manual commit that the user makes
     // without explicitly requesting signoff.
     if has_conflicts {
+        let cherry_pick_help = std::env::var("GIT_CHERRY_PICK_HELP").ok();
+        let short_oid = &commit_oid.to_hex()[..7];
+        let subject = commit.message.lines().next().unwrap_or("");
+
+        if let Some(ref help) = cherry_pick_help {
+            eprintln!("error: could not apply {short_oid}... {subject}");
+            eprintln!("hint: {help}");
+            bail!("CONFLICT_EXIT");
+        }
+
         fs::write(
             git_dir.join("CHERRY_PICK_HEAD"),
             format!("{}\n", commit_oid.to_hex()),
         )?;
-        // Write MERGE_MSG without signoff: signoff is only added by
-        // `cherry-pick --continue` (which re-reads sequencer opts),
-        // not by a bare `git commit` that the user makes manually.
-        fs::write(git_dir.join("MERGE_MSG"), &msg)?;
+
+        let commit_cleanup = config.get("commit.cleanup");
+        let cleanup_mode = args
+            .cleanup
+            .as_deref()
+            .or(commit_cleanup.as_deref())
+            .unwrap_or("default");
+        let scissors_body = cleanup_message(&msg, cleanup_mode);
+        let mut merge_msg = scissors_body;
+        if cleanup_mode.eq_ignore_ascii_case("scissors") {
+            let paths = unmerged_paths(&merge_result.index);
+            append_merge_msg_conflict_footer(&mut merge_msg, &paths);
+        }
+        if args.signoff {
+            let sob = format_signoff_line(&cname, &cemail);
+            let already_has_committer_sob = merge_msg.lines().any(|l| {
+                l.trim_start()
+                    .strip_prefix("Signed-off-by:")
+                    .is_some_and(|rest| rest.trim() == format!("{cname} <{cemail}>"))
+            });
+            if !already_has_committer_sob {
+                append_signoff_trailer(&mut merge_msg, &sob, &config);
+            }
+        }
+        fs::write(git_dir.join("MERGE_MSG"), &merge_msg)?;
 
         let head_oid_conflict = head
             .oid()
             .copied()
             .unwrap_or_else(|| ObjectId::from_bytes(&[0u8; 20]).unwrap());
         let now = time::OffsetDateTime::now_utc();
-        let ident = resolve_committer_ident(&ConfigSet::load(Some(git_dir), true)?, now)?;
+        let ident = resolve_committer_ident(&config, now)?;
         let cp_reflog = format!(
             "cherry-pick: {}",
             commit.message.lines().next().unwrap_or("")
@@ -900,14 +984,25 @@ fn cherry_pick_one_commit(repo: &Repository, commit_oid: ObjectId, args: &Args) 
             );
         }
 
-        let short_oid = &commit_oid.to_hex()[..7];
-        let subject = commit.message.lines().next().unwrap_or("");
-        eprintln!(
-            "error: could not apply {short_oid}... {subject}\n\
-             hint: after resolving the conflicts, mark the corrected paths\n\
-             hint: with 'git add <paths>' or 'git rm <paths>'\n\
-             hint: and commit the result with 'git cherry-pick --continue'"
-        );
+        eprintln!("error: could not apply {short_oid}... {subject}");
+        if merge_conflict_advice_enabled(git_dir) {
+            if args.no_commit {
+                eprintln!("hint: after resolving the conflicts, mark the corrected paths");
+                eprintln!("hint: with 'git add <paths>' or 'git rm <paths>'");
+            } else {
+                eprintln!("hint: After resolving the conflicts, mark them with");
+                eprintln!("hint: \"git add/rm <pathspec>\", then run");
+                eprintln!("hint: \"git cherry-pick --continue\".");
+                eprintln!(
+                    "hint: You can instead skip this commit with \"git cherry-pick --skip\"."
+                );
+                eprintln!("hint: To abort and get back to the state before \"git cherry-pick\",");
+                eprintln!("hint: run \"git cherry-pick --abort\".");
+            }
+            eprintln!(
+                "hint: Disable this message with \"git config set advice.mergeConflict false\""
+            );
+        }
         bail!("CONFLICT_EXIT");
     }
 
@@ -943,6 +1038,61 @@ fn branch_name(head: &HeadState) -> &str {
         HeadState::Detached { .. } => "HEAD detached",
         HeadState::Invalid => "unknown",
     }
+}
+
+fn merge_conflict_advice_enabled(git_dir: &Path) -> bool {
+    let Ok(config) = ConfigSet::load(Some(git_dir), true) else {
+        return true;
+    };
+    config.get_bool("advice.mergeConflict") != Some(Ok(false))
+}
+
+/// Refuse cherry-pick when local changes overlap the merge, matching Git's messages.
+fn error_if_cherry_pick_would_clobber_worktree(
+    repo: &Repository,
+    _git_dir: &Path,
+    head_oid: ObjectId,
+    parent_tree: ObjectId,
+    head_tree: ObjectId,
+    picked_tree: ObjectId,
+    work_tree: &Path,
+) -> Result<()> {
+    let touched = merge_touched_paths(repo, parent_tree, head_tree, picked_tree)?;
+    let staged_dirty = staged_dirty_paths_vs_head(repo, head_oid)?;
+
+    if !staged_dirty.is_empty() {
+        let overlap: BTreeSet<String> = staged_dirty.intersection(&touched).cloned().collect();
+        if !overlap.is_empty() {
+            let mut msg = String::from(
+                "Your local changes to the following files would be overwritten by merge:\n",
+            );
+            for path in overlap {
+                msg.push_str(&format!("\t{path}\n"));
+            }
+            msg.push_str("Please commit your changes or stash them before you merge.\nAborting");
+            bail!("{msg}");
+        }
+        eprintln!("error: your local changes would be overwritten by cherry-pick.");
+        eprintln!("hint: commit your changes or stash them to proceed.");
+        bail!("CHERRY_PICK_DIRTY_GENERIC");
+    }
+
+    let index = repo.load_index()?;
+    let unstaged = diff_index_to_worktree(&repo.odb, &index, work_tree)?;
+    let unstaged_paths: BTreeSet<String> = unstaged.iter().map(|e| e.path().to_string()).collect();
+    let overlap_u: BTreeSet<String> = unstaged_paths.intersection(&touched).cloned().collect();
+    if !overlap_u.is_empty() {
+        let mut msg = String::from(
+            "Your local changes to the following files would be overwritten by merge:\n",
+        );
+        for path in overlap_u {
+            msg.push_str(&format!("\t{path}\n"));
+        }
+        msg.push_str("Please commit your changes or stash them before you merge.\nAborting");
+        bail!("{msg}");
+    }
+
+    Ok(())
 }
 
 // ── --continue ──────────────────────────────────────────────────────
@@ -1071,6 +1221,62 @@ fn do_continue(mut args: Args) -> Result<()> {
         cleanup_sequencer_state(git_dir);
     }
 
+    Ok(())
+}
+
+/// After a manual `git commit` finished the current pick, resume any remaining `sequencer/todo`
+/// picks (matches Git: conflict resolution via plain commit, not only `cherry-pick --continue`).
+pub(crate) fn try_resume_pick_sequence_after_commit(repo: &Repository) -> Result<()> {
+    let git_dir = &repo.git_dir;
+    if !git_dir.join("sequencer").join("todo").exists() {
+        return Ok(());
+    }
+    if sequencer_is_revert_sequence(git_dir) {
+        return Ok(());
+    }
+    if git_dir.join("CHERRY_PICK_HEAD").exists() {
+        return Ok(());
+    }
+
+    let mut args = Args {
+        commits: vec![],
+        append_source: false,
+        no_commit: false,
+        signoff: false,
+        mainline: None,
+        r#continue: true,
+        abort: false,
+        skip: false,
+        quit: false,
+        ff: false,
+        allow_empty: false,
+        allow_empty_message: false,
+        keep_redundant_commits: false,
+        strategy: None,
+        strategy_option: vec![],
+        empty: None,
+        edit: false,
+        reference: false,
+        cleanup: None,
+    };
+    merge_sequencer_opts(git_dir, &mut args);
+    if args.keep_redundant_commits || matches!(args.empty.as_deref(), Some("keep")) {
+        args.allow_empty = true;
+    }
+    validate_sequencer_todo_pick_only(git_dir)?;
+
+    let head_file = git_dir.join("sequencer").join("head");
+    let stored_orig = if let Ok(s) = fs::read_to_string(&head_file) {
+        ObjectId::from_hex(s.trim()).ok()
+    } else {
+        None
+    };
+    let remaining = load_sequencer_todo(git_dir);
+    if !remaining.is_empty() {
+        run_commit_sequence(repo, &remaining, &args, stored_orig)?;
+    } else {
+        cleanup_sequencer_state(git_dir);
+    }
     Ok(())
 }
 
@@ -1287,6 +1493,9 @@ fn write_sequencer_opts(git_dir: &Path, args: &Args) -> Result<()> {
     if let Some(ref empty) = args.empty {
         opts.push_str(&format!("\tempty = {empty}\n"));
     }
+    if let Some(ref c) = args.cleanup {
+        opts.push_str(&format!("\tcleanup = {c}\n"));
+    }
     fs::write(seq_dir.join("opts"), &opts)?;
     Ok(())
 }
@@ -1353,6 +1562,7 @@ fn merge_sequencer_opts(git_dir: &Path, args: &mut Args) {
                 "strategy" => args.strategy = Some(val.to_string()),
                 "strategy-option" => args.strategy_option.push(val.to_string()),
                 "empty" => args.empty = Some(val.to_string()),
+                "cleanup" => args.cleanup = Some(val.to_string()),
                 _ => {}
             }
         }

--- a/grit/src/commands/commit.rs
+++ b/grit/src/commands/commit.rs
@@ -18,6 +18,9 @@ use grit_lib::refs::{append_reflog, list_refs};
 use grit_lib::repo::Repository;
 use grit_lib::rev_parse::resolve_revision;
 use grit_lib::state::{resolve_head, HeadState};
+
+use crate::commands::cherry_pick::try_resume_pick_sequence_after_commit;
+use crate::commands::revert::try_resume_revert_sequence_after_commit;
 use grit_lib::write_tree::{
     write_tree_from_index, write_tree_from_index_subset, write_tree_partial_from_index,
 };
@@ -26,7 +29,7 @@ use crate::ident::{resolve_email, resolve_name, IdentRole};
 
 use std::collections::{BTreeSet, HashSet};
 use std::fs;
-use std::io::{self, Read, Write};
+use std::io::{self, IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use time::format_description::well_known::Rfc3339;
@@ -425,6 +428,12 @@ pub fn run(mut args: Args) -> Result<()> {
 
     let repo = Repository::discover(None).context("not a git repository")?;
 
+    let had_cp_head = repo.git_dir.join("CHERRY_PICK_HEAD").exists();
+    let had_rv_head = repo.git_dir.join("REVERT_HEAD").exists();
+    let seq_todo_path = repo.git_dir.join("sequencer").join("todo");
+    let resume_pick_after_cp = had_cp_head && seq_todo_path.exists();
+    let resume_revert_after_rv = had_rv_head && seq_todo_path.exists();
+
     let reset_author_allowed = args.amend
         || args.reuse_message.is_some()
         || args.reedit_message.is_some()
@@ -480,6 +489,14 @@ pub fn run(mut args: Args) -> Result<()> {
         Err(Error::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => Index::new(),
         Err(e) => return Err(e.into()),
     };
+
+    if index.entries.iter().any(|e| e.stage() != 0) {
+        eprintln!("error: Committing is not possible because you have unmerged files.");
+        eprintln!("hint: Fix them up in the work tree, and then use 'git add/rm <file>'");
+        eprintln!("hint: as appropriate to mark resolution and make a commit.");
+        eprintln!("fatal: Exiting because of an unresolved conflict.");
+        std::process::exit(128);
+    }
 
     if args.dry_run && !args.pathspec.is_empty() {
         let Some(wt) = work_tree else {
@@ -553,6 +570,24 @@ pub fn run(mut args: Args) -> Result<()> {
     };
     let mut parents = Vec::new();
     let old_head_oid = head.oid().cloned();
+
+    if had_cp_head && args.amend {
+        eprintln!("fatal: You are in the middle of a cherry-pick -- cannot amend.");
+        std::process::exit(128);
+    }
+    if had_rv_head && args.amend {
+        eprintln!("fatal: You are in the middle of a revert -- cannot amend.");
+        std::process::exit(128);
+    }
+
+    if had_cp_head && !args.pathspec.is_empty() {
+        eprintln!("fatal: cannot do a partial commit during a cherry-pick.");
+        std::process::exit(128);
+    }
+    if had_rv_head && !args.pathspec.is_empty() {
+        eprintln!("fatal: cannot do a partial commit during a revert.");
+        std::process::exit(128);
+    }
 
     if args.amend {
         // Amend: use the parent(s) of the current HEAD commit
@@ -799,23 +834,95 @@ pub fn run(mut args: Args) -> Result<()> {
         } else {
             format!("Signed-off-by: {committer}")
         };
-        if !message.contains(&trailer) {
-            let trimmed = message.trim_end();
-            message = format!("{trimmed}\n\n{trailer}\n");
-            // Also update raw_message if present
-            if let Some(ref raw) = raw_message {
-                let trimmed_raw = {
-                    let mut end = raw.len();
-                    while end > 0
-                        && (raw[end - 1] == b'\n' || raw[end - 1] == b' ' || raw[end - 1] == b'\r')
-                    {
-                        end -= 1;
+        let name_email = if let Some(angle_end) = committer.find('>') {
+            committer[..=angle_end].to_string()
+        } else {
+            committer.clone()
+        };
+        let already_has_sob = message.lines().any(|l| {
+            l.trim_start()
+                .strip_prefix("Signed-off-by:")
+                .is_some_and(|rest| rest.trim() == name_email)
+        });
+        if !already_has_sob && !message.contains(&trailer) {
+            const SCISSORS: &str = "# ------------------------ >8 ------------------------";
+            fn unsigned_conflicts_start(msg: &str) -> Option<usize> {
+                if let Some(i) = msg.find("\nConflicts:") {
+                    return Some(i + 1);
+                }
+                if msg.starts_with("Conflicts:") {
+                    return Some(0);
+                }
+                None
+            }
+            fn insert_trailer_before(msg: &str, pos: usize, trailer: &str) -> String {
+                let before = msg[..pos].trim_end_matches(['\n', '\r', ' ', '\t']);
+                let after = &msg[pos..];
+                format!("{before}\n\n{trailer}\n{after}")
+            }
+
+            if (had_cp_head || had_rv_head) && message.contains(SCISSORS) {
+                if let Some(pos) = message.find(SCISSORS) {
+                    message = insert_trailer_before(&message, pos, &trailer);
+                    if let Some(ref raw) = raw_message {
+                        if let Ok(s) = std::str::from_utf8(raw) {
+                            if let Some(p) = s.find(SCISSORS) {
+                                raw_message =
+                                    Some(insert_trailer_before(s, p, &trailer).into_bytes());
+                            }
+                        }
                     }
-                    &raw[..end]
-                };
-                let mut new_raw = trimmed_raw.to_vec();
-                new_raw.extend_from_slice(format!("\n\n{trailer}\n").as_bytes());
-                raw_message = Some(new_raw);
+                }
+            } else if args.amend {
+                if let Some(pos) = unsigned_conflicts_start(&message) {
+                    message = insert_trailer_before(&message, pos, &trailer);
+                    if let Some(ref raw) = raw_message {
+                        if let Ok(s) = std::str::from_utf8(raw) {
+                            if let Some(p) = unsigned_conflicts_start(s) {
+                                raw_message =
+                                    Some(insert_trailer_before(s, p, &trailer).into_bytes());
+                            }
+                        }
+                    }
+                } else {
+                    let trimmed = message.trim_end();
+                    message = format!("{trimmed}\n\n{trailer}\n");
+                    if let Some(ref raw) = raw_message {
+                        let trimmed_raw = {
+                            let mut end = raw.len();
+                            while end > 0
+                                && (raw[end - 1] == b'\n'
+                                    || raw[end - 1] == b' '
+                                    || raw[end - 1] == b'\r')
+                            {
+                                end -= 1;
+                            }
+                            &raw[..end]
+                        };
+                        let mut new_raw = trimmed_raw.to_vec();
+                        new_raw.extend_from_slice(format!("\n\n{trailer}\n").as_bytes());
+                        raw_message = Some(new_raw);
+                    }
+                }
+            } else {
+                let trimmed = message.trim_end();
+                message = format!("{trimmed}\n\n{trailer}\n");
+                if let Some(ref raw) = raw_message {
+                    let trimmed_raw = {
+                        let mut end = raw.len();
+                        while end > 0
+                            && (raw[end - 1] == b'\n'
+                                || raw[end - 1] == b' '
+                                || raw[end - 1] == b'\r')
+                        {
+                            end -= 1;
+                        }
+                        &raw[..end]
+                    };
+                    let mut new_raw = trimmed_raw.to_vec();
+                    new_raw.extend_from_slice(format!("\n\n{trailer}\n").as_bytes());
+                    raw_message = Some(new_raw);
+                }
             }
         }
     }
@@ -991,6 +1098,12 @@ pub fn run(mut args: Args) -> Result<()> {
     let _ = grit_lib::rerere::rerere_post_commit(&repo);
     let _ = crate::commands::maintenance::run_auto_after_commit(&repo, args.quiet);
     cleanup_merge_state(&repo.git_dir);
+    if resume_pick_after_cp {
+        try_resume_pick_sequence_after_commit(&repo)?;
+    }
+    if resume_revert_after_rv {
+        try_resume_revert_sequence_after_commit(&repo)?;
+    }
 
     // Refresh the index file Git used for this commit (including `GIT_INDEX_FILE`).
     let mut index_refresh = match repo.load_index_at(&index_path) {
@@ -1499,6 +1612,8 @@ struct MessageResult {
     message: String,
     /// Raw bytes when the message is not valid UTF-8.
     raw_bytes: Option<Vec<u8>>,
+    /// Message came from `.git/MERGE_MSG` (cherry-pick / revert conflict template).
+    from_merge_msg: bool,
 }
 
 fn resolved_index_path(repo: &Repository) -> PathBuf {
@@ -1717,6 +1832,7 @@ fn raw_to_message_result(raw: Vec<u8>) -> Result<MessageResult> {
         Ok(s) => Ok(MessageResult {
             message: ensure_trailing_newline(&s),
             raw_bytes: None,
+            from_merge_msg: false,
         }),
         Err(_) => {
             let lossy = String::from_utf8_lossy(&raw).to_string();
@@ -1727,6 +1843,7 @@ fn raw_to_message_result(raw: Vec<u8>) -> Result<MessageResult> {
             Ok(MessageResult {
                 message: ensure_trailing_newline(&lossy),
                 raw_bytes: Some(raw_nl),
+                from_merge_msg: false,
             })
         }
     }
@@ -1864,6 +1981,10 @@ fn resolve_commit_editor(repo: &Repository) -> String {
     // Harness sets `EDITOR=:` / `VISUAL=:` as non-interactive placeholders; never launch `vi`
     // in that case (would hang). Fall back to `true` like a no-op editor.
     if visual_present || editor_present {
+        "true".to_owned()
+    } else if !std::io::stdin().is_terminal() {
+        // Non-interactive runs (CI / agents) may inherit `GIT_EDITOR=vim` from the parent
+        // environment; launching vi would hang when stdin is not a tty.
         "true".to_owned()
     } else {
         "vi".to_owned()
@@ -2146,6 +2267,7 @@ fn prepare_commit_message(
                 return Ok(MessageResult {
                     message: ensure_trailing_newline(&cleaned),
                     raw_bytes: None,
+                    from_merge_msg: false,
                 });
             }
             if rev == sq {
@@ -2171,12 +2293,14 @@ fn prepare_commit_message(
             return Ok(MessageResult {
                 message: ensure_trailing_newline(&cleaned),
                 raw_bytes: None,
+                from_merge_msg: false,
             });
         }
         let combined = format!("{prefix}{body}");
         return Ok(MessageResult {
             message: ensure_trailing_newline(&combined),
             raw_bytes: None,
+            from_merge_msg: false,
         });
     }
 
@@ -2186,6 +2310,7 @@ fn prepare_commit_message(
         return Ok(MessageResult {
             message: ensure_trailing_newline(&cleaned),
             raw_bytes: None,
+            from_merge_msg: false,
         });
     }
 
@@ -2211,11 +2336,13 @@ fn prepare_commit_message(
             return Ok(MessageResult {
                 message: ensure_trailing_newline(&cleaned),
                 raw_bytes: None,
+                from_merge_msg: false,
             });
         }
         return Ok(MessageResult {
             message: commit.message,
             raw_bytes: None,
+            from_merge_msg: false,
         });
     }
 
@@ -2231,6 +2358,7 @@ fn prepare_commit_message(
         return Ok(MessageResult {
             message: String::new(),
             raw_bytes: None,
+            from_merge_msg: false,
         });
     }
 
@@ -2238,6 +2366,7 @@ fn prepare_commit_message(
         return Ok(MessageResult {
             message: ensure_trailing_newline(&initial),
             raw_bytes: None,
+            from_merge_msg: false,
         });
     }
 
@@ -2254,6 +2383,7 @@ fn prepare_commit_message(
         return Ok(MessageResult {
             message: ensure_trailing_newline(&cleaned),
             raw_bytes: None,
+            from_merge_msg: false,
         });
     }
 
@@ -2270,6 +2400,7 @@ fn prepare_commit_message(
         return Ok(MessageResult {
             message: ensure_trailing_newline(&msg),
             raw_bytes: None,
+            from_merge_msg: true,
         });
     }
 
@@ -2279,6 +2410,7 @@ fn prepare_commit_message(
             return Ok(MessageResult {
                 message: ensure_trailing_newline(&msg),
                 raw_bytes: None,
+                from_merge_msg: false,
             });
         }
     }
@@ -2289,6 +2421,7 @@ fn prepare_commit_message(
         return Ok(MessageResult {
             message: ensure_trailing_newline(&content),
             raw_bytes: None,
+            from_merge_msg: false,
         });
     }
 
@@ -2300,6 +2433,7 @@ fn prepare_commit_message(
             return Ok(MessageResult {
                 message: commit.message,
                 raw_bytes: None,
+                from_merge_msg: false,
             });
         }
     }
@@ -2308,6 +2442,7 @@ fn prepare_commit_message(
         return Ok(MessageResult {
             message: String::new(),
             raw_bytes: None,
+            from_merge_msg: false,
         });
     }
 

--- a/grit/src/commands/merge.rs
+++ b/grit/src/commands/merge.rs
@@ -308,7 +308,7 @@ fn bail_if_index_tree_differs_from_head(
 
 /// The resolve strategy does not allow *any* staged difference from HEAD (including removals),
 /// unlike recursive/ort which only care when the merge would touch those paths.
-fn bail_if_resolve_index_not_clean_vs_head(
+pub(crate) fn bail_if_resolve_index_not_clean_vs_head(
     repo: &Repository,
     head_oid: ObjectId,
     autostash: bool,
@@ -352,6 +352,59 @@ fn bail_if_resolve_index_not_clean_vs_head(
     }
     msg.push_str("Please commit your changes or stash them before you merge.\nAborting");
     bail!("{msg}");
+}
+
+/// Stage-0 index paths that differ from `HEAD^{tree}` (including staged additions/removals).
+pub(crate) fn staged_dirty_paths_vs_head(
+    repo: &Repository,
+    head_oid: ObjectId,
+) -> Result<BTreeSet<String>> {
+    let index = repo.load_index()?;
+    let head_tree = commit_tree(repo, head_oid)?;
+    let head_entries = tree_to_map(tree_to_index_entries(repo, &head_tree, "")?);
+    let mut dirty_paths: BTreeSet<String> = BTreeSet::new();
+    for e in index.entries.iter().filter(|e| e.stage() == 0) {
+        let rel = String::from_utf8_lossy(&e.path).to_string();
+        match head_entries.get(&e.path) {
+            Some(he) => {
+                if he.oid != e.oid || he.mode != e.mode {
+                    dirty_paths.insert(rel);
+                }
+            }
+            None => {
+                dirty_paths.insert(rel);
+            }
+        }
+    }
+    for path in head_entries.keys() {
+        if !index
+            .entries
+            .iter()
+            .any(|e| e.stage() == 0 && e.path == *path)
+        {
+            dirty_paths.insert(String::from_utf8_lossy(path).to_string());
+        }
+    }
+    Ok(dirty_paths)
+}
+
+/// Paths that differ between `parent_tree` and `head_tree` or between `parent_tree` and `theirs_tree`.
+///
+/// Used to detect whether local changes overlap a cherry-pick / revert three-way merge.
+pub(crate) fn merge_touched_paths(
+    repo: &Repository,
+    parent_tree: ObjectId,
+    head_tree: ObjectId,
+    theirs_tree: ObjectId,
+) -> Result<BTreeSet<String>> {
+    let mut paths = BTreeSet::new();
+    for e in diff_trees(&repo.odb, Some(&parent_tree), Some(&head_tree), "")? {
+        paths.insert(e.path().to_string());
+    }
+    for e in diff_trees(&repo.odb, Some(&parent_tree), Some(&theirs_tree), "")? {
+        paths.insert(e.path().to_string());
+    }
+    Ok(paths)
 }
 
 /// Fast-forward index: the merge target tree plus **unrelated** staged additions (paths not in
@@ -6984,8 +7037,8 @@ fn parse_date_to_git_ts(date_str: &str) -> Option<String> {
     None
 }
 
-/// Apply cleanup mode to a commit message.
-fn cleanup_message(msg: &str, mode: &str) -> String {
+/// Apply cleanup mode to a commit message (matches Git `cleanup_mode` for MERGE_MSG templates).
+pub(crate) fn cleanup_message(msg: &str, mode: &str) -> String {
     match mode {
         "verbatim" => {
             // Keep message exactly as-is

--- a/grit/src/commands/reset.rs
+++ b/grit/src/commands/reset.rs
@@ -712,6 +712,10 @@ fn reset_commit(
         if !extra.skip_sequencer_head_cleanup {
             let _ = std::fs::remove_file(repo.git_dir.join("CHERRY_PICK_HEAD"));
             let _ = std::fs::remove_file(repo.git_dir.join("REVERT_HEAD"));
+            let seq = repo.git_dir.join("sequencer");
+            if seq.is_dir() {
+                let _ = std::fs::remove_dir_all(&seq);
+            }
         }
     }
 

--- a/grit/src/commands/rev_parse.rs
+++ b/grit/src/commands/rev_parse.rs
@@ -395,9 +395,22 @@ pub fn run(args: Args) -> Result<()> {
             }
             return Ok(());
         }
-        let oid = match resolve_revision(current, spec) {
-            Ok(oid) => oid,
-            Err(e) => return fail_verify_resolve(quiet, &e, Some(current)),
+        let oid = if matches!(spec, "REVERT_HEAD" | "CHERRY_PICK_HEAD") {
+            let path = current.git_dir.join(spec);
+            let raw = match std::fs::read_to_string(&path) {
+                Ok(s) => s,
+                Err(_) => return fail_verify(quiet, false),
+            };
+            let line = raw.lines().next().unwrap_or("").trim();
+            match line.parse::<grit_lib::objects::ObjectId>() {
+                Ok(o) => o,
+                Err(_) => return fail_verify(quiet, false),
+            }
+        } else {
+            match resolve_revision(current, spec) {
+                Ok(oid) => oid,
+                Err(e) => return fail_verify_resolve(quiet, &e, Some(current)),
+            }
         };
         if let Some(mut len) = short_len {
             if len == 0 {

--- a/grit/src/commands/revert.rs
+++ b/grit/src/commands/revert.rs
@@ -22,7 +22,7 @@ use tempfile::NamedTempFile;
 
 use grit_lib::config::ConfigSet;
 use grit_lib::index::{Index, IndexEntry, MODE_EXECUTABLE, MODE_SYMLINK};
-use grit_lib::merge_file::MergeFavor;
+use grit_lib::merge_file::{ConflictStyle, MergeFavor};
 use grit_lib::merge_trees::{
     index_tree_oid_matches_head, merge_trees_three_way, WhitespaceMergeOptions,
 };
@@ -35,9 +35,11 @@ use grit_lib::rev_parse::resolve_revision;
 use grit_lib::state::{resolve_head, HeadState};
 use grit_lib::write_tree::write_tree_from_index;
 
+use super::merge::cleanup_message;
 use super::sequencer::{
-    rollback_is_safe, sequencer_is_pick_sequence, sequencer_is_revert_sequence,
-    strip_first_sequencer_todo_line, write_abort_safety_file,
+    append_merge_msg_conflict_footer, rollback_is_safe, sequencer_is_pick_sequence,
+    sequencer_is_revert_sequence, strip_first_sequencer_todo_line, unmerged_paths,
+    write_abort_safety_file,
 };
 
 /// Arguments for `grit revert`.
@@ -99,6 +101,10 @@ pub struct Args {
     /// Disable reference-format commit lines even if `revert.reference` is set.
     #[arg(long = "no-reference", conflicts_with = "reference")]
     pub no_reference: bool,
+
+    /// Message cleanup mode for conflict `MERGE_MSG` (matches `git revert --cleanup`).
+    #[arg(long = "cleanup", value_name = "MODE", hide = true)]
+    pub cleanup: Option<String>,
 }
 
 /// Run the `revert` command.
@@ -248,6 +254,9 @@ fn write_revert_sequencer_opts(git_dir: &Path, args: &Args) -> Result<()> {
     if args.no_reference {
         opts.push_str("\treference = false\n");
     }
+    if let Some(ref c) = args.cleanup {
+        opts.push_str(&format!("\tcleanup = {c}\n"));
+    }
     fs::write(seq_dir.join("opts"), &opts)?;
     Ok(())
 }
@@ -294,6 +303,7 @@ fn merge_revert_sequencer_opts(git_dir: &Path, args: &mut Args) {
                     args.no_reference = true;
                     args.reference = false;
                 }
+                "cleanup" => args.cleanup = Some(val.to_string()),
                 _ => {}
             }
         }
@@ -679,6 +689,8 @@ fn resolve_revert_editor(git_dir: &Path) -> String {
     }
     if std::env::var("VISUAL").is_ok() || std::env::var("EDITOR").is_ok() {
         "true".to_owned()
+    } else if !stdin().is_terminal() {
+        "true".to_owned()
     } else {
         "vi".to_owned()
     }
@@ -797,9 +809,21 @@ fn revert_one_commit(repo: &Repository, spec: &str, args: &Args) -> Result<()> {
         error_dirty_index_revert(repo, head_oid)?;
     }
 
+    let config = ConfigSet::load(Some(git_dir), true)?;
+
     let use_reference = should_use_reference_format(git_dir, args)?;
     let comment_char = comment_char_for_revert(git_dir);
     let (favor, ws_opts) = parse_strategy_options_revert(&args.strategy_option);
+    let short_oid = &commit_oid.to_hex()[..7];
+    let subject = commit.message.lines().next().unwrap_or("");
+    let label_theirs = format!("parent of {short_oid} ({subject})");
+    let label_base = format!("{short_oid} ({subject})");
+
+    let conflict_style = match config.get("merge.conflictstyle").as_deref() {
+        Some("diff3") | Some("zdiff3") => ConflictStyle::Diff3,
+        _ => ConflictStyle::Merge,
+    };
+
     let merged = merge_trees_three_way(
         repo,
         commit_tree_oid,
@@ -807,7 +831,9 @@ fn revert_one_commit(repo: &Repository, spec: &str, args: &Args) -> Result<()> {
         parent_tree_oid,
         favor,
         ws_opts,
-        "parent of reverted commit",
+        label_base.as_str(),
+        label_theirs.as_str(),
+        conflict_style,
     )?;
     let mut merged_index = merged.index;
     let conflict_map = merged.conflict_content;
@@ -837,9 +863,6 @@ fn revert_one_commit(repo: &Repository, spec: &str, args: &Args) -> Result<()> {
 
     let (title_line, body_suffix) =
         merge_commit_message_for_revert(&commit, commit_oid, use_reference, comment_char);
-    let short_oid = &commit_oid.to_hex()[..7];
-    let subject = commit.message.lines().next().unwrap_or("");
-
     let template_msg = if use_reference {
         format!("{title_line}\n\n{body_suffix}")
     } else {
@@ -847,19 +870,29 @@ fn revert_one_commit(repo: &Repository, spec: &str, args: &Args) -> Result<()> {
     };
 
     if has_conflicts {
-        let msg = template_msg.clone();
         fs::write(
             git_dir.join("REVERT_HEAD"),
             format!("{}\n", commit_oid.to_hex()),
         )?;
-        fs::write(
-            git_dir.join("CHERRY_PICK_HEAD"),
-            format!("{}\n", commit_oid.to_hex()),
-        )?;
-        fs::write(git_dir.join("MERGE_MSG"), &msg)?;
+
+        let commit_cleanup = config.get("commit.cleanup");
+        let cleanup_mode = args
+            .cleanup
+            .as_deref()
+            .or(commit_cleanup.as_deref())
+            .unwrap_or("default");
+        let scissors_body = cleanup_message(&template_msg, cleanup_mode);
+        let mut merge_msg = scissors_body;
+        if cleanup_mode.eq_ignore_ascii_case("scissors") {
+            let paths = unmerged_paths(&merged_index);
+            append_merge_msg_conflict_footer(&mut merge_msg, &paths);
+        }
+        fs::write(git_dir.join("MERGE_MSG"), &merge_msg)?;
 
         eprintln!("error: could not revert {short_oid}... {subject}");
-        if merge_conflict_advice_enabled(git_dir) {
+        if let Ok(help) = std::env::var("GIT_REVERT_HELP") {
+            eprintln!("hint: {help}");
+        } else if merge_conflict_advice_enabled(git_dir) {
             eprintln!("hint: After resolving the conflicts, mark them with");
             eprintln!("hint: \"git add/rm <pathspec>\", then run");
             eprintln!("hint: \"git revert --continue\".");
@@ -942,6 +975,7 @@ pub(crate) fn do_continue() -> Result<()> {
         edit: false,
         reference: false,
         no_reference: false,
+        cleanup: None,
     };
     merge_revert_sequencer_opts(git_dir, &mut opts);
 
@@ -1029,6 +1063,49 @@ pub(crate) fn do_continue() -> Result<()> {
         cleanup_revert_sequencer_only(git_dir);
     }
 
+    Ok(())
+}
+
+/// After a manual `git commit` finished the current revert, resume remaining `sequencer/todo` reverts.
+pub(crate) fn try_resume_revert_sequence_after_commit(repo: &Repository) -> Result<()> {
+    let git_dir = &repo.git_dir;
+    if !git_dir.join("sequencer").join("todo").exists() {
+        return Ok(());
+    }
+    if !sequencer_is_revert_sequence(git_dir) {
+        return Ok(());
+    }
+    if git_dir.join("REVERT_HEAD").exists() {
+        return Ok(());
+    }
+
+    let mut opts = Args {
+        commits: vec![],
+        no_commit: false,
+        signoff: false,
+        mainline: None,
+        r#continue: true,
+        abort: false,
+        skip: false,
+        quit: false,
+        strategy: None,
+        strategy_option: vec![],
+        no_edit: false,
+        edit: false,
+        reference: false,
+        no_reference: false,
+        cleanup: None,
+    };
+    merge_revert_sequencer_opts(git_dir, &mut opts);
+    validate_revert_sequencer_todo(repo, git_dir)?;
+
+    let remaining = load_revert_sequencer_todo(repo, git_dir);
+    if !remaining.is_empty() {
+        let specs: Vec<String> = remaining.iter().map(|o| o.to_hex()).collect();
+        run_revert_sequence(repo, &specs, &opts, None)?;
+    } else {
+        cleanup_revert_sequencer_only(git_dir);
+    }
     Ok(())
 }
 

--- a/grit/src/commands/sequencer.rs
+++ b/grit/src/commands/sequencer.rs
@@ -1,8 +1,11 @@
 //! Shared helpers for Git-compatible cherry-pick / revert sequencer state under
 //! `.git/sequencer/`.
 
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::Path;
+
+use grit_lib::index::Index;
 
 use grit_lib::objects::ObjectId;
 use grit_lib::state::resolve_head;
@@ -88,10 +91,40 @@ pub fn rollback_is_safe(git_dir: &Path) -> bool {
     actual == expected
 }
 
+/// Append Git's scissors + `# Conflicts:` trailer to `MERGE_MSG` during sequencer conflicts.
+pub(crate) fn append_merge_msg_conflict_footer(msg: &mut String, conflicted_paths: &[Vec<u8>]) {
+    msg.push('\n');
+    msg.push_str("# ------------------------ >8 ------------------------\n");
+    msg.push_str("# Do not modify or remove the line above.\n");
+    msg.push_str("# Everything below it will be ignored.\n");
+    msg.push_str("#\n");
+    msg.push_str("# Conflicts:\n");
+    for p in conflicted_paths {
+        msg.push_str("#\t");
+        msg.push_str(&String::from_utf8_lossy(p));
+        msg.push('\n');
+    }
+}
+
+/// Collect paths with unmerged index entries (sorted, unique).
+pub(crate) fn unmerged_paths(index: &Index) -> Vec<Vec<u8>> {
+    let mut paths: BTreeSet<Vec<u8>> = BTreeSet::new();
+    for e in &index.entries {
+        if e.stage() != 0 {
+            paths.insert(e.path.clone());
+        }
+    }
+    paths.into_iter().collect()
+}
+
 /// Remove the first non-empty, non-comment line from `sequencer/todo`.
 pub fn strip_first_sequencer_todo_line(git_dir: &Path) -> std::io::Result<()> {
     let path = git_dir.join("sequencer").join("todo");
-    let content = fs::read_to_string(&path)?;
+    let content = match fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e),
+    };
     let mut removed = false;
     let mut out = Vec::new();
     for line in content.lines() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves `cherry-pick` / `revert` conflict behavior to align with upstream Git semantics exercised by `t3507-cherry-pick-conflict.sh`.

## Changes

- **merge_trees**: `label_theirs` and `merge.conflictstyle` (merge vs diff3) for conflict markers.
- **cherry-pick / revert**: Dirty worktree checks before merge; `MERGE_MSG` cleanup; `GIT_CHERRY_PICK_HELP` / `GIT_REVERT_HELP` early exit without pseudo-refs where appropriate; sequencer opts including cleanup mode.
- **sequencer**: Shared conflict footer helpers; safer todo stripping; resume multi-step sequences after a manual commit.
- **commit**: Guards for partial commits and `--amend` during cherry-pick/revert; sign-off placement with conflict/scissors templates; `MessageResult.from_merge_msg` wired through all paths.
- **reset**: Remove `.git/sequencer` on non-soft reset when clearing merge state.
- **rev-parse**: `--verify` for `CHERRY_PICK_HEAD` / `REVERT_HEAD` reads the file directly.

## Validation

- `cargo fmt`, `cargo check -p grit-rs`, `cargo clippy -p grit-rs -D warnings`
- `cargo test -p grit-lib --lib`

Note: `t3507-cherry-pick-conflict.sh` may still have remaining failures; this commit captures the current implementation progress.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-57f87d07-0a3b-4064-82b6-1ac3e7ba0b1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57f87d07-0a3b-4064-82b6-1ac3e7ba0b1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

