### PR TITLE
fix: push submodule recursion and fetch FETCH_HEAD (t5531 progress)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -949,7 +949,7 @@ t5528-push-default	t5	yes	31	13	18	false	ok	1
 t5529-push-errors	t5	yes	8	8	0	true	ok	0
 t5530-upload-pack-error	t5	yes	11	3	8	false	ok	0
 t5531-deep-nested-push	t5	yes	4	4	0	true	ok	0
-t5531-deep-submodule-push	t5	yes	29	6	23	false	ok	0
+t5531-deep-submodule-push	t5	yes	29	21	8	false	ok	0
 t5532-fetch-proxy	t5	yes	5	4	1	false	ok	0
 t5533-push-cas	t5	yes	23	11	12	false	ok	0
 t5534-push-signed	t5	skip	13	0	0	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.1% of harness tests passing (35,212 / 45,112).">
+<meta property="og:description" content="78.1% of harness tests passing (35,245 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.1% of harness tests passing (35,212 / 45,112).">
+<meta name="twitter:description" content="78.1% of harness tests passing (35,245 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T13:51:28+00:00" class="gen-time" title="2026-04-09 13:51 UTC">2026-04-09 13:51 UTC</time> · <a href="https://github.com/schacon/grit/commit/1b2deb6d814ce62f9b7b0fab0b751f2cf7de238c" style="color:#58a6ff">1b2deb6</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T16:03:53+00:00" class="gen-time" title="2026-04-09 16:03 UTC">2026-04-09 16:03 UTC</time> · <a href="https://github.com/schacon/grit/commit/e21f56e868c440bbf8e0cd98724990dbb13d8b57" style="color:#58a6ff">e21f56e</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,212</div>
+      <div class="summary-big-val">35,245</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>722 files fully passing</span>
+    <span>725 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -230,22 +230,22 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">68/178 files · 2 skipped · 2,668/4,437 tests</span>
+        <span class="group-meta">70/178 files · 2 skipped · 2,683/4,437 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.1%"></div></div>
-        <span class="group-pct pct-blue">60.1%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.5%"></div></div>
+        <span class="group-pct pct-blue">60.5%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">23/167 files · 17 skipped · 1,478/4,139 tests</span>
+        <span class="group-meta">24/167 files · 17 skipped · 1,496/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:35.7%"></div></div>
-        <span class="group-pct pct-red">35.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:36.1%"></div></div>
+        <span class="group-pct pct-red">36.1%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35212 of 45112 tests passing across 1405 harness files (78.1% pass rate).</desc>
+  <desc id="svg-desc">35245 of 45112 tests passing across 1405 harness files (78.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.1% pass rate · 35,212 / 45,112 tests · 1,405 files in scope · 722 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.1% pass rate · 35,245 / 45,112 tests · 1,405 files in scope · 725 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="547" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T13:51:28+00:00" class="gen-time" title="2026-04-09 13:51 UTC">2026-04-09 13:51 UTC</time> · <a href="https://github.com/schacon/grit/commit/1b2deb6d814ce62f9b7b0fab0b751f2cf7de238c" style="color:#58a6ff">1b2deb6</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T16:03:53+00:00" class="gen-time" title="2026-04-09 16:03 UTC">2026-04-09 16:03 UTC</time> · <a href="https://github.com/schacon/grit/commit/e21f56e868c440bbf8e0cd98724990dbb13d8b57" style="color:#58a6ff">e21f56e</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,212</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,245</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -2037,14 +2037,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="7" data-passed="3">
+<tr class="" data-group="t1" data-tests="7" data-passed="7" data-full-pass="1">
   <td class="mono">t1090-sparse-checkout-scope</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">7</td>
-  <td class="right">3</td>
+  <td class="right">7</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:42.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="34" data-passed="34" data-full-pass="1">
@@ -3457,14 +3457,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:97.1%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="36" data-passed="36" data-full-pass="1">
+<tr class="" data-group="t1" data-tests="36" data-passed="32">
   <td class="mono">t12770-for-each-ref-perl-format</td>
   <td>t1</td>
-  <td><span class="badge ok">full pass</span></td>
+  <td></td>
   <td class="right">36</td>
-  <td class="right">36</td>
+  <td class="right">32</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:88.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="36" data-passed="35">
@@ -7607,14 +7607,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:16.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="10" data-passed="6">
+<tr class="" data-group="t4" data-tests="10" data-passed="10" data-full-pass="1">
   <td class="mono">t4064-diff-oidfind</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">10</td>
-  <td class="right">6</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:60.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="7" data-passed="7" data-full-pass="1">
@@ -8137,14 +8137,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="12" data-passed="1">
+<tr class="" data-group="t4" data-tests="12" data-passed="12" data-full-pass="1">
   <td class="mono">t4128-apply-root</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">12</td>
-  <td class="right">1</td>
+  <td class="right">12</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:8.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="23" data-passed="9">
@@ -9017,14 +9017,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="9" data-passed="6">
+<tr class="" data-group="t5" data-tests="9" data-passed="4">
   <td class="mono">t5318-pack-objects-revs-exclude</td>
   <td>t5</td>
   <td></td>
   <td class="right">9</td>
-  <td class="right">6</td>
+  <td class="right">4</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:66.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:44.4%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="98" data-passed="20">
@@ -9647,14 +9647,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="29" data-passed="6">
+<tr class="" data-group="t5" data-tests="29" data-passed="21">
   <td class="mono">t5531-deep-submodule-push</td>
   <td>t5</td>
   <td></td>
   <td class="right">29</td>
-  <td class="right">6</td>
+  <td class="right">21</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:20.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:72.4%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="5" data-passed="4">
@@ -10307,14 +10307,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="10" data-passed="5">
+<tr class="" data-group="t5" data-tests="10" data-passed="10" data-full-pass="1">
   <td class="mono">t5620-backfill</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">10</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="12" data-passed="12" data-full-pass="1">

--- a/grit-lib/src/lib.rs
+++ b/grit-lib/src/lib.rs
@@ -63,6 +63,7 @@ pub mod patch_ids;
 pub mod pathspec;
 pub mod promisor;
 pub mod prune_packed;
+pub mod push_submodules;
 pub mod quote_path;
 pub mod reflog;
 pub mod refs;

--- a/grit-lib/src/push_submodules.rs
+++ b/grit-lib/src/push_submodules.rs
@@ -1,0 +1,560 @@
+//! Submodule recursion for `git push` (`--recurse-submodules`).
+//!
+//! Mirrors the subset of Git's `submodule.c` / `transport.c` logic needed for
+//! `check`, `on-demand`, and `only` modes over local (file) transport.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use crate::combined_tree_diff::{combined_diff_paths_filtered, CombinedTreeDiffOptions};
+use crate::diff::{diff_trees, DiffStatus};
+use crate::error::Result;
+use crate::index::MODE_GITLINK;
+use crate::objects::{parse_commit, ObjectId, ObjectKind};
+use crate::refs;
+use crate::repo::Repository;
+
+fn resolve_remote_url_to_local_git_dir(url: &str, base_for_relative: &Path) -> Option<PathBuf> {
+    let url = url.trim();
+    if url.starts_with("git://")
+        || url.starts_with("http://")
+        || url.starts_with("https://")
+        || url.starts_with("ssh://")
+    {
+        return None;
+    }
+    let path_str = url.strip_prefix("file://").unwrap_or(url);
+    let mut p = PathBuf::from(path_str);
+    if p.is_relative() {
+        p = base_for_relative.join(p);
+    }
+    let p = if p.ends_with(".git") || p.join("HEAD").exists() {
+        p
+    } else {
+        p.join(".git")
+    };
+    if p.join("HEAD").exists() {
+        Some(p)
+    } else {
+        None
+    }
+}
+
+/// True when `rev-list <oids> --not <remote_tip_oids>` is non-empty: some gitlink commit is not on the remote.
+fn oids_not_on_remote_repo(
+    submodule_repo: &Repository,
+    oids: &[ObjectId],
+    remote_git_dir: &Path,
+) -> Result<bool> {
+    if oids.is_empty() {
+        return Ok(false);
+    }
+    let remote_heads = refs::list_refs(remote_git_dir, "refs/heads/")?;
+    let negative: Vec<String> = remote_heads.iter().map(|(_, o)| o.to_hex()).collect();
+    let positive: Vec<String> = oids.iter().map(|o| o.to_hex()).collect();
+    let options = RevListOptions::default();
+    let r = rev_list(submodule_repo, &positive, &negative, &options)?;
+    Ok(!r.commits.is_empty())
+}
+use crate::rev_list::{rev_list, RevListOptions};
+use crate::state::{resolve_head, HeadState};
+
+/// How `git push` should recurse into submodules.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PushRecurseSubmodules {
+    /// No submodule handling (default when unset).
+    Off,
+    /// Verify gitlink targets exist on a submodule remote (`check`).
+    Check,
+    /// Push submodule repos as needed (`on-demand`).
+    OnDemand,
+    /// Push only submodules, not the superproject (`only`).
+    Only,
+}
+
+/// Parse `--recurse-submodules=<value>` or `push.recurseSubmodules` / `submodule.recurse`.
+///
+/// Returns an error for invalid values (`yes`, unknown strings, etc.).
+pub fn parse_push_recurse_submodules_arg(
+    opt: &str,
+    arg: &str,
+) -> std::result::Result<PushRecurseSubmodules, String> {
+    let arg = arg.trim();
+    if arg.is_empty() {
+        return Err(format!("option `{opt}` requires a value"));
+    }
+
+    // Internal sentinel used when Git recurses from `only` into a child push.
+    if arg == "only-is-on-demand" {
+        return Ok(PushRecurseSubmodules::OnDemand);
+    }
+
+    match crate::config::parse_bool(arg) {
+        Ok(true) => Err(format!("bad {opt} argument: {arg}")),
+        Ok(false) => Ok(PushRecurseSubmodules::Off),
+        Err(_) => {
+            if arg.eq_ignore_ascii_case("on-demand") {
+                Ok(PushRecurseSubmodules::OnDemand)
+            } else if arg.eq_ignore_ascii_case("check") {
+                Ok(PushRecurseSubmodules::Check)
+            } else if arg.eq_ignore_ascii_case("only") {
+                Ok(PushRecurseSubmodules::Only)
+            } else if arg.eq_ignore_ascii_case("no") || arg.eq_ignore_ascii_case("false") {
+                Ok(PushRecurseSubmodules::Off)
+            } else {
+                Err(format!("bad {opt} argument: {arg}"))
+            }
+        }
+    }
+}
+
+fn mode_from_octal(mode_str: &str) -> Option<u32> {
+    u32::from_str_radix(mode_str, 8).ok()
+}
+
+fn is_gitlink_mode(mode_str: &str) -> bool {
+    mode_from_octal(mode_str) == Some(MODE_GITLINK)
+}
+
+/// Collect submodule paths and the gitlink OIDs introduced along the walk
+/// `git log <tips> --not --remotes=<remote>`, using merge-aware diffs like Git's
+/// `collect_changed_submodules`.
+///
+/// When `refs/remotes/<remote>/` is empty (path remotes, or before any fetch), pass
+/// `fallback_remote_git_dir` with the push destination repository so we exclude its
+/// `refs/heads/*` tips instead (matches Git's reachable set for fresh remotes).
+pub fn collect_changed_gitlinks_for_push(
+    repo: &Repository,
+    commit_tips: &[ObjectId],
+    exclude_remote_name: &str,
+    fallback_remote_git_dir: Option<&Path>,
+) -> Result<HashMap<String, Vec<ObjectId>>> {
+    if commit_tips.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let prefix = format!("refs/remotes/{exclude_remote_name}/");
+    let remote_refs = refs::list_refs(&repo.git_dir, &prefix)?;
+    let mut negative_hex: Vec<String> = remote_refs.iter().map(|(_, oid)| oid.to_hex()).collect();
+
+    if negative_hex.is_empty() {
+        if let Some(rgd) = fallback_remote_git_dir {
+            let heads = refs::list_refs(rgd, "refs/heads/")?;
+            negative_hex = heads.iter().map(|(_, oid)| oid.to_hex()).collect();
+        }
+    }
+
+    let positive_hex: Vec<String> = commit_tips.iter().map(|o| o.to_hex()).collect();
+    let options = RevListOptions::default();
+    let walked = rev_list(repo, &positive_hex, &negative_hex, &options)?;
+
+    let odb = &repo.odb;
+    let walk_opts = CombinedTreeDiffOptions {
+        recursive: true,
+        tree_in_recursive: false,
+    };
+
+    let mut by_path: HashMap<String, Vec<ObjectId>> = HashMap::new();
+
+    for commit_oid in walked.commits {
+        let obj = odb.read(&commit_oid)?;
+        if obj.kind != ObjectKind::Commit {
+            continue;
+        }
+        let commit = parse_commit(&obj.data)?;
+        let parents = commit.parents;
+
+        if parents.is_empty() {
+            let entries = diff_trees(odb, None, Some(&commit.tree), "")?;
+            for e in entries {
+                if !is_gitlink_mode(&e.new_mode) {
+                    continue;
+                }
+                let path = e.path().to_string();
+                by_path.entry(path).or_default().push(e.new_oid);
+            }
+        } else if parents.len() == 1 {
+            let pobj = odb.read(&parents[0])?;
+            if pobj.kind != ObjectKind::Commit {
+                continue;
+            }
+            let parent = parse_commit(&pobj.data)?;
+            let entries = diff_trees(odb, Some(&parent.tree), Some(&commit.tree), "")?;
+            for e in entries {
+                if !matches!(
+                    e.status,
+                    DiffStatus::Added
+                        | DiffStatus::Modified
+                        | DiffStatus::TypeChanged
+                        | DiffStatus::Renamed
+                ) {
+                    continue;
+                }
+                let (mode, oid) = match e.status {
+                    DiffStatus::Deleted => continue,
+                    _ => (&e.new_mode, e.new_oid),
+                };
+                if !is_gitlink_mode(mode) {
+                    continue;
+                }
+                let path = e
+                    .new_path
+                    .as_deref()
+                    .or(e.old_path.as_deref())
+                    .unwrap_or("");
+                if path.is_empty() {
+                    continue;
+                }
+                by_path.entry(path.to_string()).or_default().push(oid);
+            }
+        } else {
+            let paths =
+                combined_diff_paths_filtered(odb, &commit.tree, &parents, &walk_opts, None)?;
+            for p in paths {
+                if (p.merge_mode & 0o170000) != MODE_GITLINK {
+                    continue;
+                }
+                if p.merge_oid.is_zero() {
+                    continue;
+                }
+                by_path.entry(p.path).or_default().push(p.merge_oid);
+            }
+        }
+    }
+
+    for v in by_path.values_mut() {
+        v.sort();
+        v.dedup();
+    }
+
+    Ok(by_path)
+}
+
+/// Work tree path for a submodule at `rel_path` in the superproject.
+pub fn submodule_worktree_path(super_repo: &Repository, rel_path: &str) -> PathBuf {
+    super_repo
+        .work_tree
+        .as_ref()
+        .map(|wt| wt.join(rel_path))
+        .unwrap_or_else(|| super_repo.git_dir.join(rel_path))
+}
+
+/// True if `path` under the superproject looks like a checked-out nested repo (has `.git`).
+fn submodule_populated_at(super_repo: &Repository, rel_path: &str) -> bool {
+    let wd = submodule_worktree_path(super_repo, rel_path);
+    wd.join(".git").exists()
+}
+
+/// Whether the gitlink OIDs are commits present in the submodule repo and reachable from some ref.
+pub fn submodule_commits_fully_pushed(
+    super_repo: &Repository,
+    rel_path: &str,
+    oids: &[ObjectId],
+) -> Result<bool> {
+    if oids.is_empty() {
+        return Ok(true);
+    }
+
+    let wd = submodule_worktree_path(super_repo, rel_path);
+    if !wd.join(".git").exists() {
+        // Without a checkout Git skips the strict check (expert path).
+        return Ok(true);
+    }
+
+    let sub = Repository::discover(Some(&wd))?;
+    let odb = &sub.odb;
+
+    for oid in oids {
+        let obj = match odb.read(oid) {
+            Ok(o) => o,
+            Err(_) => return Ok(false),
+        };
+        match obj.kind {
+            ObjectKind::Commit => {}
+            ObjectKind::Tag => {
+                return Err(crate::error::Error::Message(format!(
+                    "submodule entry '{rel_path}' ({}) is a tag, not a commit",
+                    oid.to_hex()
+                )));
+            }
+            other => {
+                return Err(crate::error::Error::Message(format!(
+                    "submodule entry '{rel_path}' ({}) is a {other:?}, not a commit",
+                    oid.to_hex()
+                )));
+            }
+        }
+    }
+
+    let all_refs = refs::list_refs(&sub.git_dir, "refs/")?;
+    let negative: Vec<String> = all_refs.iter().map(|(_, o)| o.to_hex()).collect();
+    let positive: Vec<String> = oids.iter().map(|o| o.to_hex()).collect();
+    let options = RevListOptions::default();
+    let r = rev_list(&sub, &positive, &negative, &options)?;
+    Ok(r.commits.is_empty())
+}
+
+/// True if `oids` contains commits not reachable from `refs/remotes/<remote_name>/` in the submodule.
+pub fn submodule_needs_push_to_remote(
+    super_repo: &Repository,
+    rel_path: &str,
+    _remote_name: &str,
+    oids: &[ObjectId],
+) -> Result<bool> {
+    if oids.is_empty() {
+        return Ok(false);
+    }
+
+    if !submodule_populated_at(super_repo, rel_path) {
+        return Ok(false);
+    }
+
+    let wd = submodule_worktree_path(super_repo, rel_path);
+    let sub = Repository::discover(Some(&wd))?;
+
+    for oid in oids {
+        let obj = match sub.odb.read(oid) {
+            Ok(o) => o,
+            Err(_) => return Ok(false),
+        };
+        if obj.kind != ObjectKind::Commit {
+            return Ok(false);
+        }
+    }
+
+    // Match Git's `submodule_needs_pushing`: `rev-list <oids> --not --remotes` uses **all**
+    // submodule remote-tracking refs, not the superproject's remote name (which may be a URL).
+    let all_remote_tracking = refs::list_refs(&sub.git_dir, "refs/remotes/")?;
+    if !all_remote_tracking.is_empty() {
+        let negative: Vec<String> = all_remote_tracking
+            .iter()
+            .map(|(_, o)| o.to_hex())
+            .collect();
+        let positive: Vec<String> = oids.iter().map(|o| o.to_hex()).collect();
+        let options = RevListOptions::default();
+        let r = rev_list(&sub, &positive, &negative, &options)?;
+        return Ok(!r.commits.is_empty());
+    }
+
+    // No remote-tracking refs (e.g. `grit fetch` did not update `refs/remotes/*`): probe each
+    // configured `remote.*.url` that resolves to a local repo, like a one-sided `--remotes`.
+    let cfg = crate::config::ConfigSet::load(Some(&sub.git_dir), true).unwrap_or_default();
+    let mut saw_url = false;
+    for entry in cfg.entries() {
+        let Some(rest) = entry.key.strip_prefix("remote.") else {
+            continue;
+        };
+        let Some((_remote, key)) = rest.split_once('.') else {
+            continue;
+        };
+        if key != "url" {
+            continue;
+        }
+        saw_url = true;
+        let Some(val) = entry.value.as_deref() else {
+            continue;
+        };
+        let Some(remote_git_dir) = resolve_remote_url_to_local_git_dir(val, &wd) else {
+            continue;
+        };
+        if oids_not_on_remote_repo(&sub, oids, &remote_git_dir)? {
+            return Ok(true);
+        }
+    }
+    if !saw_url {
+        return Ok(false);
+    }
+    Ok(false)
+}
+
+/// Ensure every gitlink OID in `changed` names a commit object (not a tag/tree/blob).
+///
+/// Tries the superproject ODB first, then the checked-out submodule's ODB (embedded repos keep
+/// submodule objects outside the superproject object store).
+pub fn verify_push_gitlinks_are_commits(
+    repo: &Repository,
+    changed: &HashMap<String, Vec<ObjectId>>,
+) -> Result<()> {
+    for (path, oids) in changed {
+        let sub_odb = if submodule_populated_at(repo, path) {
+            let wd = submodule_worktree_path(repo, path);
+            Repository::discover(Some(&wd)).ok().map(|s| s.odb)
+        } else {
+            None
+        };
+
+        for oid in oids {
+            let obj = match repo.odb.read(oid) {
+                Ok(o) => o,
+                Err(crate::error::Error::ObjectNotFound(_)) => {
+                    let Some(ref sodb) = sub_odb else {
+                        return Err(crate::error::Error::ObjectNotFound(oid.to_hex()));
+                    };
+                    sodb.read(oid)?
+                }
+                Err(e) => return Err(e),
+            };
+            match obj.kind {
+                ObjectKind::Commit => {}
+                ObjectKind::Tag => {
+                    return Err(crate::error::Error::Message(format!(
+                        "submodule entry '{path}' ({}) is a tag, not a commit",
+                        oid.to_hex()
+                    )));
+                }
+                other => {
+                    return Err(crate::error::Error::Message(format!(
+                        "submodule entry '{path}' ({}) is a {other:?}, not a commit",
+                        oid.to_hex()
+                    )));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Submodule paths that still need to be pushed to `remote_name` (non-empty rev-list against remote-tracking).
+pub fn find_unpushed_submodule_paths(
+    super_repo: &Repository,
+    pushed_commit_tips: &[ObjectId],
+    remote_name: &str,
+    fallback_remote_git_dir: Option<&Path>,
+) -> Result<Vec<String>> {
+    let changed = collect_changed_gitlinks_for_push(
+        super_repo,
+        pushed_commit_tips,
+        remote_name,
+        fallback_remote_git_dir,
+    )?;
+    let mut needs: Vec<String> = Vec::new();
+    for (path, oids) in changed {
+        if submodule_needs_push_to_remote(super_repo, &path, remote_name, &oids)? {
+            needs.push(path);
+        }
+    }
+    needs.sort();
+    needs.dedup();
+    Ok(needs)
+}
+
+/// Print Git's standard "unpushed submodule" error and return a formatted anyhow-friendly message.
+pub fn format_unpushed_submodules_error(paths: &[String]) -> String {
+    let mut msg = String::from(
+        "The following submodule paths contain changes that can\n\
+not be found on any remote:\n",
+    );
+    for p in paths {
+        msg.push_str(&format!("  {p}\n"));
+    }
+    msg.push_str(
+        "\nPlease try\n\n\
+\tgit push --recurse-submodules=on-demand\n\n\
+or cd to the path and use\n\n\
+\tgit push\n\n\
+to push them to a remote.\n\n\
+Aborting.",
+    );
+    msg
+}
+
+/// Resolve `HEAD` in `git_dir` to a short branch name when symbolic; `"HEAD"` when detached.
+pub fn head_ref_short_name(git_dir: &Path) -> Result<String> {
+    let head = resolve_head(git_dir)?;
+    Ok(match head {
+        HeadState::Branch { refname, .. } => refname
+            .strip_prefix("refs/heads/")
+            .unwrap_or(&refname)
+            .to_string(),
+        HeadState::Detached { .. } | HeadState::Invalid => "HEAD".to_string(),
+    })
+}
+
+fn refspec_is_pushable_for_validation(spec: &str) -> bool {
+    if spec.starts_with('+') {
+        return refspec_is_pushable_for_validation(&spec[1..]);
+    }
+    if spec == ":" || spec == "+:" {
+        return false;
+    }
+    if spec.contains('*') {
+        return false;
+    }
+    let (src, _) = if let Some(i) = spec.find(':') {
+        (&spec[..i], &spec[i + 1..])
+    } else {
+        (spec, spec)
+    };
+    !src.is_empty()
+}
+
+/// Validate refspecs for nested submodule push (`submodule--helper push-check` subset).
+pub fn validate_submodule_push_refspecs(
+    submodule_git_dir: &Path,
+    superproject_head_branch: &str,
+    refspecs: &[String],
+) -> Result<()> {
+    for spec in refspecs {
+        if !refspec_is_pushable_for_validation(spec) {
+            continue;
+        }
+        let (force, rest) = spec
+            .strip_prefix('+')
+            .map(|s| (true, s))
+            .unwrap_or((false, spec.as_str()));
+        let (src, _) = if let Some(i) = rest.find(':') {
+            (&rest[..i], &rest[i + 1..])
+        } else {
+            (rest, rest)
+        };
+        if src.is_empty() {
+            continue;
+        }
+
+        let sub_head = resolve_head(submodule_git_dir)?;
+        let (detached, head_branch) = match &sub_head {
+            HeadState::Branch { refname, .. } => (
+                false,
+                refname
+                    .strip_prefix("refs/heads/")
+                    .unwrap_or(refname)
+                    .to_string(),
+            ),
+            _ => (true, String::new()),
+        };
+
+        let matches = count_src_refspec_matches(submodule_git_dir, src)?;
+        match matches {
+            1 => {}
+            _ => {
+                if src == "HEAD" && !detached && head_branch == superproject_head_branch {
+                    // Allowed: submodule on same branch as superproject.
+                } else {
+                    return Err(crate::error::Error::Message(format!(
+                        "src refspec '{src}' must name a ref"
+                    )));
+                }
+            }
+        }
+        let _ = force;
+    }
+    Ok(())
+}
+
+fn count_src_refspec_matches(git_dir: &Path, src: &str) -> Result<usize> {
+    if src.starts_with("refs/") {
+        return Ok(usize::from(refs::resolve_ref(git_dir, src).is_ok()));
+    }
+    if src.len() == 40
+        && src.parse::<ObjectId>().is_ok() {
+            return Ok(1);
+        }
+    let mut n = 0usize;
+    for prefix in ["refs/heads/", "refs/tags/", "refs/remotes/"] {
+        let full = format!("{prefix}{src}");
+        if refs::resolve_ref(git_dir, &full).is_ok() {
+            n += 1;
+        }
+    }
+    Ok(n)
+}

--- a/grit/src/commands/_submodule_run_update_inner.rs.inc
+++ b/grit/src/commands/_submodule_run_update_inner.rs.inc
@@ -95,8 +95,11 @@ fn run_update_inner(args: &UpdateArgs, discover_base: Option<PathBuf>) -> Result
 
         let modules_dir = submodule_modules_git_dir(&repo.git_dir, &m.path);
 
+        // When `--recursive` is set, do not skip submodules that are already at the recorded
+        // commit: nested `.gitmodules` paths may still need `submodule update` (t5531 nested clone).
         if !args.remote
             && !args.force
+            && !args.recursive
             && sub_path.join(".git").exists()
             && read_submodule_head(&sub_path).as_deref() == Some(recorded_oid)
         {

--- a/grit/src/commands/fetch.rs
+++ b/grit/src/commands/fetch.rs
@@ -745,13 +745,25 @@ fn fetch_remote(
                 )
             }
         };
-        let (heads, tags, _, _) = crate::fetch_transport::fetch_via_upload_pack_skipping(
+        let (mut heads, mut tags, _, _) = crate::fetch_transport::fetch_via_upload_pack_skipping(
             git_dir,
             &remote_path,
             upload_pack_cmd.as_deref(),
             compute_wants,
             has_cli_refspecs,
         )?;
+        // If upload-pack advertised no branch tips (or negotiation returned early) but the remote
+        // repository has `refs/heads/*` on disk, read them directly so `refs/remotes/` updates
+        // match Git's local fetch behavior (needed for submodule `origin/main` after `git fetch`).
+        let remote_repo_upload = remote_repo
+            .as_ref()
+            .expect("upload-pack path requires local remote repository");
+        if heads.is_empty() {
+            heads = refs::list_refs(&remote_repo_upload.git_dir, "refs/heads/")?;
+        }
+        if tags.is_empty() {
+            tags = refs::list_refs(&remote_repo_upload.git_dir, "refs/tags/")?;
+        }
         (heads, tags)
     } else {
         let remote_repo = remote_repo
@@ -1205,7 +1217,14 @@ fn fetch_remote(
             let for_merge = if has_merge_cfg {
                 fetch_head_is_for_merge_with_branch(git_dir, config, remote_name, refname)
             } else if refspecs.is_empty() {
-                idx == 0
+                // Without explicit fetch refspecs, tie FETCH_HEAD's for-merge line to the branch
+                // checked out locally when it exists on the remote. If HEAD is on a branch but the
+                // remote does not have that ref, no branch line is for-merge (do not use `idx==0`,
+                // since advertised order can put another branch first and break `FETCH_HEAD` tests).
+                match current_branch_from_head(git_dir) {
+                    Some(b) => refname == &format!("refs/heads/{b}"),
+                    None => idx == 0,
+                }
             } else {
                 fetch_head_is_for_merge_first_refspec_only(&refspecs, idx == 0)
             };

--- a/grit/src/commands/push.rs
+++ b/grit/src/commands/push.rs
@@ -12,6 +12,12 @@ use grit_lib::gitmodules::{oids_from_copied_object_paths, verify_gitmodules_for_
 use grit_lib::hooks::{run_hook, run_hook_capture, HookResult};
 use grit_lib::merge_base::is_ancestor;
 use grit_lib::objects::ObjectId;
+use grit_lib::push_submodules::{
+    collect_changed_gitlinks_for_push, find_unpushed_submodule_paths,
+    format_unpushed_submodules_error, head_ref_short_name, parse_push_recurse_submodules_arg,
+    submodule_worktree_path, validate_submodule_push_refspecs, verify_push_gitlinks_are_commits,
+    PushRecurseSubmodules,
+};
 use grit_lib::refs;
 use grit_lib::repo::Repository;
 use grit_lib::state::resolve_head;
@@ -19,7 +25,7 @@ use grit_lib::state::resolve_head;
 use std::fs;
 use std::io::{self, IsTerminal};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 /// Arguments for `grit push`.
 #[derive(Debug, ClapArgs)]
@@ -91,9 +97,17 @@ pub struct Args {
     #[arg(long = "no-verify")]
     pub no_verify: bool,
 
-    /// Check, on-demand, or no recursion into submodules.
-    #[arg(long = "recurse-submodules")]
-    pub recurse_submodules: Option<String>,
+    /// Submodule recursion mode (`check`, `on-demand`, `only`, `no`). Repeatable; last wins.
+    #[arg(
+        long = "recurse-submodules",
+        value_name = "MODE",
+        action = clap::ArgAction::Append
+    )]
+    pub recurse_submodules: Vec<String>,
+
+    /// Disable submodule recursion (overrides config and prior `--recurse-submodules`).
+    #[arg(long = "no-recurse-submodules")]
+    pub no_recurse_submodules: bool,
 
     /// Sign the push (accepted but not implemented; value: true, false, if-asked).
     #[arg(long = "signed", num_args = 0..=1, default_missing_value = "true", require_equals = true)]
@@ -237,6 +251,93 @@ fn sort_applied_indices(
     idx
 }
 
+fn grit_bin_for_nested_push() -> PathBuf {
+    std::env::current_exe().unwrap_or_else(|_| PathBuf::from("grit"))
+}
+
+fn effective_push_recurse_submodules(
+    args: &Args,
+    config: &ConfigSet,
+) -> Result<PushRecurseSubmodules> {
+    if args.no_recurse_submodules {
+        return Ok(PushRecurseSubmodules::Off);
+    }
+    let mut mode = PushRecurseSubmodules::Off;
+    if let Some(v) = config
+        .get("push.recurseSubmodules")
+        .or_else(|| config.get("push.recursesubmodules"))
+    {
+        mode = parse_push_recurse_submodules_arg("push.recurseSubmodules", &v)
+            .map_err(|e| anyhow::anyhow!(e))?;
+    } else if let Some(v) = config.get("submodule.recurse") {
+        if parse_bool(&v).unwrap_or(false) {
+            mode = PushRecurseSubmodules::OnDemand;
+        }
+    }
+    if std::env::var("GRIT_PUSH_RECURSE_ONLY_IS_ON_DEMAND")
+        .ok()
+        .as_deref()
+        == Some("1")
+    {
+        if mode == PushRecurseSubmodules::Only {
+            eprintln!(
+                "warning: recursing into submodule with push.recurseSubmodules=only; using on-demand instead"
+            );
+        }
+        mode = PushRecurseSubmodules::OnDemand;
+    }
+    for token in &args.recurse_submodules {
+        mode = parse_push_recurse_submodules_arg("--recurse-submodules", token)
+            .map_err(|e| anyhow::anyhow!(e))?;
+    }
+    Ok(mode)
+}
+
+fn run_nested_submodule_push(
+    submodule_workdir: &Path,
+    remote_and_refspecs: Option<(&str, &[String])>,
+    dry_run: bool,
+    quiet: bool,
+    push_options: &[String],
+    recurse_only_is_on_demand: bool,
+) -> Result<()> {
+    let mut cmd = Command::new(grit_bin_for_nested_push());
+    cmd.current_dir(submodule_workdir);
+    cmd.arg("push");
+    if recurse_only_is_on_demand {
+        cmd.arg("--recurse-submodules=only-is-on-demand");
+    }
+    if dry_run {
+        cmd.arg("--dry-run");
+    }
+    if quiet {
+        cmd.arg("--quiet");
+    }
+    for o in push_options {
+        cmd.arg(format!("--push-option={o}"));
+    }
+    if let Some((remote_name, refspecs)) = remote_and_refspecs {
+        cmd.arg(remote_name);
+        for s in refspecs {
+            cmd.arg(s);
+        }
+    }
+    cmd.stdin(Stdio::null());
+    if recurse_only_is_on_demand {
+        cmd.env("GRIT_PUSH_RECURSE_ONLY_IS_ON_DEMAND", "1");
+    }
+    let status = cmd.status().with_context(|| {
+        format!(
+            "failed to spawn grit push in {}",
+            submodule_workdir.display()
+        )
+    })?;
+    if !status.success() {
+        std::process::exit(status.code().unwrap_or(1));
+    }
+    Ok(())
+}
+
 fn sort_collateral_indices(
     updates: &[RefUpdate],
     pre_reject: &[Option<String>],
@@ -328,8 +429,11 @@ fn run_push_via_system_git(repo: &Repository, args: &Args) -> Result<()> {
     if args.no_verify {
         cmd.arg("--no-verify");
     }
-    if let Some(v) = &args.recurse_submodules {
+    for v in &args.recurse_submodules {
         cmd.arg(format!("--recurse-submodules={v}"));
+    }
+    if args.no_recurse_submodules {
+        cmd.arg("--no-recurse-submodules");
     }
     if let Some(v) = &args.signed {
         if v == "true" || v.is_empty() {
@@ -460,6 +564,11 @@ pub fn run(args: Args) -> Result<()> {
         };
 
     // Push to each URL
+    let path_style_remote = args
+        .remote
+        .as_ref()
+        .is_some_and(|r| r.contains('/') || r.starts_with('.') || std::path::Path::new(r).exists());
+
     for url in &urls {
         push_to_url(
             &repo,
@@ -470,10 +579,32 @@ pub fn run(args: Args) -> Result<()> {
             current_branch.as_deref(),
             push_all,
             &push_refspecs_from_config,
+            path_style_remote,
         )?;
     }
 
     Ok(())
+}
+
+fn submodule_push_refspecs(
+    args: &Args,
+    current_branch: Option<&str>,
+    push_all: bool,
+    push_refspecs_from_config: &[String],
+) -> Vec<String> {
+    if push_all {
+        return Vec::new();
+    }
+    if !args.refspecs.is_empty() {
+        return args.refspecs.clone();
+    }
+    if !push_refspecs_from_config.is_empty() {
+        return push_refspecs_from_config.to_vec();
+    }
+    if let Some(b) = current_branch {
+        return vec![b.to_owned()];
+    }
+    Vec::new()
 }
 
 fn push_to_url(
@@ -485,6 +616,7 @@ fn push_to_url(
     current_branch: Option<&str>,
     push_all: bool,
     push_refspecs_from_config: &[String],
+    path_style_remote: bool,
 ) -> Result<()> {
     if protocol_wire::effective_client_protocol_version() == 1 {
         wire_trace::trace_packet_push('<', "version 1");
@@ -573,6 +705,9 @@ fn push_to_url(
 
     // Build list of ref updates
     let mut updates = Vec::new();
+    // Local commit OIDs that would be advertised as push tips (including refs already up to date
+    // on the remote). Submodule recursion runs on this set, matching Git transport behavior.
+    let mut submodule_tips: Vec<ObjectId> = Vec::new();
 
     if args.mirror {
         // Mirror: push all local refs to remote, and delete remote refs
@@ -585,6 +720,7 @@ fn push_to_url(
             }
             let old_oid = refs::resolve_ref(&remote_repo.git_dir, refname).ok();
             if old_oid.as_ref() == Some(local_oid) {
+                submodule_tips.push(*local_oid);
                 continue;
             }
             updates.push(RefUpdate {
@@ -622,6 +758,7 @@ fn push_to_url(
             remote_name,
             args,
             &mut updates,
+            &mut submodule_tips,
             &negs,
             refspec_force,
         )?;
@@ -632,6 +769,7 @@ fn push_to_url(
         for (refname, local_oid) in &local_branches {
             let old_oid = refs::resolve_ref(&remote_repo.git_dir, refname).ok();
             if old_oid.as_ref() == Some(local_oid) {
+                submodule_tips.push(*local_oid);
                 continue;
             }
             updates.push(RefUpdate {
@@ -740,6 +878,7 @@ fn push_to_url(
                         let remote_ref = dst.replacen('*', matched, 1);
                         let old_oid = refs::resolve_ref(&remote_repo.git_dir, &remote_ref).ok();
                         if old_oid.as_ref() == Some(local_oid) {
+                            submodule_tips.push(*local_oid);
                             continue;
                         }
                         updates.push(RefUpdate {
@@ -840,6 +979,7 @@ fn push_to_url(
                     remote_name,
                     args,
                     &mut updates,
+                    &mut submodule_tips,
                     &negs,
                     refspec_force,
                 )?;
@@ -867,6 +1007,7 @@ fn push_to_url(
                         let remote_ref = dst_pat.replacen('*', matched, 1);
                         let old_oid = refs::resolve_ref(&remote_repo.git_dir, &remote_ref).ok();
                         if old_oid.as_ref() == Some(local_oid) {
+                            submodule_tips.push(*local_oid);
                             continue;
                         }
                         updates.push(RefUpdate {
@@ -907,6 +1048,8 @@ fn push_to_url(
                         expected_oid: None,
                         refspec_force: force_flag,
                     });
+                } else {
+                    submodule_tips.push(local_oid);
                 }
             }
             i += 1;
@@ -1017,6 +1160,110 @@ fn push_to_url(
                 .unwrap_or(usize::MAX);
             ia.cmp(&ib).then_with(|| a.remote_ref.cmp(&b.remote_ref))
         });
+    }
+
+    let recurse_mode = effective_push_recurse_submodules(args, config)?;
+
+    let mut combined_tips: Vec<ObjectId> = updates.iter().filter_map(|u| u.new_oid).collect();
+    combined_tips.extend(submodule_tips.iter().copied());
+    combined_tips.sort();
+    combined_tips.dedup();
+
+    if !repo.is_bare()
+        && !matches!(recurse_mode, PushRecurseSubmodules::Off)
+        && !(args.mirror || push_all || args.delete)
+        && !combined_tips.is_empty()
+    {
+        let tips = combined_tips;
+        let sub_refspecs =
+            submodule_push_refspecs(args, current_branch, push_all, push_refspecs_from_config);
+        let changed = collect_changed_gitlinks_for_push(
+            repo,
+            &tips,
+            remote_name,
+            Some(remote_repo.git_dir.as_path()),
+        )?;
+        verify_push_gitlinks_are_commits(repo, &changed)?;
+
+        if matches!(
+            recurse_mode,
+            PushRecurseSubmodules::OnDemand | PushRecurseSubmodules::Only
+        ) {
+            let super_head_branch = head_ref_short_name(&repo.git_dir)?;
+            let nested_only = std::env::var("GRIT_PUSH_RECURSE_ONLY_IS_ON_DEMAND")
+                .ok()
+                .as_deref()
+                == Some("1");
+            let to_push = find_unpushed_submodule_paths(
+                repo,
+                &tips,
+                remote_name,
+                Some(remote_repo.git_dir.as_path()),
+            )?;
+            for sub_path in &to_push {
+                let wd = submodule_worktree_path(repo, sub_path);
+                if !wd.join(".git").exists() {
+                    continue;
+                }
+                let sub_repo = match Repository::discover(Some(&wd)) {
+                    Ok(r) => r,
+                    Err(_) => continue,
+                };
+                if refs::list_refs(&sub_repo.git_dir, "refs/remotes/")
+                    .map(|r| r.is_empty())
+                    .unwrap_or(true)
+                {
+                    continue;
+                }
+                if !path_style_remote {
+                    validate_submodule_push_refspecs(
+                        &sub_repo.git_dir,
+                        &super_head_branch,
+                        &sub_refspecs,
+                    )
+                    .map_err(|e| anyhow::Error::msg(e.to_string()))?;
+                }
+                if !args.quiet {
+                    eprintln!("Pushing submodule '{sub_path}'");
+                }
+                let remote_specs = if path_style_remote {
+                    None
+                } else {
+                    Some((remote_name, sub_refspecs.as_slice()))
+                };
+                run_nested_submodule_push(
+                    &wd,
+                    remote_specs,
+                    args.dry_run,
+                    args.quiet,
+                    &args.push_option,
+                    nested_only,
+                )?;
+            }
+        }
+
+        let check_after = recurse_mode == PushRecurseSubmodules::Check
+            || (matches!(
+                recurse_mode,
+                PushRecurseSubmodules::OnDemand | PushRecurseSubmodules::Only
+            ) && !args.dry_run);
+        if check_after {
+            let needs = find_unpushed_submodule_paths(
+                repo,
+                &tips,
+                remote_name,
+                Some(remote_repo.git_dir.as_path()),
+            )?;
+            if !needs.is_empty() {
+                let msg = format_unpushed_submodules_error(&needs);
+                eprintln!("{}", msg.trim_end());
+                bail!("failed to push all needed submodules");
+            }
+        }
+    }
+
+    if recurse_mode == PushRecurseSubmodules::Only {
+        return Ok(());
     }
 
     if updates.is_empty() {
@@ -1815,6 +2062,7 @@ fn collect_matching_push_updates(
     remote_name: &str,
     args: &Args,
     updates: &mut Vec<RefUpdate>,
+    submodule_tips: &mut Vec<ObjectId>,
     negative_patterns: &[String],
     refspec_force: bool,
 ) -> Result<()> {
@@ -1828,6 +2076,7 @@ fn collect_matching_push_updates(
         }
         let old_oid = refs::resolve_ref(&remote_repo.git_dir, refname).ok();
         if old_oid.as_ref() == Some(local_oid) {
+            submodule_tips.push(*local_oid);
             continue;
         }
         let dst = refname

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -2415,8 +2415,11 @@ fn apply_globals(opts: &GlobalOpts) -> Result<()> {
             .map(|kv| format!("'{}'", kv))
             .collect::<Vec<_>>()
             .join(" ");
+        // Git's config reader applies the last occurrence of a key. Inherited
+        // `GIT_CONFIG_PARAMETERS` (e.g. from the test harness) must not override
+        // command-line `-c` values, so append new entries after the existing payload.
         let merged = match std::env::var("GIT_CONFIG_PARAMETERS") {
-            Ok(existing) if !existing.trim().is_empty() => format!("{extra} {existing}"),
+            Ok(existing) if !existing.trim().is_empty() => format!("{existing} {extra}"),
             _ => extra,
         };
         std::env::set_var("GIT_CONFIG_PARAMETERS", merged);


### PR DESCRIPTION
- Add grit-lib push_submodules helpers for gitlink walks, checks, nested pushes
- Wire grit push: recurse check/on-demand/only, config + CLI precedence, path remotes
- Merge push tip OIDs with up-to-date refs before submodule checks (match git transport)
- Append GIT_CONFIG_PARAMETERS so command-line -c wins over inherited env
- Fetch: fill heads from disk when upload-pack advertises none; fix FETCH_HEAD for-merge for current branch when multiple remote heads exist
- Submodule update: with --recursive, still recurse when submodule already at recorded commit
- Refresh harness CSV/docs (t5531-deep-submodule-push 21/29)