### PR TITLE
fix: implement git grep --textconv and rev:path blob grep

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1276,7 +1276,7 @@ t7811-grep-open	t7	yes	10	7	3	false	ok	0
 t7812-grep-icase-non-ascii	t7	yes	18	18	0	true	ok	0
 t7813-grep-icase-iso	t7	yes	2	2	0	true	ok	0
 t7814-grep-recurse-submodules	t7	yes	27	19	8	false	ok	7
-t7815-grep-binary	t7	yes	22	20	2	false	ok	0
+t7815-grep-binary	t7	yes	22	22	0	true	ok	0
 t7816-grep-binary-pattern	t7	yes	145	145	0	true	ok	0
 t7817-grep-sparse-checkout	t7	yes	8	5	3	false	ok	0
 t7818-grep-extended	t7	yes	11	8	3	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78% of harness tests passing (35,205 / 45,112).">
+<meta property="og:description" content="78% of harness tests passing (35,207 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78% of harness tests passing (35,205 / 45,112).">
+<meta name="twitter:description" content="78% of harness tests passing (35,207 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T12:58:52+00:00" class="gen-time" title="2026-04-09 12:58 UTC">2026-04-09 12:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/c9e26ba46f5a86c3328f4d62484968547c8560d9" style="color:#58a6ff">c9e26ba</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T14:34:46+00:00" class="gen-time" title="2026-04-09 14:34 UTC">2026-04-09 14:34 UTC</time> · <a href="https://github.com/schacon/grit/commit/999b424740b71e52cf30bf6fade3e1ef735f68bd" style="color:#58a6ff">999b424</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,205</div>
+      <div class="summary-big-val">35,207</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>719 files fully passing</span>
+    <span>720 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -263,7 +263,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">43/126 files · 11 skipped · 2,468/3,614 tests</span>
+        <span class="group-meta">44/126 files · 11 skipped · 2,470/3,614 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.3%"></div></div>

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35205 of 45112 tests passing across 1405 harness files (78% pass rate).</desc>
+  <desc id="svg-desc">35207 of 45112 tests passing across 1405 harness files (78% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78% pass rate · 35,205 / 45,112 tests · 1,405 files in scope · 719 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78% pass rate · 35,207 / 45,112 tests · 1,405 files in scope · 720 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="546" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T12:58:52+00:00" class="gen-time" title="2026-04-09 12:58 UTC">2026-04-09 12:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/c9e26ba46f5a86c3328f4d62484968547c8560d9" style="color:#58a6ff">c9e26ba</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T14:34:46+00:00" class="gen-time" title="2026-04-09 14:34 UTC">2026-04-09 14:34 UTC</time> · <a href="https://github.com/schacon/grit/commit/999b424740b71e52cf30bf6fade3e1ef735f68bd" style="color:#58a6ff">999b424</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,205</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,207</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -12917,14 +12917,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
   <td class="right small">7</td>
 </tr>
-<tr class="" data-group="t7" data-tests="22" data-passed="20">
+<tr class="" data-group="t7" data-tests="22" data-passed="22" data-full-pass="1">
   <td class="mono">t7815-grep-binary</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">22</td>
-  <td class="right">20</td>
+  <td class="right">22</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="145" data-passed="145" data-full-pass="1">

--- a/grit/src/commands/grep.rs
+++ b/grit/src/commands/grep.rs
@@ -15,10 +15,11 @@ use crate::explicit_exit::ExplicitExit;
 use grit_lib::attributes::quote_path_for_check_attr;
 use grit_lib::config::ConfigSet;
 use grit_lib::index::{MODE_GITLINK, MODE_TREE};
-use grit_lib::objects::{parse_commit, parse_tree, ObjectKind};
+use grit_lib::merge_diff::{blob_text_for_diff, blob_text_for_diff_with_oid, diff_textconv_active};
+use grit_lib::objects::{parse_commit, parse_tree, ObjectId, ObjectKind};
 use grit_lib::refs::resolve_ref;
 use grit_lib::repo::Repository;
-use grit_lib::rev_parse::{discover_optional, resolve_revision, show_prefix};
+use grit_lib::rev_parse::{discover_optional, resolve_revision, show_prefix, split_treeish_colon};
 use grit_lib::wildmatch::wildmatch;
 
 use crate::pathspec::resolve_pathspec;
@@ -219,7 +220,7 @@ pub struct Args {
     #[arg(long = "no-index")]
     pub no_index: bool,
 
-    /// Use textconv filter (accepted but not yet implemented).
+    /// Use `diff.<driver>.textconv` when `diff=<driver>` applies (search converted bytes).
     #[arg(long = "textconv")]
     pub textconv: bool,
 
@@ -458,6 +459,21 @@ fn run_inner(pattern_tokens: Vec<PatternToken>, mut args: Args) -> Result<()> {
         pathspecs
     };
 
+    let single_rev_path =
+        (!args.no_index && !args.cached && tree_ish.is_none() && pathspecs.len() == 1)
+            .then(|| pathspecs[0].as_str())
+            .and_then(split_treeish_colon)
+            .filter(|(rev, path)| !rev.is_empty() && !path.is_empty())
+            .and_then(|(rev, path)| {
+                let spec = format!("{rev}:{path}");
+                let oid = resolve_revision(&repo, &spec)
+                    .or_else(|_| resolve_ref(&repo.git_dir, &spec))
+                    .or_else(|_| resolve_ref(&repo.git_dir, &format!("refs/heads/{spec}")))
+                    .ok()?;
+                let obj = repo.odb.read(&oid).ok()?;
+                (obj.kind == ObjectKind::Blob).then(|| (rev.to_string(), path.to_string()))
+            });
+
     let mut pattern_tokens = pattern_tokens;
     if pattern_tokens.is_empty() {
         if let Some(p) = first_pos_pattern {
@@ -517,7 +533,31 @@ fn run_inner(pattern_tokens: Vec<PatternToken>, mut args: Args) -> Result<()> {
     let mut need_sep = false;
 
     let found_any;
-    if args.no_index {
+    if let Some((rev, file_path)) = single_rev_path {
+        let diff_attrs = if let Some(ref wt) = repo.work_tree {
+            let wt_attrs = load_diff_attrs(wt);
+            if wt_attrs.is_empty() {
+                load_diff_attrs_from_index(&repo)
+            } else {
+                wt_attrs
+            }
+        } else {
+            load_diff_attrs_from_index(&repo)
+        };
+        let rev_path_label = format!("{rev}:{file_path}");
+        found_any = grep_one_blob_at_revision(
+            &repo,
+            &rev,
+            &file_path,
+            &rev_path_label,
+            &compiled,
+            &args,
+            &diff_attrs,
+            &mut need_sep,
+            out,
+            &mut open_paths,
+        )?;
+    } else if args.no_index {
         // --no-index: walk the filesystem instead of using the index
         let start_dir = std::env::current_dir().context("cannot get current directory")?;
         found_any = grep_filesystem(
@@ -707,6 +747,100 @@ fn run_open_in_pager(
     Ok(())
 }
 
+/// `git grep` with a single `rev:path` pathspec (e.g. `HEAD:a`): search one blob from that revision.
+fn grep_one_blob_at_revision(
+    repo: &Repository,
+    rev: &str,
+    file_path: &str,
+    rev_path_label: &str,
+    compiled: &CompiledGrep,
+    args: &Args,
+    diff_attrs: &[DiffAttrRule],
+    need_sep: &mut bool,
+    out: &mut (impl Write + ?Sized),
+    open_paths: &mut Option<Vec<String>>,
+) -> Result<bool> {
+    let spec = rev_path_label.to_string();
+    let blob_oid = resolve_revision(repo, &spec)
+        .or_else(|_| resolve_ref(&repo.git_dir, &spec))
+        .or_else(|_| resolve_ref(&repo.git_dir, &format!("refs/heads/{spec}")))
+        .with_context(|| format!("not a valid object: '{spec}'"))?;
+    let obj = repo
+        .odb
+        .read(&blob_oid)
+        .with_context(|| format!("object not found: {blob_oid}"))?;
+    if obj.kind != ObjectKind::Blob {
+        bail!("'{spec}' is not a blob");
+    }
+    let binary_override = check_binary_override(diff_attrs, file_path);
+    let is_binary = grep_is_binary(repo, file_path, &obj.data, args, binary_override);
+    if is_binary && args.ignore_binary {
+        return Ok(false);
+    }
+    let rel = cwd_strip_repo_rel(repo, file_path, args);
+    if is_binary && !args.text_mode {
+        if args.count || args.files_with_matches || args.files_without_match || args.quiet {
+            let content = blob_as_grep_text(
+                repo,
+                file_path,
+                &obj.data,
+                Some(&blob_oid),
+                args,
+                binary_override,
+            );
+            return grep_content(
+                &rel,
+                Some(rev),
+                &content,
+                compiled,
+                args,
+                need_sep,
+                out,
+                open_paths,
+            );
+        }
+        let content = blob_as_grep_text(
+            repo,
+            file_path,
+            &obj.data,
+            Some(&blob_oid),
+            args,
+            binary_override,
+        );
+        let has_match = compiled
+            .atoms
+            .iter()
+            .any(|r| r.as_ref().is_some_and(|re| re.is_match(&content)));
+        if has_match {
+            if !args.quiet {
+                let quoted = path_for_output(file_path, args);
+                let display = format!("{rev}:{quoted}");
+                writeln!(out, "Binary file {} matches", display)?;
+            }
+            return Ok(true);
+        }
+        return Ok(false);
+    }
+    let content = blob_as_grep_text(
+        repo,
+        file_path,
+        &obj.data,
+        Some(&blob_oid),
+        args,
+        binary_override,
+    );
+    grep_content(
+        &rel,
+        Some(rev),
+        &content,
+        compiled,
+        args,
+        need_sep,
+        out,
+        open_paths,
+    )
+}
+
 /// Grep the index (--cached mode), optionally recursing into submodules.
 /// `path_prefix` is prepended to filenames for submodule display (e.g. "submodule/").
 fn grep_cached(
@@ -791,19 +925,21 @@ fn grep_cached(
                 Ok(o) => o,
                 Err(_) => continue,
             };
-            let content_is_binary = obj.data.iter().take(8000).any(|&b| b == 0);
             let binary_override = check_binary_override(&diff_attrs, &path_str);
-            let is_binary = match binary_override {
-                BinaryOverride::ForceBinary => true,
-                BinaryOverride::ForceText => false,
-                BinaryOverride::None => content_is_binary,
-            };
+            let is_binary = grep_is_binary(repo, &path_str, &obj.data, args, binary_override);
             if is_binary && args.ignore_binary {
                 continue;
             }
             if is_binary && !args.text_mode {
                 if args.count || args.files_with_matches || args.files_without_match || args.quiet {
-                    let content = String::from_utf8_lossy(&obj.data);
+                    let content = blob_as_grep_text(
+                        repo,
+                        &path_str,
+                        &obj.data,
+                        Some(&entry.oid),
+                        args,
+                        binary_override,
+                    );
                     let rel = worktree_display_rel(repo, path_prefix, &path_str, args);
                     if grep_content(
                         &rel, None, &content, compiled, args, need_sep, out, open_paths,
@@ -811,7 +947,14 @@ fn grep_cached(
                         found_any = true;
                     }
                 } else {
-                    let content = String::from_utf8_lossy(&obj.data);
+                    let content = blob_as_grep_text(
+                        repo,
+                        &path_str,
+                        &obj.data,
+                        Some(&entry.oid),
+                        args,
+                        binary_override,
+                    );
                     let has_match = compiled
                         .atoms
                         .iter()
@@ -822,7 +965,14 @@ fn grep_cached(
                     }
                 }
             } else {
-                let content = String::from_utf8_lossy(&obj.data);
+                let content = blob_as_grep_text(
+                    repo,
+                    &path_str,
+                    &obj.data,
+                    Some(&entry.oid),
+                    args,
+                    binary_override,
+                );
                 let rel = worktree_display_rel(repo, path_prefix, &path_str, args);
                 if grep_content(
                     &rel, None, &content, compiled, args, need_sep, out, open_paths,
@@ -844,19 +994,21 @@ fn grep_cached(
             Ok(o) => o,
             Err(_) => continue,
         };
-        let content_is_binary = obj.data.iter().take(8000).any(|&b| b == 0);
         let binary_override = check_binary_override(&diff_attrs, &path_str);
-        let is_binary = match binary_override {
-            BinaryOverride::ForceBinary => true,
-            BinaryOverride::ForceText => false,
-            BinaryOverride::None => content_is_binary,
-        };
+        let is_binary = grep_is_binary(repo, &path_str, &obj.data, args, binary_override);
         if is_binary && args.ignore_binary {
             continue;
         }
         if is_binary && !args.text_mode {
             if args.count || args.files_with_matches || args.files_without_match || args.quiet {
-                let content = String::from_utf8_lossy(&obj.data);
+                let content = blob_as_grep_text(
+                    repo,
+                    &path_str,
+                    &obj.data,
+                    Some(&entry.oid),
+                    args,
+                    binary_override,
+                );
                 let rel = worktree_display_rel(repo, path_prefix, &path_str, args);
                 if grep_content(
                     &rel, None, &content, compiled, args, need_sep, out, open_paths,
@@ -864,7 +1016,14 @@ fn grep_cached(
                     found_any = true;
                 }
             } else {
-                let content = String::from_utf8_lossy(&obj.data);
+                let content = blob_as_grep_text(
+                    repo,
+                    &path_str,
+                    &obj.data,
+                    Some(&entry.oid),
+                    args,
+                    binary_override,
+                );
                 let has_match = compiled
                     .atoms
                     .iter()
@@ -875,7 +1034,14 @@ fn grep_cached(
                 }
             }
         } else {
-            let content = String::from_utf8_lossy(&obj.data);
+            let content = blob_as_grep_text(
+                repo,
+                &path_str,
+                &obj.data,
+                Some(&entry.oid),
+                args,
+                binary_override,
+            );
             let rel = worktree_display_rel(repo, path_prefix, &path_str, args);
             if grep_content(
                 &rel, None, &content, compiled, args, need_sep, out, open_paths,
@@ -976,19 +1142,15 @@ fn grep_worktree(
                 Ok(c) => c,
                 Err(_) => continue,
             };
-            let content_is_binary = content.iter().take(8000).any(|&b| b == 0);
             let binary_override = check_binary_override(&diff_attrs, &path_str);
-            let is_binary = match binary_override {
-                BinaryOverride::ForceBinary => true,
-                BinaryOverride::ForceText => false,
-                BinaryOverride::None => content_is_binary,
-            };
+            let is_binary = grep_is_binary(repo, &path_str, &content, args, binary_override);
             if is_binary && args.ignore_binary {
                 continue;
             }
             if is_binary && !args.text_mode {
                 if args.count || args.files_with_matches || args.files_without_match || args.quiet {
-                    let content_str = String::from_utf8_lossy(&content);
+                    let content_str =
+                        blob_as_grep_text(repo, &path_str, &content, None, args, binary_override);
                     let rel = worktree_display_rel(repo, path_prefix, &path_str, args);
                     if grep_content(
                         &rel,
@@ -1003,7 +1165,8 @@ fn grep_worktree(
                         found_any = true;
                     }
                 } else {
-                    let content_str = String::from_utf8_lossy(&content);
+                    let content_str =
+                        blob_as_grep_text(repo, &path_str, &content, None, args, binary_override);
                     let has_match = compiled
                         .atoms
                         .iter()
@@ -1014,7 +1177,8 @@ fn grep_worktree(
                     }
                 }
             } else {
-                let content_str = String::from_utf8_lossy(&content);
+                let content_str =
+                    blob_as_grep_text(repo, &path_str, &content, None, args, binary_override);
                 let rel = worktree_display_rel(repo, path_prefix, &path_str, args);
                 if grep_content(
                     &rel,
@@ -1051,19 +1215,21 @@ fn grep_worktree(
                 Ok(o) => o,
                 Err(_) => continue,
             };
-            let content_is_binary = obj.data.iter().take(8000).any(|&b| b == 0);
             let binary_override = check_binary_override(&diff_attrs, &path_str);
-            let is_binary = match binary_override {
-                BinaryOverride::ForceBinary => true,
-                BinaryOverride::ForceText => false,
-                BinaryOverride::None => content_is_binary,
-            };
+            let is_binary = grep_is_binary(repo, &path_str, &obj.data, args, binary_override);
             if is_binary && args.ignore_binary {
                 continue;
             }
             if is_binary && !args.text_mode {
                 if args.count || args.files_with_matches || args.files_without_match || args.quiet {
-                    let content_str = String::from_utf8_lossy(&obj.data);
+                    let content_str = blob_as_grep_text(
+                        repo,
+                        &path_str,
+                        &obj.data,
+                        Some(&entry.oid),
+                        args,
+                        binary_override,
+                    );
                     let rel = worktree_display_rel(repo, path_prefix, &path_str, args);
                     if grep_content(
                         &rel,
@@ -1078,7 +1244,14 @@ fn grep_worktree(
                         found_any = true;
                     }
                 } else {
-                    let content_str = String::from_utf8_lossy(&obj.data);
+                    let content_str = blob_as_grep_text(
+                        repo,
+                        &path_str,
+                        &obj.data,
+                        Some(&entry.oid),
+                        args,
+                        binary_override,
+                    );
                     let has_match = compiled
                         .atoms
                         .iter()
@@ -1089,7 +1262,14 @@ fn grep_worktree(
                     }
                 }
             } else {
-                let content_str = String::from_utf8_lossy(&obj.data);
+                let content_str = blob_as_grep_text(
+                    repo,
+                    &path_str,
+                    &obj.data,
+                    Some(&entry.oid),
+                    args,
+                    binary_override,
+                );
                 let rel = worktree_display_rel(repo, path_prefix, &path_str, args);
                 if grep_content(
                     &rel,
@@ -1116,13 +1296,8 @@ fn grep_worktree(
             Err(_) => continue,
         };
 
-        let content_is_binary = content.iter().take(8000).any(|&b| b == 0);
         let binary_override = check_binary_override(&diff_attrs, &path_str);
-        let is_binary = match binary_override {
-            BinaryOverride::ForceBinary => true,
-            BinaryOverride::ForceText => false,
-            BinaryOverride::None => content_is_binary,
-        };
+        let is_binary = grep_is_binary(repo, &path_str, &content, args, binary_override);
 
         if is_binary && args.ignore_binary {
             continue;
@@ -1130,7 +1305,8 @@ fn grep_worktree(
 
         if is_binary && !args.text_mode {
             if args.count || args.files_with_matches || args.files_without_match || args.quiet {
-                let content_str = String::from_utf8_lossy(&content);
+                let content_str =
+                    blob_as_grep_text(repo, &path_str, &content, None, args, binary_override);
                 let rel = worktree_display_rel(repo, path_prefix, &path_str, args);
                 if grep_content(
                     &rel,
@@ -1145,7 +1321,8 @@ fn grep_worktree(
                     found_any = true;
                 }
             } else {
-                let content_str = String::from_utf8_lossy(&content);
+                let content_str =
+                    blob_as_grep_text(repo, &path_str, &content, None, args, binary_override);
                 let has_match = compiled
                     .atoms
                     .iter()
@@ -1156,7 +1333,8 @@ fn grep_worktree(
                 }
             }
         } else {
-            let content_str = String::from_utf8_lossy(&content);
+            let content_str =
+                blob_as_grep_text(repo, &path_str, &content, None, args, binary_override);
             let rel = worktree_display_rel(repo, path_prefix, &path_str, args);
             if grep_content(
                 &rel,
@@ -1410,6 +1588,74 @@ fn check_binary_override(rules: &[DiffAttrRule], path: &str) -> BinaryOverride {
         }
     }
     result
+}
+
+/// True when `git grep --textconv` should run `diff.<driver>.textconv` for this path.
+///
+/// `-diff` (`ForceBinary`) disables textconv, matching Git.
+fn path_has_active_textconv(
+    repo: &Repository,
+    path_for_attrs: &str,
+    args: &Args,
+    binary_override: BinaryOverride,
+) -> bool {
+    if args.no_textconv || !args.textconv || binary_override == BinaryOverride::ForceBinary {
+        return false;
+    }
+    let config = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+    diff_textconv_active(repo.git_dir.as_path(), &config, path_for_attrs)
+}
+
+/// Whether grep treats blob bytes as binary (NUL heuristic, `.gitattributes`, `--textconv`).
+fn grep_is_binary(
+    repo: &Repository,
+    path_for_attrs: &str,
+    raw_bytes: &[u8],
+    args: &Args,
+    binary_override: BinaryOverride,
+) -> bool {
+    let content_is_binary = raw_bytes.iter().take(8000).any(|&b| b == 0);
+    match binary_override {
+        BinaryOverride::ForceBinary => true,
+        BinaryOverride::ForceText => false,
+        BinaryOverride::None => {
+            if !content_is_binary {
+                false
+            } else if path_has_active_textconv(repo, path_for_attrs, args, binary_override) {
+                false
+            } else {
+                true
+            }
+        }
+    }
+}
+
+/// Search text: optional textconv when `--textconv` and a driver applies.
+fn blob_as_grep_text(
+    repo: &Repository,
+    path_for_attrs: &str,
+    blob: &[u8],
+    blob_oid: Option<&ObjectId>,
+    args: &Args,
+    binary_override: BinaryOverride,
+) -> String {
+    if !path_has_active_textconv(repo, path_for_attrs, args, binary_override) {
+        return String::from_utf8_lossy(blob).into_owned();
+    }
+    let config = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+    if let Some(oid) = blob_oid {
+        blob_text_for_diff_with_oid(
+            &repo.odb,
+            repo.git_dir.as_path(),
+            &config,
+            path_for_attrs,
+            blob,
+            oid,
+            true,
+        )
+    } else {
+        blob_text_for_diff(repo.git_dir.as_path(), &config, path_for_attrs, blob, true)
+    }
 }
 
 /// Grep the filesystem recursively (--no-index mode).
@@ -2431,20 +2677,22 @@ fn grep_tree(
                 Err(_) => continue,
             };
 
-            let content_is_binary = obj.data.iter().take(8000).any(|&b| b == 0);
             let binary_override = check_binary_override(diff_attrs, &full_name);
-            let is_binary = match binary_override {
-                BinaryOverride::ForceBinary => true,
-                BinaryOverride::ForceText => false,
-                BinaryOverride::None => content_is_binary,
-            };
+            let is_binary = grep_is_binary(repo, &full_name, &obj.data, args, binary_override);
 
             if is_binary && args.ignore_binary {
                 continue;
             }
 
             if is_binary && !args.text_mode {
-                let content = String::from_utf8_lossy(&obj.data);
+                let content = blob_as_grep_text(
+                    repo,
+                    &full_name,
+                    &obj.data,
+                    Some(&entry.oid),
+                    args,
+                    binary_override,
+                );
                 let has_match = compiled
                     .atoms
                     .iter()
@@ -2460,7 +2708,14 @@ fn grep_tree(
                     found = true;
                 }
             } else {
-                let content = String::from_utf8_lossy(&obj.data);
+                let content = blob_as_grep_text(
+                    repo,
+                    &full_name,
+                    &obj.data,
+                    Some(&entry.oid),
+                    args,
+                    binary_override,
+                );
                 let rel = cwd_strip_repo_rel(repo, &full_name, args);
                 if grep_content(
                     &rel, tree_name, &content, compiled, args, need_sep, out, open_paths,

--- a/logs/2026-04-09_t7815-grep-binary.md
+++ b/logs/2026-04-09_t7815-grep-binary.md
@@ -2,13 +2,13 @@
 
 ## Issue
 
-Harness reported 21/22 with "1 known breakage(s) vanished" for `git grep .fi a`, which was still `test_expect_failure` while grit (Rust regex) matches C Git behavior on REG_STARTEND-capable platforms.
+Harness needed `git grep --textconv` to run `diff.<driver>.textconv` on paths with `diff=<driver>`, and `git grep --textconv PATTERN HEAD:path` to resolve a single blob and honor textconv (test 22).
 
 ## Change
 
-- `tests/t7815-grep-binary.sh`: `test_expect_failure` → `test_expect_success` for `git grep .fi a` (same prereqs `!CYGWIN,!MACOS`).
+- `grit/src/commands/grep.rs`: When `--textconv` and `diff_textconv_active`, search via `blob_text_for_diff` / `blob_text_for_diff_with_oid` (with OID when known). NUL blobs with an active textconv driver are treated as searchable text for this mode. Added a single-pathspec fast path for `rev:path` that resolves to a blob (fixes `HEAD:a` without walking the tree).
 - Refreshed `data/test-files.csv` and dashboards via `./scripts/run-tests.sh t7815-grep-binary.sh`.
 
 ## Result
 
-22/22 pass, exit 0, no vanished-breakage warning.
+22/22 pass.


### PR DESCRIPTION
- Run diff.<driver>.textconv when --textconv and diff=<driver> apply
- Resolve single pathspec rev:path to a blob for HEAD:a-style grep
- Refresh t7815 harness status (22/22)