### PR TITLE
fix: make t2002-checkout-cache-u pass (diff-files smudged stat)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -461,7 +461,7 @@ t1800-ls-remote	t1	yes	24	22	2	false	ok	0
 t1900-repo-info	t1	yes	37	37	0	true	ok	0
 t1901-repo-structure	t1	yes	4	4	0	true	ok	0
 t2000-conflict-when-checking-files-out	t2	yes	14	13	1	false	ok	0
-t2002-checkout-cache-u	t2	yes	3	2	1	false	ok	0
+t2002-checkout-cache-u	t2	yes	3	3	0	true	ok	0
 t2003-checkout-cache-mkdir	t2	yes	10	10	0	true	ok	0
 t2004-checkout-cache-temp	t2	yes	23	23	0	true	ok	0
 t2005-checkout-index-symlinks	t2	yes	3	3	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.2% of harness tests passing (35,289 / 45,112).">
+<meta property="og:description" content="78.2% of harness tests passing (35,290 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.2% of harness tests passing (35,289 / 45,112).">
+<meta name="twitter:description" content="78.2% of harness tests passing (35,290 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T15:06:57+00:00" class="gen-time" title="2026-04-09 15:06 UTC">2026-04-09 15:06 UTC</time> · <a href="https://github.com/schacon/grit/commit/c4ad2e9f44715e944bf5d633e8117c550d9c487c" style="color:#58a6ff">c4ad2e9</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T15:27:58+00:00" class="gen-time" title="2026-04-09 15:27 UTC">2026-04-09 15:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/d453c985a004bbafaab0d0367914b362de89e59b" style="color:#58a6ff">d453c98</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,289</div>
+      <div class="summary-big-val">35,290</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>733 files fully passing</span>
+    <span>734 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -208,11 +208,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t2</span>
         <span class="group-desc">Basic commands concerning the working tree</span>
