### PR TITLE
fix: unified diff hunk boundaries match git (t4117-apply-reject)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -787,7 +787,7 @@ t4113-apply-ending	t4	yes	3	1	2	false	ok	0
 t4114-apply-typechange	t4	yes	12	9	3	false	ok	0
 t4115-apply-symlink	t4	yes	8	2	6	false	ok	0
 t4116-apply-reverse	t4	yes	7	6	1	false	ok	0
-t4117-apply-reject	t4	yes	8	5	3	false	ok	0
+t4117-apply-reject	t4	yes	8	8	0	true	ok	0
 t4118-apply-empty-context	t4	yes	3	3	0	true	ok	0
 t4119-apply-config	t4	yes	11	3	8	false	ok	0
 t4120-apply-popt	t4	yes	12	5	7	false	ok	0
@@ -1193,7 +1193,7 @@ t7111-reset-table	t7	yes	42	34	8	false	ok	0
 t7112-reset-submodule	t7	yes	76	24	52	false	ok	0
 t7113-post-index-change-hook	t7	yes	4	1	3	false	ok	0
 t7201-co	t7	yes	46	17	29	false	ok	0
-t7300-clean	t7	yes	53	52	1	false	ok	2
+t7300-clean	t7	yes	53	52	1	false	ok	0
 t7301-clean-interactive	t7	yes	23	8	15	false	ok	0
 t7400-submodule-basic	t7	yes	124	51	73	false	ok	0
 t7401-submodule-summary	t7	yes	25	6	19	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.3% of harness tests passing (35,304 / 45,112).">
