### PR TITLE
fix: make t7012-skip-worktree-writing pass (diff pathspecs, sparse cl…

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -805,7 +805,7 @@ commit → check it off → move on.
 - [ ] `t7815-grep-binary` █████████████████░░░ 19/22 (3 left) — git grep in binary files
 - [x] `t7417-submodule-path-url` — check handling of .gitmodule path with dash
 - [ ] `t7113-post-index-change-hook` █████░░░░░░░░░░░░░░░ 1/4 (3 left) — post index change hook
-- [ ] `t7012-skip-worktree-writing` ████████████░░░░░░░░ 7/11 (4 left) — test worktree writing operations when skip-worktree is used
+- [x] `t7012-skip-worktree-writing` — test worktree writing operations when skip-worktree is used (11/11)
 - [ ] `t7604-merge-custom-message` ██████████░░░░░░░░░░ 4/8 (4 left) — git merge
 
 - [ ] `t7106-reset-unborn-branch` ████████░░░░░░░░░░░░ 3/7 (4 left) — git reset should work on unborn branch

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1156,7 +1156,7 @@ t7008-filter-branch-null-sha1	t7	yes	6	5	1	false	ok	0
 t7008-show-stat-raw-name	t7	yes	21	21	0	true	ok	0
 t7010-setup	t7	yes	16	11	5	false	ok	0
 t7011-skip-worktree-reading	t7	yes	15	12	3	false	ok	0
-t7012-skip-worktree-writing	t7	yes	11	10	1	false	ok	6
+t7012-skip-worktree-writing	t7	yes	11	11	0	true	ok	6
 t7020-commit-encoding	t7	yes	26	26	0	true	ok	0
 t7030-verify-tag	t7	skip	16	0	0	false	ok	0
 t7031-verify-tag-signed-ssh	t7	skip	14	0	0	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.2% of harness tests passing (35,289 / 45,112).">
+<meta property="og:description" content="78.2% of harness tests passing (35,290 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.2% of harness tests passing (35,289 / 45,112).">
+<meta name="twitter:description" content="78.2% of harness tests passing (35,290 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T15:06:57+00:00" class="gen-time" title="2026-04-09 15:06 UTC">2026-04-09 15:06 UTC</time> · <a href="https://github.com/schacon/grit/commit/c4ad2e9f44715e944bf5d633e8117c550d9c487c" style="color:#58a6ff">c4ad2e9</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T15:48:15+00:00" class="gen-time" title="2026-04-09 15:48 UTC">2026-04-09 15:48 UTC</time> · <a href="https://github.com/schacon/grit/commit/d453c985a004bbafaab0d0367914b362de89e59b" style="color:#58a6ff">d453c98</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,289</div>
+      <div class="summary-big-val">35,290</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>733 files fully passing</span>
+    <span>734 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -263,7 +263,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">45/126 files · 11 skipped · 2,472/3,614 tests</span>
+        <span class="group-meta">46/126 files · 11 skipped · 2,473/3,614 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.4%"></div></div>

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35289 of 45112 tests passing across 1405 harness files (78.2% pass rate).</desc>
+  <desc id="svg-desc">35290 of 45112 tests passing across 1405 harness files (78.2% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.2% pass rate · 35,289 / 45,112 tests · 1,405 files in scope · 733 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.2% pass rate · 35,290 / 45,112 tests · 1,405 files in scope · 734 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="547" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T15:06:57+00:00" class="gen-time" title="2026-04-09 15:06 UTC">2026-04-09 15:06 UTC</time> · <a href="https://github.com/schacon/grit/commit/c4ad2e9f44715e944bf5d633e8117c550d9c487c" style="color:#58a6ff">c4ad2e9</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T15:48:15+00:00" class="gen-time" title="2026-04-09 15:48 UTC">2026-04-09 15:48 UTC</time> · <a href="https://github.com/schacon/grit/commit/d453c985a004bbafaab0d0367914b362de89e59b" style="color:#58a6ff">d453c98</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,289</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,290</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -11717,14 +11717,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:80.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="11" data-passed="10">
+<tr class="" data-group="t7" data-tests="11" data-passed="11" data-full-pass="1">
   <td class="mono">t7012-skip-worktree-writing</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">11</td>
-  <td class="right">10</td>
+  <td class="right">11</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">6</td>
 </tr>
 <tr class="" data-group="t7" data-tests="26" data-passed="26" data-full-pass="1">

--- a/grit-lib/src/diff.rs
+++ b/grit-lib/src/diff.rs
@@ -584,19 +584,15 @@ pub fn diff_index_to_worktree(
             }
             continue;
         }
-        if ie.skip_worktree() {
-            // Sparse checkout: paths outside the cone are not expected to exist on disk.
-            // Git's status omits them from the index↔worktree diff (wt-status.c).
+        // Sparse checkout: paths outside the cone are not expected on disk; `assume_unchanged`
+        // is treated as clean without reading the filesystem (wt-status.c).
+        if ie.skip_worktree() || ie.assume_unchanged() {
             continue;
         }
         // Use str slice directly to avoid allocation for path joining;
         // only allocate String if we need it for DiffEntry output.
         let path_str_ref = std::str::from_utf8(&ie.path).unwrap_or("");
         let is_intent_to_add = ie.intent_to_add();
-
-        if ie.assume_unchanged() || ie.skip_worktree() {
-            continue;
-        }
 
         // Gitlink entries (submodules): compare checked-out HEAD to the recorded commit.
         // An uninitialized path (no `.git` in the directory) is not dirty — same as Git.
@@ -1052,6 +1048,15 @@ pub fn diff_tree_to_worktree(
     let mut result = Vec::new();
 
     for path in &all_paths {
+        if index_entries
+            .get(path.as_bytes())
+            .is_some_and(|ie| ie.skip_worktree())
+        {
+            // Sparse checkout: `git diff <rev>` does not report tree↔worktree drift for
+            // skip-worktree paths (they are outside the sparse cone). Matches t7012 stash flow.
+            continue;
+        }
+
         let tree_entry = tree_map.get(path.as_str());
 
         // Gitlink entries (submodules) — compare HEAD commit, not file content.

--- a/grit/src/commands/diff.rs
+++ b/grit/src/commands/diff.rs
@@ -1022,7 +1022,7 @@ pub fn run(mut args: Args) -> Result<()> {
 
     let raw_args: Vec<String> = std::env::args().collect();
     let has_separator = raw_args.iter().any(|a| a == "--");
-    let (mut revs, paths) = parse_rev_and_paths(&args.args, has_separator);
+    let (mut revs, raw_path_args) = parse_rev_and_paths(&args.args, has_separator);
     // Options parsed by clap can remain in the `revs` bucket when `--` separates paths
     // (`git diff -D -- path`). Drop duplicates so they are not treated as revision names.
     if args.irreversible_delete {
@@ -1033,7 +1033,11 @@ pub fn run(mut args: Args) -> Result<()> {
     }
 
     // Outside any repository, `git diff <path> <path>` behaves like `diff --no-index` (t4035).
-    if Repository::discover(None).is_err() && revs.is_empty() && paths.len() == 2 && !args.cached {
+    if Repository::discover(None).is_err()
+        && revs.is_empty()
+        && raw_path_args.len() == 2
+        && !args.cached
+    {
         return run_no_index(args);
     }
 
@@ -1108,13 +1112,13 @@ pub fn run(mut args: Args) -> Result<()> {
             p.pop(); // trailing '/'
             p
         });
-    let paths: Vec<String> = paths
-        .into_iter()
+    let paths: Vec<String> = raw_path_args
+        .iter()
         .map(|p| {
             if let Some(wt) = repo.work_tree.as_ref() {
-                resolve_pathspec(&p, wt, pathspec_prefix.as_deref())
+                resolve_pathspec(p, wt, pathspec_prefix.as_deref())
             } else {
-                p
+                p.clone()
             }
         })
         .collect();
@@ -1515,7 +1519,7 @@ pub fn run(mut args: Args) -> Result<()> {
     };
 
     // Filter by pathspecs
-    let entries = filter_by_paths(entries, &paths);
+    let entries = filter_by_paths(entries, &raw_path_args);
 
     // Build whitespace mode from flags
     let ws_mode = WhitespaceMode {
@@ -3443,6 +3447,10 @@ fn parse_rev_and_paths(args: &[String], has_separator: bool) -> (Vec<String>, Ve
         for arg in args {
             if in_paths {
                 paths.push(arg.clone());
+            } else if arg.starts_with(":!") || arg.starts_with(":^") {
+                // Git pathspec exclusion (`:!` / `:^`); never a revision (t7012, `git diff HEAD :!path`).
+                in_paths = true;
+                paths.push(arg.clone());
             } else if std::fs::symlink_metadata(std::path::Path::new(arg)).is_ok() {
                 in_paths = true;
                 paths.push(arg.clone());
@@ -3534,17 +3542,39 @@ fn commit_or_tree_oid(repo: &Repository, spec: &str) -> Result<ObjectId> {
 
 /// Filter diff entries to only those matching the given pathspecs.
 /// Empty pathspecs means include everything.
+///
+/// Supports Git exclude pathspecs (`:!` / `:^`): when only exclusions are given, the
+/// include set defaults to `.` (all paths), then exclusions are removed (same as `git rm`).
 fn filter_by_paths(entries: Vec<DiffEntry>, paths: &[String]) -> Vec<DiffEntry> {
     if paths.is_empty() {
         return entries;
+    }
+    let mut include_specs: Vec<&str> = Vec::new();
+    let mut exclude_inners: Vec<&str> = Vec::new();
+    for spec in paths {
+        if let Some(inner) = spec.strip_prefix(":!").or_else(|| spec.strip_prefix(":^")) {
+            exclude_inners.push(inner);
+        } else {
+            include_specs.push(spec.as_str());
+        }
+    }
+    if include_specs.is_empty() && !exclude_inners.is_empty() {
+        include_specs.push(".");
     }
     entries
         .into_iter()
         .filter(|e| {
             let path = e.path();
-            paths
+            let included = include_specs.iter().any(|spec| {
+                if spec == &"." || spec.is_empty() {
+                    return true;
+                }
+                crate::pathspec::pathspec_matches(spec, path)
+            });
+            let excluded = exclude_inners
                 .iter()
-                .any(|spec| crate::pathspec::pathspec_matches(spec, path))
+                .any(|inner| crate::pathspec::pathspec_matches(inner, path));
+            included && !excluded
         })
         .collect()
 }

--- a/grit/src/commands/sparse_checkout.rs
+++ b/grit/src/commands/sparse_checkout.rs
@@ -19,6 +19,7 @@ use grit_lib::sparse_checkout::{
     ConeWorkspace, NonConePatterns,
 };
 use grit_lib::state::resolve_head;
+use std::collections::HashSet;
 use std::fs;
 use std::io::{self, BufRead, Write};
 use std::path::{Path, PathBuf};
@@ -1190,6 +1191,96 @@ fn apply_sparse_patterns(repo: &Repository, patterns: &[String], cone_mode: bool
 
     repo.write_index_at(&index_path, &mut index)
         .context("writing index")?;
+
+    // Remove untracked paths outside the sparse cone (Git `sparse_checkout_set` / t7012).
+    let indexed_paths: HashSet<String> = index
+        .entries
+        .iter()
+        .map(|e| String::from_utf8_lossy(&e.path).into_owned())
+        .collect();
+    remove_untracked_outside_sparse(
+        work_tree,
+        work_tree,
+        &indexed_paths,
+        patterns,
+        effective_cone,
+        cone_struct.as_ref(),
+        &non_cone,
+    )?;
+
+    Ok(())
+}
+
+fn remove_untracked_outside_sparse(
+    work_tree: &Path,
+    current: &Path,
+    indexed_paths: &HashSet<String>,
+    patterns: &[String],
+    effective_cone: bool,
+    cone_struct: Option<&ConePatterns>,
+    non_cone: &NonConePatterns,
+) -> Result<()> {
+    let Ok(read_dir) = fs::read_dir(current) else {
+        return Ok(());
+    };
+    for ent in read_dir {
+        let ent = ent.context("reading work tree directory")?;
+        let path = ent.path();
+        let rel = path
+            .strip_prefix(work_tree)
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        if rel == ".git" || rel.starts_with(".git/") {
+            continue;
+        }
+        let meta = fs::symlink_metadata(&path).context("stat work tree path")?;
+        if meta.is_dir() {
+            remove_untracked_outside_sparse(
+                work_tree,
+                &path,
+                indexed_paths,
+                patterns,
+                effective_cone,
+                cone_struct,
+                non_cone,
+            )?;
+            if fs::read_dir(&path)
+                .map(|mut d| d.next().is_none())
+                .unwrap_or(false)
+            {
+                let included = if effective_cone {
+                    path_in_sparse_checkout(&rel, true, cone_struct, non_cone)
+                } else {
+                    path_in_sparse_checkout_lines(&rel, patterns)
+                };
+                if !included && !indexed_paths.contains(&rel) {
+                    let _ = fs::remove_dir(&path);
+                    if let Some(parent) = path.parent() {
+                        remove_empty_dirs_up_to(parent, work_tree);
+                    }
+                }
+            }
+            continue;
+        }
+        if !meta.is_file() && !meta.file_type().is_symlink() {
+            continue;
+        }
+        if indexed_paths.contains(&rel) {
+            continue;
+        }
+        let included = if effective_cone {
+            path_in_sparse_checkout(&rel, true, cone_struct, non_cone)
+        } else {
+            path_in_sparse_checkout_lines(&rel, patterns)
+        };
+        if !included {
+            let _ = fs::remove_file(&path);
+            if let Some(parent) = path.parent() {
+                remove_empty_dirs_up_to(parent, work_tree);
+            }
+        }
+    }
     Ok(())
 }
 

--- a/logs/2026-04-09_t7012-skip-worktree-writing.md
+++ b/logs/2026-04-09_t7012-skip-worktree-writing.md
@@ -1,0 +1,20 @@
+# t7012-skip-worktree-writing
+
+## Failures addressed
+
+1. **Test 11 (stash + sparse + `git diff --quiet HEAD ":!modified"`)**
+   - `parse_rev_and_paths` treated `:!modified` as a second revision → wrong diff mode and bogus errors.
+   - `filter_by_paths` did not implement exclude pathspecs (`:!` / `:^`).
+   - `diff_tree_to_worktree` still diffed `skip-worktree` paths vs tree (Git omits them for `git diff <rev>`).
+   - After `stash push`, `addme` stayed as untracked on disk; `sparse-checkout set` must remove untracked paths outside the cone (Git behavior; `test_path_is_missing addme`).
+
+## Changes
+
+- `grit/src/commands/diff.rs`: path-aware rev/path split for `:!` / `:^`; filter with default include `.` when only exclusions; pass raw pathspecs into filter (resolved paths only for blob/two-path modes).
+- `grit-lib/src/diff.rs`: skip `skip-worktree` in `diff_tree_to_worktree`; dedupe `diff_index_to_worktree` skip/assume-unchanged handling.
+- `grit/src/commands/sparse_checkout.rs`: after writing index, walk worktree and delete untracked files/dirs not in sparse patterns (skip `.git`).
+
+## Verification
+
+- `cargo fmt`, `cargo clippy --fix --allow-dirty`, `cargo test -p grit-lib --lib`
+- `./scripts/run-tests.sh t7012-skip-worktree-writing.sh` → 11/11

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   308 |
+| Completed   |   309 |
 | In progress |     5 |
-| Remaining   |   456 |
+| Remaining   |   455 |
 | **Total**   |   769 |
 
-Task lines in `PLAN.md`: 308 completed (`[x]`), 5 in progress (`[~]`), 456 remaining (`[ ]`).
+Task lines in `PLAN.md`: 309 completed (`[x]`), 5 in progress (`[~]`), 455 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t7012-skip-worktree-writing` — 11/11 tests pass (`diff` `:!` / `:^` exclude pathspecs; `diff_tree_to_worktree` skips `skip-worktree` paths; `sparse-checkout set` removes untracked files outside the cone)
 - `t5620-backfill` — 10/10 tests pass (expanded-cone path matching: top-level dirs excluded unless in cone; `sparse-checkout` hydrates before apply + empty-index rebuild from HEAD; promisor lazy-fetch reads local ODB first; checkout skips `skip_worktree` paths)
 - `t4128-apply-root` — 12/12 tests pass (`apply --directory`: Git `normalize_path_copy` + trailing `/`; paths already stripped at parse time — do not strip again in `adjust_path`)
 - `t5318-pack-objects-revs-exclude` — 9/9 tests pass (`pack-objects --revs` resolves branch names via `rev_parse::resolve_revision` so packed refs work after `pack-refs`; `^master` exclusion and `--stdin-packs`; harness CSV/dashboards refreshed)


### PR DESCRIPTION
…eanup)

Implement Git exclude pathspecs for diff, skip skip-worktree paths in tree-vs-worktree diffs, and remove untracked files outside the sparse cone after sparse-checkout set so stash+sparse flows match Git.