### PR TITLE
fix: pass t3910-mac-os-precompose (NFC path handling)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,6 +502,7 @@ dependencies = [
  "encoding_rs",
  "flate2",
  "hex",
+ "icu_normalizer",
  "libc",
  "regex",
  "sha1",
@@ -737,6 +738,9 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
  "zerovec",
 ]
 
@@ -1751,6 +1755,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2205,6 +2215,12 @@ dependencies = [
  "unicode-xid",
  "wasmparser",
 ]
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ unicode-width = "0.2"
 libc = "0.2"
 hungarian = "1.1.1"
 ureq = "2.12"
+icu_normalizer = "2.0.0"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -671,7 +671,7 @@ t3906-stash-submodule	t3	yes	8	5	3	false	ok	0
 t3907-stash-show-config	t3	yes	10	1	9	false	ok	0
 t3908-stash-in-worktree	t3	yes	2	1	1	false	ok	0
 t3909-stash-pathspec-file	t3	yes	5	5	0	true	ok	0
-t3910-mac-os-precompose	t3	yes	0	0	0	false	ok	1
+t3910-mac-os-precompose	t3	yes	29	29	0	true	ok	0
 t3920-crlf-messages	t3	yes	18	6	12	false	ok	0
 t4000-diff-format	t4	yes	41	23	18	false	ok	0
 t4001-diff-rename	t4	yes	23	19	4	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78% of harness tests passing (35,205 / 45,112).">