+<meta property="og:description" content="78.4% of harness tests passing (35,347 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.3% of harness tests passing (35,304 / 45,112).">
+<meta name="twitter:description" content="78.4% of harness tests passing (35,347 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T15:27:31+00:00" class="gen-time" title="2026-04-09 15:27 UTC">2026-04-09 15:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/8954f0b086547ef9893afc7c773faf6131386c16" style="color:#58a6ff">8954f0b</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T16:33:11+00:00" class="gen-time" title="2026-04-09 16:33 UTC">2026-04-09 16:33 UTC</time> · <a href="https://github.com/schacon/grit/commit/6733b1643af44c9b6d8547e69ed4ffdbf7af4315" style="color:#58a6ff">6733b16</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">78.3%</div>
+      <div class="summary-big-val pct-blue">78.4%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,304</div>
+      <div class="summary-big-val">35,347</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:78.3%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:78.4%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>739 files fully passing</span>
+    <span>742 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -219,33 +219,33 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">53/141 files · 2 skipped · 3,924/5,369 tests</span>
+        <span class="group-meta">54/141 files · 2 skipped · 3,954/5,369 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:73.1%"></div></div>
-        <span class="group-pct pct-blue">73.1%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:73.6%"></div></div>
+        <span class="group-pct pct-blue">73.6%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">72/178 files · 2 skipped · 2,716/4,437 tests</span>
+        <span class="group-meta">73/178 files · 2 skipped · 2,719/4,437 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:61.2%"></div></div>
-        <span class="group-pct pct-blue">61.2%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:61.3%"></div></div>
+        <span class="group-pct pct-blue">61.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">26/167 files · 17 skipped · 1,489/4,139 tests</span>
+        <span class="group-meta">27/167 files · 17 skipped · 1,499/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:36.0%"></div></div>
-        <span class="group-pct pct-red">36.0%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:36.2%"></div></div>
+        <span class="group-pct pct-red">36.2%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35304 of 45112 tests passing across 1405 harness files (78.3% pass rate).</desc>
+  <desc id="svg-desc">35347 of 45112 tests passing across 1405 harness files (78.4% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.3% pass rate · 35,304 / 45,112 tests · 1,405 files in scope · 739 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.4% pass rate · 35,347 / 45,112 tests · 1,405 files in scope · 742 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="548" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="549" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T15:27:31+00:00" class="gen-time" title="2026-04-09 15:27 UTC">2026-04-09 15:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/8954f0b086547ef9893afc7c773faf6131386c16" style="color:#58a6ff">8954f0b</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T16:33:11+00:00" class="gen-time" title="2026-04-09 16:33 UTC">2026-04-09 16:33 UTC</time> · <a href="https://github.com/schacon/grit/commit/6733b1643af44c9b6d8547e69ed4ffdbf7af4315" style="color:#58a6ff">6733b16</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,304</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">78.3%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,347</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">78.4%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -6247,14 +6247,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:61.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="52" data-passed="22">
+<tr class="" data-group="t3" data-tests="52" data-passed="52" data-full-pass="1">
   <td class="mono">t3422-rebase-incompatible-options</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">52</td>
-  <td class="right">22</td>
+  <td class="right">52</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:42.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="3" data-passed="1">
@@ -8027,14 +8027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:85.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="8" data-passed="5">
+<tr class="" data-group="t4" data-tests="8" data-passed="8" data-full-pass="1">
   <td class="mono">t4117-apply-reject</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">8</td>
-  <td class="right">5</td>
+  <td class="right">8</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:62.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="3" data-passed="3" data-full-pass="1">
@@ -9177,14 +9177,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="16" data-passed="6">
+<tr class="" data-group="t5" data-tests="16" data-passed="16" data-full-pass="1">
   <td class="mono">t5334-incremental-multi-pack-index</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">16</td>
-  <td class="right">6</td>
+  <td class="right">16</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:37.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="10" data-passed="0">
@@ -12095,7 +12095,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">52</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.1%"></div></div></td>
-  <td class="right small">2</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="23" data-passed="8">
   <td class="mono">t7301-clean-interactive</td>

--- a/grit-lib/src/diff.rs
+++ b/grit-lib/src/diff.rs
@@ -1953,9 +1953,14 @@ pub fn unified_diff_with_prefix_and_funcname_and_algorithm(
 
     let old_lines: Vec<&str> = old_content.lines().collect();
 
-    let group_radius = context_lines
+    // `similar::group_diff_ops` ends a hunk when an unchanged run has length > `2 * n`.
+    // Git's xdiff merges adjacent changes while the gap between them in the old file is at most
+    // `2 * context_lines + inter_hunk_context` (see `xdl_get_hunk` in xemit.c). Match that by
+    // choosing `n` so `2 * n` equals that maximum merged gap (rounded up when the sum is odd).
+    let max_common_gap = context_lines
         .saturating_mul(2)
         .saturating_add(inter_hunk_context);
+    let group_radius = max_common_gap.div_ceil(2);
     let op_groups = group_diff_ops(diff.ops().to_vec(), group_radius);
 
     for ops in op_groups {

--- a/logs/2026-04-09_t4117-apply-reject-unified-hunk-split.md
+++ b/logs/2026-04-09_t4117-apply-reject-unified-hunk-split.md
@@ -1,0 +1,5 @@
+## t4117-apply-reject
+
+- **Issue:** `git apply --reject` failed tests 5–7 because `grit diff` produced one giant hunk while Git/xdiff emits three hunks for the same change. A single failed hunk rejected the whole patch instead of applying the middle hunk (insert `C`) and rejecting the others.
+- **Fix:** In `grit-lib` `unified_diff_with_prefix_and_funcname_and_algorithm`, pass `group_diff_ops` a radius of `ceil((2*context + inter_hunk) / 2)` instead of `2*context + inter_hunk`, matching xdiff’s `max_common` merge rule (`xdl_get_hunk` in `git/xdiff/xemit.c`).
+- **Verify:** `./scripts/run-tests.sh t4117-apply-reject.sh` → 8/8; `cargo test -p grit-lib --lib` → pass.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`grit diff` was merging change regions too aggressively: `similar::group_diff_ops` splits when an unchanged run exceeds `2 * n`, but we passed `n = 2*context + inter_hunk`, which only splits when the gap is **strictly greater** than `4*context + 2*inter_hunk`. Git’s xdiff merges while the old-file gap is at most `2*context + inter_hunk` (`xdl_get_hunk` in `git/xdiff/xemit.c`).

That produced single huge hunks where Git emits several. For `git apply --reject`, one failed sub-change rejected the entire hunk, breaking `t4117-apply-reject` (tests 5–7).

## Change

- Compute `group_radius = ceil((2*context + inter_hunk) / 2)` before calling `group_diff_ops`, so split threshold matches Git.

## Verification

- `./scripts/run-tests.sh t4117-apply-reject.sh` → 8/8
- `cargo test -p grit-lib --lib`

Dashboard/`data/test-files.csv` updated by the harness run.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a342f64-519c-4d19-b3c9-d15ae7016b73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a342f64-519c-4d19-b3c9-d15ae7016b73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

