### PR TITLE
fix(rev-list): t6102 seen non-blob in blob tree slot

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1069,7 +1069,7 @@ t6050-replace	t6	skip	37	0	0	false	ok	0
 t6060-merge-index	t6	yes	7	7	0	true	ok	0
 t6100-rev-list-in-order	t6	yes	3	3	0	true	ok	0
 t6101-rev-parse-parents	t6	yes	38	25	13	false	ok	0
-t6102-rev-list-unexpected-objects	t6	yes	22	21	1	false	ok	0
+t6102-rev-list-unexpected-objects	t6	yes	22	22	0	true	ok	0
 t6110-rev-list-sparse	t6	yes	2	2	0	true	ok	0
 t6111-rev-list-treesame	t6	yes	65	22	43	false	ok	0
 t6112-rev-list-filters-objects	t6	yes	54	38	16	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.3% of harness tests passing (35,304 / 45,112).">
+<meta property="og:description" content="78.3% of harness tests passing (35,335 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.3% of harness tests passing (35,304 / 45,112).">
+<meta name="twitter:description" content="78.3% of harness tests passing (35,335 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T15:27:31+00:00" class="gen-time" title="2026-04-09 15:27 UTC">2026-04-09 15:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/8954f0b086547ef9893afc7c773faf6131386c16" style="color:#58a6ff">8954f0b</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T16:26:05+00:00" class="gen-time" title="2026-04-09 16:26 UTC">2026-04-09 16:26 UTC</time> · <a href="https://github.com/schacon/grit/commit/e458f9d6f68df170733e2888878be9a97a7868d6" style="color:#58a6ff">e458f9d</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,304</div>
+      <div class="summary-big-val">35,335</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>739 files fully passing</span>
+    <span>741 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -219,11 +219,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">53/141 files · 2 skipped · 3,924/5,369 tests</span>
+        <span class="group-meta">54/141 files · 2 skipped · 3,954/5,369 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:73.1%"></div></div>
-        <span class="group-pct pct-blue">73.1%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:73.6%"></div></div>
+        <span class="group-pct pct-blue">73.6%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">
@@ -252,7 +252,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t6</span>
         <span class="group-desc">Revision tree commands (e.g. merge-base)</span>
-        <span class="group-meta">46/105 files · 3 skipped · 1,829/2,822 tests</span>
+        <span class="group-meta">47/105 files · 3 skipped · 1,830/2,822 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.8%"></div></div>

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35304 of 45112 tests passing across 1405 harness files (78.3% pass rate).</desc>
+  <desc id="svg-desc">35335 of 45112 tests passing across 1405 harness files (78.3% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.3% pass rate · 35,304 / 45,112 tests · 1,405 files in scope · 739 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.3% pass rate · 35,335 / 45,112 tests · 1,405 files in scope · 741 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="548" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T15:27:31+00:00" class="gen-time" title="2026-04-09 15:27 UTC">2026-04-09 15:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/8954f0b086547ef9893afc7c773faf6131386c16" style="color:#58a6ff">8954f0b</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T16:26:05+00:00" class="gen-time" title="2026-04-09 16:26 UTC">2026-04-09 16:26 UTC</time> · <a href="https://github.com/schacon/grit/commit/e458f9d6f68df170733e2888878be9a97a7868d6" style="color:#58a6ff">e458f9d</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,304</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,335</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.3%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -6247,14 +6247,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:61.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="52" data-passed="22">
+<tr class="" data-group="t3" data-tests="52" data-passed="52" data-full-pass="1">
   <td class="mono">t3422-rebase-incompatible-options</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">52</td>
-  <td class="right">22</td>
+  <td class="right">52</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:42.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="3" data-passed="1">
@@ -10847,14 +10847,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:65.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t6" data-tests="22" data-passed="21">
+<tr class="" data-group="t6" data-tests="22" data-passed="22" data-full-pass="1">
   <td class="mono">t6102-rev-list-unexpected-objects</td>
   <td>t6</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">22</td>
-  <td class="right">21</td>
+  <td class="right">22</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:95.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t6" data-tests="2" data-passed="2" data-full-pass="1">

--- a/grit-lib/src/rev_list.rs
+++ b/grit-lib/src/rev_list.rs
@@ -3277,7 +3277,15 @@ fn collect_tree_objects_filtered(
                     omitted.push(entry.oid);
                 }
             } else {
-                // Git historically tolerates lone non-blob entries in blob slots.
+                // Non-blob in a blob-named slot: Git's list-objects only tolerates this when the
+                // child OID was not yet seen (lone broken tip, t6102). If the OID was already
+                // emitted (e.g. as a tree from another tip), report corruption like upstream.
+                if emitted.contains(&entry.oid) {
+                    return Err(Error::CorruptObject(format!(
+                        "object {} is not a blob",
+                        entry.oid
+                    )));
+                }
                 if emitted.insert(entry.oid) {
                     result.push((entry.oid, path));
                 }

--- a/logs/2026-04-09_t6102-rev-list-unexpected-objects.md
+++ b/logs/2026-04-09_t6102-rev-list-unexpected-objects.md
@@ -1,0 +1,6 @@
+## 2026-04-09 — t6102-rev-list-unexpected-objects (seen non-blob)
+
+- **Issue:** Harness showed 21/22; test 4 (`traverse unexpected non-blob entry (seen)`) expected `rev-list --objects` to fail with `is not a blob` when the malformed tree’s “blob” slot pointed at an OID already listed from another tip.
+- **Cause:** `collect_tree_objects_filtered` treated non-blob children in blob modes as tolerable and skipped output when the OID was already in `emitted`, so the walk succeeded with no error.
+- **Fix:** If the child OID is already in `emitted`, return `CorruptObject` with message `object <oid> is not a blob` (matches Git `list-objects.c` / t6102). Lone-tip case unchanged (OID not yet seen).
+- **Validation:** `cargo test -p grit-lib --lib`; `./scripts/run-tests.sh t6102-rev-list-unexpected-objects.sh` → 22/22.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t6102-rev-list-unexpected-objects` was failing test 4 (`traverse unexpected non-blob entry (seen)`): `git rev-list --objects $tree $broken_tree` must fail with a message containing `is not a blob` when the broken tree’s blob-mode entry points at an OID already emitted from another tip.

## Change

In `collect_tree_objects_filtered`, when a tree entry is in blob mode but the child object is not a blob, we no longer silently skip if that OID was already in the global `emitted` set. Instead we return a corrupt-object error with `object <oid> is not a blob`, matching Git’s `list-objects.c` behavior and keeping the lone-tip tolerance intact.

## Validation

- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t6102-rev-list-unexpected-objects.sh` → 22/22
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca4b11d5-ac2d-46ab-b7e8-9abb0883bd13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca4b11d5-ac2d-46ab-b7e8-9abb0883bd13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

