### PR TITLE
fix: symbolic-ref -q on direct refs exits silently

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -162,7 +162,7 @@ t1060-object-types	t1	yes	35	35	0	true	ok	0
 t10600-for-each-ref-exclude	t1	yes	35	35	0	true	ok	0
 t10610-show-ref-dereference-extra	t1	yes	40	40	0	true	ok	0
 t10620-update-ref-nul-stdin	t1	yes	30	30	0	true	ok	0
-t10630-symbolic-ref-chain-extra	t1	yes	35	34	1	false	ok	0
+t10630-symbolic-ref-chain-extra	t1	yes	35	35	0	true	ok	0
 t10640-check-ignore-negation	t1	yes	37	37	0	true	ok	0
 t10650-merge-file-zdiff3	t1	yes	32	32	0	true	ok	0
 t10660-hash-object-known-sha	t1	yes	33	33	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.3% of harness tests passing (35,304 / 45,112).">
+<meta property="og:description" content="78.3% of harness tests passing (35,305 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.3% of harness tests passing (35,304 / 45,112).">
+<meta name="twitter:description" content="78.3% of harness tests passing (35,305 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T15:27:31+00:00" class="gen-time" title="2026-04-09 15:27 UTC">2026-04-09 15:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/8954f0b086547ef9893afc7c773faf6131386c16" style="color:#58a6ff">8954f0b</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T16:25:23+00:00" class="gen-time" title="2026-04-09 16:25 UTC">2026-04-09 16:25 UTC</time> · <a href="https://github.com/schacon/grit/commit/4ac4d9c2fd66918bb5633180c65131719b9e71f4" style="color:#58a6ff">4ac4d9c</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,304</div>
+      <div class="summary-big-val">35,305</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>739 files fully passing</span>
+    <span>740 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -197,7 +197,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">271/368 files · 8 skipped · 11,684/12,747 tests</span>
+        <span class="group-meta">272/368 files · 8 skipped · 11,685/12,747 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-green" style="width:91.7%"></div></div>

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35304 of 45112 tests passing across 1405 harness files (78.3% pass rate).</desc>
+  <desc id="svg-desc">35305 of 45112 tests passing across 1405 harness files (78.3% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.3% pass rate · 35,304 / 45,112 tests · 1,405 files in scope · 739 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.3% pass rate · 35,305 / 45,112 tests · 1,405 files in scope · 740 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="548" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T15:27:31+00:00" class="gen-time" title="2026-04-09 15:27 UTC">2026-04-09 15:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/8954f0b086547ef9893afc7c773faf6131386c16" style="color:#58a6ff">8954f0b</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T16:25:23+00:00" class="gen-time" title="2026-04-09 16:25 UTC">2026-04-09 16:25 UTC</time> · <a href="https://github.com/schacon/grit/commit/4ac4d9c2fd66918bb5633180c65131719b9e71f4" style="color:#58a6ff">4ac4d9c</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,304</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,305</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.3%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -1777,14 +1777,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="35" data-passed="34">
+<tr class="" data-group="t1" data-tests="35" data-passed="35" data-full-pass="1">
   <td class="mono">t10630-symbolic-ref-chain-extra</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">35</td>
-  <td class="right">34</td>
+  <td class="right">35</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:97.1%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="37" data-passed="37" data-full-pass="1">

--- a/grit/src/commands/symbolic_ref.rs
+++ b/grit/src/commands/symbolic_ref.rs
@@ -132,11 +132,15 @@ fn read_symbolic_ref_target(git_dir: &Path, name: &str, recurse: bool) -> Result
     match result {
         Some(target) => Ok(Some(target)),
         None => {
-            // Missing ref file, or exists as symref whose target file is missing (dangling).
+            // Distinguish: direct ref (not symbolic) vs missing ref vs symref with missing target.
             let path = git_dir.join(name);
             match read_ref_file(&path) {
+                Ok(Ref::Direct(_)) => Ok(None),
                 Ok(Ref::Symbolic(target)) => Ok(Some(target)),
-                _ => bail!("No such ref: {name}"),
+                Err(grit_lib::error::Error::Io(err)) if err.kind() == io::ErrorKind::NotFound => {
+                    bail!("No such ref: {name}");
+                }
+                Err(err) => Err(err.into()),
             }
         }
     }

--- a/logs/2026-04-09-t10630-symbolic-ref-quiet.md
+++ b/logs/2026-04-09-t10630-symbolic-ref-quiet.md
@@ -1,0 +1,15 @@
+# t10630-symbolic-ref-chain-extra
+
+## Issue
+
+Test `symbolic-ref -q on non-symbolic ref fails quietly` failed: `grit symbolic-ref -q refs/heads/master` printed `fatal: No such ref: refs/heads/master` to stderr. Git exits 1 with no stderr in quiet mode.
+
+## Fix
+
+`read_symbolic_ref_target` treated `None` from `read_symbolic_ref_target_maybe_missing` as "need fallback" and always bailed with "No such ref" when the ref file was not `Ref::Symbolic`. For a **direct** ref (OID), `None` means "not a symbolic ref", so the command should return `Ok(None)` and let the caller exit quietly with `-q`.
+
+## Validation
+
+- `sh t10630-symbolic-ref-chain-extra.sh` from `tests/` with `GUST_BIN` → 35/35
+- `./scripts/run-tests.sh t10630-symbolic-ref-chain-extra.sh`
+- `cargo clippy -p grit-rs`, `cargo test -p grit-lib --lib`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`grit symbolic-ref -q` on a **direct** ref (e.g. `refs/heads/master` with an OID) incorrectly printed `fatal: No such ref: ...` to stderr. Git exits 1 with empty stderr in quiet mode.

## Root cause

`read_symbolic_ref_target` treated `None` from `read_symbolic_ref_target_maybe_missing` as “missing ref” and bailed unless the file was symbolic. For loose OID refs, `maybe_missing` correctly returns `None` meaning “not symbolic”; the outer function must propagate that as `Ok(None)` so the command can distinguish missing refs from non-symbolic refs.

## Changes

- **`grit/src/commands/symbolic_ref.rs`**: On `None`, re-read the ref file; `Ref::Direct` → `Ok(None)`; `Ref::Symbolic` → dangling symref target (still return target); `NotFound` → bail “No such ref”.

## Verification

- `t10630-symbolic-ref-chain-extra.sh`: **35/35**
- `cargo clippy -p grit-rs`, `cargo test -p grit-lib --lib`

Harness row for `t10630-symbolic-ref-chain-extra` and dashboards updated via `./scripts/run-tests.sh`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60077336-20a5-4d16-b132-7405a8b1756d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60077336-20a5-4d16-b132-7405a8b1756d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