-        <span class="group-meta">29/61 files · 9 skipped · 664/872 tests</span>
+        <span class="group-meta">30/61 files · 9 skipped · 665/872 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:76.1%"></div></div>
-        <span class="group-pct pct-blue">76.1%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:76.3%"></div></div>
+        <span class="group-pct pct-blue">76.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t3">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35289 of 45112 tests passing across 1405 harness files (78.2% pass rate).</desc>
+  <desc id="svg-desc">35290 of 45112 tests passing across 1405 harness files (78.2% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.2% pass rate · 35,289 / 45,112 tests · 1,405 files in scope · 733 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.2% pass rate · 35,290 / 45,112 tests · 1,405 files in scope · 734 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="547" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T15:06:57+00:00" class="gen-time" title="2026-04-09 15:06 UTC">2026-04-09 15:06 UTC</time> · <a href="https://github.com/schacon/grit/commit/c4ad2e9f44715e944bf5d633e8117c550d9c487c" style="color:#58a6ff">c4ad2e9</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T15:27:58+00:00" class="gen-time" title="2026-04-09 15:27 UTC">2026-04-09 15:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/d453c985a004bbafaab0d0367914b362de89e59b" style="color:#58a6ff">d453c98</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,289</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,290</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -4767,14 +4767,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:92.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t2" data-tests="3" data-passed="2">
+<tr class="" data-group="t2" data-tests="3" data-passed="3" data-full-pass="1">
   <td class="mono">t2002-checkout-cache-u</td>
   <td>t2</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">3</td>
-  <td class="right">2</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:66.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t2" data-tests="10" data-passed="10" data-full-pass="1">

--- a/grit/src/commands/diff_files.rs
+++ b/grit/src/commands/diff_files.rs
@@ -577,6 +577,21 @@ fn parse_options(argv: &[String]) -> Result<Options> {
 
 // ── Core diff logic ──────────────────────────────────────────────────
 
+/// True when the index entry has real cached stat data from the filesystem.
+///
+/// After `read-tree` or `update-index --cacheinfo`, Git leaves ctime/mtime/dev/ino/size at
+/// zero until refresh; `diff-files` must not treat "blob on disk matches index OID" as clean
+/// in that state (see Git `ce_match_stat_basic` / `run_diff_files`).
+fn index_stat_is_trusted(entry: &IndexEntry) -> bool {
+    entry.size != 0
+        || entry.mtime_sec != 0
+        || entry.mtime_nsec != 0
+        || entry.ctime_sec != 0
+        || entry.ctime_nsec != 0
+        || entry.dev != 0
+        || entry.ino != 0
+}
+
 /// Build the list of changes between the index and the working tree.
 fn collect_changes(
     repo: &Repository,
@@ -625,9 +640,17 @@ fn collect_changes(
                 WorktreeStatus::Unchanged => { /* skip — stat says identical */ }
                 WorktreeStatus::Modified(wt_mode, wt_oid) => {
                     let idx_canonical = canonicalize_mode(*idx_mode);
-                    // Content and mode match the index: treat as clean even if the index entry
-                    // was created without racily-clean stat data (e.g. `git apply --index`,
-                    // `git am`). Smudged stat metadata alone must not imply a diff-files hit.
+                    // Content and mode match the index: treat as clean only when the index
+                    // already carries real stat data. After `read-tree` or `update-index
+                    // --cacheinfo`, Git leaves stat fields zeroed; `diff-files` must still
+                    // report dirty until `checkout-index -u` or `update-index --refresh`
+                    // (matches `ce_match_stat_basic` + `ie_modified` in Git). The OID/mode
+                    // shortcut is for smudged entries from `apply`/`am` where stat is wrong
+                    // but was recorded from the filesystem at least once.
+                    let content_matches_index = wt_oid == *idx_oid && wt_mode == idx_canonical;
+                    if content_matches_index && index_stat_is_trusted(idx_entry) {
+                        continue;
+                    }
                     if wt_oid != *idx_oid || wt_mode != idx_canonical {
                         // Detect type changes (e.g., symlink ↔ regular, regular ↔ submodule)
                         let status = if mode_type(idx_canonical) != mode_type(wt_mode) {
@@ -640,6 +663,20 @@ fn collect_changes(
                             Change {
                                 path: path.clone(),
                                 status,
+                                old_mode: idx_canonical,
+                                new_mode: wt_mode,
+                                old_oid: *idx_oid,
+                                new_oid: wt_oid,
+                            },
+                        );
+                    } else {
+                        // Same blob and mode on disk as in the index, but index stat is
+                        // uninitialized (e.g. post-`read-tree` checkout without `-u`).
+                        changes.insert(
+                            path.clone(),
+                            Change {
+                                path: path.clone(),
+                                status: 'M',
                                 old_mode: idx_canonical,
                                 new_mode: wt_mode,
                                 old_oid: *idx_oid,

--- a/logs/2026-04-09_t2002-checkout-cache-u.md
+++ b/logs/2026-04-09_t2002-checkout-cache-u.md
@@ -1,0 +1,14 @@
+# t2002-checkout-cache-u
+
+## Problem
+
+Harness failed test 2: after `read-tree` + `checkout-index -f -a` (no `-u`), `diff-files` must exit non-zero because index stat cache is still "smudged" / uninitialized. Grit treated matching blob OID as clean regardless of index stat.
+
+## Fix
+
+In `diff_files::collect_changes`, only skip reporting when worktree content matches the index OID **and** the index entry has trusted stat data (`index_stat_is_trusted`: any of size, mtime, ctime, dev, or ino non-zero). Otherwise emit an `M` change when OID+mode match (Git `ce_match_stat_basic` behavior for zeroed stat after `read-tree`).
+
+## Validation
+
+- `bash tests/t2002-checkout-cache-u.sh` — all 3 pass
+- `cargo test -p grit-lib --lib` — pass


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t2002-checkout-cache-u` failed because `diff-files` treated the working tree as clean whenever the blob OID matched the index, even when the index stat cache was still uninitialized after `read-tree` (all-zero stat fields), which is the scenario `checkout-index` without `-u` is meant to leave "smudged."

## Changes

- **`grit/src/commands/diff_files.rs`**: Added `index_stat_is_trusted()` and only apply the OID/mode "clean" shortcut when the index entry has real cached stat data. If OID and mode match but stat is untrusted, report `M` so `diff-files --exit-code` fails until `checkout-index -u` or `update-index --refresh` refreshes stat info.
- **Harness**: `./scripts/run-tests.sh t2002-checkout-cache-u.sh` — `data/test-files.csv` and dashboards updated (3/3 pass).

## Validation

- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t2002-checkout-cache-u.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7a911d1-4e29-4964-aeb3-ff971611b1b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7a911d1-4e29-4964-aeb3-ff971611b1b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

