### PR TITLE
fix: t5501 fetch/push with alternates (v0 upload-pack, thin reference clone)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -918,7 +918,7 @@ t5409-colorize-remote-messages	t5	yes	11	11	0	true	ok	0
 t5410-receive-pack	t5	yes	5	4	1	false	ok	0
 t5411-proc-receive-hook	t5	skip	2	0	0	false	ok	0
 t5500-fetch-pack	t5	skip	92	0	0	false	ok	0
-t5501-fetch-push-alternates	t5	yes	3	2	1	false	ok	0
+t5501-fetch-push-alternates	t5	yes	3	3	0	true	ok	0
 t5502-quickfetch	t5	yes	7	2	5	false	ok	0
 t5503-tagfollow	t5	yes	12	6	6	false	ok	0
 t5504-fetch-receive-strict	t5	skip	29	0	0	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.3% of harness tests passing (35,304 / 45,112).">
+<meta property="og:description" content="78.3% of harness tests passing (35,335 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.3% of harness tests passing (35,304 / 45,112).">
+<meta name="twitter:description" content="78.3% of harness tests passing (35,335 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T15:27:31+00:00" class="gen-time" title="2026-04-09 15:27 UTC">2026-04-09 15:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/8954f0b086547ef9893afc7c773faf6131386c16" style="color:#58a6ff">8954f0b</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T16:32:36+00:00" class="gen-time" title="2026-04-09 16:32 UTC">2026-04-09 16:32 UTC</time> · <a href="https://github.com/schacon/grit/commit/e458f9d6f68df170733e2888878be9a97a7868d6" style="color:#58a6ff">e458f9d</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,304</div>
+      <div class="summary-big-val">35,335</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>739 files fully passing</span>
+    <span>741 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -219,11 +219,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">53/141 files · 2 skipped · 3,924/5,369 tests</span>
+        <span class="group-meta">54/141 files · 2 skipped · 3,954/5,369 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:73.1%"></div></div>
-        <span class="group-pct pct-blue">73.1%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:73.6%"></div></div>
+        <span class="group-pct pct-blue">73.6%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">
@@ -241,7 +241,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">26/167 files · 17 skipped · 1,489/4,139 tests</span>
+        <span class="group-meta">27/167 files · 17 skipped · 1,490/4,139 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-red" style="width:36.0%"></div></div>

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35304 of 45112 tests passing across 1405 harness files (78.3% pass rate).</desc>
+  <desc id="svg-desc">35335 of 45112 tests passing across 1405 harness files (78.3% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.3% pass rate · 35,304 / 45,112 tests · 1,405 files in scope · 739 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.3% pass rate · 35,335 / 45,112 tests · 1,405 files in scope · 741 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="548" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T15:27:31+00:00" class="gen-time" title="2026-04-09 15:27 UTC">2026-04-09 15:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/8954f0b086547ef9893afc7c773faf6131386c16" style="color:#58a6ff">8954f0b</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T16:32:36+00:00" class="gen-time" title="2026-04-09 16:32 UTC">2026-04-09 16:32 UTC</time> · <a href="https://github.com/schacon/grit/commit/e458f9d6f68df170733e2888878be9a97a7868d6" style="color:#58a6ff">e458f9d</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,304</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,335</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.3%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -6247,14 +6247,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:61.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="52" data-passed="22">
+<tr class="" data-group="t3" data-tests="52" data-passed="52" data-full-pass="1">
   <td class="mono">t3422-rebase-incompatible-options</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">52</td>
-  <td class="right">22</td>
+  <td class="right">52</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:42.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="3" data-passed="1">
@@ -9337,14 +9337,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="3" data-passed="2">
+<tr class="" data-group="t5" data-tests="3" data-passed="3" data-full-pass="1">
   <td class="mono">t5501-fetch-push-alternates</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">3</td>
-  <td class="right">2</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:66.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="7" data-passed="2">

--- a/grit/src/commands/clone.rs
+++ b/grit/src/commands/clone.rs
@@ -828,7 +828,12 @@ pub fn run(mut args: Args) -> Result<()> {
         .context("setting up alternates")?;
         propagate_extensions_object_format(&source.git_dir, &dest.git_dir)?;
     } else {
-        copy_objects(&source.git_dir, &dest.git_dir).context("copying objects")?;
+        let has_reference = !args.reference.is_empty() || !args.reference_if_able.is_empty();
+        // With `--reference`, match Git: do not copy loose/pack objects from the source into the
+        // new repo; they are reached via `objects/info/alternates` only (`t5501-fetch-push-alternates`).
+        if !has_reference {
+            copy_objects(&source.git_dir, &dest.git_dir).context("copying objects")?;
+        }
         merge_alternates_from_source_objects(&source.git_dir, &dest.git_dir.join("objects"))
             .context("merging source alternates")?;
         append_reference_alternates(
@@ -838,16 +843,13 @@ pub fn run(mut args: Args) -> Result<()> {
         )
         .context("adding --reference alternates")?;
         // For local clones, borrow objects from the source via alternates (like `git clone --local`).
-        // When `--reference` / `--reference-if-able` is used, Git only records those alternates
-        // (plus merged lines from the source's own `alternates` file); the loose/pack copy from the
-        // source already materializes objects locally (`t7408-submodule-reference`).
+        // When using `--reference`, the source may match a reference path; `add_alternate_objects_line`
+        // dedupes so the same `objects` directory is not listed twice.
         let alt_dir = dest.git_dir.join("objects/info");
         let _ = fs::create_dir_all(&alt_dir);
-        if args.reference.is_empty() && args.reference_if_able.is_empty() {
-            let source_objects = source.git_dir.join("objects");
-            if let Ok(abs) = source_objects.canonicalize() {
-                add_alternate_objects_line(&alt_dir, &abs)?;
-            }
+        let source_objects = source.git_dir.join("objects");
+        if let Ok(abs) = source_objects.canonicalize() {
+            add_alternate_objects_line(&alt_dir, &abs)?;
         }
         propagate_extensions_object_format(&source.git_dir, &dest.git_dir)?;
     }
@@ -2313,7 +2315,10 @@ fn run_ssh_clone(args: Args) -> Result<()> {
         .context("setting up alternates")?;
         propagate_extensions_object_format(&source.git_dir, &dest.git_dir)?;
     } else {
-        copy_objects(&source.git_dir, &dest.git_dir).context("copying objects")?;
+        let has_reference = !args.reference.is_empty() || !args.reference_if_able.is_empty();
+        if !has_reference {
+            copy_objects(&source.git_dir, &dest.git_dir).context("copying objects")?;
+        }
         merge_alternates_from_source_objects(&source.git_dir, &dest.git_dir.join("objects"))
             .context("merging source alternates")?;
         append_reference_alternates(
@@ -2324,11 +2329,9 @@ fn run_ssh_clone(args: Args) -> Result<()> {
         .context("adding --reference alternates")?;
         let alt_dir = dest.git_dir.join("objects/info");
         let _ = fs::create_dir_all(&alt_dir);
-        if args.reference.is_empty() && args.reference_if_able.is_empty() {
-            let source_objects = source.git_dir.join("objects");
-            if let Ok(abs) = source_objects.canonicalize() {
-                add_alternate_objects_line(&alt_dir, &abs)?;
-            }
+        let source_objects = source.git_dir.join("objects");
+        if let Ok(abs) = source_objects.canonicalize() {
+            add_alternate_objects_line(&alt_dir, &abs)?;
         }
         propagate_extensions_object_format(&source.git_dir, &dest.git_dir)?;
     }

--- a/grit/src/fetch_transport.rs
+++ b/grit/src/fetch_transport.rs
@@ -297,15 +297,17 @@ pub(crate) fn spawn_upload_pack_with_proto(
         .with_context(|| format!("failed to spawn upload-pack: {script}"))
 }
 
+/// Spawn `upload-pack` for local pipe negotiation ([`fetch_via_upload_pack_skipping`], etc.).
+///
+/// Always uses **protocol v0** ref advertisement for the child (`GIT_PROTOCOL` cleared), even when
+/// the user's `protocol.version` is 2. The local fetch client reads the v0 pkt-line ref list via
+/// [`read_advertisement`]; a v2 server would emit `version 2` capability lines first and no ref
+/// rows, which breaks refspec resolution (e.g. `t5501-fetch-push-alternates`).
 pub(crate) fn spawn_upload_pack(
     cmd_template: Option<&str>,
     repo_path: &Path,
 ) -> Result<std::process::Child> {
-    spawn_upload_pack_with_proto(
-        cmd_template,
-        repo_path,
-        protocol_wire::effective_client_protocol_version(),
-    )
+    spawn_upload_pack_with_proto(cmd_template, repo_path, 0)
 }
 
 pub(crate) fn drain_child_stdout_to_eof(r: &mut impl Read) -> std::io::Result<()> {

--- a/logs/2026-04-09-t5501-fetch-push-alternates.md
+++ b/logs/2026-04-09-t5501-fetch-push-alternates.md
@@ -1,0 +1,19 @@
+# t5501-fetch-push-alternates
+
+## Failures
+
+1. **Local `git fetch`**: `spawn_upload_pack` passed `effective_client_protocol_version()` (default 2) to the child, so `upload-pack` advertised protocol v2 capability lines. The fetch client used `read_advertisement` (v0 ref list parser), saw no `refs/heads/*` lines, and failed with `could not find remote ref 'refs/heads/main'`.
+
+2. **`count_objects` mismatch after fetch**: `clone --reference` copied all loose objects from the source into the clone, so `one.count` was huge while `fetcher` only had objects fetched from `one` (Git keeps reference clones thin via alternates only).
+
+## Fixes
+
+- `fetch_transport.rs`: `spawn_upload_pack` always spawns upload-pack with protocol v0 (`client_proto == 0`, clears `GIT_PROTOCOL`) for pipe negotiation used by `fetch_via_upload_pack_skipping`.
+
+- `clone.rs` (both local-clone branches): when `--reference` or `--reference-if-able` is set, skip `copy_objects`; always add the source `objects` directory to `info/alternates` (deduped) so objects resolve like Git.
+
+## Validation
+
+- `./scripts/run-tests.sh t5501-fetch-push-alternates.sh`
+- `cargo test -p grit-lib --lib`
+- `cargo check -p grit-rs`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes `t5501-fetch-push-alternates` pass by aligning two behaviors with Git.

## Changes

1. **Local fetch / upload-pack** (`grit/src/fetch_transport.rs`): The upload-pack child used `protocol.version` 2 by default, so it advertised v2 capability lines. The local fetch path still parsed the advertisement as a v0 ref list, so `main` never appeared and fetch failed with `could not find remote ref 'refs/heads/main'`. `spawn_upload_pack` now always spawns with v0 (clears `GIT_PROTOCOL`) for this pipe negotiation.

2. **Reference clone** (`grit/src/commands/clone.rs`): `clone --reference` was copying all loose/pack objects from the source, inflating `count-objects` in the clone vs repos that only see objects via the same alternate. With `--reference` / `--reference-if-able`, we skip `copy_objects` and always add the source `objects` directory to `info/alternates` (deduped), matching Git’s thin reference clone.

## Testing

- `./scripts/run-tests.sh t5501-fetch-push-alternates.sh` (3/3)
- `cargo test -p grit-lib --lib`
- `cargo check -p grit-rs`

Task log: `logs/2026-04-09-t5501-fetch-push-alternates.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5bdcff33-b75b-45e2-a7cd-e01b15fcaa6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5bdcff33-b75b-45e2-a7cd-e01b15fcaa6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

