### PR TITLE
fix: make t3300-funny-names pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -570,7 +570,7 @@ t3206-range-diff	t3	yes	48	18	30	false	ok	0
 t3207-branch-submodule	t3	yes	20	2	18	false	ok	0
 t3210-pack-refs	t3	yes	29	29	0	true	ok	0
 t3211-peel-ref	t3	yes	8	8	0	true	ok	0
-t3300-funny-names	t3	yes	21	8	13	false	ok	0
+t3300-funny-names	t3	yes	21	21	0	true	ok	0
 t3301-notes	t3	yes	153	57	96	false	ok	0
 t3301-notes-basic	t3	yes	38	38	0	true	ok	0
 t3302-notes-index-expensive	t3	yes	12	12	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.2% of harness tests passing (35,289 / 45,112).">
+<meta property="og:description" content="78.3% of harness tests passing (35,302 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.2% of harness tests passing (35,289 / 45,112).">
+<meta name="twitter:description" content="78.3% of harness tests passing (35,302 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T15:06:57+00:00" class="gen-time" title="2026-04-09 15:06 UTC">2026-04-09 15:06 UTC</time> · <a href="https://github.com/schacon/grit/commit/c4ad2e9f44715e944bf5d633e8117c550d9c487c" style="color:#58a6ff">c4ad2e9</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T16:36:33+00:00" class="gen-time" title="2026-04-09 16:36 UTC">2026-04-09 16:36 UTC</time> · <a href="https://github.com/schacon/grit/commit/d453c985a004bbafaab0d0367914b362de89e59b" style="color:#58a6ff">d453c98</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">78.2%</div>
+      <div class="summary-big-val pct-blue">78.3%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,289</div>
+      <div class="summary-big-val">35,302</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:78.2%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:78.3%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>733 files fully passing</span>
+    <span>734 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -219,11 +219,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">52/141 files · 2 skipped · 3,923/5,369 tests</span>
+        <span class="group-meta">53/141 files · 2 skipped · 3,936/5,369 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:73.1%"></div></div>
-        <span class="group-pct pct-blue">73.1%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:73.3%"></div></div>
+        <span class="group-pct pct-blue">73.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35289 of 45112 tests passing across 1405 harness files (78.2% pass rate).</desc>
+  <desc id="svg-desc">35302 of 45112 tests passing across 1405 harness files (78.3% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.2% pass rate · 35,289 / 45,112 tests · 1,405 files in scope · 733 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.3% pass rate · 35,302 / 45,112 tests · 1,405 files in scope · 734 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="547" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="548" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T15:06:57+00:00" class="gen-time" title="2026-04-09 15:06 UTC">2026-04-09 15:06 UTC</time> · <a href="https://github.com/schacon/grit/commit/c4ad2e9f44715e944bf5d633e8117c550d9c487c" style="color:#58a6ff">c4ad2e9</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T16:36:33+00:00" class="gen-time" title="2026-04-09 16:36 UTC">2026-04-09 16:36 UTC</time> · <a href="https://github.com/schacon/grit/commit/d453c985a004bbafaab0d0367914b362de89e59b" style="color:#58a6ff">d453c98</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,289</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">78.2%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,302</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">78.3%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -5857,14 +5857,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="21" data-passed="8">
+<tr class="" data-group="t3" data-tests="21" data-passed="21" data-full-pass="1">
   <td class="mono">t3300-funny-names</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">21</td>
-  <td class="right">8</td>
+  <td class="right">21</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:38.1%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="153" data-passed="57">

--- a/grit-lib/src/quote_path.rs
+++ b/grit-lib/src/quote_path.rs
@@ -48,19 +48,15 @@ fn cq_must_quote(byte: u8, quote_fully: bool) -> bool {
     i32::from(CQ_LOOKUP[byte as usize]) + i32::from(quote_fully) > 0
 }
 
-/// Quote `path` in Git C style when needed, matching `quote_c_style` + `core.quotepath`.
-///
-/// When `quote_fully` is true (Git default, `core.quotepath=true`), non-ASCII bytes are
-/// emitted as `\ooo` escapes. When false, UTF-8 / high bytes are copied literally and only
-/// ASCII special characters are escaped.
-#[must_use]
-pub fn quote_c_style(path: &str, quote_fully: bool) -> String {
+fn quote_c_style_inner(path: &str, quote_fully: bool, force_quotes: bool) -> String {
     let bytes = path.as_bytes();
-    let mut any = false;
-    for &b in bytes {
-        if cq_must_quote(b, quote_fully) {
-            any = true;
-            break;
+    let mut any = force_quotes;
+    if !any {
+        for &b in bytes {
+            if cq_must_quote(b, quote_fully) {
+                any = true;
+                break;
+            }
         }
     }
     if !any {
@@ -96,6 +92,40 @@ pub fn quote_c_style(path: &str, quote_fully: bool) -> String {
     out
 }
 
+/// Quote `path` in Git C style when needed, matching `quote_c_style` + `core.quotepath`.
+///
+/// When `quote_fully` is true (Git default, `core.quotepath=true`), non-ASCII bytes are
+/// emitted as `\ooo` escapes. When false, UTF-8 / high bytes are copied literally and only
+/// ASCII special characters are escaped.
+#[must_use]
+pub fn quote_c_style(path: &str, quote_fully: bool) -> String {
+    quote_c_style_inner(path, quote_fully, false)
+}
+
+/// Quote for `ls-tree` default output: same as [`quote_c_style`], but paths containing `,`
+/// are always wrapped in quotes (Git `quote_path` with `ls_tree` mode).
+#[must_use]
+pub fn quote_path_for_tree_listing(path: &str, quote_fully: bool) -> String {
+    let force = path.as_bytes().contains(&b',');
+    quote_c_style_inner(path, quote_fully, force)
+}
+
+/// Format one side of a `diff --git` / `---` / `+++` line: either `prefix/path` or
+/// `"prefix<escaped-path>"` when Git would C-quote the path (see `t3300-funny-names`).
+#[must_use]
+pub fn format_diff_path_with_prefix(prefix: &str, path: &str, quote_fully: bool) -> String {
+    let quoted = quote_c_style(path, quote_fully);
+    if quoted == path {
+        format!("{prefix}{path}")
+    } else {
+        let inner = quoted
+            .strip_prefix('"')
+            .and_then(|s| s.strip_suffix('"'))
+            .unwrap_or(path);
+        format!("\"{prefix}{inner}\"")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -122,5 +152,21 @@ mod tests {
         assert_eq!(quote_c_style(s, false), "\"濱野\\t純\"");
         let s2 = "濱野 純";
         assert_eq!(quote_c_style(s2, false), "濱野 純");
+    }
+
+    #[test]
+    fn comma_forces_ls_tree_style_quotes() {
+        assert_eq!(quote_path_for_tree_listing("a,b", true), "\"a,b\"");
+        assert_eq!(quote_c_style("a,b", true), "a,b");
+    }
+
+    #[test]
+    fn diff_git_prefix_quoting() {
+        let p = "tabs\t,\" (dq) and spaces";
+        assert_eq!(
+            format_diff_path_with_prefix("a/", p, true),
+            "\"a/tabs\\t,\\\" (dq) and spaces\""
+        );
+        assert_eq!(format_diff_path_with_prefix("b/", "plain", true), "b/plain");
     }
 }

--- a/grit/src/commands/apply.rs
+++ b/grit/src/commands/apply.rs
@@ -18,6 +18,7 @@ use grit_lib::config::ConfigSet;
 use grit_lib::crlf;
 use grit_lib::index::{Index, IndexEntry};
 use grit_lib::objects::ObjectKind;
+use grit_lib::quote_path::quote_c_style;
 use grit_lib::repo::Repository;
 use grit_lib::rev_parse::resolve_revision;
 use grit_lib::ws::{self, WhitespaceGitAttr, WS_BLANK_AT_EOF, WS_DEFAULT_RULE, WS_INCOMPLETE_LINE};
@@ -1106,7 +1107,16 @@ fn header_line_file_path(line: &str, p_value: usize) -> String {
 
 /// Path from `rename from` / `copy from` lines (Git `find_name` with `terminate == 0`).
 fn find_name_extended_header(rest: &str, p_extended: usize) -> Option<String> {
-    let b = rest.trim_end_matches(['\r', '\n']).as_bytes();
+    let rest = rest.trim_end_matches(['\r', '\n']);
+    let b = rest.as_bytes();
+    if b.first() == Some(&b'"') {
+        let (decoded, tail) = unquote_c_style_diff_prefix(rest)?;
+        if !tail.trim().is_empty() {
+            return None;
+        }
+        let skip = skip_tree_prefix_bytes(&decoded, p_extended)?;
+        return bytes_to_path_string(skip).ok();
+    }
     let end = b
         .iter()
         .position(|&c| c == b'\t' || c == b'\n' || c == b'\r' || c == b' ')
@@ -1552,6 +1562,11 @@ fn parse_hunk(lines: &[&str], start: usize) -> Result<(Hunk, usize)> {
     while i < lines.len() {
         let line = lines[i];
         if line.starts_with("@@ ") || line.starts_with("diff --git ") {
+            break;
+        }
+        // `---` / `+++` with a space begin a new file header; do not treat `---` as a `-` hunk line
+        // (would misparse `--- /dev/null` as a remove of `-- /dev/null` and merge the next file).
+        if line.starts_with("--- ") || line.starts_with("+++ ") {
             break;
         }
         if line == "-- " {
@@ -2963,7 +2978,15 @@ fn write_reject_file(path: &Path, patch: &FilePatch, rejected_hunks: &[Hunk]) ->
 // Stat / numstat / summary output
 // ---------------------------------------------------------------------------
 
-fn show_stat(patches: &[FilePatch], directory: Option<&str>) {
+fn apply_quote_path_fully() -> bool {
+    Repository::discover(None)
+        .ok()
+        .and_then(|r| ConfigSet::load(Some(&r.git_dir), true).ok())
+        .map(|c| c.quote_path_fully())
+        .unwrap_or(true)
+}
+
+fn show_stat(patches: &[FilePatch], directory: Option<&str>, quote_fully: bool) {
     let stdout = io::stdout();
     let mut out = stdout.lock();
 
@@ -2977,13 +3000,14 @@ fn show_stat(patches: &[FilePatch], directory: Option<&str>) {
             .effective_path()
             .map(|p| adjust_path(p, directory))
             .unwrap_or_else(|| "(unknown)".to_string());
+        let display = quote_c_style(&path, quote_fully);
         let (add, del) = count_hunk_changes(&fp.hunks);
-        if path.len() > max_path_len {
-            max_path_len = path.len();
+        if display.len() > max_path_len {
+            max_path_len = display.len();
         }
         total_add += add;
         total_del += del;
-        entries.push((path, add, del));
+        entries.push((display, add, del));
     }
 
     for (path, add, del) in &entries {
@@ -3005,7 +3029,7 @@ fn show_stat(patches: &[FilePatch], directory: Option<&str>) {
     );
 }
 
-fn show_numstat(patches: &[FilePatch], directory: Option<&str>) {
+fn show_numstat(patches: &[FilePatch], directory: Option<&str>, quote_fully: bool) {
     let stdout = io::stdout();
     let mut out = stdout.lock();
 
@@ -3014,8 +3038,9 @@ fn show_numstat(patches: &[FilePatch], directory: Option<&str>) {
             .effective_path()
             .map(|p| adjust_path(p, directory))
             .unwrap_or_else(|| "(unknown)".to_string());
+        let display = quote_c_style(&path, quote_fully);
         let (add, del) = count_hunk_changes(&fp.hunks);
-        let _ = writeln!(out, "{add}\t{del}\t{path}");
+        let _ = writeln!(out, "{add}\t{del}\t{display}");
     }
 }
 
@@ -3157,11 +3182,16 @@ pub fn run(mut args: Args) -> Result<()> {
 
     // Info-only modes unless explicitly overridden by --apply.
     let info_only = (args.stat || args.numstat || args.summary) && !args.apply;
+    let quote_fully = if args.stat || args.numstat {
+        apply_quote_path_fully()
+    } else {
+        true
+    };
     if args.stat {
-        show_stat(&patches, args.directory.as_deref());
+        show_stat(&patches, args.directory.as_deref(), quote_fully);
     }
     if args.numstat {
-        show_numstat(&patches, args.directory.as_deref());
+        show_numstat(&patches, args.directory.as_deref(), quote_fully);
     }
     if args.summary {
         show_summary(&patches, args.directory.as_deref());

--- a/grit/src/commands/diff_index.rs
+++ b/grit/src/commands/diff_index.rs
@@ -3,8 +3,8 @@
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::diff::{
-    detect_copies, detect_renames, diff_trees, read_submodule_head_oid, stat_matches, zero_oid,
-    DiffEntry, DiffStatus,
+    detect_renames, diff_trees, read_submodule_head_oid, stat_matches, zero_oid, DiffEntry,
+    DiffStatus,
 };
 use grit_lib::index::{
     Index, IndexEntry, MODE_EXECUTABLE, MODE_GITLINK, MODE_REGULAR, MODE_SYMLINK, MODE_TREE,
@@ -12,6 +12,7 @@ use grit_lib::index::{
 use grit_lib::objects::{parse_commit, parse_tree, ObjectId, ObjectKind};
 use grit_lib::odb::Odb;
 use grit_lib::pathspec::{context_from_mode_bits, matches_pathspec_with_context};
+use grit_lib::quote_path::{format_diff_path_with_prefix, quote_c_style};
 use grit_lib::repo::Repository;
 use grit_lib::rev_list::merge_bases;
 use grit_lib::rev_parse::{abbreviate_object_id, resolve_revision};
@@ -34,6 +35,9 @@ pub struct Args {
 pub fn run(args: Args) -> Result<()> {
     let options = parse_options(&args.args)?;
     let repo = Repository::discover(None).context("not a git repository")?;
+    let quote_fully = grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true)
+        .unwrap_or_default()
+        .quote_path_fully();
     let tree_oid = resolve_tree_ish(&repo, &options.tree_ish)?;
 
     let mut tree_map = BTreeMap::new();
@@ -141,12 +145,13 @@ pub fn run(args: Args) -> Result<()> {
 
     let diff_entries = if options.find_copies {
         let threshold = options.find_renames.unwrap_or(50);
-        // Build source tree entries for copy detection.
+        // Build source tree entries for copy detection (`path, mode, oid` order matches
+        // `grit_lib::diff::detect_copies`).
         let source_tree_entries: Vec<(String, String, ObjectId)> = tree_map
             .iter()
             .map(|(path, snap)| (path.clone(), format!("{:06o}", snap.mode), snap.oid))
             .collect();
-        detect_copies(
+        grit_lib::diff::detect_copies(
             &repo.odb,
             diff_entries,
             threshold,
@@ -217,8 +222,16 @@ pub fn run(args: Args) -> Result<()> {
         } else if options.numstat {
             write_diff_index_numstat(&diff_entries, &repo.odb)?;
         } else if options.name_only {
+            let term = if options.nul_terminated { b'\0' } else { b'\n' };
+            let stdout = std::io::stdout();
+            let mut out = stdout.lock();
             for entry in &diff_entries {
-                println!("{}", entry.path());
+                if options.nul_terminated {
+                    out.write_all(entry.path().as_bytes())?;
+                } else {
+                    write!(out, "{}", quote_c_style(entry.path(), quote_fully))?;
+                }
+                out.write_all(&[term])?;
             }
         } else if options.patch {
             let stdout = std::io::stdout();
@@ -244,41 +257,35 @@ pub fn run(args: Args) -> Result<()> {
                 )?;
             }
         } else if options.name_status {
-            for entry in &diff_entries {
-                match (entry.status, entry.score) {
-                    (DiffStatus::Renamed, Some(s)) => {
-                        println!(
-                            "R{:03}\t{}\t{}",
-                            s,
-                            entry.old_path.as_deref().unwrap_or(""),
-                            entry.new_path.as_deref().unwrap_or("")
-                        );
-                    }
-                    (DiffStatus::Copied, Some(s)) => {
-                        println!(
-                            "C{:03}\t{}\t{}",
-                            s,
-                            entry.old_path.as_deref().unwrap_or(""),
-                            entry.new_path.as_deref().unwrap_or("")
-                        );
-                    }
-                    _ => {
-                        println!("{}\t{}", entry.status.letter(), entry.path());
-                    }
-                }
-            }
+            let stdout = std::io::stdout();
+            let mut out = stdout.lock();
+            write_diff_index_name_status(
+                &mut out,
+                &diff_entries,
+                quote_fully,
+                options.nul_terminated,
+            )?;
         } else {
-            let terminator = if options.nul_terminated { "\0" } else { "\n" };
             let stdout = std::io::stdout();
             let mut out = stdout.lock();
             for entry in &diff_entries {
-                let line = render_raw_diff_entry(entry, &repo, options.abbrev, !options.cached)?;
                 if options.nul_terminated {
-                    // In -z mode, the colon-prefixed status line ends with NUL,
-                    // then path(s) follow separated/terminated by NUL
-                    write!(out, "{}{}", line, terminator)?;
+                    write_raw_diff_index_z(
+                        &mut out,
+                        entry,
+                        &repo,
+                        options.abbrev,
+                        !options.cached,
+                    )?;
                 } else {
-                    writeln!(out, "{}", line)?;
+                    let line = render_raw_diff_entry(
+                        entry,
+                        &repo,
+                        options.abbrev,
+                        !options.cached,
+                        quote_fully,
+                    )?;
+                    writeln!(out, "{line}")?;
                 }
             }
         }
@@ -854,9 +861,17 @@ fn diff_tree_vs_worktree(
 
     for (path, index_snapshot) in index_map {
         // Match Git: `diff-index` without `--cached` reports tree↔index differences first.
-        // Only when the tree and index agree for a path do we compare the index to the work tree
-        // (t1501: new staged file + dirty worktree still shows as `A` with zero OIDs, not `M`).
-        if tree_map.get(path).copied() != Some(*index_snapshot) {
+        // Compare index to worktree when:
+        // - Tree and index agree for this path (t1501: tree≠index stays as tree↔index only), or
+        // - The path is not in the tree but is in the index (staged add): chmod/content drift in
+        //   the work tree must update the recorded snapshot so rename output shows `new mode`
+        //   (t3300-funny-names).
+        let tree_snap = tree_map.get(path).copied();
+        let compare_worktree = match tree_snap {
+            Some(ts) => ts == *index_snapshot,
+            None => true,
+        };
+        if !compare_worktree {
             continue;
         }
 
@@ -930,22 +945,37 @@ fn diff_tree_vs_worktree(
         match read_worktree_snapshot_from_meta(repo, &abs, &meta)? {
             Some(worktree_snapshot) => {
                 if worktree_snapshot != *index_snapshot {
-                    let old = tree_map.get(path).copied().or(Some(*index_snapshot));
-                    // Use zero OID for worktree side — the blob is not
-                    // in the object database, matching git's behaviour.
-                    let wt_placeholder = Snapshot {
-                        mode: worktree_snapshot.mode,
-                        oid: zero_oid(),
-                    };
-                    merged.insert(
-                        path.clone(),
-                        RawChange {
-                            path: path.clone(),
-                            status: 'M',
-                            old,
-                            new: Some(wt_placeholder),
-                        },
-                    );
+                    if tree_snap.is_none() {
+                        // Staged add only in the index: refresh the `new` snapshot from the work
+                        // tree (e.g. `chmod` after `git add`) while keeping status `A` so rename
+                        // detection still pairs the delete with this add (t3300-funny-names).
+                        merged.insert(
+                            path.clone(),
+                            RawChange {
+                                path: path.clone(),
+                                status: 'A',
+                                old: None,
+                                new: Some(worktree_snapshot),
+                            },
+                        );
+                    } else {
+                        let old = tree_map.get(path).copied().or(Some(*index_snapshot));
+                        // Use zero OID for worktree side — the blob is not
+                        // in the object database, matching git's behaviour.
+                        let wt_placeholder = Snapshot {
+                            mode: worktree_snapshot.mode,
+                            oid: zero_oid(),
+                        };
+                        merged.insert(
+                            path.clone(),
+                            RawChange {
+                                path: path.clone(),
+                                status: 'M',
+                                old,
+                                new: Some(wt_placeholder),
+                            },
+                        );
+                    }
                 }
             }
             None => {
@@ -1056,12 +1086,129 @@ fn raw_change_to_diff_entry(change: &RawChange) -> DiffEntry {
     }
 }
 
+pub(crate) fn write_diff_index_name_status(
+    out: &mut impl std::io::Write,
+    entries: &[DiffEntry],
+    quote_fully: bool,
+    nul: bool,
+) -> Result<()> {
+    for entry in entries {
+        match (entry.status, entry.score) {
+            (DiffStatus::Renamed, Some(s)) => {
+                if nul {
+                    write!(out, "R{s:03}\0")?;
+                    out.write_all(entry.old_path.as_deref().unwrap_or("").as_bytes())?;
+                    out.write_all(b"\0")?;
+                    out.write_all(entry.new_path.as_deref().unwrap_or("").as_bytes())?;
+                    out.write_all(b"\0")?;
+                } else {
+                    writeln!(
+                        out,
+                        "R{s:03}\t{}\t{}",
+                        quote_c_style(entry.old_path.as_deref().unwrap_or(""), quote_fully),
+                        quote_c_style(entry.new_path.as_deref().unwrap_or(""), quote_fully),
+                    )?;
+                }
+            }
+            (DiffStatus::Copied, Some(s)) => {
+                if nul {
+                    write!(out, "C{s:03}\0")?;
+                    out.write_all(entry.old_path.as_deref().unwrap_or("").as_bytes())?;
+                    out.write_all(b"\0")?;
+                    out.write_all(entry.new_path.as_deref().unwrap_or("").as_bytes())?;
+                    out.write_all(b"\0")?;
+                } else {
+                    writeln!(
+                        out,
+                        "C{s:03}\t{}\t{}",
+                        quote_c_style(entry.old_path.as_deref().unwrap_or(""), quote_fully),
+                        quote_c_style(entry.new_path.as_deref().unwrap_or(""), quote_fully),
+                    )?;
+                }
+            }
+            _ => {
+                if nul {
+                    write!(out, "{}\0", entry.status.letter())?;
+                    out.write_all(entry.path().as_bytes())?;
+                    out.write_all(b"\0")?;
+                } else {
+                    writeln!(
+                        out,
+                        "{}\t{}",
+                        entry.status.letter(),
+                        quote_c_style(entry.path(), quote_fully)
+                    )?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn write_raw_diff_index_z(
+    out: &mut impl std::io::Write,
+    entry: &DiffEntry,
+    repo: &Repository,
+    abbrev: Option<usize>,
+    diff_index_uncached: bool,
+) -> Result<()> {
+    let width = abbrev.unwrap_or(40).clamp(4, 40);
+
+    let (old_oid_disp, new_oid_disp) = if diff_index_uncached && entry.status == DiffStatus::Added {
+        ("0".repeat(width), "0".repeat(width))
+    } else {
+        let old_oid = if entry.old_oid == zero_oid() {
+            "0".repeat(width)
+        } else {
+            match abbrev {
+                Some(min_len) => abbreviate_object_id(repo, entry.old_oid, min_len)?,
+                None => entry.old_oid.to_hex(),
+            }
+        };
+        let new_oid = if entry.new_oid == zero_oid() {
+            "0".repeat(width)
+        } else {
+            match abbrev {
+                Some(min_len) => abbreviate_object_id(repo, entry.new_oid, min_len)?,
+                None => entry.new_oid.to_hex(),
+            }
+        };
+        (old_oid, new_oid)
+    };
+
+    let status_str = match (entry.status, entry.score) {
+        (DiffStatus::Renamed, Some(s)) => format!("R{s:03}"),
+        (DiffStatus::Copied, Some(s)) => format!("C{s:03}"),
+        _ => entry.status.letter().to_string(),
+    };
+
+    write!(
+        out,
+        ":{} {} {} {} {}\0",
+        entry.old_mode, entry.new_mode, old_oid_disp, new_oid_disp, status_str
+    )?;
+    match entry.status {
+        DiffStatus::Renamed | DiffStatus::Copied => {
+            out.write_all(entry.old_path.as_deref().unwrap_or("").as_bytes())?;
+            out.write_all(b"\0")?;
+            out.write_all(entry.new_path.as_deref().unwrap_or("").as_bytes())?;
+            out.write_all(b"\0")?;
+        }
+        _ => {
+            out.write_all(entry.path().as_bytes())?;
+            out.write_all(b"\0")?;
+        }
+    }
+    Ok(())
+}
+
 /// Render a DiffEntry in raw format.
 fn render_raw_diff_entry(
     entry: &DiffEntry,
     repo: &Repository,
     abbrev: Option<usize>,
     diff_index_uncached: bool,
+    quote_fully: bool,
 ) -> Result<String> {
     let width = abbrev.unwrap_or(40).clamp(4, 40);
 
@@ -1099,11 +1246,11 @@ fn render_raw_diff_entry(
         DiffStatus::Renamed | DiffStatus::Copied => {
             format!(
                 "{}\t{}",
-                entry.old_path.as_deref().unwrap_or(""),
-                entry.new_path.as_deref().unwrap_or("")
+                quote_c_style(entry.old_path.as_deref().unwrap_or(""), quote_fully),
+                quote_c_style(entry.new_path.as_deref().unwrap_or(""), quote_fully),
             )
         }
-        _ => entry.path().to_owned(),
+        _ => quote_c_style(entry.path(), quote_fully),
     };
 
     Ok(format!(
@@ -1567,9 +1714,13 @@ pub(crate) fn write_patch_entry_inner(
     work_tree: Option<&Path>,
     path_prefix: &str,
 ) -> Result<()> {
-    use grit_lib::diff::unified_diff;
+    use grit_lib::diff::unified_diff_with_prefix;
 
     validate_patch_entry_oids(entry)?;
+
+    let quote_fully = grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true)
+        .unwrap_or_default()
+        .quote_path_fully();
 
     let old_path = entry
         .old_path
@@ -1588,9 +1739,11 @@ pub(crate) fn write_patch_entry_inner(
             format!("{path_prefix}/{new_path}"),
         )
     };
+    let git_old = format_diff_path_with_prefix("a/", &disp_old, quote_fully);
+    let git_new = format_diff_path_with_prefix("b/", &disp_new, quote_fully);
 
     if entry.old_mode == "160000" || entry.new_mode == "160000" {
-        writeln!(out, "diff --git a/{disp_old} b/{disp_new}")?;
+        writeln!(out, "diff --git {git_old} {git_new}")?;
         match entry.status {
             DiffStatus::Added => {
                 writeln!(out, "new file mode {}", entry.new_mode)?;
@@ -1601,7 +1754,11 @@ pub(crate) fn write_patch_entry_inner(
                     &entry.new_oid.to_hex()[..7]
                 )?;
                 writeln!(out, "--- /dev/null")?;
-                writeln!(out, "+++ b/{disp_new}")?;
+                writeln!(
+                    out,
+                    "+++ {}",
+                    format_diff_path_with_prefix("b/", &disp_new, quote_fully)
+                )?;
                 writeln!(out, "@@ -0,0 +1 @@")?;
                 writeln!(out, "+Subproject commit {}", entry.new_oid.to_hex())?;
             }
@@ -1613,7 +1770,11 @@ pub(crate) fn write_patch_entry_inner(
                     &entry.old_oid.to_hex()[..7],
                     &entry.new_oid.to_hex()[..7]
                 )?;
-                writeln!(out, "--- a/{disp_old}")?;
+                writeln!(
+                    out,
+                    "--- {}",
+                    format_diff_path_with_prefix("a/", &disp_old, quote_fully)
+                )?;
                 writeln!(out, "+++ /dev/null")?;
                 writeln!(out, "@@ -1 +0,0 @@")?;
                 writeln!(out, "-Subproject commit {}", entry.old_oid.to_hex())?;
@@ -1627,8 +1788,16 @@ pub(crate) fn write_patch_entry_inner(
                         &entry.new_oid.to_hex()[..7],
                         entry.old_mode
                     )?;
-                    writeln!(out, "--- a/{disp_old}")?;
-                    writeln!(out, "+++ b/{disp_new}")?;
+                    writeln!(
+                        out,
+                        "--- {}",
+                        format_diff_path_with_prefix("a/", &disp_old, quote_fully)
+                    )?;
+                    writeln!(
+                        out,
+                        "+++ {}",
+                        format_diff_path_with_prefix("b/", &disp_new, quote_fully)
+                    )?;
                     writeln!(out, "@@ -1 +1 @@")?;
                     writeln!(out, "-Subproject commit {}", entry.old_oid.to_hex())?;
                     writeln!(out, "+Subproject commit {}", entry.new_oid.to_hex())?;
@@ -1640,8 +1809,16 @@ pub(crate) fn write_patch_entry_inner(
                         &entry.new_oid.to_hex()[..7],
                         entry.old_mode
                     )?;
-                    writeln!(out, "--- a/{disp_old}")?;
-                    writeln!(out, "+++ b/{disp_new}")?;
+                    writeln!(
+                        out,
+                        "--- {}",
+                        format_diff_path_with_prefix("a/", &disp_old, quote_fully)
+                    )?;
+                    writeln!(
+                        out,
+                        "+++ {}",
+                        format_diff_path_with_prefix("b/", &disp_new, quote_fully)
+                    )?;
                     writeln!(out, "@@ -1 +0,0 @@")?;
                     writeln!(out, "-Subproject commit {}", entry.old_oid.to_hex())?;
                 } else {
@@ -1652,8 +1829,16 @@ pub(crate) fn write_patch_entry_inner(
                         &entry.new_oid.to_hex()[..7],
                         entry.new_mode
                     )?;
-                    writeln!(out, "--- a/{disp_old}")?;
-                    writeln!(out, "+++ b/{disp_new}")?;
+                    writeln!(
+                        out,
+                        "--- {}",
+                        format_diff_path_with_prefix("a/", &disp_old, quote_fully)
+                    )?;
+                    writeln!(
+                        out,
+                        "+++ {}",
+                        format_diff_path_with_prefix("b/", &disp_new, quote_fully)
+                    )?;
                     writeln!(out, "@@ -0,0 +1 @@")?;
                     writeln!(out, "+Subproject commit {}", entry.new_oid.to_hex())?;
                 }
@@ -1667,8 +1852,16 @@ pub(crate) fn write_patch_entry_inner(
                         &entry.new_oid.to_hex()[..7],
                         entry.old_mode
                     )?;
-                    writeln!(out, "--- a/{disp_old}")?;
-                    writeln!(out, "+++ b/{disp_new}")?;
+                    writeln!(
+                        out,
+                        "--- {}",
+                        format_diff_path_with_prefix("a/", &disp_old, quote_fully)
+                    )?;
+                    writeln!(
+                        out,
+                        "+++ {}",
+                        format_diff_path_with_prefix("b/", &disp_new, quote_fully)
+                    )?;
                     writeln!(out, "@@ -1 +0,0 @@")?;
                     writeln!(out, "-Subproject commit {}", entry.old_oid.to_hex())?;
                 } else if entry.new_mode == "160000" {
@@ -1679,8 +1872,16 @@ pub(crate) fn write_patch_entry_inner(
                         &entry.new_oid.to_hex()[..7],
                         entry.new_mode
                     )?;
-                    writeln!(out, "--- a/{disp_old}")?;
-                    writeln!(out, "+++ b/{disp_new}")?;
+                    writeln!(
+                        out,
+                        "--- {}",
+                        format_diff_path_with_prefix("a/", &disp_old, quote_fully)
+                    )?;
+                    writeln!(
+                        out,
+                        "+++ {}",
+                        format_diff_path_with_prefix("b/", &disp_new, quote_fully)
+                    )?;
                     writeln!(out, "@@ -0,0 +1 @@")?;
                     writeln!(out, "+Subproject commit {}", entry.new_oid.to_hex())?;
                 }
@@ -1690,7 +1891,7 @@ pub(crate) fn write_patch_entry_inner(
         return Ok(());
     }
 
-    writeln!(out, "diff --git a/{disp_old} b/{disp_new}")?;
+    writeln!(out, "diff --git {git_old} {git_new}")?;
 
     match entry.status {
         DiffStatus::Added => {
@@ -1732,10 +1933,14 @@ pub(crate) fn write_patch_entry_inner(
             }
         }
         DiffStatus::Renamed => {
+            if entry.old_mode != entry.new_mode {
+                writeln!(out, "old mode {}", entry.old_mode)?;
+                writeln!(out, "new mode {}", entry.new_mode)?;
+            }
             let sim = entry.score.unwrap_or(100);
             writeln!(out, "similarity index {sim}%")?;
-            writeln!(out, "rename from {old_path}")?;
-            writeln!(out, "rename to {new_path}")?;
+            writeln!(out, "rename from {}", quote_c_style(old_path, quote_fully))?;
+            writeln!(out, "rename to {}", quote_c_style(new_path, quote_fully))?;
             if entry.old_oid != entry.new_oid {
                 writeln!(
                     out,
@@ -1748,8 +1953,8 @@ pub(crate) fn write_patch_entry_inner(
         DiffStatus::Copied => {
             let sim = entry.score.unwrap_or(100);
             writeln!(out, "similarity index {sim}%")?;
-            writeln!(out, "copy from {old_path}")?;
-            writeln!(out, "copy to {new_path}")?;
+            writeln!(out, "copy from {}", quote_c_style(old_path, quote_fully))?;
+            writeln!(out, "copy to {}", quote_c_style(new_path, quote_fully))?;
             if entry.old_oid != entry.new_oid {
                 writeln!(
                     out,
@@ -1792,20 +1997,17 @@ pub(crate) fn write_patch_entry_inner(
         && (is_binary_driver_path(repo, work_tree, old_path)
             || is_binary_driver_path(repo, work_tree, new_path));
     if treat_as_binary_by_driver || is_binary(&old_raw) || is_binary(&new_raw) {
-        let display_old = if entry.status == DiffStatus::Added {
-            "/dev/null"
+        let bo = if entry.status == DiffStatus::Added {
+            "/dev/null".to_owned()
         } else {
-            old_path
+            format_diff_path_with_prefix("a/", old_path, quote_fully)
         };
-        let display_new = if entry.status == DiffStatus::Deleted {
-            "/dev/null"
+        let bn = if entry.status == DiffStatus::Deleted {
+            "/dev/null".to_owned()
         } else {
-            new_path
+            format_diff_path_with_prefix("b/", new_path, quote_fully)
         };
-        writeln!(
-            out,
-            "Binary files a/{display_old} and b/{display_new} differ"
-        )?;
+        writeln!(out, "Binary files {bo} and {bn} differ")?;
         return Ok(());
     }
 
@@ -1815,20 +2017,23 @@ pub(crate) fn write_patch_entry_inner(
     let display_old = if entry.status == DiffStatus::Added {
         "/dev/null".to_owned()
     } else {
-        disp_old.clone()
+        format_diff_path_with_prefix("a/", &disp_old, quote_fully)
     };
     let display_new = if entry.status == DiffStatus::Deleted {
         "/dev/null".to_owned()
     } else {
-        disp_new.clone()
+        format_diff_path_with_prefix("b/", &disp_new, quote_fully)
     };
 
-    let patch = unified_diff(
+    let patch = unified_diff_with_prefix(
         &old_content,
         &new_content,
         &display_old,
         &display_new,
         context_lines,
+        0,
+        "",
+        "",
     );
     write!(out, "{patch}")?;
 

--- a/grit/src/commands/diff_tree.rs
+++ b/grit/src/commands/diff_tree.rs
@@ -14,8 +14,9 @@ use grit_lib::combined_tree_diff::{
 };
 use grit_lib::config::ConfigSet;
 use grit_lib::diff::{
-    count_changes, detect_renames, diff_trees, diff_trees_show_tree_entries, format_raw,
-    format_raw_abbrev, unified_diff, DiffEntry, DiffStatus,
+    count_changes, detect_copies as lib_detect_copies, detect_renames, diff_trees,
+    diff_trees_show_tree_entries, format_raw, format_raw_abbrev, unified_diff_with_prefix,
+    DiffEntry, DiffStatus,
 };
 use grit_lib::merge_base::merge_bases_first_vs_rest;
 use grit_lib::merge_diff::{
@@ -24,7 +25,10 @@ use grit_lib::merge_diff::{
 use grit_lib::objects::{parse_commit, parse_tree, ObjectId, ObjectKind};
 use grit_lib::odb::Odb;
 use grit_lib::pathspec::{context_from_mode_octal, matches_pathspec_with_context};
+use grit_lib::quote_path::{format_diff_path_with_prefix, quote_c_style};
 use grit_lib::repo::{resolve_dot_git, Repository};
+
+use crate::commands::diff_index::write_diff_index_name_status;
 use grit_lib::rev_parse::resolve_revision;
 use regex::Regex;
 use std::io::{self, BufRead, Write};
@@ -117,6 +121,8 @@ struct Options {
     max_depth: Option<i32>,
     /// Exit with 1 if there are differences.
     exit_code: bool,
+    /// NUL-terminate fields/lines (`-z`) for machine-readable output.
+    nul_terminated: bool,
     /// Suppress all output, implies exit_code.
     quiet: bool,
     /// Re-merge parents and diff against merge result tree.
@@ -168,6 +174,7 @@ impl Default for Options {
             stat_too: false,
             max_depth: None,
             exit_code: false,
+            nul_terminated: false,
             quiet: false,
             remerge_diff: false,
             reverse: false,
@@ -232,6 +239,7 @@ fn parse_options(argv: &[String]) -> Result<Options> {
                     opts.quiet = true;
                     opts.exit_code = true;
                 }
+                "-z" => opts.nul_terminated = true,
                 "--remerge-diff" => opts.remerge_diff = true,
                 "--full-index" => opts.full_index = true,
                 _ if arg.starts_with("--max-depth=") => {
@@ -449,7 +457,7 @@ fn run_two_trees(repo: &Repository, opts: &Options, out: &mut impl Write) -> Res
     };
     let oid1 = resolve_to_tree(repo, spec_a)?;
     let oid2 = resolve_to_tree(repo, spec_b)?;
-    let max_tree_depth = resolve_max_tree_depth(repo)?;
+    let max_tree_depth = resolve_max_tree_depth(repo);
     let old_tree = if is_magic_empty_tree_oid(&oid1) {
         None
     } else {
@@ -470,15 +478,7 @@ fn run_two_trees(repo: &Repository, opts: &Options, out: &mut impl Write) -> Res
     let filtered = filter_entries(&repo.odb, &repo, entries, opts)?;
     let has_diff = !filtered.is_empty();
     if !opts.quiet {
-        print_diff(
-            out,
-            &repo.odb,
-            &filtered,
-            opts,
-            old_tree,
-            &repo.git_dir,
-            repo.work_tree.as_deref(),
-        )?;
+        print_diff(out, repo, &filtered, opts, old_tree)?;
     }
     Ok(has_diff)
 }
@@ -495,7 +495,7 @@ fn run_one_commit(repo: &Repository, opts: &Options, out: &mut impl Write) -> Re
     match obj.kind {
         ObjectKind::Commit => {
             let commit = parse_commit(&obj.data).context("parsing commit")?;
-            let max_tree_depth = resolve_max_tree_depth(repo)?;
+            let max_tree_depth = resolve_max_tree_depth(repo);
             validate_tree_depth_limit(&repo.odb, &commit.tree, 0, max_tree_depth)?;
             if commit.parents.is_empty() {
                 if opts.root {
@@ -504,15 +504,7 @@ fn run_one_commit(repo: &Repository, opts: &Options, out: &mut impl Write) -> Re
                     has_diff = !filtered.is_empty();
                     if !opts.quiet && (has_diff || opts.pretty.is_some()) {
                         write_commit_header(out, &oid, &obj.data, opts)?;
-                        print_diff(
-                            out,
-                            &repo.odb,
-                            &filtered,
-                            opts,
-                            None,
-                            &repo.git_dir,
-                            repo.work_tree.as_deref(),
-                        )?;
+                        print_diff(out, repo, &filtered, opts, None)?;
                     }
                 }
             } else if commit.parents.len() == 2
@@ -614,15 +606,7 @@ fn run_one_commit(repo: &Repository, opts: &Options, out: &mut impl Write) -> Re
                 has_diff = !filtered.is_empty();
                 if !opts.quiet && (has_diff || opts.pretty.is_some()) {
                     write_commit_header(out, &oid, &obj.data, opts)?;
-                    print_diff(
-                        out,
-                        &repo.odb,
-                        &filtered,
-                        opts,
-                        Some(&parent_tree),
-                        &repo.git_dir,
-                        repo.work_tree.as_deref(),
-                    )?;
+                    print_diff(out, repo, &filtered, opts, Some(&parent_tree))?;
                 }
             }
         }
@@ -759,15 +743,7 @@ fn process_stdin_commit(
             let filtered = filter_entries(&repo.odb, &repo, entries, opts)?;
             let hd = !filtered.is_empty();
             if !opts.quiet {
-                print_diff(
-                    out,
-                    &repo.odb,
-                    &filtered,
-                    opts,
-                    None,
-                    &repo.git_dir,
-                    repo.work_tree.as_deref(),
-                )?;
+                print_diff(out, repo, &filtered, opts, None)?;
             }
             hd
         } else {
@@ -779,15 +755,7 @@ fn process_stdin_commit(
         let filtered = filter_entries(&repo.odb, &repo, entries, opts)?;
         let hd = !filtered.is_empty();
         if !opts.quiet {
-            print_diff(
-                out,
-                &repo.odb,
-                &filtered,
-                opts,
-                None,
-                &repo.git_dir,
-                repo.work_tree.as_deref(),
-            )?;
+            print_diff(out, repo, &filtered, opts, None)?;
         }
         hd
     };
@@ -824,15 +792,7 @@ fn process_stdin_two_trees(
     let filtered = filter_entries(&repo.odb, &repo, entries, opts)?;
     let has_diff = !filtered.is_empty();
     if !opts.quiet {
-        print_diff(
-            out,
-            &repo.odb,
-            &filtered,
-            opts,
-            None,
-            &repo.git_dir,
-            repo.work_tree.as_deref(),
-        )?;
+        print_diff(out, repo, &filtered, opts, None)?;
     }
     Ok(has_diff)
 }
@@ -1054,7 +1014,7 @@ fn collect_tree_blobs_recursive(
     odb: &Odb,
     tree_oid: &ObjectId,
     prefix: &str,
-) -> Result<Vec<(ObjectId, String, String)>> {
+) -> Result<Vec<(String, String, ObjectId)>> {
     let obj = odb.read(tree_oid)?;
     let tree = parse_tree(&obj.data)?;
     let mut result = Vec::new();
@@ -1071,78 +1031,10 @@ fn collect_tree_blobs_recursive(
                 result.extend(sub);
             }
         } else {
-            result.push((entry.oid, path, format!("{:06o}", entry.mode)));
+            result.push((path, format!("{:06o}", entry.mode), entry.oid));
         }
     }
     Ok(result)
-}
-
-/// Detect copies among added entries by checking if their blob matches
-/// any existing (unchanged or modified) entry in the old tree.
-///
-/// `old_tree_entries` provides all blobs from the old tree for
-/// `--find-copies-harder`.  When `harder` is false, only entries in
-/// the diff itself are considered as sources.
-fn detect_copies(
-    _odb: &grit_lib::odb::Odb,
-    entries: Vec<DiffEntry>,
-    threshold: u32,
-    harder: bool,
-    old_tree_entries: &[(ObjectId, String, String)], // (oid, path, mode)
-) -> Vec<DiffEntry> {
-    use std::collections::HashMap;
-
-    // Build source map: blob OID → (path, mode).
-    let mut sources: HashMap<ObjectId, (String, String)> = HashMap::new();
-
-    if harder {
-        // Use all old-tree blobs as potential copy sources.
-        for (oid, path, mode) in old_tree_entries {
-            sources
-                .entry(*oid)
-                .or_insert_with(|| (path.clone(), mode.clone()));
-        }
-    }
-
-    // Also add modified entries from the diff as sources.
-    for entry in &entries {
-        match entry.status {
-            DiffStatus::Added | DiffStatus::Deleted => {}
-            _ => {
-                if entry.old_oid.as_bytes() != &[0u8; 20] {
-                    if let Some(ref p) = entry.old_path {
-                        sources
-                            .entry(entry.old_oid)
-                            .or_insert_with(|| (p.clone(), entry.old_mode.clone()));
-                    }
-                }
-            }
-        }
-    }
-
-    let mut result = Vec::with_capacity(entries.len());
-    for entry in entries {
-        if entry.status == DiffStatus::Added {
-            if let Some((src_path, src_mode)) = sources.get(&entry.new_oid) {
-                // Exact OID match → 100% copy.
-                if 100 >= threshold {
-                    result.push(DiffEntry {
-                        old_path: Some(src_path.clone()),
-                        new_path: entry.new_path,
-                        old_oid: entry.new_oid,
-                        new_oid: entry.new_oid,
-                        old_mode: src_mode.clone(),
-                        new_mode: entry.new_mode,
-                        status: DiffStatus::Copied,
-                        score: Some(100),
-                    });
-                    continue;
-                }
-            }
-        }
-        result.push(entry);
-    }
-    result
 }
 
 fn is_gitlink_mode(mode: &str) -> bool {
@@ -1383,16 +1275,67 @@ fn print_combined_paths(
     Ok(())
 }
 
+fn write_raw_diff_tree_z(
+    out: &mut impl Write,
+    entry: &DiffEntry,
+    abbrev_len: Option<usize>,
+) -> Result<()> {
+    let ellipsis = if std::env::var("GIT_PRINT_SHA1_ELLIPSIS").ok().as_deref() == Some("yes") {
+        "..."
+    } else {
+        ""
+    };
+    let old_hex = format!("{}", entry.old_oid);
+    let new_hex = format!("{}", entry.new_oid);
+    let (old_disp, new_disp) = if let Some(len) = abbrev_len {
+        let oa = &old_hex[..len.min(old_hex.len())];
+        let na = &new_hex[..len.min(new_hex.len())];
+        (oa.to_string(), na.to_string())
+    } else {
+        (old_hex, new_hex)
+    };
+
+    let status_str = match (entry.status, entry.score) {
+        (DiffStatus::Renamed, Some(s)) => format!("R{s:03}"),
+        (DiffStatus::Copied, Some(s)) => format!("C{s:03}"),
+        _ => entry.status.letter().to_string(),
+    };
+
+    write!(
+        out,
+        ":{} {} {}{} {}{} {}\0",
+        entry.old_mode, entry.new_mode, old_disp, ellipsis, new_disp, ellipsis, status_str
+    )?;
+    match entry.status {
+        DiffStatus::Renamed | DiffStatus::Copied => {
+            out.write_all(entry.old_path.as_deref().unwrap_or("").as_bytes())?;
+            out.write_all(b"\0")?;
+            out.write_all(entry.new_path.as_deref().unwrap_or("").as_bytes())?;
+            out.write_all(b"\0")?;
+        }
+        _ => {
+            out.write_all(entry.path().as_bytes())?;
+            out.write_all(b"\0")?;
+        }
+    }
+    Ok(())
+}
+
 /// Print the diff entries according to `opts.format`.
 fn print_diff(
     out: &mut impl Write,
-    odb: &Odb,
+    repo: &Repository,
     entries: &[DiffEntry],
     opts: &Options,
     old_tree_oid: Option<&ObjectId>,
-    git_dir: &Path,
-    work_tree: Option<&Path>,
 ) -> Result<bool> {
+    let odb = &repo.odb;
+    let git_dir: &Path = repo.git_dir.as_ref();
+    let work_tree = repo.work_tree.as_deref();
+    let quote_fully = ConfigSet::load(Some(&repo.git_dir), true)
+        .unwrap_or_default()
+        .quote_path_fully();
+
     // Apply rename detection if requested.
     let owned_entries;
     let old_blobs = if opts.find_copies.is_some() && opts.find_copies_harder {
@@ -1407,7 +1350,7 @@ fn print_diff(
     let entries = if let Some(threshold) = opts.find_renames {
         let mut result = detect_renames(odb, entries.to_vec(), threshold);
         if let Some(copy_threshold) = opts.find_copies {
-            result = detect_copies(
+            result = lib_detect_copies(
                 odb,
                 result,
                 copy_threshold,
@@ -1418,7 +1361,7 @@ fn print_diff(
         owned_entries = result;
         &owned_entries[..]
     } else if let Some(copy_threshold) = opts.find_copies {
-        owned_entries = detect_copies(
+        owned_entries = lib_detect_copies(
             odb,
             entries.to_vec(),
             copy_threshold,
@@ -1461,11 +1404,18 @@ fn print_diff(
             // Otherwise show raw output normally.
             let suppress_raw = opts.pretty.is_some() && opts.summary;
             if !suppress_raw {
-                for entry in entries {
-                    if let Some(abbrev_len) = opts.abbrev {
-                        writeln!(out, "{}", format_raw_abbrev(entry, abbrev_len))?;
-                    } else {
-                        writeln!(out, "{}", format_raw(entry))?;
+                if opts.nul_terminated {
+                    let abbrev = opts.abbrev;
+                    for entry in entries {
+                        write_raw_diff_tree_z(out, entry, abbrev)?;
+                    }
+                } else {
+                    for entry in entries {
+                        if let Some(abbrev_len) = opts.abbrev {
+                            writeln!(out, "{}", format_raw_abbrev(entry, abbrev_len))?;
+                        } else {
+                            writeln!(out, "{}", format_raw(entry))?;
+                        }
                     }
                 }
             }
@@ -1476,7 +1426,7 @@ fn print_diff(
         OutputFormat::Patch => {
             // --patch-with-stat: show stat before patch
             if opts.patch_with_stat {
-                print_stat_summary(out, odb, entries)?;
+                print_stat_summary(out, odb, entries, quote_fully)?;
                 writeln!(out)?;
             }
             // --patch-with-raw: show raw before patch
@@ -1499,46 +1449,28 @@ fn print_diff(
                     opts.abbrev,
                     opts.full_index,
                     git_dir,
+                    quote_fully,
                 )?;
             }
         }
         OutputFormat::Stat => {
-            print_stat_summary(out, odb, entries)?;
+            print_stat_summary(out, odb, entries, quote_fully)?;
             if opts.summary {
                 write_summary(out, entries)?;
             }
         }
         OutputFormat::NameOnly => {
             for entry in entries {
-                writeln!(out, "{}", entry.path())?;
+                if opts.nul_terminated {
+                    out.write_all(entry.path().as_bytes())?;
+                    out.write_all(b"\0")?;
+                } else {
+                    writeln!(out, "{}", quote_c_style(entry.path(), quote_fully))?;
+                }
             }
         }
         OutputFormat::NameStatus => {
-            for entry in entries {
-                match (entry.status, entry.score) {
-                    (DiffStatus::Renamed, Some(s)) => {
-                        writeln!(
-                            out,
-                            "R{:03}\t{}\t{}",
-                            s,
-                            entry.old_path.as_deref().unwrap_or(""),
-                            entry.new_path.as_deref().unwrap_or("")
-                        )?;
-                    }
-                    (DiffStatus::Copied, Some(s)) => {
-                        writeln!(
-                            out,
-                            "C{:03}\t{}\t{}",
-                            s,
-                            entry.old_path.as_deref().unwrap_or(""),
-                            entry.new_path.as_deref().unwrap_or("")
-                        )?;
-                    }
-                    _ => {
-                        writeln!(out, "{}\t{}", entry.status.letter(), entry.path())?;
-                    }
-                }
-            }
+            write_diff_index_name_status(out, entries, quote_fully, opts.nul_terminated)?;
         }
     }
     Ok(false)
@@ -1615,6 +1547,7 @@ fn write_patch_entry(
     abbrev: Option<usize>,
     full_index: bool,
     git_dir: &Path,
+    quote_fully: bool,
 ) -> Result<bool> {
     let (old_content, new_content) = read_blob_pair(odb, entry)?;
 
@@ -1632,7 +1565,10 @@ fn write_patch_entry(
     let old_abbrev = abbrev_oid(&old_hex, abbrev, full_index);
     let new_abbrev = abbrev_oid(&new_hex, abbrev, full_index);
 
-    writeln!(out, "diff --git a/{old_path} b/{new_path}")?;
+    let git_old = format_diff_path_with_prefix("a/", old_path, quote_fully);
+    let git_new = format_diff_path_with_prefix("b/", new_path, quote_fully);
+
+    writeln!(out, "diff --git {git_old} {git_new}")?;
 
     match entry.status {
         DiffStatus::Added => {
@@ -1655,10 +1591,14 @@ fn write_patch_entry(
             }
         }
         DiffStatus::Renamed => {
+            if entry.old_mode != entry.new_mode {
+                writeln!(out, "old mode {}", entry.old_mode)?;
+                writeln!(out, "new mode {}", entry.new_mode)?;
+            }
             let sim = entry.score.unwrap_or(100);
             writeln!(out, "similarity index {sim}%")?;
-            writeln!(out, "rename from {old_path}")?;
-            writeln!(out, "rename to {new_path}")?;
+            writeln!(out, "rename from {}", quote_c_style(old_path, quote_fully))?;
+            writeln!(out, "rename to {}", quote_c_style(new_path, quote_fully))?;
             if entry.old_oid != entry.new_oid {
                 writeln!(out, "index {old_abbrev}..{new_abbrev}")?;
             }
@@ -1666,8 +1606,8 @@ fn write_patch_entry(
         DiffStatus::Copied => {
             let sim = entry.score.unwrap_or(100);
             writeln!(out, "similarity index {sim}%")?;
-            writeln!(out, "copy from {old_path}")?;
-            writeln!(out, "copy to {new_path}")?;
+            writeln!(out, "copy from {}", quote_c_style(old_path, quote_fully))?;
+            writeln!(out, "copy to {}", quote_c_style(new_path, quote_fully))?;
             if entry.old_oid != entry.new_oid {
                 writeln!(out, "index {old_abbrev}..{new_abbrev}")?;
             }
@@ -1679,31 +1619,45 @@ fn write_patch_entry(
         DiffStatus::Unmerged => {}
     }
 
-    let display_old = if entry.status == DiffStatus::Added {
-        "/dev/null"
-    } else {
-        old_path
-    };
-    let display_new = if entry.status == DiffStatus::Deleted {
-        "/dev/null"
-    } else {
-        new_path
-    };
     let path_for_attrs = entry.path();
     let old_raw = old_content.as_bytes();
     let new_raw = new_content.as_bytes();
     if is_binary_for_diff(git_dir, path_for_attrs, old_raw)
         || is_binary_for_diff(git_dir, path_for_attrs, new_raw)
     {
-        writeln!(out, "Binary files a/{new_path} and b/{new_path} differ")?;
+        let bo = if entry.status == DiffStatus::Added {
+            "/dev/null".to_owned()
+        } else {
+            format_diff_path_with_prefix("a/", old_path, quote_fully)
+        };
+        let bn = if entry.status == DiffStatus::Deleted {
+            "/dev/null".to_owned()
+        } else {
+            format_diff_path_with_prefix("b/", new_path, quote_fully)
+        };
+        writeln!(out, "Binary files {bo} and {bn} differ")?;
         return Ok(false);
     }
-    let patch = unified_diff(
+
+    let display_old = if entry.status == DiffStatus::Added {
+        "/dev/null".to_owned()
+    } else {
+        format_diff_path_with_prefix("a/", old_path, quote_fully)
+    };
+    let display_new = if entry.status == DiffStatus::Deleted {
+        "/dev/null".to_owned()
+    } else {
+        format_diff_path_with_prefix("b/", new_path, quote_fully)
+    };
+    let patch = unified_diff_with_prefix(
         &old_content,
         &new_content,
-        display_old,
-        display_new,
+        &display_old,
+        &display_new,
         context_lines,
+        0,
+        "",
+        "",
     );
     write!(out, "{patch}")?;
 
@@ -1711,10 +1665,19 @@ fn write_patch_entry(
 }
 
 /// Write a `--stat` summary.
-fn print_stat_summary(out: &mut impl Write, odb: &Odb, entries: &[DiffEntry]) -> Result<bool> {
+fn print_stat_summary(
+    out: &mut impl Write,
+    odb: &Odb,
+    entries: &[DiffEntry],
+    quote_fully: bool,
+) -> Result<bool> {
     use grit_lib::diff::format_stat_line_width;
 
-    let max_path_len = entries.iter().map(|e| e.path().len()).max().unwrap_or(0);
+    let max_path_len = entries
+        .iter()
+        .map(|e| quote_c_style(e.path(), quote_fully).len())
+        .max()
+        .unwrap_or(0);
     let mut total_ins = 0usize;
     let mut total_del = 0usize;
 
@@ -1733,10 +1696,11 @@ fn print_stat_summary(out: &mut impl Write, odb: &Odb, entries: &[DiffEntry]) ->
     let count_width = format!("{}", max_count).len();
 
     for (path, ins, del) in &file_stats {
+        let q = quote_c_style(path, quote_fully);
         writeln!(
             out,
             "{}",
-            format_stat_line_width(path, *ins, *del, max_path_len, count_width)
+            format_stat_line_width(&q, *ins, *del, max_path_len, count_width)
         )?;
     }
 
@@ -1794,15 +1758,13 @@ fn is_magic_empty_tree_oid(oid: &ObjectId) -> bool {
         || hex == "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 }
 
-fn resolve_max_tree_depth(repo: &Repository) -> Result<usize> {
-    let config = grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true)?;
-    let depth = if let Some(raw) = config.get("core.maxtreedepth") {
-        raw.parse::<usize>()
-            .map_err(|_| anyhow::anyhow!("invalid core.maxtreedepth: '{raw}'"))?
+fn resolve_max_tree_depth(repo: &Repository) -> usize {
+    let config = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+    if let Some(raw) = config.get("core.maxtreedepth") {
+        raw.parse::<usize>().unwrap_or(DEFAULT_MAX_TREE_DEPTH)
     } else {
         DEFAULT_MAX_TREE_DEPTH
-    };
-    Ok(depth)
+    }
 }
 
 fn validate_tree_depth_limit(

--- a/grit/src/commands/ls_tree.rs
+++ b/grit/src/commands/ls_tree.rs
@@ -583,16 +583,18 @@ fn print_entry(
         } else {
             "      -".to_string()
         };
+        let path_disp = grit_lib::quote_path::quote_path_for_tree_listing(name, quote_fully);
         write!(
             out,
-            "{:06o} {kind_str} {} {size_str}\t{name}",
+            "{:06o} {kind_str} {} {size_str}\t{path_disp}",
             entry.mode,
             ls_tree_object_name(repo, entry, args)?
         )?;
     } else {
+        let path_disp = grit_lib::quote_path::quote_path_for_tree_listing(name, quote_fully);
         write!(
             out,
-            "{:06o} {kind_str} {}\t{name}",
+            "{:06o} {kind_str} {}\t{path_disp}",
             entry.mode,
             ls_tree_object_name(repo, entry, args)?
         )?;

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -2715,9 +2715,16 @@ fn preprocess_commit_argv(rest: &[String]) -> Vec<String> {
 }
 
 /// Strip leading `-C <dir>` pairs from `rest` and `chdir` for each (Git allows `-C` after the subcommand).
+///
+/// Do not confuse this with `diff-tree -C` / `diff-index -C` (find copies): the next token there is
+/// another flag (e.g. `--find-copies-harder`), not a directory path.
 fn strip_subcommand_leading_change_dir(rest: &mut Vec<String>) -> Result<()> {
     while rest.len() >= 2 && rest[0] == "-C" {
-        let new_dir = PathBuf::from(&rest[1]);
+        let next = rest[1].as_str();
+        if next.starts_with('-') {
+            break;
+        }
+        let new_dir = PathBuf::from(next);
         if !new_dir.as_os_str().is_empty() {
             std::env::set_current_dir(&new_dir)?;
         }

--- a/logs/2026-04-09_t3300-funny-names.md
+++ b/logs/2026-04-09_t3300-funny-names.md
@@ -1,0 +1,18 @@
+# t3300-funny-names
+
+## Summary
+
+Made `tests/t3300-funny-names.sh` pass (21/21).
+
+## Changes
+
+- **Path quoting**: `quote_path_for_tree_listing` (comma forces quotes for `ls-tree`); `format_diff_path_with_prefix` for Git-style `diff --git "a/…" "b/…"` headers and unified-diff `---`/`+++` lines.
+- **diff-index**: C-style quoting for `--name-status` / raw; `-z` raw and name-status aligned with Git; `lib::detect_copies` for `-C`; worktree refresh for index-only adds preserves `A` while updating mode/OID for rename+mode patches.
+- **diff-tree**: `-z`, `lib_detect_copies`, quoted name output, resilient `core.maxtreedepth` load.
+- **apply**: Quoted `rename to` paths with spaces; `--stat`/`--numstat` use `core.quotepath`; `parse_hunk` stops at `--- ` / `+++ ` so concatenated hunks do not merge files.
+- **main**: `strip_subcommand_leading_change_dir` ignores `-C` when the next arg starts with `-` (fixes `diff-tree -C` being treated as chdir).
+
+## Validation
+
+- `./scripts/run-tests.sh t3300-funny-names.sh` → 21/21
+- `cargo test -p grit-lib --lib`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible quoting and `-z` output for `ls-tree`, `diff-index`, and `diff-tree`, fixes unified-diff header formatting (`"a/…"` / `"b/…"`), and corrects `apply` parsing and `--stat`/`--numstat` path display so `t3300-funny-names` passes.

## Key fixes

- **Subcommand `-C` vs `diff-tree -C`**: only chdir when the token after `-C` is not another flag (prevents ENOENT from using `--find-copies-harder` as a path).
- **`apply`**: C-quote parsing for `rename to` with spaces; hunk parser stops at `--- ` / `+++ ` so back-to-back traditional patches are not merged; `--stat`/`--numstat` honor `core.quotepath`.
- **`diff-index`**: worktree refresh for index-only adds updates mode/OID while keeping status `A` for rename detection; uses `grit_lib::diff::detect_copies` for `-C`.

## Validation

- `./scripts/run-tests.sh t3300-funny-names.sh` (21/21)
- `cargo test -p grit-lib --lib`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ebabc31-1e5c-48fa-9941-e8d4591a7ee9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ebabc31-1e5c-48fa-9941-e8d4591a7ee9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