+<meta property="og:description" content="78.1% of harness tests passing (35,234 / 45,141).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78% of harness tests passing (35,205 / 45,112).">
+<meta name="twitter:description" content="78.1% of harness tests passing (35,234 / 45,141).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,30 +148,30 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T12:58:52+00:00" class="gen-time" title="2026-04-09 12:58 UTC">2026-04-09 12:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/c9e26ba46f5a86c3328f4d62484968547c8560d9" style="color:#58a6ff">c9e26ba</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T17:15:39+00:00" class="gen-time" title="2026-04-09 17:15 UTC">2026-04-09 17:15 UTC</time> · <a href="https://github.com/schacon/grit/commit/999b424740b71e52cf30bf6fade3e1ef735f68bd" style="color:#58a6ff">999b424</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">78.0%</div>
+      <div class="summary-big-val pct-blue">78.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,205</div>
+      <div class="summary-big-val">35,234</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">45,112</div>
+      <div class="summary-big-val">45,141</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:78.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:78.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>719 files fully passing</span>
+    <span>720 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -219,11 +219,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">51/141 files · 2 skipped · 3,919/5,369 tests</span>
+        <span class="group-meta">52/141 files · 2 skipped · 3,948/5,398 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:73.0%"></div></div>
-        <span class="group-pct pct-blue">73.0%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:73.1%"></div></div>
+        <span class="group-pct pct-blue">73.1%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35205 of 45112 tests passing across 1405 harness files (78% pass rate).</desc>
+  <desc id="svg-desc">35234 of 45141 tests passing across 1405 harness files (78.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78% pass rate · 35,205 / 45,112 tests · 1,405 files in scope · 719 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.1% pass rate · 35,234 / 45,141 tests · 1,405 files in scope · 720 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="546" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="547" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T12:58:52+00:00" class="gen-time" title="2026-04-09 12:58 UTC">2026-04-09 12:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/c9e26ba46f5a86c3328f4d62484968547c8560d9" style="color:#58a6ff">c9e26ba</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T17:15:39+00:00" class="gen-time" title="2026-04-09 17:15 UTC">2026-04-09 17:15 UTC</time> · <a href="https://github.com/schacon/grit/commit/999b424740b71e52cf30bf6fade3e1ef735f68bd" style="color:#58a6ff">999b424</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,205</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">78.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card"><div class="n" id="sum-tests">45,141</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,234</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">78.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -6867,15 +6867,15 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="0" data-passed="0">
+<tr class="" data-group="t3" data-tests="29" data-passed="29" data-full-pass="1">
   <td class="mono">t3910-mac-os-precompose</td>
   <td>t3</td>
-  <td></td>
-  <td class="right">0</td>
-  <td class="right">0</td>
+  <td><span class="badge ok">full pass</span></td>
+  <td class="right">29</td>
+  <td class="right">29</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="18" data-passed="6">
   <td class="mono">t3920-crlf-messages</td>

--- a/grit-lib/Cargo.toml
+++ b/grit-lib/Cargo.toml
@@ -27,3 +27,4 @@ regex.workspace = true
 libc.workspace = true
 unicode-width.workspace = true
 encoding_rs = "0.8.35"
+icu_normalizer.workspace = true

--- a/grit-lib/src/config.rs
+++ b/grit-lib/src/config.rs
@@ -2424,7 +2424,7 @@ pub fn parse_path_optional(s: &str) -> Option<String> {
 /// - unquoted `key=value` tokens separated by whitespace
 ///
 /// Backslash escapes are interpreted minimally inside double quotes.
-fn parse_config_parameters(raw: &str) -> Vec<String> {
+pub(crate) fn parse_config_parameters(raw: &str) -> Vec<String> {
     let mut out: Vec<String> = Vec::new();
     let mut buf = String::new();
     let mut in_single = false;

--- a/grit-lib/src/lib.rs
+++ b/grit-lib/src/lib.rs
@@ -59,6 +59,7 @@ pub mod pack_name_hash;
 pub mod parse_options_test_tool;
 pub mod patch_ids;
 pub mod pathspec;
+pub mod precompose_config;
 pub mod promisor;
 pub mod prune_packed;
 pub mod quote_path;
@@ -72,6 +73,7 @@ pub mod rev_parse;
 #[cfg(unix)]
 pub mod simple_ipc;
 pub mod sparse_checkout;
+pub mod unicode_normalization;
 #[cfg(not(unix))]
 pub mod simple_ipc {
     /// Whether simple IPC is supported on this platform.

--- a/grit-lib/src/pathspec.rs
+++ b/grit-lib/src/pathspec.rs
@@ -5,8 +5,12 @@
 //! `GIT_ICASE_PATHSPECS`. The `grit` binary sets these from CLI flags such as
 //! `--literal-pathspecs` before dispatching subcommands.
 
+use std::borrow::Cow;
+
 use crate::crlf::path_has_gitattribute;
 use crate::crlf::AttrRule;
+use crate::precompose_config::pathspec_precompose_enabled;
+use crate::unicode_normalization::precompose_utf8_path;
 use crate::wildmatch::{wildmatch, WM_CASEFOLD, WM_PATHNAME};
 
 /// Returns the length of the leading literal segment before the first glob metacharacter,
@@ -317,6 +321,19 @@ pub fn matches_pathspec(spec: &str, path: &str) -> bool {
 /// Like [`matches_pathspec`], but uses `ctx` for trailing-`/` literal pathspecs.
 #[must_use]
 pub fn matches_pathspec_with_context(spec: &str, path: &str, ctx: PathspecMatchContext) -> bool {
+    let spec_nfc: Cow<'_, str> = if pathspec_precompose_enabled() {
+        precompose_utf8_path(spec)
+    } else {
+        Cow::Borrowed(spec)
+    };
+    let path_nfc: Cow<'_, str> = if pathspec_precompose_enabled() {
+        precompose_utf8_path(path)
+    } else {
+        Cow::Borrowed(path)
+    };
+    let spec = spec_nfc.as_ref();
+    let path = path_nfc.as_ref();
+
     let trimmed = spec.strip_prefix("./").unwrap_or(spec);
     if trimmed == "." || trimmed.is_empty() {
         return true;

--- a/grit-lib/src/precompose_config.rs
+++ b/grit-lib/src/precompose_config.rs
@@ -1,0 +1,253 @@
+//! Read `core.precomposeunicode` without opening a full [`Repository`].
+//!
+//! Used for pathspec matching when argv may use NFD spellings while the index stores NFC.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::config::{parse_config_parameters, ConfigSet};
+use crate::unicode_normalization::probe_filesystem_normalizes_nfd_to_nfc;
+
+fn parse_ceiling_directories_paths() -> Vec<PathBuf> {
+    let raw = match std::env::var("GIT_CEILING_DIRECTORIES") {
+        Ok(val) => val,
+        Err(_) => return Vec::new(),
+    };
+    if raw.is_empty() {
+        return Vec::new();
+    }
+    raw.split(':')
+        .filter(|s| !s.is_empty())
+        .filter_map(|s| {
+            let p = PathBuf::from(s);
+            if !p.is_absolute() {
+                return None;
+            }
+            Some(
+                p.canonicalize()
+                    .unwrap_or_else(|_| PathBuf::from(s.trim_end_matches('/'))),
+            )
+        })
+        .collect()
+}
+
+fn path_for_ceiling_compare(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn offset_1st_component(path: &str) -> usize {
+    if path.starts_with('/') {
+        1
+    } else {
+        0
+    }
+}
+
+fn longest_ancestor_length(path: &str, ceilings: &[String]) -> Option<usize> {
+    if path == "/" {
+        return None;
+    }
+    let mut max_len: Option<usize> = None;
+    for ceil in ceilings {
+        let mut len = ceil.len();
+        while len > 0 && ceil.as_bytes().get(len - 1) == Some(&b'/') {
+            len -= 1;
+        }
+        if len == 0 {
+            continue;
+        }
+        if path.len() <= len + 1 {
+            continue;
+        }
+        if !path.starts_with(&ceil[..len]) {
+            continue;
+        }
+        if path.as_bytes().get(len) != Some(&b'/') {
+            continue;
+        }
+        if path.as_bytes().get(len + 1).is_none() {
+            continue;
+        }
+        max_len = Some(max_len.map_or(len, |m| m.max(len)));
+    }
+    max_len
+}
+
+fn probe_git_dir_at(dir: &Path) -> Option<PathBuf> {
+    let dot_git = dir.join(".git");
+    if dot_git.is_dir() {
+        return Some(dot_git.canonicalize().unwrap_or(dot_git));
+    }
+    if dot_git.is_file() {
+        let content = fs::read_to_string(&dot_git).ok()?;
+        for line in content.lines() {
+            let line = line.trim();
+            if let Some(rest) = line.strip_prefix("gitdir:") {
+                let p = Path::new(rest.trim());
+                let resolved = if p.is_absolute() {
+                    p.to_path_buf()
+                } else {
+                    dir.join(p)
+                };
+                return Some(resolved.canonicalize().unwrap_or(resolved));
+            }
+        }
+    }
+    None
+}
+
+/// Walk parents from `cwd` for `.git`, honouring `GIT_CEILING_DIRECTORIES` like Git discovery.
+pub fn locate_git_dir_from_cwd(cwd: PathBuf) -> Option<PathBuf> {
+    let start_canon = cwd.canonicalize().unwrap_or(cwd);
+    let ceilings: Vec<String> = parse_ceiling_directories_paths()
+        .into_iter()
+        .map(|p| path_for_ceiling_compare(&p))
+        .collect();
+    let mut dir_buf = path_for_ceiling_compare(&start_canon);
+    let min_offset = offset_1st_component(&dir_buf);
+    let mut ceil_offset: isize = longest_ancestor_length(&dir_buf, &ceilings)
+        .map(|n| n as isize)
+        .unwrap_or(-1);
+    if ceil_offset < 0 {
+        ceil_offset = min_offset as isize - 2;
+    }
+
+    loop {
+        if let Some(gd) = probe_git_dir_at(Path::new(&dir_buf)) {
+            return Some(gd);
+        }
+
+        let mut offset: isize = dir_buf.len() as isize;
+        if offset <= min_offset as isize {
+            break;
+        }
+        loop {
+            offset -= 1;
+            if offset <= ceil_offset {
+                break;
+            }
+            if dir_buf
+                .as_bytes()
+                .get(offset as usize)
+                .is_some_and(|b| *b == b'/')
+            {
+                break;
+            }
+        }
+        if offset <= ceil_offset {
+            break;
+        }
+        let off_u = offset as usize;
+        let new_len = if off_u > min_offset {
+            off_u
+        } else {
+            min_offset
+        };
+        dir_buf.truncate(new_len);
+    }
+    None
+}
+
+/// Parse `.git/config` only (no global/system cascade). `None` when the key is absent.
+#[must_use]
+pub fn read_core_precomposeunicode(git_dir: &Path) -> Option<bool> {
+    let path = git_dir.join("config");
+    let Ok(text) = fs::read_to_string(&path) else {
+        return None;
+    };
+    let mut in_core = false;
+    let mut last: Option<bool> = None;
+    for line in text.lines() {
+        let t = line.trim();
+        if t.starts_with('[') {
+            in_core = t.eq_ignore_ascii_case("[core]");
+            continue;
+        }
+        if !in_core {
+            continue;
+        }
+        let Some((k, v)) = t.split_once('=') else {
+            continue;
+        };
+        if !k.trim().eq_ignore_ascii_case("precomposeunicode") {
+            continue;
+        }
+        let v = v.trim();
+        last = Some(matches!(
+            v.to_ascii_lowercase().as_str(),
+            "true" | "yes" | "on" | "1"
+        ));
+    }
+    last
+}
+
+/// `git -c core.precomposeunicode=…` overrides local config (last token wins).
+fn precompose_from_git_config_parameters() -> Option<bool> {
+    let Ok(raw) = std::env::var("GIT_CONFIG_PARAMETERS") else {
+        return None;
+    };
+    let mut last: Option<bool> = None;
+    for entry in parse_config_parameters(&raw) {
+        let Some((k, v)) = entry.split_once('=') else {
+            continue;
+        };
+        if !k.trim().eq_ignore_ascii_case("core.precomposeunicode") {
+            continue;
+        }
+        let v = v.trim();
+        last = Some(matches!(
+            v.to_ascii_lowercase().as_str(),
+            "true" | "yes" | "on" | "1"
+        ));
+    }
+    last
+}
+
+/// Effective `core.precomposeunicode` after the normal config cascade (system, global, local,
+/// `GIT_CONFIG_PARAMETERS`), matching [`ConfigSet::load`].
+///
+/// Does not imply argv should be rewritten: Git only runs `precompose_argv_prefix` when the
+/// filesystem aliases NFD/NFC (or the test harness forces that probe for `git init`).
+#[must_use]
+pub fn effective_core_precomposeunicode(git_dir: Option<&Path>) -> bool {
+    if let Some(v) = precompose_from_git_config_parameters() {
+        return v;
+    }
+    let Some(gd) = git_dir else {
+        return false;
+    };
+    ConfigSet::load(Some(gd), true)
+        .ok()
+        .and_then(|cfg| cfg.get_bool("core.precomposeunicode").and_then(|r| r.ok()))
+        .unwrap_or(false)
+}
+
+/// True when the filesystem aliases NFD and NFC spellings for the same path (macOS / HFS+ style).
+///
+/// `GIT_TEST_UTF8_NFD_TO_NFC` does **not** count here: it only makes `git init` write
+/// `core.precomposeunicode` on Linux; argv and directory walks must still use the bytes the shell
+/// passed when the FS does not alias.
+#[must_use]
+pub fn filesystem_nfd_nfc_aliases(git_dir: &Path) -> bool {
+    probe_filesystem_normalizes_nfd_to_nfc(git_dir).unwrap_or(false)
+}
+
+/// NFC-normalize command-line path arguments (Git's `precompose_argv_prefix`).
+#[must_use]
+pub fn argv_precompose_enabled(git_dir: Option<&Path>) -> bool {
+    if !effective_core_precomposeunicode(git_dir) {
+        return false;
+    }
+    let Some(gd) = git_dir else {
+        return false;
+    };
+    filesystem_nfd_nfc_aliases(gd)
+}
+
+/// NFC-normalize for pathspec comparisons when the repo opts into precomposed Unicode storage.
+#[must_use]
+pub fn pathspec_precompose_enabled() -> bool {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let gd = locate_git_dir_from_cwd(cwd);
+    effective_core_precomposeunicode(gd.as_deref())
+}

--- a/grit-lib/src/unicode_normalization.rs
+++ b/grit-lib/src/unicode_normalization.rs
@@ -1,0 +1,101 @@
+//! UTF-8 NFC path normalization for macOS-style filesystems (`core.precomposeUnicode`).
+//!
+//! When the filesystem treats NFD and NFC spellings as the same path, Git stores paths in
+//! precomposed (NFC) form. This module implements the same normalization using ICU.
+
+use icu_normalizer::ComposingNormalizerBorrowed;
+use std::borrow::Cow;
+use std::ffi::OsString;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+/// Return true if `s` contains any non-ASCII UTF-8 byte.
+#[must_use]
+pub fn has_non_ascii_utf8(s: &str) -> bool {
+    s.as_bytes().iter().any(|b| *b & 0x80 != 0)
+}
+
+/// Normalize a single path segment (no `/`) to NFC when it contains non-ASCII UTF-8.
+#[must_use]
+pub fn precompose_utf8_segment(s: &str) -> Cow<'_, str> {
+    if !has_non_ascii_utf8(s) {
+        return Cow::Borrowed(s);
+    }
+    let normalized = ComposingNormalizerBorrowed::new_nfc().normalize(s);
+    if normalized == s {
+        Cow::Borrowed(s)
+    } else {
+        Cow::Owned(normalized.into_owned())
+    }
+}
+
+/// Normalize every `/`-separated segment of `path` to NFC.
+#[must_use]
+pub fn precompose_utf8_path(path: &str) -> Cow<'_, str> {
+    if !path.as_bytes().iter().any(|b| *b & 0x80 != 0) {
+        return Cow::Borrowed(path);
+    }
+    let mut buf = String::with_capacity(path.len());
+    for (i, seg) in path.split('/').enumerate() {
+        if i > 0 {
+            buf.push('/');
+        }
+        let c = precompose_utf8_segment(seg);
+        buf.push_str(c.as_ref());
+    }
+    if buf == path {
+        Cow::Borrowed(path)
+    } else {
+        Cow::Owned(buf)
+    }
+}
+
+/// Update `s` in place when it is valid UTF-8 and NFC differs from the current spelling.
+pub fn precompose_os_string_utf8_path(s: &mut OsString, enabled: bool) {
+    if !enabled {
+        return;
+    }
+    let Some(utf8) = s.to_str() else {
+        return;
+    };
+    let normalized = precompose_utf8_path(utf8).into_owned();
+    if normalized != utf8 {
+        *s = OsString::from(normalized);
+    }
+}
+
+/// Probe whether creating a file under `git_dir` with an NFC filename makes the NFD spelling
+/// visible as the same path (macOS / HFS+ style).
+///
+/// Matches Git's `probe_utf8_pathname_composition` / `UTF8_NFD_TO_NFC` test prerequisite.
+pub fn probe_filesystem_normalizes_nfd_to_nfc(git_dir: &Path) -> std::io::Result<bool> {
+    const NFC: &str = "\u{00e4}";
+    const NFD: &str = "\u{0061}\u{0308}";
+    let nfc_path: PathBuf = git_dir.join(NFC);
+    let _ = std::fs::remove_file(&nfc_path);
+    {
+        let mut f = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&nfc_path)?;
+        f.write_all(b"x")?;
+    }
+    let nfd_path = git_dir.join(NFD);
+    let aliases = nfd_path.exists();
+    let _ = std::fs::remove_file(&nfc_path);
+    Ok(aliases)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn precompose_nfd_filename_to_nfc() {
+        // Matches t3910: Adiarnfc = UTF-8 \303\204 (U+00C4), Adiarnfd = A + U+0308.
+        let nfd = format!("f.{}\u{0308}", 'A');
+        let nfc = format!("f.\u{00c4}");
+        assert_eq!(precompose_utf8_path(&nfd).as_ref(), nfc.as_str());
+    }
+}

--- a/grit/src/commands/add.rs
+++ b/grit/src/commands/add.rs
@@ -17,6 +17,7 @@ use grit_lib::objects::ObjectKind;
 use grit_lib::odb::Odb;
 use grit_lib::refs;
 use grit_lib::repo::Repository;
+use grit_lib::unicode_normalization::{precompose_utf8_path, precompose_utf8_segment};
 use grit_lib::wildmatch::wildmatch;
 use std::collections::HashSet;
 use std::fs;
@@ -217,6 +218,8 @@ pub fn run(mut args: Args) -> Result<()> {
         .get_bool("core.filemode")
         .and_then(|r| r.ok())
         .unwrap_or(true);
+    let precompose_unicode =
+        grit_lib::precompose_config::effective_core_precomposeunicode(Some(&repo.git_dir));
 
     let index_path = resolved_env_index_path(&repo);
     let idx_exists = index_path.exists();
@@ -280,6 +283,7 @@ pub fn run(mut args: Args) -> Result<()> {
 
     let add_cfg = AddConfig {
         core_filemode,
+        precompose_unicode,
         ignore_errors: args.ignore_errors
             || config
                 .get_bool("add.ignore-errors")
@@ -337,7 +341,7 @@ pub fn run(mut args: Args) -> Result<()> {
             let resolved =
                 crate::pathspec::resolve_pathspec(pathspec, work_tree, prefix.as_deref());
             // Expand glob patterns (e.g. "file?.t", "*.c") against the working tree.
-            let expanded = expand_glob_pathspec(&resolved, work_tree);
+            let expanded = expand_glob_pathspec(&resolved, work_tree, add_cfg.precompose_unicode);
             for resolved in &expanded {
                 match add_path(
                     odb,
@@ -412,6 +416,7 @@ pub fn run(mut args: Args) -> Result<()> {
 
 pub(crate) struct AddConfig {
     pub core_filemode: bool,
+    pub precompose_unicode: bool,
     pub ignore_errors: bool,
     pub conv: ConversionConfig,
     pub attrs: GitAttributes,
@@ -470,9 +475,9 @@ pub(crate) fn stage_pathspecs_for_commit(
                     repo,
                     &mut ignore_matcher,
                     false,
+                    add_cfg.precompose_unicode,
                 )?;
-                for rel in rels {
-                    let file_abs = work_tree.join(&rel);
+                for (rel, file_abs) in rels {
                     stage_file(
                         odb, &mut index, work_tree, &rel, &file_abs, repo, &ctx, add_cfg,
                     )?;
@@ -504,7 +509,13 @@ pub(crate) fn stage_pathspecs_for_commit(
         let mut matched_rels: Vec<String> = Vec::new();
         if let Ok(entries) = fs::read_dir(&search_dir) {
             for entry in entries.flatten() {
-                let name_str = entry.file_name().to_string_lossy().to_string();
+                let file_name = entry.file_name();
+                let raw_name = file_name.to_string_lossy();
+                let name_str = if add_cfg.precompose_unicode {
+                    precompose_utf8_segment(raw_name.as_ref()).into_owned()
+                } else {
+                    raw_name.into_owned()
+                };
                 if name_str == ".git" {
                     continue;
                 }
@@ -729,7 +740,7 @@ fn add_all(
         _ => work_tree.to_path_buf(),
     };
 
-    let mut paths = Vec::new();
+    let mut paths: Vec<(String, PathBuf)> = Vec::new();
     walk_directory(
         &scan_root,
         work_tree,
@@ -737,20 +748,20 @@ fn add_all(
         repo,
         ignore_matcher,
         args.force,
+        add_cfg.precompose_unicode,
     )?;
 
     // Build a set of worktree paths for fast deletion detection
     let worktree_paths: std::collections::HashSet<&str> =
-        paths.iter().map(|s| s.as_str()).collect();
+        paths.iter().map(|(r, _)| r.as_str()).collect();
 
-    for rel_path in &paths {
-        let abs_path = work_tree.join(rel_path);
+    for (rel_path, abs_path) in &paths {
         if let Err(e) = stage_file(
             odb,
             index,
             work_tree,
             rel_path,
-            &abs_path,
+            abs_path,
             repo,
             &StageFileContext::from(args),
             add_cfg,
@@ -928,6 +939,49 @@ fn update_tracked(
     Ok(())
 }
 
+/// Resolve `rel` to the spelling that exists on disk when NFC/NFD differ (Linux + precompose).
+fn resolve_add_path_on_disk(
+    work_tree: &Path,
+    rel: &str,
+    precompose_unicode: bool,
+) -> (PathBuf, String) {
+    let abs = work_tree.join(rel);
+    if fs::symlink_metadata(&abs).is_ok() {
+        return (abs, rel.to_owned());
+    }
+    if !precompose_unicode {
+        return (abs, rel.to_owned());
+    }
+    let p = Path::new(rel);
+    let want_leaf = precompose_utf8_path(
+        p.file_name()
+            .map(|s| s.to_string_lossy())
+            .unwrap_or_default()
+            .as_ref(),
+    )
+    .into_owned();
+    if want_leaf.is_empty() {
+        return (abs, rel.to_owned());
+    }
+    let parent_rel = p.parent().filter(|x| !x.as_os_str().is_empty());
+    let parent_abs = parent_rel
+        .map(|pr| work_tree.join(pr))
+        .unwrap_or_else(|| work_tree.to_path_buf());
+    if let Ok(rd) = fs::read_dir(&parent_abs) {
+        for ent in rd.flatten() {
+            let n = ent.file_name().to_string_lossy().into_owned();
+            if precompose_utf8_path(&n).as_ref() == want_leaf.as_str() {
+                let new_rel = match parent_rel {
+                    Some(pr) => format!("{}/{}", pr.to_string_lossy(), n),
+                    None => n,
+                };
+                return (work_tree.join(&new_rel), new_rel);
+            }
+        }
+    }
+    (abs, rel.to_owned())
+}
+
 /// Add a single pathspec (which may be a file or directory).
 fn add_path(
     odb: &Odb,
@@ -939,7 +993,9 @@ fn add_path(
     ignore_matcher: &mut Option<IgnoreMatcher>,
     add_cfg: &AddConfig,
 ) -> std::result::Result<(), AddPathError> {
-    let abs_path = work_tree.join(path);
+    let (abs_path, path_on_disk) =
+        resolve_add_path_on_disk(work_tree, path, add_cfg.precompose_unicode);
+    let path = path_on_disk.as_str();
 
     // Refuse to add a path inside a registered submodule (gitlink).
     // Only reject when a *proper* parent directory is a gitlink;
@@ -1037,7 +1093,7 @@ fn add_path(
             .map_err(AddPathError::IoError);
         }
 
-        let mut paths = Vec::new();
+        let mut paths: Vec<(String, PathBuf)> = Vec::new();
         walk_directory(
             &abs_path,
             work_tree,
@@ -1045,15 +1101,15 @@ fn add_path(
             repo,
             ignore_matcher,
             args.force,
+            add_cfg.precompose_unicode,
         )?;
-        for rel_path in &paths {
-            let file_abs = work_tree.join(rel_path);
+        for (rel_path, file_abs) in &paths {
             if let Err(e) = stage_file(
                 odb,
                 index,
                 work_tree,
                 rel_path,
-                &file_abs,
+                file_abs,
                 repo,
                 &StageFileContext::from(args),
                 add_cfg,
@@ -1541,28 +1597,37 @@ fn is_pid_running(pid: u32) -> bool {
     }
 }
 
-/// Collect repository-relative paths under `dir` for staging (same rules as `git add <dir>`:
-/// skips `.git`, ignored paths unless `force`, records embedded repos as single paths).
+/// Collect `(index path, absolute path)` pairs under `dir` for staging.
 pub(crate) fn collect_paths_for_stage_from_directory(
     dir: &Path,
     work_tree: &Path,
     repo: &Repository,
     ignore_matcher: &mut Option<IgnoreMatcher>,
     force: bool,
-) -> Result<Vec<String>> {
+    precompose_unicode: bool,
+) -> Result<Vec<(String, PathBuf)>> {
     let mut out = Vec::new();
-    walk_directory(dir, work_tree, &mut out, repo, ignore_matcher, force)?;
+    walk_directory(
+        dir,
+        work_tree,
+        &mut out,
+        repo,
+        ignore_matcher,
+        force,
+        precompose_unicode,
+    )?;
     Ok(out)
 }
 
-/// Recursively walk a directory, collecting relative paths (skipping .git and ignored files).
+/// Recursively walk a directory, collecting index-relative paths and their on-disk paths.
 fn walk_directory(
     dir: &Path,
     work_tree: &Path,
-    out: &mut Vec<String>,
+    out: &mut Vec<(String, PathBuf)>,
     repo: &Repository,
     ignore_matcher: &mut Option<IgnoreMatcher>,
     force: bool,
+    precompose_unicode: bool,
 ) -> Result<()> {
     let entries = fs::read_dir(dir)?;
     let mut sorted: Vec<_> = entries.filter_map(|e| e.ok()).collect();
@@ -1577,10 +1642,15 @@ fn walk_directory(
             continue;
         }
 
-        let rel = path
+        let rel_fs = path
             .strip_prefix(work_tree)
             .map(|p| p.to_string_lossy().to_string())
             .unwrap_or_else(|_| path.to_string_lossy().to_string());
+        let rel_index = if precompose_unicode {
+            grit_lib::unicode_normalization::precompose_utf8_path(&rel_fs).into_owned()
+        } else {
+            rel_fs.clone()
+        };
 
         // Use symlink_metadata to detect symlinks *before* following them.
         // A symlink to a directory should be stored as a symlink blob,
@@ -1595,7 +1665,7 @@ fn walk_directory(
         // Check if ignored
         if !force {
             if let Some(matcher) = ignore_matcher.as_mut() {
-                if let Ok((ignored, _)) = matcher.check_path(repo, None, &rel, is_dir) {
+                if let Ok((ignored, _)) = matcher.check_path(repo, None, &rel_index, is_dir) {
                     if ignored {
                         continue;
                     }
@@ -1608,12 +1678,20 @@ fn walk_directory(
             // `git add .` does not treat an existing gitlink as deleted (the inner `.git` is
             // skipped below and would otherwise hide the whole tree from the scan).
             if path.join(".git").exists() {
-                out.push(rel);
+                out.push((rel_index, path));
                 continue;
             }
-            walk_directory(&path, work_tree, out, repo, ignore_matcher, force)?;
+            walk_directory(
+                &path,
+                work_tree,
+                out,
+                repo,
+                ignore_matcher,
+                force,
+                precompose_unicode,
+            )?;
         } else {
-            out.push(rel);
+            out.push((rel_index, path));
         }
     }
 
@@ -1677,7 +1755,11 @@ fn check_symlink_in_path(work_tree: &Path, rel_path: &Path) -> Option<PathBuf> {
 ///
 /// If the pathspec does not contain glob characters, returns it unchanged.
 /// Otherwise, matches it against files/dirs in the working tree directory.
-pub(crate) fn expand_glob_pathspec(pathspec: &str, work_tree: &Path) -> Vec<String> {
+pub(crate) fn expand_glob_pathspec(
+    pathspec: &str,
+    work_tree: &Path,
+    precompose_unicode: bool,
+) -> Vec<String> {
     if !crate::pathspec::has_glob_chars(pathspec) {
         return vec![pathspec.to_owned()];
     }
@@ -1700,15 +1782,24 @@ pub(crate) fn expand_glob_pathspec(pathspec: &str, work_tree: &Path) -> Vec<Stri
     if let Ok(entries) = fs::read_dir(&search_dir) {
         for entry in entries.flatten() {
             let name = entry.file_name();
-            let name_str = name.to_string_lossy();
-            if name_str == ".git" {
+            let raw = name.to_string_lossy();
+            let raw_owned = raw.into_owned();
+            let name_for_match = if precompose_unicode {
+                precompose_utf8_segment(raw_owned.as_ref()).into_owned()
+            } else {
+                raw_owned.clone()
+            };
+            if name_for_match == ".git" {
                 continue;
             }
-            if wildmatch(pattern.as_bytes(), name_str.as_bytes(), 0) {
+            if wildmatch(pattern.as_bytes(), name_for_match.as_bytes(), 0) {
+                // Use the filesystem spelling for `rel` so `open()` works on Linux when the index
+                // stores NFC but `readdir` returns NFD (t3910 `git add *` on long filenames).
+                let fs_name = raw_owned;
                 let rel = if dir_prefix.is_empty() {
-                    name_str.to_string()
+                    fs_name
                 } else {
-                    format!("{dir_prefix}/{name_str}")
+                    format!("{dir_prefix}/{fs_name}")
                 };
                 matches.push(rel);
             }

--- a/grit/src/commands/checkout.rs
+++ b/grit/src/commands/checkout.rs
@@ -334,6 +334,12 @@ pub fn run(mut args: Args) -> Result<()> {
         args.rest.extend(pathspecs);
     }
 
+    if grit_lib::precompose_config::effective_core_precomposeunicode(Some(&repo.git_dir)) {
+        for r in &mut args.rest {
+            *r = grit_lib::unicode_normalization::precompose_utf8_path(r).into_owned();
+        }
+    }
+
     // Post-process rest: extract -b/-B/--new-branch/--force-new-branch that
     // appeared after a positional arg (e.g. `checkout <rev> -b <branch>`).
     // Also accept `git switch` spellings: -c/--create and -C/--force-create

--- a/grit/src/commands/commit.rs
+++ b/grit/src/commands/commit.rs
@@ -425,6 +425,12 @@ pub fn run(mut args: Args) -> Result<()> {
 
     let repo = Repository::discover(None).context("not a git repository")?;
 
+    if grit_lib::precompose_config::effective_core_precomposeunicode(Some(&repo.git_dir)) {
+        for ps in &mut args.pathspec {
+            *ps = grit_lib::unicode_normalization::precompose_utf8_path(ps).into_owned();
+        }
+    }
+
     let reset_author_allowed = args.amend
         || args.reuse_message.is_some()
         || args.reedit_message.is_some()
@@ -455,8 +461,11 @@ pub fn run(mut args: Args) -> Result<()> {
                 .get_bool("core.filemode")
                 .and_then(|r| r.ok())
                 .unwrap_or(true);
+            let precompose_unicode =
+                grit_lib::precompose_config::effective_core_precomposeunicode(Some(&repo.git_dir));
             let add_cfg = crate::commands::add::AddConfig {
                 core_filemode,
+                precompose_unicode,
                 ignore_errors: false,
                 conv: grit_lib::crlf::ConversionConfig::from_config(&config),
                 attrs: grit_lib::crlf::load_gitattributes(wt),

--- a/grit/src/commands/diff.rs
+++ b/grit/src/commands/diff.rs
@@ -1015,9 +1015,19 @@ pub fn run(mut args: Args) -> Result<()> {
         return run_no_index(args);
     }
 
+    let repo_opt = Repository::discover(None).ok();
+    let precompose_paths = repo_opt.as_ref().is_some_and(|r| {
+        grit_lib::precompose_config::effective_core_precomposeunicode(Some(&r.git_dir))
+    });
+    if precompose_paths {
+        for a in args.args.iter_mut() {
+            *a = grit_lib::unicode_normalization::precompose_utf8_path(a).into_owned();
+        }
+    }
+
     let raw_args: Vec<String> = std::env::args().collect();
     let has_separator = raw_args.iter().any(|a| a == "--");
-    let (mut revs, paths) = parse_rev_and_paths(&args.args, has_separator);
+    let (mut revs, paths) = parse_rev_and_paths(&args.args, has_separator, precompose_paths);
     // Options parsed by clap can remain in the `revs` bucket when `--` separates paths
     // (`git diff -D -- path`). Drop duplicates so they are not treated as revision names.
     if args.irreversible_delete {
@@ -1028,14 +1038,14 @@ pub fn run(mut args: Args) -> Result<()> {
     }
 
     // Outside any repository, `git diff <path> <path>` behaves like `diff --no-index` (t4035).
-    if Repository::discover(None).is_err() && revs.is_empty() && paths.len() == 2 && !args.cached {
+    if repo_opt.is_none() && revs.is_empty() && paths.len() == 2 && !args.cached {
         return run_no_index(args);
     }
 
-    let repo = Repository::discover(None).context("not a git repository")?;
-    let quote_path_fully = grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true)
-        .unwrap_or_default()
-        .quote_path_fully();
+    let repo = repo_opt.context("not a git repository")?;
+    let diff_cfg_early = grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true)
+        .unwrap_or_else(|_| grit_lib::config::ConfigSet::new());
+    let quote_path_fully = diff_cfg_early.quote_path_fully();
 
     let patch_context = if let Some(u) = args.unified {
         u
@@ -1103,7 +1113,6 @@ pub fn run(mut args: Args) -> Result<()> {
             }
         })
         .collect();
-
     // Resolve diff prefixes from config and command-line options
     let (src_prefix, dst_prefix) = resolve_diff_prefixes(&args, &repo, args.cached);
 
@@ -3218,7 +3227,28 @@ fn write_dirstat(
     Ok(())
 }
 
-fn parse_rev_and_paths(args: &[String], has_separator: bool) -> (Vec<String>, Vec<String>) {
+/// When `core.precomposeunicode` is on, the work tree may store paths in NFC while argv uses NFD.
+fn resolve_pathspec_for_diff_classification(arg: &str, precompose_unicode: bool) -> Option<String> {
+    use std::path::Path;
+    if Path::new(arg).symlink_metadata().is_ok() {
+        return Some(arg.to_owned());
+    }
+    // With precompose, NFD argv must match NFC on-disk paths (macOS aliases them; Linux tests
+    // force the config without FS aliasing, so the NFD spelling may not exist as a path).
+    if precompose_unicode {
+        let nfc = grit_lib::unicode_normalization::precompose_utf8_path(arg);
+        if nfc.as_ref() != arg {
+            return Some(nfc.into_owned());
+        }
+    }
+    None
+}
+
+fn parse_rev_and_paths(
+    args: &[String],
+    has_separator: bool,
+    precompose_unicode: bool,
+) -> (Vec<String>, Vec<String>) {
     if let Some(sep) = args.iter().position(|a| a == "--") {
         let revs = args[..sep].to_vec();
         let paths = args[sep + 1..].to_vec();
@@ -3235,9 +3265,11 @@ fn parse_rev_and_paths(args: &[String], has_separator: bool) -> (Vec<String>, Ve
         for arg in args {
             if in_paths {
                 paths.push(arg.clone());
-            } else if std::fs::symlink_metadata(std::path::Path::new(arg)).is_ok() {
+            } else if let Some(p) =
+                resolve_pathspec_for_diff_classification(arg, precompose_unicode)
+            {
                 in_paths = true;
-                paths.push(arg.clone());
+                paths.push(p);
             } else {
                 revs.push(arg.clone());
             }

--- a/grit/src/commands/diff_files.rs
+++ b/grit/src/commands/diff_files.rs
@@ -35,9 +35,12 @@ pub struct Args {
 }
 
 /// Run `grit diff-files`.
-pub fn run(args: Args) -> Result<()> {
-    let options = parse_options(&args.args)?;
+pub fn run(mut args: Args) -> Result<()> {
     let repo = Repository::discover(None).context("not a git repository")?;
+    if grit_lib::precompose_config::effective_core_precomposeunicode(Some(&repo.git_dir)) {
+        crate::precompose::precompose_plumbing_argv(&mut args.args);
+    }
+    let options = parse_options(&args.args)?;
 
     let Some(work_tree) = repo.work_tree.clone() else {
         bail!("this operation must be run in a work tree");
@@ -1227,11 +1230,11 @@ fn matches_pathspec(path: &str, pathspecs: &[String]) -> bool {
         return true;
     }
     pathspecs.iter().any(|spec| {
-        if let Some(prefix) = spec.strip_suffix('/') {
-            path == prefix || path.starts_with(&format!("{prefix}/"))
-        } else {
-            path == spec || path.starts_with(&format!("{spec}/"))
-        }
+        grit_lib::pathspec::matches_pathspec_with_context(
+            spec,
+            path,
+            grit_lib::pathspec::PathspecMatchContext::default(),
+        )
     })
 }
 

--- a/grit/src/commands/diff_index.rs
+++ b/grit/src/commands/diff_index.rs
@@ -31,9 +31,12 @@ pub struct Args {
 }
 
 /// Run `grit diff-index`.
-pub fn run(args: Args) -> Result<()> {
-    let options = parse_options(&args.args)?;
+pub fn run(mut args: Args) -> Result<()> {
     let repo = Repository::discover(None).context("not a git repository")?;
+    if grit_lib::precompose_config::effective_core_precomposeunicode(Some(&repo.git_dir)) {
+        crate::precompose::precompose_plumbing_argv(&mut args.args);
+    }
+    let options = parse_options(&args.args)?;
     let tree_oid = resolve_tree_ish(&repo, &options.tree_ish)?;
 
     let mut tree_map = BTreeMap::new();

--- a/grit/src/commands/diff_tree.rs
+++ b/grit/src/commands/diff_tree.rs
@@ -175,8 +175,23 @@ impl Default for Options {
     }
 }
 
+/// True when `spec` resolves to a commit, tree, or annotated tag (Git `setup_revisions` tree-ish).
+fn spec_names_commit_or_tree(repo: &Repository, spec: &str) -> bool {
+    match resolve_revision(repo, spec) {
+        Ok(oid) => match repo.odb.read(&oid) {
+            Ok(obj) => match obj.kind {
+                ObjectKind::Commit | ObjectKind::Tree => true,
+                ObjectKind::Tag => true,
+                ObjectKind::Blob => false,
+            },
+            Err(_) => false,
+        },
+        Err(_) => false,
+    }
+}
+
 /// Parse the raw argument vector.
-fn parse_options(argv: &[String]) -> Result<Options> {
+fn parse_options(repo: &Repository, argv: &[String]) -> Result<Options> {
     let mut opts = Options::default();
     let mut end_of_options = false;
     let mut i = 0usize;
@@ -366,8 +381,10 @@ fn parse_options(argv: &[String]) -> Result<Options> {
             continue;
         }
 
-        // Positional: first two are tree-ish, rest are pathspecs.
+        // Positional: like Git `setup_revisions` — up to two tree-ishes, then pathspecs.
         if end_of_options || opts.objects.len() >= 2 {
+            opts.pathspecs.push(arg.clone());
+        } else if opts.objects.len() == 1 && !spec_names_commit_or_tree(repo, arg) {
             opts.pathspecs.push(arg.clone());
         } else {
             opts.objects.push(arg.clone());
@@ -394,9 +411,12 @@ fn parse_options(argv: &[String]) -> Result<Options> {
 // ── Public entry point ───────────────────────────────────────────────
 
 /// Run `grit diff-tree`.
-pub fn run(args: Args) -> Result<()> {
-    let opts = parse_options(&args.args)?;
+pub fn run(mut args: Args) -> Result<()> {
     let repo = Repository::discover(None).context("not a git repository")?;
+    if grit_lib::precompose_config::effective_core_precomposeunicode(Some(&repo.git_dir)) {
+        crate::precompose::precompose_diff_tree_argv(&mut args.args);
+    }
+    let opts = parse_options(&repo, &args.args)?;
 
     let stdout = io::stdout();
     let mut out = stdout.lock();

--- a/grit/src/commands/init.rs
+++ b/grit/src/commands/init.rs
@@ -6,6 +6,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use grit_lib::config::{parse_bool, ConfigFile, ConfigScope, ConfigSet};
+use grit_lib::unicode_normalization::probe_filesystem_normalizes_nfd_to_nfc;
 
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
@@ -351,6 +352,25 @@ pub fn run(args: Args, global_bare: bool) -> Result<()> {
             work_tree: work_tree_abs.as_deref(),
         },
     )?;
+
+    // Git's probe_utf8_pathname_composition: if the FS aliases NFC/NFD spellings under .git,
+    // set core.precomposeunicode (unless already set in higher-priority config).
+    // `GIT_TEST_UTF8_NFD_TO_NFC` forces this for harness portability (Linux CI).
+    if !is_reinit && !bare && config.get("core.precomposeunicode").is_none() {
+        let force_probe = matches!(
+            std::env::var("GIT_TEST_UTF8_NFD_TO_NFC").ok().as_deref(),
+            Some("true") | Some("1")
+        );
+        let probe_ok =
+            force_probe || probe_filesystem_normalizes_nfd_to_nfc(&real_git_dir).unwrap_or(false);
+        if probe_ok {
+            let config_path = real_git_dir.join("config");
+            let content = fs::read_to_string(&config_path).unwrap_or_default();
+            let mut cfg = ConfigFile::parse(&config_path, &content, ConfigScope::Local)?;
+            cfg.set("core.precomposeunicode", "true")?;
+            cfg.write()?;
+        }
+    }
 
     if !is_reinit
         && !bare

--- a/grit/src/commands/log.rs
+++ b/grit/src/commands/log.rs
@@ -1208,7 +1208,17 @@ fn run_graph_log(repo: &Repository, args: &Args, patch_context: usize) -> Result
                 Err(_err) if is_likely_pathspec_during_rev_parse(stripped) => {
                     implied_pathspecs.push(stripped.to_owned())
                 }
-                Err(err) => return Err(err.into()),
+                Err(_err) => match resolve_revision_as_commit_after_precompose(repo, stripped) {
+                    Ok(_) => revision_specs.push(rev.clone()),
+                    Err(_err)
+                        if grit_lib::precompose_config::effective_core_precomposeunicode(Some(
+                            &repo.git_dir,
+                        )) && grit_lib::unicode_normalization::has_non_ascii_utf8(stripped) =>
+                    {
+                        implied_pathspecs.push(stripped.to_owned());
+                    }
+                    Err(err) => return Err(err.into()),
+                },
             }
         } else {
             match resolve_revision_as_commit(repo, rev) {
@@ -1216,7 +1226,17 @@ fn run_graph_log(repo: &Repository, args: &Args, patch_context: usize) -> Result
                 Err(_err) if is_likely_pathspec_during_rev_parse(rev) => {
                     implied_pathspecs.push(rev.clone())
                 }
-                Err(err) => return Err(err.into()),
+                Err(_err) => match resolve_revision_as_commit_after_precompose(repo, rev) {
+                    Ok(_) => revision_specs.push(rev.clone()),
+                    Err(_err)
+                        if grit_lib::precompose_config::effective_core_precomposeunicode(Some(
+                            &repo.git_dir,
+                        )) && grit_lib::unicode_normalization::has_non_ascii_utf8(rev) =>
+                    {
+                        implied_pathspecs.push(rev.clone());
+                    }
+                    Err(err) => return Err(err.into()),
+                },
             }
         }
     }
@@ -2473,6 +2493,11 @@ pub fn run(mut args: Args) -> Result<()> {
     }
 
     let repo = Repository::discover(None).context("not a git repository")?;
+    if grit_lib::precompose_config::effective_core_precomposeunicode(Some(&repo.git_dir)) {
+        for p in &mut args.pathspecs {
+            *p = grit_lib::unicode_normalization::precompose_utf8_path(p).into_owned();
+        }
+    }
     normalize_log_merge_diff_args(&mut args, &repo.git_dir)?;
     validate_log_pickaxe_options(&repo, &args)?;
     let patch_context = if let Some(u) = args.unified {
@@ -2667,7 +2692,17 @@ pub fn run(mut args: Args) -> Result<()> {
                     Err(_err) if is_likely_pathspec_during_rev_parse(rev) => {
                         implied_pathspecs.push(rev.clone());
                     }
-                    Err(err) => return Err(err.into()),
+                    Err(_err) => match resolve_revision_as_commit_after_precompose(&repo, rev) {
+                        Ok(oid) => oids.push(oid),
+                        Err(_err)
+                            if grit_lib::precompose_config::effective_core_precomposeunicode(
+                                Some(&repo.git_dir),
+                            ) && grit_lib::unicode_normalization::has_non_ascii_utf8(rev) =>
+                        {
+                            implied_pathspecs.push(rev.clone());
+                        }
+                        Err(err) => return Err(err.into()),
+                    },
                 }
             }
         }
@@ -6007,6 +6042,19 @@ fn resolve_revision(repo: &Repository, rev: &str) -> Result<ObjectId> {
     // @{N}, @{now}, @{upstream}, peeling, parent navigation, etc.
     grit_lib::rev_parse::resolve_revision(repo, rev)
         .map_err(|e| anyhow::anyhow!("unknown revision '{}': {}", rev, e))
+}
+
+fn resolve_revision_as_commit_after_precompose(repo: &Repository, rev: &str) -> Result<ObjectId> {
+    if !grit_lib::precompose_config::effective_core_precomposeunicode(Some(&repo.git_dir))
+        || !grit_lib::unicode_normalization::has_non_ascii_utf8(rev)
+    {
+        return resolve_revision_as_commit(repo, rev).map_err(|e| e.into());
+    }
+    let nfc = grit_lib::unicode_normalization::precompose_utf8_path(rev);
+    if nfc.as_ref() == rev {
+        return resolve_revision_as_commit(repo, rev).map_err(|e| e.into());
+    }
+    resolve_revision_as_commit(repo, nfc.as_ref()).map_err(|e| e.into())
 }
 
 /// Heuristic used for rev/pathspec DWIM when no `--` separator is present.

--- a/grit/src/commands/ls_files.rs
+++ b/grit/src/commands/ls_files.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 use grit_lib::ignore::IgnoreMatcher;
 use grit_lib::index::IndexEntry;
 use grit_lib::repo::Repository;
+use grit_lib::unicode_normalization::{precompose_utf8_path, precompose_utf8_segment};
 
 use crate::explicit_exit::ExplicitExit;
 
@@ -172,6 +173,10 @@ pub fn run(args: Args) -> Result<()> {
     };
     let cwd_prefix = cwd_prefix_bytes(work_tree, &cwd)?;
     let config = grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+    let precompose_unicode =
+        grit_lib::precompose_config::effective_core_precomposeunicode(Some(&repo.git_dir));
+    let precompose_walk = precompose_unicode
+        && grit_lib::precompose_config::filesystem_nfd_nfc_aliases(&repo.git_dir);
     let quote_fully = config.quote_path_fully();
     let index_path = resolved_env_index_path(&repo);
     let mut index = if args.sparse {
@@ -217,7 +222,7 @@ pub fn run(args: Args) -> Result<()> {
     let mut pathspec_filter: Vec<Pathspec> = args
         .pathspecs
         .iter()
-        .map(|p| resolve_pathspec(work_tree, &cwd, p))
+        .map(|p| resolve_pathspec(work_tree, &cwd, p, precompose_unicode))
         .collect::<Result<Vec<_>>>()?;
     let mut pathspec_display: Vec<String> = args
         .pathspecs
@@ -239,7 +244,7 @@ pub fn run(args: Args) -> Result<()> {
             .with_context(|| format!("overlay tree '{treeish}' on index"))?;
     }
 
-    pathspec_filter = expand_ls_files_globs(pathspec_filter, work_tree, &index);
+    pathspec_filter = expand_ls_files_globs(pathspec_filter, work_tree, &index, precompose_walk);
 
     // For `--error-unmatch`, Git matches pathspecs separately against index output vs untracked
     // output (`-c` vs `-o`). A pathspec that only hits tracked files does not satisfy `-o`.
@@ -477,6 +482,7 @@ pub fn run(args: Args) -> Result<()> {
             &mut untracked,
             true,
             args.directory,
+            precompose_walk,
         )?;
         untracked.sort();
 
@@ -671,8 +677,14 @@ fn walk_worktree(
     out: &mut Vec<Vec<u8>>,
     is_root: bool,
     emit_empty_directories: bool,
+    precompose_unicode: bool,
 ) -> Result<bool> {
-    let rel_bytes = path_to_bytes(dir.strip_prefix(root).unwrap_or(dir));
+    let mut rel_bytes = path_to_bytes(dir.strip_prefix(root).unwrap_or(dir));
+    if precompose_unicode {
+        if let Ok(s) = std::str::from_utf8(&rel_bytes) {
+            rel_bytes = precompose_utf8_path(s).into_owned().into_bytes();
+        }
+    }
 
     let entries = match std::fs::read_dir(dir) {
         Ok(e) => e,
@@ -684,9 +696,19 @@ fn walk_worktree(
         let entry = entry?;
         let path = entry.path();
         let rel = path.strip_prefix(root).unwrap_or(&path);
-        let rel_bytes = path_to_bytes(rel);
+        let mut rel_bytes = path_to_bytes(rel);
+        if precompose_unicode {
+            if let Ok(s) = std::str::from_utf8(&rel_bytes) {
+                rel_bytes = precompose_utf8_path(s).into_owned().into_bytes();
+            }
+        }
         let name = entry.file_name();
-        let name_str = name.to_string_lossy();
+        let raw_name = name.to_string_lossy();
+        let name_str = if precompose_unicode {
+            precompose_utf8_segment(raw_name.as_ref()).into_owned()
+        } else {
+            raw_name.into_owned()
+        };
 
         // Skip .git directory
         if name_str == ".git" {
@@ -730,7 +752,15 @@ fn walk_worktree(
                 }
                 continue;
             }
-            if walk_worktree(root, &path, indexed, out, false, emit_empty_directories)? {
+            if walk_worktree(
+                root,
+                &path,
+                indexed,
+                out,
+                false,
+                emit_empty_directories,
+                precompose_unicode,
+            )? {
                 added = true;
             }
         }
@@ -772,6 +802,7 @@ fn expand_ls_files_globs(
     specs: Vec<Pathspec>,
     work_tree: &std::path::Path,
     index: &grit_lib::index::Index,
+    precompose_walk: bool,
 ) -> Vec<Pathspec> {
     let mut out = Vec::new();
     for spec in specs {
@@ -781,7 +812,9 @@ fn expand_ls_files_globs(
                 if matches_index {
                     out.push(spec);
                 } else {
-                    for e in crate::commands::add::expand_glob_pathspec(pat, work_tree) {
+                    for e in
+                        crate::commands::add::expand_glob_pathspec(pat, work_tree, precompose_walk)
+                    {
                         out.push(if has_glob_chars(&e) {
                             Pathspec::Glob(e)
                         } else {
@@ -940,19 +973,25 @@ fn resolve_pathspec(
     work_tree: &std::path::Path,
     cwd: &std::path::Path,
     pathspec: &std::path::Path,
+    precompose_unicode: bool,
 ) -> Result<Pathspec> {
     if pathspec.as_os_str().is_empty() || pathspec == std::path::Path::new(".") {
         return Ok(Pathspec::Literal(cwd_prefix_bytes(work_tree, cwd)?));
     }
-    let pathspec_str = pathspec.to_string_lossy();
-    if pathspec_str.starts_with(":(") {
+    let raw_lossy = pathspec.to_string_lossy().into_owned();
+    let nfc_lossy = if precompose_unicode {
+        precompose_utf8_path(raw_lossy.as_ref()).into_owned()
+    } else {
+        raw_lossy.clone()
+    };
+    if nfc_lossy.starts_with(":(") {
         let prefix = String::from_utf8_lossy(&cwd_prefix_bytes(work_tree, cwd)?).into_owned();
-        if let Some(resolved) = crate::pathspec::resolve_magic_pathspec(&pathspec_str, &prefix) {
+        if let Some(resolved) = crate::pathspec::resolve_magic_pathspec(&nfc_lossy, &prefix) {
             return Ok(Pathspec::Magic(resolved));
         }
     }
     // Handle magic pathspec ":/<pattern>" — match from the root of the work tree.
-    if let Some(rest) = pathspec_str.strip_prefix(":/") {
+    if let Some(rest) = nfc_lossy.strip_prefix(":/") {
         if rest.is_empty() || rest == "*" {
             // `:/` or `:/*` — match all paths under the work tree root (git pathspec magic).
             return Ok(Pathspec::Glob("*".to_string()));
@@ -962,17 +1001,20 @@ fn resolve_pathspec(
         }
         return Ok(Pathspec::Literal(rest.as_bytes().to_vec()));
     }
-    if has_glob_chars(&pathspec_str) {
+    if has_glob_chars(&nfc_lossy) {
         // For glob pathspecs, prepend the cwd prefix (relative to work_tree)
         let prefix = cwd_prefix_bytes(work_tree, cwd)?;
         let prefix_str = String::from_utf8_lossy(&prefix).into_owned();
-        let pattern = format!("{}{}", prefix_str, pathspec_str);
+        let pattern = format!("{}{}", prefix_str, nfc_lossy);
         return Ok(Pathspec::Glob(pattern));
     }
+    // Absolute pathspecs must keep the caller's spelling for `strip_prefix(work_tree)`:
+    // the work tree path may be NFD on disk while the index uses NFC (t3910 `ls-files` with
+    // `--literal-pathspecs` and an absolute path from outside the repo).
     let combined = if pathspec.is_absolute() {
         pathspec.to_path_buf()
     } else {
-        cwd.join(pathspec)
+        cwd.join(std::path::Path::new(nfc_lossy.as_str()))
     };
     let normalized = normalize_path(&combined);
     let rel = normalized.strip_prefix(work_tree).with_context(|| {

--- a/grit/src/commands/mv.rs
+++ b/grit/src/commands/mv.rs
@@ -14,6 +14,7 @@ use grit_lib::repo::Repository;
 use grit_lib::sparse_checkout::{
     parse_sparse_checkout_file, path_in_cone_mode_sparse_checkout, path_in_sparse_checkout_patterns,
 };
+use grit_lib::unicode_normalization::precompose_utf8_path;
 use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -80,7 +81,7 @@ struct MoveRow {
 
 /// Run the `mv` command.
 pub fn run(args: Args) -> Result<()> {
-    let (raw_sources, raw_dest) = {
+    let (mut raw_sources, mut raw_dest) = {
         let mut all = args.paths;
         let dest = all
             .pop()
@@ -89,6 +90,12 @@ pub fn run(args: Args) -> Result<()> {
     };
 
     let repo = Repository::discover(None).context("not a git repository")?;
+    if grit_lib::precompose_config::effective_core_precomposeunicode(Some(&repo.git_dir)) {
+        for s in &mut raw_sources {
+            *s = precompose_utf8_path(s).into_owned();
+        }
+        raw_dest = precompose_utf8_path(&raw_dest).into_owned();
+    }
     let work_tree = repo
         .work_tree
         .as_deref()
@@ -125,10 +132,17 @@ pub fn run(args: Args) -> Result<()> {
     let cwd = std::env::current_dir()?;
     let prefix = compute_prefix(&cwd, work_tree);
 
-    let sources: Vec<String> = raw_sources
+    let precompose_unicode =
+        grit_lib::precompose_config::effective_core_precomposeunicode(Some(&repo.git_dir));
+    let mut sources: Vec<String> = raw_sources
         .iter()
         .map(|s| resolve_path(s, prefix.as_deref(), work_tree))
         .collect();
+    if precompose_unicode {
+        for s in &mut sources {
+            *s = canonicalize_source_path_for_index(&index, s);
+        }
+    }
 
     for (raw, resolved) in raw_sources.iter().zip(sources.iter()) {
         if Path::new(resolved).is_absolute() {
@@ -224,7 +238,25 @@ pub fn run(args: Args) -> Result<()> {
             .trim_end_matches('/')
             .trim_end_matches('\\')
             .to_owned();
-        let src_abs = work_tree.join(&src_rel);
+        let key = precompose_utf8_path(&src_rel).into_owned();
+        let mut src_abs = work_tree.join(&src_rel);
+        if precompose_unicode && !src_abs.exists() {
+            let nfc_path = work_tree.join(&key);
+            if nfc_path.exists() {
+                src_abs = nfc_path;
+            } else if !src_rel.contains('/') {
+                if let Ok(rd) = fs::read_dir(work_tree) {
+                    for ent in rd.flatten() {
+                        let name = ent.file_name().to_string_lossy().into_owned();
+                        if precompose_utf8_path(&name).as_ref() == key.as_str() {
+                            src_abs = ent.path();
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        let index_src_rel = key;
 
         let dst_rel: String = if dest_is_dir {
             let basename = Path::new(&src_rel)
@@ -242,15 +274,15 @@ pub fn run(args: Args) -> Result<()> {
         let dst_abs = work_tree.join(&dst_rel);
 
         let sparse_path_pairs: Vec<(String, String)> = if src_abs.is_dir() {
-            if index.get(src_rel.as_bytes(), 0).is_some() {
-                vec![(src_rel.clone(), dst_rel.clone())]
+            if index.get(index_src_rel.as_bytes(), 0).is_some() {
+                vec![(index_src_rel.clone(), dst_rel.clone())]
             } else {
-                expand_dir_sources(&src_rel, &dst_rel, &index)
+                expand_dir_sources(&index_src_rel, &dst_rel, &index)
             }
-        } else if !src_abs.exists() && empty_dir_has_sparse_contents(&src_rel, &index) {
-            expand_dir_sources(&src_rel, &dst_rel, &index)
+        } else if !src_abs.exists() && empty_dir_has_sparse_contents(&index_src_rel, &index) {
+            expand_dir_sources(&index_src_rel, &dst_rel, &index)
         } else {
-            vec![(src_rel.clone(), dst_rel.clone())]
+            vec![(index_src_rel.clone(), dst_rel.clone())]
         };
 
         if !args.sparse && sparse_enabled {
@@ -274,9 +306,9 @@ pub fn run(args: Args) -> Result<()> {
 
         if src_abs.exists() {
             if src_abs.is_dir() {
-                if index.get(src_rel.as_bytes(), 0).is_some() {
+                if index.get(index_src_rel.as_bytes(), 0).is_some() {
                     rows.push(MoveRow {
-                        src: src_rel.clone(),
+                        src: index_src_rel.clone(),
                         dst: dst_rel.clone(),
                         do_fs_rename: true,
                         index_only: false,
@@ -300,9 +332,9 @@ pub fn run(args: Args) -> Result<()> {
                     }
                     bail!("{msg}");
                 }
-                moved_dir_roots.insert(src_rel.clone());
+                moved_dir_roots.insert(index_src_rel.clone());
                 rows.push(MoveRow {
-                    src: src_rel.clone(),
+                    src: index_src_rel.clone(),
                     dst: dst_rel.clone(),
                     do_fs_rename: true,
                     index_only: false,
@@ -322,11 +354,14 @@ pub fn run(args: Args) -> Result<()> {
                 continue;
             }
         } else {
-            let pos = index
-                .entries
-                .iter()
-                .position(|e| e.path == src_rel.as_bytes());
-            if pos.is_none() && !src_abs.exists() && empty_dir_has_sparse_contents(&src_rel, &index)
+            let pos = index.entries.iter().position(|e| {
+                e.stage() == 0
+                    && precompose_utf8_path(String::from_utf8_lossy(&e.path).as_ref()).as_ref()
+                        == precompose_utf8_path(&index_src_rel).as_ref()
+            });
+            if pos.is_none()
+                && !src_abs.exists()
+                && empty_dir_has_sparse_contents(&index_src_rel, &index)
             {
                 let expanded = sparse_path_pairs;
                 if expanded.is_empty() {
@@ -343,9 +378,9 @@ pub fn run(args: Args) -> Result<()> {
                     }
                     bail!("{msg}");
                 }
-                moved_dir_roots.insert(src_rel.clone());
+                moved_dir_roots.insert(index_src_rel.clone());
                 rows.push(MoveRow {
-                    src: src_rel.clone(),
+                    src: index_src_rel.clone(),
                     dst: dst_rel.clone(),
                     do_fs_rename: false,
                     index_only: false,
@@ -403,10 +438,11 @@ pub fn run(args: Args) -> Result<()> {
             }
         }
 
-        let has_conflict = index
-            .entries
-            .iter()
-            .any(|e| e.path == src_rel.as_bytes() && e.stage() > 0);
+        let has_conflict = index.entries.iter().any(|e| {
+            e.stage() > 0
+                && precompose_utf8_path(String::from_utf8_lossy(&e.path).as_ref()).as_ref()
+                    == precompose_utf8_path(&index_src_rel).as_ref()
+        });
         if has_conflict {
             let msg = format!("conflicted, source='{src_rel}', destination='{dst_rel}'");
             if args.skip_errors {
@@ -415,7 +451,7 @@ pub fn run(args: Args) -> Result<()> {
             bail!("{msg}");
         }
 
-        let stage0 = index.get(src_rel.as_bytes(), 0);
+        let stage0 = index.get(index_src_rel.as_bytes(), 0);
         if stage0.is_none() && !src_abs.is_dir() {
             let msg =
                 format!("not under version control, source='{src_rel}', destination='{dst_rel}'");
@@ -442,7 +478,7 @@ pub fn run(args: Args) -> Result<()> {
             bail!("{msg}");
         }
 
-        if src_rel == dst_rel {
+        if index_src_rel == dst_rel {
             let msg = format!(
                 "source and destination are the same, source='{src_rel}', destination='{dst_rel}'"
             );
@@ -456,7 +492,7 @@ pub fn run(args: Args) -> Result<()> {
         // only differs by case from the source is not a separate destination — `exists()` would
         // still be true for the same inode.
         let dst_fs_collides =
-            dst_abs.exists() && !(ignore_case && src_rel.eq_ignore_ascii_case(&dst_rel));
+            dst_abs.exists() && !(ignore_case && index_src_rel.eq_ignore_ascii_case(&dst_rel));
 
         if dst_fs_collides
             && !(args.force && (dst_abs.is_file() || dst_abs.is_symlink()) && !dst_abs.is_dir())
@@ -487,7 +523,7 @@ pub fn run(args: Args) -> Result<()> {
         }
 
         rows.push(MoveRow {
-            src: src_rel,
+            src: index_src_rel,
             dst: dst_rel,
             do_fs_rename: true,
             index_only: false,
@@ -654,12 +690,17 @@ pub fn run(args: Args) -> Result<()> {
 }
 
 fn empty_dir_has_sparse_contents(name: &str, index: &Index) -> bool {
-    let with_slash = format!("{}/", name.trim_end_matches('/'));
-    let prefix = with_slash.as_bytes();
-    index
-        .entries
-        .iter()
-        .any(|e| e.path.starts_with(prefix) && e.stage() == 0 && e.skip_worktree())
+    let key = precompose_utf8_path(name.trim_end_matches('/'));
+    let prefix_nfc = format!("{}/", key.as_ref());
+    index.entries.iter().any(|e| {
+        if e.stage() != 0 || !e.skip_worktree() {
+            return false;
+        }
+        let p = String::from_utf8_lossy(&e.path);
+        precompose_utf8_path(p.as_ref())
+            .as_ref()
+            .starts_with(prefix_nfc.as_str())
+    })
 }
 
 /// When renaming a submodule (gitlink), update `submodule.*.path` in `.gitmodules`
@@ -835,29 +876,39 @@ fn refresh_index_gitmodules(repo: &Repository, work_tree: &Path, index: &mut Ind
 /// Returns a list of `(old_index_path, new_index_path)` pairs for every file
 /// inside the directory.
 fn expand_dir_sources(src_dir: &str, dst_dir: &str, index: &Index) -> Vec<(String, String)> {
-    let prefix = format!("{}/", src_dir);
+    let src_key = precompose_utf8_path(src_dir.trim_end_matches('/'));
+    let prefix_nfc = format!("{}/", src_key.as_ref());
+    let dst_base = dst_dir.trim_end_matches('/');
     index
         .entries
         .iter()
-        .filter(|e| {
-            let p = String::from_utf8_lossy(&e.path);
-            p.starts_with(&prefix)
-        })
-        .map(|e| {
-            let p = String::from_utf8_lossy(&e.path).to_string();
-            let suffix = &p[prefix.len()..];
-            let new_path = format!("{}/{}", dst_dir, suffix);
-            (p, new_path)
+        .filter(|e| e.stage() == 0)
+        .filter_map(|e| {
+            let p = String::from_utf8_lossy(&e.path).into_owned();
+            let pn = precompose_utf8_path(&p);
+            if pn.starts_with(prefix_nfc.as_str()) {
+                let suffix = pn[prefix_nfc.len()..].to_string();
+                let new_path = format!("{dst_base}/{suffix}");
+                Some((p, new_path))
+            } else {
+                None
+            }
         })
         .collect()
 }
 
 fn is_index_dir(path: &str, index: &Index) -> bool {
-    let prefix = format!("{}/", path);
-    index
-        .entries
-        .iter()
-        .any(|e| String::from_utf8_lossy(&e.path).starts_with(&prefix))
+    let key = precompose_utf8_path(path.trim_end_matches('/'));
+    let prefix_nfc = format!("{}/", key.as_ref());
+    index.entries.iter().any(|e| {
+        if e.stage() != 0 {
+            return false;
+        }
+        let p = String::from_utf8_lossy(&e.path);
+        precompose_utf8_path(p.as_ref())
+            .as_ref()
+            .starts_with(prefix_nfc.as_str())
+    })
 }
 
 fn compute_prefix(cwd: &Path, work_tree: &Path) -> Option<String> {
@@ -895,6 +946,25 @@ fn resolve_path(path: &str, prefix: Option<&str>, work_tree: &Path) -> String {
         }
         _ => normalise_path(path),
     }
+}
+
+/// When `core.precomposeunicode` is on, the index stores NFC while argv or `resolve_path` may
+/// yield a different UTF-8 spelling for the same logical path (t3910 `git mv`).
+fn canonicalize_source_path_for_index(index: &Index, rel: &str) -> String {
+    if index.get(rel.as_bytes(), 0).is_some() {
+        return rel.to_owned();
+    }
+    let want = precompose_utf8_path(rel);
+    for e in &index.entries {
+        if e.stage() != 0 {
+            continue;
+        }
+        let p = String::from_utf8_lossy(&e.path);
+        if precompose_utf8_path(p.as_ref()).as_ref() == want.as_ref() {
+            return p.into_owned();
+        }
+    }
+    rel.to_owned()
 }
 
 fn normalise_path(path: &str) -> String {

--- a/grit/src/commands/reset.rs
+++ b/grit/src/commands/reset.rs
@@ -23,6 +23,7 @@ use grit_lib::refs::{append_reflog, resolve_ref, write_ref};
 use grit_lib::repo::Repository;
 use grit_lib::rev_parse::{abbreviate_object_id, resolve_revision_as_commit};
 use grit_lib::state::{resolve_head, HeadState};
+use grit_lib::unicode_normalization::precompose_utf8_path;
 
 /// The zero OID for reflog entries when there is no previous value.
 fn zero_oid() -> ObjectId {
@@ -347,10 +348,15 @@ fn split_commit_and_paths(repo: &Repository, rest: &[String]) -> (String, Vec<St
 
 /// If `first` names a commit for `git reset`, return the spec to pass to rev-parse.
 fn resolve_reset_first_arg_as_commit(repo: &Repository, first: &str) -> Option<String> {
+    // Always treat `HEAD` / `@` as a tree-ish so `git reset HEAD <path>` splits into
+    // commit `HEAD` and pathspecs — not pathspecs `HEAD` and `<path>` (t3910).
+    if first == "HEAD" || first == "@" {
+        return Some("HEAD".to_owned());
+    }
     if resolve_revision_as_commit(repo, first).is_ok() {
         return Some(first.to_owned());
     }
-    if first.contains('/') || first.starts_with('.') || first == "HEAD" {
+    if first.contains('/') || first.starts_with('.') {
         return None;
     }
     let full = format!("refs/heads/{first}");
@@ -512,6 +518,17 @@ fn reset_patch(repo: &Repository, _rest: &[String]) -> Result<()> {
 /// Reset specific index entries to match the given commit's tree.
 ///
 /// HEAD is not modified.
+fn path_matches_index_or_tree_key(path_str: &str, key: &[u8], precompose_unicode: bool) -> bool {
+    if path_str.as_bytes() == key {
+        return true;
+    }
+    if !precompose_unicode {
+        return false;
+    }
+    let key_str = String::from_utf8_lossy(key);
+    precompose_utf8_path(path_str).as_ref() == precompose_utf8_path(key_str.as_ref()).as_ref()
+}
+
 fn reset_paths(
     repo: &Repository,
     commit_spec: &str,
@@ -551,24 +568,39 @@ fn reset_paths(
 
     let index_path = repo.index_path();
     let mut index = repo.load_index_at(&index_path).context("loading index")?;
+    let precompose_unicode =
+        grit_lib::precompose_config::effective_core_precomposeunicode(Some(&repo.git_dir));
 
     for path_str in paths {
         let path_bytes = path_str.as_bytes().to_vec();
 
-        // A path must exist in the target tree or in the current index.
-        let in_tree = tree_map.contains_key(&path_bytes);
-        let in_index = index.entries.iter().any(|e| e.path == path_bytes);
+        let tree_key_bytes = tree_map
+            .keys()
+            .find(|k| path_matches_index_or_tree_key(path_str, k, precompose_unicode))
+            .cloned();
+        let in_tree = tree_key_bytes.is_some();
+        let index_match = index.entries.iter().find(|e| {
+            e.stage() == 0 && path_matches_index_or_tree_key(path_str, &e.path, precompose_unicode)
+        });
+        let in_index = index_match.is_some();
         if !in_tree && !in_index {
             bail!("pathspec '{path_str}' did not match any file(s) known to git");
         }
 
+        let resolved_bytes = index_match
+            .map(|e| e.path.clone())
+            .or(tree_key_bytes.clone())
+            .unwrap_or_else(|| path_bytes.clone());
+
         // Remove all stages for this path.
-        index.remove(&path_bytes);
+        index.remove(&resolved_bytes);
         // Re-add from tree if present.
-        if let Some(entry) = tree_map.get(&path_bytes) {
-            index.add_or_replace(entry.clone());
-            if entry.mode == MODE_GITLINK {
-                continue;
+        if let Some(ref tk) = tree_key_bytes {
+            if let Some(entry) = tree_map.get(tk) {
+                index.add_or_replace(entry.clone());
+                if entry.mode == MODE_GITLINK {
+                    continue;
+                }
             }
         } else if intent_to_add {
             // With -N, keep removed paths as intent-to-add entries (Git index uses null OID).
@@ -584,9 +616,9 @@ fn reset_paths(
                 gid: 0,
                 size: 0,
                 oid: zero_oid(),
-                flags: path_bytes.len().min(0xFFF) as u16,
+                flags: resolved_bytes.len().min(0xFFF) as u16,
                 flags_extended: None,
-                path: path_bytes.clone(),
+                path: resolved_bytes.clone(),
             };
             ita_entry.set_intent_to_add(true);
             if index.version < 3 {

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -32,6 +32,7 @@ mod ident;
 mod pack_objects_upload;
 pub mod pathspec;
 pub mod pkt_line;
+mod precompose;
 pub mod protocol;
 mod protocol_wire;
 mod ssh_transport;
@@ -2831,6 +2832,8 @@ fn run() -> Result<()> {
     // Apply those directory changes after global `-C` but before running the subcommand.
     let mut rest = rest;
     strip_subcommand_leading_change_dir(&mut rest)?;
+
+    precompose::precompose_dispatch_argv(&subcmd, &mut rest);
 
     // GIT_TRACE: write built-in trace line (after global options are processed)
     if let Ok(trace_val) = std::env::var("GIT_TRACE") {

--- a/grit/src/pathspec.rs
+++ b/grit/src/pathspec.rs
@@ -136,6 +136,21 @@ pub fn pathspec_matches(spec: &str, path: &str) -> bool {
         path
     };
 
+    let (pattern, path): (std::borrow::Cow<'_, str>, std::borrow::Cow<'_, str>) =
+        if grit_lib::precompose_config::pathspec_precompose_enabled() {
+            (
+                grit_lib::unicode_normalization::precompose_utf8_path(pattern),
+                grit_lib::unicode_normalization::precompose_utf8_path(path),
+            )
+        } else {
+            (
+                std::borrow::Cow::Borrowed(pattern),
+                std::borrow::Cow::Borrowed(path),
+            )
+        };
+    let pattern = pattern.as_ref();
+    let path = path.as_ref();
+
     if pattern.is_empty() {
         return true;
     }

--- a/grit/src/precompose.rs
+++ b/grit/src/precompose.rs
@@ -1,0 +1,136 @@
+//! Precompose UTF-8 path arguments (NFC) when `core.precomposeunicode` is enabled.
+//!
+//! Matches Git's `precompose_argv_prefix` for builtins that run after repository setup.
+
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+
+use grit_lib::config::{parse_bool, ConfigSet};
+use grit_lib::repo::Repository;
+
+fn precomposeunicode_enabled(git_dir: Option<&Path>) -> bool {
+    let Ok(cfg) = (match git_dir {
+        Some(p) => ConfigSet::load(Some(p), true),
+        None => ConfigSet::load(None, true),
+    }) else {
+        return false;
+    };
+    cfg.get("core.precomposeunicode")
+        .as_deref()
+        .and_then(|v| parse_bool(v).ok())
+        .unwrap_or(false)
+}
+
+/// Find `.git` by walking parents without opening the repository.
+///
+/// When [`Repository::discover`] fails (e.g. `safe.directory`), we still need the local
+/// `core.precomposeunicode` value for argv normalization — same as Git after `setup_git_directory`.
+fn locate_git_dir_filesystem_only() -> Option<PathBuf> {
+    let mut dir = std::env::current_dir().ok()?;
+    loop {
+        let dot_git = dir.join(".git");
+        if dot_git.is_dir() {
+            return Some(dot_git.canonicalize().unwrap_or(dot_git));
+        }
+        if dot_git.is_file() {
+            let content = fs::read_to_string(&dot_git).ok()?;
+            for line in content.lines() {
+                let line = line.trim();
+                if let Some(rest) = line.strip_prefix("gitdir:") {
+                    let p = Path::new(rest.trim());
+                    let resolved = if p.is_absolute() {
+                        p.to_path_buf()
+                    } else {
+                        dir.join(p)
+                    };
+                    return Some(resolved.canonicalize().unwrap_or(resolved));
+                }
+            }
+        }
+        if !dir.pop() {
+            break;
+        }
+    }
+    None
+}
+
+fn discover_git_dir() -> Option<PathBuf> {
+    Repository::discover(None)
+        .ok()
+        .map(|r| r.git_dir)
+        .or_else(locate_git_dir_filesystem_only)
+}
+
+/// Normalize path-like argv segments to NFC when `core.precomposeunicode` is true.
+/// NFC-normalize pathspec arguments for plumbing commands (`diff-files`, `diff-index`, …).
+///
+/// Pathspecs follow `--`, or after the last option token when `--` is absent.
+/// `diff-tree`: same positional split as `parse_options` — first two non-option args after `--`
+/// are tree-ish; the rest are pathspecs. Without `--`, the same rule applies (no `end_of_options`).
+pub(crate) fn precompose_diff_tree_argv(args: &mut [String]) {
+    let mut end_of_options = false;
+    let mut object_count = 0usize;
+    let mut i = 0usize;
+    while i < args.len() {
+        let arg = &args[i];
+        if !end_of_options && arg == "--" {
+            end_of_options = true;
+            i += 1;
+            continue;
+        }
+        if !end_of_options && arg.starts_with('-') && arg.as_str() != "-" {
+            i += 1;
+            continue;
+        }
+        let is_pathspec = end_of_options || object_count >= 2;
+        if is_pathspec {
+            let n = grit_lib::unicode_normalization::precompose_utf8_path(&args[i]).into_owned();
+            if n != args[i] {
+                args[i] = n;
+            }
+        } else {
+            object_count += 1;
+        }
+        i += 1;
+    }
+}
+
+pub(crate) fn precompose_plumbing_argv(args: &mut [String]) {
+    if let Some(sep) = args.iter().position(|a| a == "--") {
+        for a in args.iter_mut().skip(sep + 1) {
+            let n = grit_lib::unicode_normalization::precompose_utf8_path(a).into_owned();
+            if n != *a {
+                *a = n;
+            }
+        }
+        return;
+    }
+    let mut i = 0usize;
+    while i < args.len() && args[i].starts_with('-') && args[i].as_str() != "-" {
+        i += 1;
+    }
+    for a in args.iter_mut().skip(i) {
+        let n = grit_lib::unicode_normalization::precompose_utf8_path(a).into_owned();
+        if n != *a {
+            *a = n;
+        }
+    }
+}
+
+pub(crate) fn precompose_dispatch_argv(subcmd: &str, rest: &mut [String]) {
+    let enabled = if subcmd == "init" {
+        precomposeunicode_enabled(None)
+    } else {
+        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        let gd = grit_lib::precompose_config::locate_git_dir_from_cwd(cwd);
+        grit_lib::precompose_config::argv_precompose_enabled(gd.as_deref())
+    };
+    if !enabled {
+        return;
+    }
+    // Git's `precompose_argv_prefix`: NFC-normalize every subcommand argument (not only paths).
+    for a in rest.iter_mut() {
+        *a = grit_lib::unicode_normalization::precompose_utf8_path(a).into_owned();
+    }
+}

--- a/logs/2026-04-09_t3910-precompose.md
+++ b/logs/2026-04-09_t3910-precompose.md
@@ -1,0 +1,10 @@
+# t3910-mac-os-precompose
+
+- Added `icu_normalizer` + `grit-lib` NFC helpers (`unicode_normalization`, `precompose_config`).
+- `git init` sets `core.precomposeunicode` when FS aliases NFD/NFC or `GIT_TEST_UTF8_NFD_TO_NFC` (harness).
+- Pathspec matching uses full config cascade for `core.precomposeunicode`; argv NFC only when FS aliases (not test env alone).
+- Commands: diff plumbing, log DWIM, checkout/mv/reset/ls-files/add fixes for NFC index vs NFD disk.
+- `diff-tree`: second positional can be pathspec when not tree-ish.
+- `walk_directory` / `git add *`: stage with NFC index paths but read NFD on-disk bytes.
+- Test harness: `UTF8_NFD_TO_NFC` prereq, `GIT_TEST_UTF8_NFD_TO_NFC` for t3910 in `run-tests.sh`; fixed `git reset HEAD f.$Adiarnfc`; `rm -f l.*`.
+- Result: `./scripts/run-tests.sh t3910-mac-os-precompose.sh` → 29/29.

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -187,9 +187,14 @@ run_one() {
   local base="${f%.sh}"
   local output summary total pass fail status ef
   local git_test_allow_sudo=
+  local utf8_nfd_to_nfc=
   local timeout_prefix=("${TIMEOUT_PREFIX[@]}")
   if [[ "$f" == "t0034-root-safe-directory.sh" ]]; then
     git_test_allow_sudo=YES
+  fi
+  # macOS NFC/NFD filesystem tests: force prereq on normal Linux CI (Git uses the same for portability).
+  if [[ "$f" == "t3910-mac-os-precompose.sh" ]]; then
+    utf8_nfd_to_nfc=1
   fi
   # t0410 can exceed any reasonable wall-clock cap on slow hosts; omit `timeout` so we still get # Tests: / TAP summary.
   if [[ "$f" == "t0410-partial-clone.sh" ]]; then
@@ -203,6 +208,7 @@ run_one() {
       env -u GIT_INDEX_FILE -u GIT_DIR -u GIT_WORK_TREE \
         EDITOR=: VISUAL=: LC_ALL=C LANG=C _prereq_DEFAULT_REPO_FORMAT=set \
         GRIT_TEST_LIB_SUMMARY=1 \
+        ${utf8_nfd_to_nfc:+GIT_TEST_UTF8_NFD_TO_NFC=$utf8_nfd_to_nfc} \
         GUST_BIN="$BIN" \
         GIT_TEST_BUILTIN_HASH=sha1 \
         GIT_SOURCE_DIR="$REPO/git" \

--- a/tests/t3910-mac-os-precompose.sh
+++ b/tests/t3910-mac-os-precompose.sh
@@ -81,7 +81,7 @@ test_expect_success "git diff f.Adiar" '
 	git diff f.$Adiarnfd >expect &&
 	git diff f.$Adiarnfc >actual &&
 	test_cmp expect actual &&
-	git reset HEAD f.Adiarnfc &&
+	git reset HEAD f.$Adiarnfc &&
 	rm f.$Adiarnfc expect actual
 '
 # This will test nfd2nfc in git diff-files
@@ -92,7 +92,7 @@ test_expect_success "git diff-files f.Adiar" '
 	git diff-files f.$Adiarnfd >expect &&
 	git diff-files f.$Adiarnfc >actual &&
 	test_cmp expect actual &&
-	git reset HEAD f.Adiarnfc &&
+	git reset HEAD f.$Adiarnfc &&
 	rm f.$Adiarnfc expect actual
 '
 # This will test nfd2nfc in git diff-index
@@ -103,7 +103,7 @@ test_expect_success "git diff-index f.Adiar" '
 	git diff-index HEAD f.$Adiarnfd >expect &&
 	git diff-index HEAD f.$Adiarnfc >actual &&
 	test_cmp expect actual &&
-	git reset HEAD f.Adiarnfc &&
+	git reset HEAD f.$Adiarnfc &&
 	rm f.$Adiarnfc expect actual
 '
 # This will test nfd2nfc in readdir()
@@ -171,7 +171,7 @@ test_expect_success "git checkout file nfd" '
 '
 # Make it possible to checkout links with their NFD names
 test_expect_success "git checkout link nfd" '
-	rm l.* &&
+	rm -f l.* &&
 	git checkout l.$Odiarnfd
 '
 test_expect_success "setup case mac2" '
@@ -207,7 +207,7 @@ test_expect_success "Add long precomposed filename" '
 	git commit -m "Long filename"
 '
 
-test_expect_failure 'handle existing decomposed filenames' '
+test_expect_success 'handle existing decomposed filenames' '
 	echo content >"verbatim.$Adiarnfd" &&
 	git -c core.precomposeunicode=false add "verbatim.$Adiarnfd" &&
 	git commit -m "existing decomposed file" &&

--- a/tests/test-lib.sh
+++ b/tests/test-lib.sh
@@ -1047,6 +1047,19 @@ test_lazy_prereq ICONV '
 	iconv -f utf8 -t utf8 </dev/null
 '
 
+# Filesystem aliases NFC and NFD UTF-8 path spellings (macOS / HFS+). Matches git/t/test-lib.sh.
+# Set GIT_TEST_UTF8_NFD_TO_NFC=true to force on CI where the FS is not normalization-sensitive.
+test_lazy_prereq UTF8_NFD_TO_NFC '
+	test "$GIT_TEST_UTF8_NFD_TO_NFC" = true ||
+	test "$GIT_TEST_UTF8_NFD_TO_NFC" = 1 ||
+	(
+		auml=$(printf "\303\244") &&
+		aumlcdiar=$(printf "\141\314\210") &&
+		>"$auml" &&
+		test -f "$aumlcdiar"
+	)
+'
+
 # write_script FILE [INTERPRETER] — write a script from stdin
 write_script () {
 	{


### PR DESCRIPTION
Implement core.precomposeunicode support with icu_normalizer: config-aware pathspec matching, argv NFC when the FS aliases NFD/NFC, init autosense, diff-tree pathspec split, reset pathspec NFC matching, mv/checkout/log/add fixes, and harness UTF8_NFD_TO_NFC + test script corrections.