### PR TITLE
feat: untracked cache (UNTR) extension and t7063 support

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.1% of harness tests passing (35,240 / 45,112).">
+<meta property="og:description" content="78.2% of harness tests passing (35,276 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.1% of harness tests passing (35,240 / 45,112).">
+<meta name="twitter:description" content="78.2% of harness tests passing (35,276 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T14:02:56+00:00" class="gen-time" title="2026-04-09 14:02 UTC">2026-04-09 14:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/e76e016793472595007208eec9693bdb6a4d41c2" style="color:#58a6ff">e76e016</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T16:39:31+00:00" class="gen-time" title="2026-04-09 16:39 UTC">2026-04-09 16:39 UTC</time> · <a href="https://github.com/schacon/grit/commit/c4ad2e9f44715e944bf5d633e8117c550d9c487c" style="color:#58a6ff">c4ad2e9</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">78.1%</div>
+      <div class="summary-big-val pct-blue">78.2%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,240</div>
+      <div class="summary-big-val">35,276</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:78.1%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:78.2%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>730 files fully passing</span>
+    <span>732 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -186,11 +186,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t0</span>
         <span class="group-desc">Absolute basics and global stuff</span>
-        <span class="group-meta">38/64 files · 21 skipped · 4,868/5,136 tests</span>
+        <span class="group-meta">39/64 files · 21 skipped · 4,884/5,136 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:94.8%"></div></div>
-        <span class="group-pct pct-green">94.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:95.1%"></div></div>
+        <span class="group-pct pct-green">95.1%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t1">
@@ -230,11 +230,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">70/178 files · 2 skipped · 2,683/4,437 tests</span>
+        <span class="group-meta">71/178 files · 2 skipped · 2,703/4,437 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.5%"></div></div>
-        <span class="group-pct pct-blue">60.5%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:60.9%"></div></div>
+        <span class="group-pct pct-blue">60.9%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35240 of 45112 tests passing across 1405 harness files (78.1% pass rate).</desc>
+  <desc id="svg-desc">35276 of 45112 tests passing across 1405 harness files (78.2% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.1% pass rate · 35,240 / 45,112 tests · 1,405 files in scope · 730 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.2% pass rate · 35,276 / 45,112 tests · 1,405 files in scope · 732 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="547" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T14:02:56+00:00" class="gen-time" title="2026-04-09 14:02 UTC">2026-04-09 14:02 UTC</time> · <a href="https://github.com/schacon/grit/commit/e76e016793472595007208eec9693bdb6a4d41c2" style="color:#58a6ff">e76e016</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T16:39:31+00:00" class="gen-time" title="2026-04-09 16:39 UTC">2026-04-09 16:39 UTC</time> · <a href="https://github.com/schacon/grit/commit/c4ad2e9f44715e944bf5d633e8117c550d9c487c" style="color:#58a6ff">c4ad2e9</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,240</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">78.1%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,276</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">78.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -907,14 +907,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:97.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t0" data-tests="16" data-passed="0">
+<tr class="" data-group="t0" data-tests="16" data-passed="16" data-full-pass="1">
   <td class="mono">t0500-progress-display</td>
   <td>t0</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">16</td>
-  <td class="right">0</td>
+  <td class="right">16</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t0" data-tests="33" data-passed="12">
@@ -7477,14 +7477,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:28.6%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="27" data-passed="7">
+<tr class="" data-group="t4" data-tests="27" data-passed="27" data-full-pass="1">
   <td class="mono">t4051-diff-function-name</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">27</td>
-  <td class="right">7</td>
+  <td class="right">27</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:25.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="89" data-passed="89" data-full-pass="1">

--- a/grit-lib/src/ewah_bitmap.rs
+++ b/grit-lib/src/ewah_bitmap.rs
@@ -1,0 +1,289 @@
+//! Git-compatible EWAH bitmap serialization (`git/ewah/ewah_io.c` + `ewah_bitmap.c`).
+//! Used by the index UNTR extension (`dir.c`).
+
+type Eword = u64;
+const BITS_IN_EWORD: usize = 64;
+const RLW_RUNNING_BITS: usize = 32;
+const RLW_LITERAL_BITS: usize = BITS_IN_EWORD - 1 - RLW_RUNNING_BITS;
+const RLW_LARGEST_RUNNING_COUNT: Eword = (1u64 << RLW_RUNNING_BITS) - 1;
+const RLW_LARGEST_LITERAL_COUNT: Eword = (1u64 << RLW_LITERAL_BITS) - 1;
+const RLW_LARGEST_RUNNING_COUNT_SHIFT: Eword = RLW_LARGEST_RUNNING_COUNT << 1;
+const RLW_RUNNING_LEN_PLUS_BIT: Eword = (1u64 << (RLW_RUNNING_BITS + 1)) - 1;
+
+#[inline]
+fn rlw_get_run_bit(word: Eword) -> bool {
+    word & 1 != 0
+}
+
+#[inline]
+fn rlw_set_run_bit(word: &mut Eword, b: bool) {
+    if b {
+        *word |= 1;
+    } else {
+        *word &= !1u64;
+    }
+}
+
+#[inline]
+fn rlw_set_running_len(word: &mut Eword, l: Eword) {
+    *word |= RLW_LARGEST_RUNNING_COUNT_SHIFT;
+    *word &= (l << 1) | !RLW_LARGEST_RUNNING_COUNT_SHIFT;
+}
+
+#[inline]
+fn rlw_get_running_len(word: Eword) -> Eword {
+    (word >> 1) & RLW_LARGEST_RUNNING_COUNT
+}
+
+#[inline]
+fn rlw_get_literal_words(word: Eword) -> Eword {
+    word >> (1 + RLW_RUNNING_BITS)
+}
+
+#[inline]
+fn rlw_set_literal_words(word: &mut Eword, l: Eword) {
+    *word |= !RLW_RUNNING_LEN_PLUS_BIT;
+    *word &= (l << (RLW_RUNNING_BITS + 1)) | RLW_RUNNING_LEN_PLUS_BIT;
+}
+
+#[inline]
+fn rlw_size(word: Eword) -> Eword {
+    rlw_get_running_len(word) + rlw_get_literal_words(word)
+}
+
+fn min_sz(a: usize, b: usize) -> usize {
+    if a < b {
+        a
+    } else {
+        b
+    }
+}
+
+/// In-memory EWAH bitmap matching Git's layout.
+#[derive(Debug)]
+pub(crate) struct EwahBitmap {
+    buffer: Vec<Eword>,
+    buffer_size: usize,
+    rlw_index: usize,
+    pub bit_size: usize,
+}
+
+impl EwahBitmap {
+    pub(crate) fn new() -> Self {
+        Self {
+            buffer: vec![0; 32],
+            buffer_size: 1,
+            rlw_index: 0,
+            bit_size: 0,
+        }
+    }
+
+    #[inline]
+    fn rlw_mut(&mut self) -> &mut Eword {
+        &mut self.buffer[self.rlw_index]
+    }
+
+    fn buffer_grow(&mut self, new_size: usize) {
+        if new_size > self.buffer.len() {
+            let n = new_size.max(self.buffer.len() * 2);
+            self.buffer.resize(n, 0);
+        }
+    }
+
+    fn buffer_push(&mut self, value: Eword) {
+        self.buffer_grow(self.buffer_size + 1);
+        self.buffer[self.buffer_size] = value;
+        self.buffer_size += 1;
+    }
+
+    fn buffer_push_rlw(&mut self, value: Eword) {
+        self.buffer_push(value);
+        self.rlw_index = self.buffer_size - 1;
+    }
+
+    /// Append `number` words of all-0 or all-1 without changing `bit_size` (Git `add_empty_words`).
+    fn add_empty_words_inner(&mut self, v: bool, mut number: usize) {
+        let v_bit = v;
+        let rlw = *self.rlw_mut();
+        if rlw_get_run_bit(rlw) != v_bit && rlw_size(rlw) == 0 {
+            rlw_set_run_bit(self.rlw_mut(), v_bit);
+        } else if rlw_get_literal_words(rlw) != 0 || rlw_get_run_bit(rlw) != v_bit {
+            self.buffer_push_rlw(0);
+            if v_bit {
+                rlw_set_run_bit(self.rlw_mut(), true);
+            }
+        }
+
+        let runlen = rlw_get_running_len(*self.rlw_mut());
+        let can_add = min_sz(number, (RLW_LARGEST_RUNNING_COUNT - runlen) as usize);
+        rlw_set_running_len(self.rlw_mut(), runlen + can_add as Eword);
+        number -= can_add;
+
+        while number >= RLW_LARGEST_RUNNING_COUNT as usize {
+            self.buffer_push_rlw(0);
+            if v_bit {
+                rlw_set_run_bit(self.rlw_mut(), true);
+            }
+            rlw_set_running_len(self.rlw_mut(), RLW_LARGEST_RUNNING_COUNT);
+            number -= RLW_LARGEST_RUNNING_COUNT as usize;
+        }
+
+        if number > 0 {
+            self.buffer_push_rlw(0);
+            if v_bit {
+                rlw_set_run_bit(self.rlw_mut(), true);
+            }
+            rlw_set_running_len(self.rlw_mut(), number as Eword);
+        }
+    }
+
+    fn add_empty_word(&mut self, v: bool) -> usize {
+        let rlw = *self.rlw_mut();
+        let no_literal = rlw_get_literal_words(rlw) == 0;
+        let run_len = rlw_get_running_len(rlw);
+
+        if no_literal && run_len == 0 {
+            rlw_set_run_bit(self.rlw_mut(), v);
+        }
+
+        if no_literal
+            && rlw_get_run_bit(*self.rlw_mut()) == v
+            && run_len < RLW_LARGEST_RUNNING_COUNT
+        {
+            rlw_set_running_len(self.rlw_mut(), run_len + 1);
+            return 0;
+        }
+
+        self.buffer_push_rlw(0);
+        rlw_set_run_bit(self.rlw_mut(), v);
+        rlw_set_running_len(self.rlw_mut(), 1);
+        1
+    }
+
+    fn add_literal(&mut self, new_data: Eword) -> usize {
+        let current_num = rlw_get_literal_words(*self.rlw_mut());
+        if current_num >= RLW_LARGEST_LITERAL_COUNT {
+            self.buffer_push_rlw(0);
+            rlw_set_literal_words(self.rlw_mut(), 1);
+            self.buffer_push(new_data);
+            return 2;
+        }
+        rlw_set_literal_words(self.rlw_mut(), current_num + 1);
+        self.buffer_push(new_data);
+        1
+    }
+
+    /// Set bit `i` where `i >= self.bit_size` (Git `ewah_set` append-only).
+    pub(crate) fn set_bit_extend(&mut self, i: usize) {
+        debug_assert!(i >= self.bit_size);
+        let dist = (i + 1).div_ceil(BITS_IN_EWORD) - self.bit_size.div_ceil(BITS_IN_EWORD);
+        self.bit_size = i + 1;
+        if dist > 0 {
+            if dist > 1 {
+                self.add_empty_words_inner(false, dist - 1);
+            }
+            let _ = self.add_literal(1u64 << (i % BITS_IN_EWORD));
+            return;
+        }
+        if rlw_get_literal_words(*self.rlw_mut()) == 0 {
+            let rl = rlw_get_running_len(*self.rlw_mut());
+            rlw_set_running_len(self.rlw_mut(), rl - 1);
+            let _ = self.add_literal(1u64 << (i % BITS_IN_EWORD));
+            return;
+        }
+        let last = self.buffer_size - 1;
+        self.buffer[last] |= 1u64 << (i % BITS_IN_EWORD);
+        if self.buffer[last] == !0u64 {
+            self.buffer_size -= 1;
+            let rlw_i = self.rlw_index;
+            let prev_lit = rlw_get_literal_words(self.buffer[rlw_i]);
+            rlw_set_literal_words(&mut self.buffer[rlw_i], prev_lit - 1);
+            let _ = self.add_empty_word(true);
+        }
+    }
+
+    pub(crate) fn serialize(&self, out: &mut Vec<u8>) {
+        let bitsize = (self.bit_size as u32).to_be_bytes();
+        out.extend_from_slice(&bitsize);
+        let word_count = (self.buffer_size as u32).to_be_bytes();
+        out.extend_from_slice(&word_count);
+        for w in self.buffer.iter().take(self.buffer_size) {
+            out.extend_from_slice(&w.to_be_bytes());
+        }
+        // Git `ewah_serialize_to`: RLW offset is in 64-bit words, not bytes.
+        let rlw_pos = (self.rlw_index as u32).to_be_bytes();
+        out.extend_from_slice(&rlw_pos);
+    }
+
+    /// Deserialize from `data`; returns bytes consumed.
+    pub(crate) fn deserialize_prefix(data: &[u8]) -> Option<(Self, usize)> {
+        if data.len() < 8 {
+            return None;
+        }
+        let bit_size = u32::from_be_bytes(data[0..4].try_into().ok()?) as usize;
+        let mut pos = 4;
+        let buffer_size = u32::from_be_bytes(data[pos..pos + 4].try_into().ok()?) as usize;
+        pos += 4;
+        let need = buffer_size.checked_mul(8)?;
+        if data.len() < pos + need + 4 {
+            return None;
+        }
+        let mut buffer = vec![0u64; buffer_size.max(32)];
+        for i in 0..buffer_size {
+            buffer[i] = u64::from_be_bytes(data[pos + i * 8..pos + i * 8 + 8].try_into().ok()?);
+        }
+        pos += need;
+        let rlw_word_index = u32::from_be_bytes(data[pos..pos + 4].try_into().ok()?) as usize;
+        pos += 4;
+        // Git may serialize an empty bitmap (`buffer_size == 0`); RLW index is still present.
+        if buffer_size > 0 && rlw_word_index >= buffer_size {
+            return None;
+        }
+        Some((
+            Self {
+                buffer,
+                buffer_size,
+                rlw_index: rlw_word_index,
+                bit_size,
+            },
+            pos,
+        ))
+    }
+
+    /// Iterate set bits (`ewah_each_bit`).
+    pub(crate) fn each_set_bit(&self, mut f: impl FnMut(usize)) {
+        let mut pos = 0usize;
+        let mut pointer = 0usize;
+        while pointer < self.buffer_size {
+            let word = self.buffer[pointer];
+            if rlw_get_run_bit(word) {
+                let len = rlw_get_running_len(word) as usize * BITS_IN_EWORD;
+                for k in 0..len {
+                    f(pos + k);
+                }
+                pos += len;
+            } else {
+                pos += rlw_get_running_len(word) as usize * BITS_IN_EWORD;
+            }
+            pointer += 1;
+            let mut k = 0u64;
+            while k < rlw_get_literal_words(word) {
+                let lit = self.buffer[pointer];
+                for c in 0..BITS_IN_EWORD {
+                    if lit & (1u64 << c) != 0 {
+                        f(pos + c);
+                    }
+                }
+                pos += BITS_IN_EWORD;
+                pointer += 1;
+                k += 1;
+            }
+        }
+    }
+}
+
+impl Default for EwahBitmap {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/grit-lib/src/index.rs
+++ b/grit-lib/src/index.rs
@@ -28,6 +28,7 @@ use crate::objects::{parse_tree, ObjectId, ObjectKind, TreeEntry};
 use crate::odb::Odb;
 use crate::repo::Repository;
 use crate::rev_parse;
+use crate::untracked_cache;
 
 /// File mode for a regular (non-executable) file.
 pub const MODE_REGULAR: u32 = 0o100644;
@@ -42,6 +43,8 @@ pub const MODE_TREE: u32 = 0o040000;
 
 /// Git index extension signature `sdir` (sparse directory entries present).
 const INDEX_EXT_SPARSE_DIRECTORIES: u32 = u32::from_be_bytes(*b"sdir");
+/// Git index extension signature `UNTR` (untracked cache).
+const INDEX_EXT_UNTRACKED: u32 = u32::from_be_bytes(*b"UNTR");
 
 /// A single entry in the Git index.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -181,6 +184,8 @@ pub struct Index {
     pub entries: Vec<IndexEntry>,
     /// When true, the on-disk index includes the `sdir` extension (sparse index).
     pub sparse_directories: bool,
+    /// Optional untracked-cache extension (`UNTR`), matching Git's `istate->untracked`.
+    pub untracked_cache: Option<untracked_cache::UntrackedCache>,
 }
 
 /// Options for loading an index from disk.
@@ -241,6 +246,7 @@ impl Index {
             version,
             entries: Vec::new(),
             sparse_directories: false,
+            untracked_cache: None,
         }
     }
 
@@ -257,6 +263,7 @@ impl Index {
                 version: v,
                 entries: Vec::new(),
                 sparse_directories: false,
+                untracked_cache: None,
             };
         }
 
@@ -285,6 +292,7 @@ impl Index {
             version,
             entries: Vec::new(),
             sparse_directories: false,
+            untracked_cache: None,
         }
     }
 
@@ -299,6 +307,7 @@ impl Index {
                 version: v,
                 entries: Vec::new(),
                 sparse_directories: false,
+                untracked_cache: None,
             };
         }
 
@@ -330,6 +339,7 @@ impl Index {
             version,
             entries: Vec::new(),
             sparse_directories: false,
+            untracked_cache: None,
         }
     }
 
@@ -575,6 +585,7 @@ impl Index {
         }
 
         let mut sparse_directories = false;
+        let mut untracked_cache = None;
         while pos + 8 <= body.len() {
             let sig = u32::from_be_bytes(
                 body[pos..pos + 4]
@@ -594,6 +605,9 @@ impl Index {
             }
             if sig == INDEX_EXT_SPARSE_DIRECTORIES {
                 sparse_directories = true;
+            } else if sig == INDEX_EXT_UNTRACKED {
+                let ext_data = &body[pos..pos + ext_sz];
+                untracked_cache = untracked_cache::parse_untracked_extension(ext_data);
             }
             pos += ext_sz;
         }
@@ -605,6 +619,7 @@ impl Index {
             version,
             entries,
             sparse_directories,
+            untracked_cache,
         })
     }
 
@@ -721,12 +736,18 @@ impl Index {
             out.extend_from_slice(&INDEX_EXT_SPARSE_DIRECTORIES.to_be_bytes());
             out.extend_from_slice(&0u32.to_be_bytes());
         }
+        if let Some(uc) = &self.untracked_cache {
+            let payload = untracked_cache::write_untracked_extension(uc);
+            out.extend_from_slice(&INDEX_EXT_UNTRACKED.to_be_bytes());
+            out.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+            out.extend_from_slice(&payload);
+        }
         Ok(())
     }
 
     /// Add or replace an entry (matched by path + stage).
     pub fn add_or_replace(&mut self, entry: IndexEntry) {
-        let path = &entry.path;
+        let path = entry.path.clone();
         let stage = entry.stage();
         // Binary search for the insertion point by (path, stage)
         let result = self.entries.binary_search_by(|e| {
@@ -743,6 +764,11 @@ impl Index {
             Err(pos) => {
                 // Not found — insert at sorted position
                 self.entries.insert(pos, entry);
+            }
+        }
+        if stage == 0 {
+            if let Ok(p) = std::str::from_utf8(&path) {
+                self.invalidate_untracked_cache_for_path(p);
             }
         }
     }
@@ -764,7 +790,20 @@ impl Index {
     pub fn remove(&mut self, path: &[u8]) -> bool {
         let before = self.entries.len();
         self.entries.retain(|e| e.path != path);
-        self.entries.len() < before
+        let removed = self.entries.len() < before;
+        if removed {
+            if let Ok(p) = std::str::from_utf8(path) {
+                self.invalidate_untracked_cache_for_path(p);
+            }
+        }
+        removed
+    }
+
+    /// Invalidate UNTR nodes affected by an index change (Git `untracked_cache_*_index`).
+    pub fn invalidate_untracked_cache_for_path(&mut self, path: &str) {
+        if let Some(uc) = self.untracked_cache.as_mut() {
+            untracked_cache::invalidate_path(uc, path);
+        }
     }
 
     /// Remove every index entry whose path lies strictly under `path` (all stages).
@@ -778,6 +817,10 @@ impl Index {
             return;
         }
         let plen = prefix.len();
+        let had_descendant = self.entries.iter().any(|e| {
+            let ep = e.path.as_slice();
+            ep.len() > plen && ep.starts_with(prefix) && ep[plen] == b'/'
+        });
         self.entries.retain(|e| {
             let ep = e.path.as_slice();
             if ep.len() <= plen {
@@ -789,6 +832,9 @@ impl Index {
             // Drop paths strictly under `prefix/` (keep same-length prefix matches like "d-other").
             ep[plen] != b'/'
         });
+        if had_descendant {
+            self.invalidate_untracked_cache_for_path(path);
+        }
     }
 
     /// Sort entries in Git's canonical order: by path, then by stage.

--- a/grit-lib/src/lib.rs
+++ b/grit-lib/src/lib.rs
@@ -28,6 +28,7 @@ pub mod delta_encode;
 pub mod diff;
 pub mod diffstat;
 pub mod error;
+mod ewah_bitmap;
 pub mod fast_export;
 pub mod fast_import;
 pub mod fetch_head;
@@ -75,6 +76,7 @@ pub mod rev_parse;
 #[cfg(unix)]
 pub mod simple_ipc;
 pub mod sparse_checkout;
+pub mod untracked_cache;
 #[cfg(not(unix))]
 pub mod simple_ipc {
     /// Whether simple IPC is supported on this platform.

--- a/grit-lib/src/untracked_cache.rs
+++ b/grit-lib/src/untracked_cache.rs
@@ -1,0 +1,1340 @@
+//! Git index UNTR (untracked cache) — `git/dir.c` / `read-cache.c`.
+
+use std::collections::BTreeSet;
+use std::ffi::CStr;
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
+
+use crate::config::{parse_path, ConfigSet};
+use crate::error::{Error, Result};
+use crate::ewah_bitmap::EwahBitmap;
+use crate::ignore::IgnoreMatcher;
+use crate::index::{Index, MODE_GITLINK};
+use crate::objects::{ObjectId, ObjectKind};
+use crate::odb::Odb;
+use crate::repo::Repository;
+
+pub const DIR_SHOW_OTHER_DIRECTORIES: u32 = 1 << 1;
+pub const DIR_HIDE_EMPTY_DIRECTORIES: u32 = 1 << 2;
+
+/// Git `struct stat_data` on disk (36 bytes).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct StatDataDisk {
+    pub ctime_sec: u32,
+    pub ctime_nsec: u32,
+    pub mtime_sec: u32,
+    pub mtime_nsec: u32,
+    pub dev: u32,
+    pub ino: u32,
+    pub uid: u32,
+    pub gid: u32,
+    pub size: u32,
+}
+
+const STAT_DATA_LEN: usize = 36;
+
+impl StatDataDisk {
+    fn to_bytes(self) -> [u8; STAT_DATA_LEN] {
+        let mut out = [0u8; STAT_DATA_LEN];
+        out[0..4].copy_from_slice(&self.ctime_sec.to_be_bytes());
+        out[4..8].copy_from_slice(&self.ctime_nsec.to_be_bytes());
+        out[8..12].copy_from_slice(&self.mtime_sec.to_be_bytes());
+        out[12..16].copy_from_slice(&self.mtime_nsec.to_be_bytes());
+        out[16..20].copy_from_slice(&self.dev.to_be_bytes());
+        out[20..24].copy_from_slice(&self.ino.to_be_bytes());
+        out[24..28].copy_from_slice(&self.uid.to_be_bytes());
+        out[28..32].copy_from_slice(&self.gid.to_be_bytes());
+        out[32..36].copy_from_slice(&self.size.to_be_bytes());
+        out
+    }
+
+    fn from_bytes(b: &[u8]) -> Option<Self> {
+        if b.len() < STAT_DATA_LEN {
+            return None;
+        }
+        Some(Self {
+            ctime_sec: u32::from_be_bytes(b[0..4].try_into().ok()?),
+            ctime_nsec: u32::from_be_bytes(b[4..8].try_into().ok()?),
+            mtime_sec: u32::from_be_bytes(b[8..12].try_into().ok()?),
+            mtime_nsec: u32::from_be_bytes(b[12..16].try_into().ok()?),
+            dev: u32::from_be_bytes(b[16..20].try_into().ok()?),
+            ino: u32::from_be_bytes(b[20..24].try_into().ok()?),
+            uid: u32::from_be_bytes(b[24..28].try_into().ok()?),
+            gid: u32::from_be_bytes(b[28..32].try_into().ok()?),
+            size: u32::from_be_bytes(b[32..36].try_into().ok()?),
+        })
+    }
+}
+
+#[cfg(unix)]
+fn stat_data_from_meta(meta: &fs::Metadata) -> StatDataDisk {
+    StatDataDisk {
+        ctime_sec: meta.ctime() as u32,
+        ctime_nsec: meta.ctime_nsec() as u32,
+        mtime_sec: meta.mtime() as u32,
+        mtime_nsec: meta.mtime_nsec() as u32,
+        dev: meta.dev() as u32,
+        ino: meta.ino() as u32,
+        uid: meta.uid(),
+        gid: meta.gid(),
+        size: meta.len() as u32,
+    }
+}
+
+#[cfg(not(unix))]
+fn stat_data_from_meta(meta: &fs::Metadata) -> StatDataDisk {
+    StatDataDisk {
+        mtime_sec: meta
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_secs() as u32)
+            .unwrap_or(0),
+        size: meta.len() as u32,
+        ..Default::default()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct OidStat {
+    pub stat: StatDataDisk,
+    pub oid: ObjectId,
+    pub valid: bool,
+}
+
+impl Default for OidStat {
+    fn default() -> Self {
+        Self {
+            stat: StatDataDisk::default(),
+            oid: ObjectId::zero(),
+            valid: false,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct UntrackedCacheDir {
+    pub name: String,
+    pub untracked: Vec<String>,
+    pub dirs: Vec<UntrackedCacheDir>,
+    pub recurse: bool,
+    pub check_only: bool,
+    pub valid: bool,
+    pub exclude_oid: ObjectId,
+    pub stat_data: StatDataDisk,
+}
+
+impl UntrackedCacheDir {
+    fn new(name: String) -> Self {
+        Self {
+            name,
+            untracked: Vec::new(),
+            dirs: Vec::new(),
+            recurse: false,
+            check_only: false,
+            valid: false,
+            exclude_oid: ObjectId::zero(),
+            stat_data: StatDataDisk::default(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct UntrackedCache {
+    pub ident: Vec<u8>,
+    pub ss_info_exclude: OidStat,
+    pub ss_excludes_file: OidStat,
+    pub dir_flags: u32,
+    pub exclude_per_dir: String,
+    pub root: Option<UntrackedCacheDir>,
+    pub dir_created: u64,
+    pub gitignore_invalidated: u64,
+    pub dir_invalidated: u64,
+    pub dir_opened: u64,
+}
+
+impl UntrackedCache {
+    pub fn new_shell(dir_flags: u32, ident: Vec<u8>) -> Self {
+        Self {
+            ident,
+            ss_info_exclude: OidStat::default(),
+            ss_excludes_file: OidStat::default(),
+            dir_flags,
+            exclude_per_dir: ".gitignore".to_string(),
+            root: None,
+            dir_created: 0,
+            gitignore_invalidated: 0,
+            dir_invalidated: 0,
+            dir_opened: 0,
+        }
+    }
+
+    pub fn reset_stats(&mut self) {
+        self.dir_created = 0;
+        self.gitignore_invalidated = 0;
+        self.dir_invalidated = 0;
+        self.dir_opened = 0;
+    }
+}
+
+fn encode_varint(mut value: u64, buf: &mut Vec<u8>) {
+    let mut varint = [0u8; 16];
+    let mut pos = varint.len() - 1;
+    varint[pos] = (value & 127) as u8;
+    while {
+        value >>= 7;
+        value != 0
+    } {
+        pos -= 1;
+        value -= 1;
+        varint[pos] = 128 | ((value & 127) as u8);
+    }
+    buf.extend_from_slice(&varint[pos..]);
+}
+
+fn decode_varint(bytes: &[u8]) -> Option<(u64, usize)> {
+    if bytes.is_empty() {
+        return None;
+    }
+    let mut i = 0usize;
+    let mut c = bytes[i];
+    i += 1;
+    let mut val = (c & 127) as u64;
+    while c & 128 != 0 {
+        if i >= bytes.len() {
+            return None;
+        }
+        c = bytes[i];
+        i += 1;
+        val = ((val + 1) << 7) + (c & 127) as u64;
+    }
+    Some((val, i))
+}
+
+struct WriteDirCtx<'a> {
+    index: &'a mut usize,
+    valid: EwahBitmap,
+    check_only: EwahBitmap,
+    sha1_valid: EwahBitmap,
+    out: Vec<u8>,
+    sb_stat: Vec<u8>,
+    sb_sha1: Vec<u8>,
+}
+
+fn write_one_dir(ucd: &UntrackedCacheDir, wd: &mut WriteDirCtx<'_>) {
+    let i = *wd.index;
+    *wd.index += 1;
+
+    let mut ucd = ucd.clone();
+    if !ucd.valid {
+        ucd.untracked.clear();
+        ucd.check_only = false;
+    }
+
+    if ucd.check_only {
+        wd.check_only.set_bit_extend(i);
+    }
+    if ucd.valid {
+        wd.valid.set_bit_extend(i);
+        wd.sb_stat.extend_from_slice(&ucd.stat_data.to_bytes());
+    }
+    if !ucd.exclude_oid.is_zero() {
+        wd.sha1_valid.set_bit_extend(i);
+        wd.sb_sha1.extend_from_slice(ucd.exclude_oid.as_bytes());
+    }
+
+    ucd.untracked.sort();
+    encode_varint(ucd.untracked.len() as u64, &mut wd.out);
+
+    let recurse_count = ucd.dirs.iter().filter(|d| d.recurse).count() as u64;
+    encode_varint(recurse_count, &mut wd.out);
+
+    wd.out.extend_from_slice(ucd.name.as_bytes());
+    wd.out.push(0);
+
+    for n in &ucd.untracked {
+        wd.out.extend_from_slice(n.as_bytes());
+        wd.out.push(0);
+    }
+
+    let mut subdirs: Vec<_> = ucd.dirs.iter().filter(|d| d.recurse).collect();
+    subdirs.sort_by(|a, b| a.name.cmp(&b.name));
+    for d in subdirs {
+        write_one_dir(d, wd);
+    }
+}
+
+/// Serialize UNTR payload (extension body only, no signature header).
+pub fn write_untracked_extension(uc: &UntrackedCache) -> Vec<u8> {
+    let mut out = Vec::new();
+    encode_varint(uc.ident.len() as u64, &mut out);
+    out.extend_from_slice(&uc.ident);
+
+    let mut hdr = Vec::with_capacity(STAT_DATA_LEN * 2 + 4);
+    hdr.extend_from_slice(&uc.ss_info_exclude.stat.to_bytes());
+    hdr.extend_from_slice(&uc.ss_excludes_file.stat.to_bytes());
+    hdr.extend_from_slice(&uc.dir_flags.to_be_bytes());
+    out.extend_from_slice(&hdr);
+    out.extend_from_slice(uc.ss_info_exclude.oid.as_bytes());
+    out.extend_from_slice(uc.ss_excludes_file.oid.as_bytes());
+    out.extend_from_slice(uc.exclude_per_dir.as_bytes());
+    out.push(0);
+
+    let Some(root) = &uc.root else {
+        encode_varint(0, &mut out);
+        return out;
+    };
+
+    let mut wd = WriteDirCtx {
+        index: &mut 0,
+        valid: EwahBitmap::new(),
+        check_only: EwahBitmap::new(),
+        sha1_valid: EwahBitmap::new(),
+        out: Vec::new(),
+        sb_stat: Vec::new(),
+        sb_sha1: Vec::new(),
+    };
+    let mut sorted_root = root.clone();
+    sorted_root.untracked.sort();
+    sorted_root.dirs.sort_by(|a, b| a.name.cmp(&b.name));
+    write_one_dir(&sorted_root, &mut wd);
+
+    encode_varint(*wd.index as u64, &mut out);
+    out.append(&mut wd.out);
+
+    // Match Git `write_untracked_extension`: valid, check_only, sha1_valid (`dir.c`).
+    let mut tmp = Vec::new();
+    wd.valid.serialize(&mut tmp);
+    out.append(&mut tmp);
+    tmp.clear();
+    wd.check_only.serialize(&mut tmp);
+    out.append(&mut tmp);
+    tmp.clear();
+    wd.sha1_valid.serialize(&mut tmp);
+    out.append(&mut tmp);
+    out.append(&mut wd.sb_stat);
+    out.append(&mut wd.sb_sha1);
+    out.push(0);
+    out
+}
+
+/// Parse UNTR body (after 4-byte signature + 4-byte size).
+pub fn parse_untracked_extension(data: &[u8]) -> Option<UntrackedCache> {
+    if data.len() <= 1 || data[data.len() - 1] != 0 {
+        return None;
+    }
+    let end = data.len() - 1;
+    let data = &data[..end];
+
+    let (ident_len, c) = decode_varint(data)?;
+    let start = c;
+    if start + ident_len as usize > data.len() {
+        return None;
+    }
+    let ident = data[start..start + ident_len as usize].to_vec();
+    let mut pos = start + ident_len as usize;
+
+    const HDR: usize = STAT_DATA_LEN * 2 + 4;
+    if data.len() < pos + HDR + 40 {
+        return None;
+    }
+    let info_stat = StatDataDisk::from_bytes(&data[pos..])?;
+    pos += STAT_DATA_LEN;
+    let excl_stat = StatDataDisk::from_bytes(&data[pos..])?;
+    pos += STAT_DATA_LEN;
+    let dir_flags = u32::from_be_bytes(data[pos..pos + 4].try_into().ok()?);
+    pos += 4;
+    let oid_info = ObjectId::from_bytes(&data[pos..pos + 20]).ok()?;
+    pos += 20;
+    let oid_excl = ObjectId::from_bytes(&data[pos..pos + 20]).ok()?;
+    pos += 20;
+
+    let eos = data[pos..].iter().position(|&b| b == 0)?;
+    let exclude_per_dir = String::from_utf8(data[pos..pos + eos].to_vec()).ok()?;
+    pos += eos + 1;
+
+    let mut uc = UntrackedCache {
+        ident,
+        ss_info_exclude: OidStat {
+            stat: info_stat,
+            oid: oid_info,
+            valid: true,
+        },
+        ss_excludes_file: OidStat {
+            stat: excl_stat,
+            oid: oid_excl,
+            valid: true,
+        },
+        dir_flags,
+        exclude_per_dir,
+        root: None,
+        dir_created: 0,
+        gitignore_invalidated: 0,
+        dir_invalidated: 0,
+        dir_opened: 0,
+    };
+
+    if pos >= data.len() {
+        return Some(uc);
+    }
+    let (n_nodes, c) = decode_varint(&data[pos..])?;
+    pos += c;
+    if n_nodes == 0 {
+        return Some(uc);
+    }
+
+    fn read_one_dir(data: &[u8], pos: &mut usize) -> Option<UntrackedCacheDir> {
+        let (untracked_nr, c) = decode_varint(&data[*pos..])?;
+        *pos += c;
+        let (dirs_nr, c) = decode_varint(&data[*pos..])?;
+        *pos += c;
+        let untracked_nr = untracked_nr as usize;
+        let dirs_nr = dirs_nr as usize;
+
+        let name_start = *pos;
+        let name_end = name_start + data[name_start..].iter().position(|&b| b == 0)?;
+        let name = String::from_utf8(data[name_start..name_end].to_vec()).ok()?;
+        *pos = name_end + 1;
+
+        let mut untracked = Vec::with_capacity(untracked_nr);
+        for _ in 0..untracked_nr {
+            let s = *pos;
+            let e = s + data[s..].iter().position(|&b| b == 0)?;
+            untracked.push(String::from_utf8(data[s..e].to_vec()).ok()?);
+            *pos = e + 1;
+        }
+
+        let mut ucd = UntrackedCacheDir::new(name);
+        ucd.untracked = untracked;
+
+        for _ in 0..dirs_nr {
+            ucd.dirs.push(read_one_dir(data, pos)?);
+        }
+        Some(ucd)
+    }
+
+    let mut read_pos = pos;
+    let mut root = read_one_dir(data, &mut read_pos)?;
+
+    let rest = &data[read_pos..];
+    let (valid_bm, vlen) = EwahBitmap::deserialize_prefix(rest)?;
+    let rest = &rest[vlen..];
+    let (check_bm, clen) = EwahBitmap::deserialize_prefix(rest)?;
+    let rest = &rest[clen..];
+    let (sha_bm, slen) = EwahBitmap::deserialize_prefix(rest)?;
+    let rest = &rest[slen..];
+
+    let n = n_nodes as usize;
+    let mut check_bits = Vec::new();
+    check_bm.each_set_bit(|i| check_bits.push(i));
+    let mut valid_bits = Vec::new();
+    valid_bm.each_set_bit(|i| valid_bits.push(i));
+    let mut sha_bits = Vec::new();
+    sha_bm.each_set_bit(|i| sha_bits.push(i));
+
+    let stat_len = valid_bits.len() * STAT_DATA_LEN;
+    let oid_len = sha_bits.len() * 20;
+    if rest.len() < stat_len + oid_len {
+        return None;
+    }
+    let (stat_part, tail) = rest.split_at(stat_len);
+    let (oid_part, after_oids) = tail.split_at(oid_len);
+    if !after_oids.is_empty() {
+        return None;
+    }
+    let mut stat_slice = stat_part;
+    let mut oid_slice = oid_part;
+
+    fn apply(
+        u: &mut UntrackedCacheDir,
+        idx: &mut usize,
+        check: &[usize],
+        valid: &[usize],
+        sha: &[usize],
+        stat_bytes: &mut &[u8],
+        oid_bytes: &mut &[u8],
+    ) -> Option<()> {
+        let i = *idx;
+        *idx += 1;
+        u.check_only = check.contains(&i);
+        if valid.contains(&i) {
+            u.valid = true;
+            if stat_bytes.len() < STAT_DATA_LEN {
+                return None;
+            }
+            u.stat_data = StatDataDisk::from_bytes(&stat_bytes[..STAT_DATA_LEN])?;
+            *stat_bytes = &stat_bytes[STAT_DATA_LEN..];
+        }
+        if sha.contains(&i) {
+            if oid_bytes.len() < 20 {
+                return None;
+            }
+            u.exclude_oid = ObjectId::from_bytes(&oid_bytes[..20]).ok()?;
+            *oid_bytes = &oid_bytes[20..];
+        }
+        u.dirs.sort_by(|a, b| a.name.cmp(&b.name));
+        for d in &mut u.dirs {
+            apply(d, idx, check, valid, sha, stat_bytes, oid_bytes)?;
+        }
+        Some(())
+    }
+
+    let mut idx = 0usize;
+    apply(
+        &mut root,
+        &mut idx,
+        &check_bits,
+        &valid_bits,
+        &sha_bits,
+        &mut stat_slice,
+        &mut oid_slice,
+    )?;
+    if idx != n {
+        return None;
+    }
+    uc.root = Some(root);
+    Some(uc)
+}
+
+pub fn untracked_cache_ident(work_tree: &Path) -> Vec<u8> {
+    #[cfg(unix)]
+    let sysname = {
+        let mut uts: libc::utsname = unsafe { std::mem::zeroed() };
+        unsafe {
+            if libc::uname(&mut uts) == 0 {
+                CStr::from_ptr(uts.sysname.as_ptr())
+                    .to_string_lossy()
+                    .into_owned()
+            } else {
+                "unknown".to_string()
+            }
+        }
+    };
+    #[cfg(not(unix))]
+    let sysname = "unknown".to_string();
+
+    let loc = work_tree.display().to_string();
+    let mut s = format!("Location {loc}, system {sysname}");
+    s.push('\0');
+    s.into_bytes()
+}
+
+pub fn dir_flags_from_config(config: &ConfigSet) -> u32 {
+    if config
+        .get("status.showUntrackedFiles")
+        .or_else(|| config.get("status.showuntrackedfiles"))
+        .is_some_and(|v| v.eq_ignore_ascii_case("all"))
+    {
+        0
+    } else {
+        DIR_SHOW_OTHER_DIRECTORIES | DIR_HIDE_EMPTY_DIRECTORIES
+    }
+}
+
+fn global_excludes_path(repo: &Repository, config: &ConfigSet) -> Option<PathBuf> {
+    let raw = config
+        .get("core.excludesFile")
+        .or_else(|| config.get("core.excludesfile"))?;
+    let expanded = parse_path(&raw);
+    let p = Path::new(&expanded);
+    if p.is_absolute() {
+        Some(p.to_path_buf())
+    } else {
+        repo.work_tree.as_ref().map(|wt| wt.join(p))
+    }
+}
+
+fn file_stat_and_blob_oid(path: &Path) -> Result<(StatDataDisk, ObjectId)> {
+    match fs::metadata(path) {
+        Ok(meta) => {
+            let st = stat_data_from_meta(&meta);
+            let mut f = fs::File::open(path).map_err(Error::Io)?;
+            let mut buf = Vec::new();
+            f.read_to_end(&mut buf).map_err(Error::Io)?;
+            // Match Git's untracked-cache header: empty exclude files use the null OID in UNTR
+            // (see t7063 `expect-empty` after `update-index --untracked-cache`).
+            let oid = if buf.is_empty() {
+                ObjectId::zero()
+            } else {
+                Odb::hash_object_data(ObjectKind::Blob, &buf)
+            };
+            Ok((st, oid))
+        }
+        Err(_) => Ok((StatDataDisk::default(), ObjectId::zero())),
+    }
+}
+
+fn do_invalidate_gitignore(dir: &mut UntrackedCacheDir) {
+    dir.valid = false;
+    dir.untracked.clear();
+    for d in &mut dir.dirs {
+        do_invalidate_gitignore(d);
+    }
+}
+
+fn invalidate_gitignore(uc: &mut UntrackedCache) {
+    if let Some(root) = uc.root.as_mut() {
+        do_invalidate_gitignore(root);
+    }
+}
+
+fn invalidate_directory(uc: &mut UntrackedCache, dir: &mut UntrackedCacheDir) {
+    if dir.valid {
+        uc.dir_invalidated += 1;
+    }
+    dir.valid = false;
+    dir.untracked.clear();
+    for d in &mut dir.dirs {
+        d.recurse = false;
+    }
+}
+
+pub fn invalidate_path(uc: &mut UntrackedCache, path: &str) {
+    let Some(mut root) = uc.root.take() else {
+        return;
+    };
+    let _ = invalidate_one_component(uc, &mut root, path);
+    uc.root = Some(root);
+}
+
+fn invalidate_one_component(
+    uc: &mut UntrackedCache,
+    dir: &mut UntrackedCacheDir,
+    path: &str,
+) -> bool {
+    if let Some(slash) = path.find('/') {
+        let (comp, tail) = path.split_at(slash);
+        let tail = &tail[1..];
+        if let Some(d) = dir.dirs.iter_mut().find(|x| x.name == comp) {
+            let ret = invalidate_one_component(uc, d, tail);
+            if ret {
+                invalidate_directory(uc, dir);
+            }
+            ret
+        } else {
+            false
+        }
+    } else {
+        invalidate_directory(uc, dir);
+        uc.dir_flags & DIR_SHOW_OTHER_DIRECTORIES != 0
+    }
+}
+
+fn has_tracked_under(
+    tracked: &BTreeSet<String>,
+    gitlinks: &BTreeSet<String>,
+    rel_dir: &str,
+) -> bool {
+    let prefix = if rel_dir.is_empty() {
+        String::new()
+    } else {
+        format!("{rel_dir}/")
+    };
+    tracked
+        .range::<String, _>(prefix.clone()..)
+        .next()
+        .is_some_and(|t| t.starts_with(&prefix))
+        || gitlinks.iter().any(|g| {
+            g.as_str() == rel_dir || (!rel_dir.is_empty() && g.starts_with(&format!("{rel_dir}/")))
+        })
+}
+
+fn relative_path(parent: &str, name: &str) -> String {
+    if parent.is_empty() {
+        name.to_string()
+    } else {
+        format!("{parent}/{name}")
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum UntrackedIgnoredMode {
+    No,
+    Traditional,
+    Matching,
+}
+
+fn fill_exclude_oids(
+    repo: &Repository,
+    _work_tree: &Path,
+    config: &ConfigSet,
+    uc: &mut UntrackedCache,
+) -> Result<()> {
+    let info_path = repo.git_dir.join("info/exclude");
+    let (st_i, oid_i) = file_stat_and_blob_oid(&info_path)?;
+    if uc.ss_info_exclude.valid
+        && (uc.ss_info_exclude.stat != st_i || uc.ss_info_exclude.oid != oid_i)
+    {
+        uc.gitignore_invalidated += 1;
+        invalidate_gitignore(uc);
+    }
+    uc.ss_info_exclude.stat = st_i;
+    uc.ss_info_exclude.oid = oid_i;
+    uc.ss_info_exclude.valid = true;
+
+    let (st_e, oid_e) = if let Some(p) = global_excludes_path(repo, config) {
+        file_stat_and_blob_oid(&p)?
+    } else {
+        (StatDataDisk::default(), ObjectId::zero())
+    };
+    if uc.ss_excludes_file.valid
+        && (uc.ss_excludes_file.stat != st_e || uc.ss_excludes_file.oid != oid_e)
+    {
+        uc.gitignore_invalidated += 1;
+        invalidate_gitignore(uc);
+    }
+    uc.ss_excludes_file.stat = st_e;
+    uc.ss_excludes_file.oid = oid_e;
+    uc.ss_excludes_file.valid = true;
+
+    Ok(())
+}
+
+fn lookup_or_create_child<'a>(
+    parent: &'a mut UntrackedCacheDir,
+    name: &str,
+    uc: &mut UntrackedCache,
+) -> &'a mut UntrackedCacheDir {
+    if let Some(i) = parent.dirs.iter().position(|d| d.name == name) {
+        return &mut parent.dirs[i];
+    }
+    uc.dir_created += 1;
+    parent.dirs.push(UntrackedCacheDir::new(name.to_string()));
+    let n = parent.dirs.len() - 1;
+    &mut parent.dirs[n]
+}
+
+fn valid_cached_dir(ucd: &UntrackedCacheDir, abs: &Path, check_only: bool) -> bool {
+    if !ucd.valid {
+        return false;
+    }
+    let meta = match fs::symlink_metadata(abs) {
+        Ok(m) => m,
+        Err(_) => return false,
+    };
+    stat_data_from_meta(&meta) == ucd.stat_data && ucd.check_only == check_only
+}
+
+enum DirSource {
+    Disk(fs::ReadDir),
+    Cache {
+        dir_idx: usize,
+        file_idx: usize,
+        child_dirs: Vec<UntrackedCacheDir>,
+        child_files: Vec<String>,
+    },
+}
+
+/// Refresh untracked cache tree and counters (for `git status`).
+pub fn refresh_untracked_cache_for_status(
+    repo: &Repository,
+    index: &Index,
+    work_tree: &Path,
+    config: &ConfigSet,
+    uc: &mut UntrackedCache,
+    show_all_untracked: bool,
+    ignored_mode: UntrackedIgnoredMode,
+) -> Result<()> {
+    uc.reset_stats();
+    let requested_flags = if show_all_untracked {
+        0u32
+    } else {
+        DIR_SHOW_OTHER_DIRECTORIES | DIR_HIDE_EMPTY_DIRECTORIES
+    };
+
+    if uc.dir_flags != requested_flags {
+        if uc.dir_flags != dir_flags_from_config(config) {
+            *uc = UntrackedCache::new_shell(requested_flags, untracked_cache_ident(work_tree));
+        }
+    }
+    uc.dir_flags = requested_flags;
+
+    fill_exclude_oids(repo, work_tree, config, uc)?;
+
+    let tracked: BTreeSet<String> = index
+        .entries
+        .iter()
+        .map(|e| String::from_utf8_lossy(&e.path).into_owned())
+        .collect();
+    let gitlinks: BTreeSet<String> = index
+        .entries
+        .iter()
+        .filter(|e| e.stage() == 0 && e.mode == MODE_GITLINK)
+        .map(|e| String::from_utf8_lossy(&e.path).into_owned())
+        .collect();
+
+    let mut matcher = IgnoreMatcher::from_repository(repo)?;
+
+    if uc.root.is_none() {
+        uc.root = Some(UntrackedCacheDir::new(String::new()));
+        uc.dir_created += 1;
+    }
+    let mut root = uc
+        .root
+        .take()
+        .ok_or_else(|| Error::IndexError("no uc root".into()))?;
+
+    read_directory_recursive(
+        repo,
+        index,
+        work_tree,
+        &tracked,
+        &gitlinks,
+        &mut matcher,
+        ignored_mode,
+        show_all_untracked,
+        &mut root,
+        "",
+        work_tree,
+        uc,
+    )?;
+
+    uc.root = Some(root);
+
+    Ok(())
+}
+
+fn read_directory_recursive(
+    repo: &Repository,
+    index: &Index,
+    work_tree: &Path,
+    tracked: &BTreeSet<String>,
+    gitlinks: &BTreeSet<String>,
+    matcher: &mut IgnoreMatcher,
+    ignored_mode: UntrackedIgnoredMode,
+    show_all: bool,
+    ucd: &mut UntrackedCacheDir,
+    rel: &str,
+    abs: &Path,
+    uc: &mut UntrackedCache,
+) -> Result<()> {
+    let check_only = false;
+    let use_disk = !valid_cached_dir(ucd, abs, check_only);
+    let mut src = if use_disk {
+        invalidate_directory(uc, ucd);
+        uc.dir_opened += 1;
+        let p = if abs == work_tree && rel.is_empty() {
+            work_tree.to_path_buf()
+        } else {
+            abs.to_path_buf()
+        };
+        DirSource::Disk(fs::read_dir(&p).map_err(Error::Io)?)
+    } else {
+        let mut child_dirs: Vec<_> = ucd.dirs.iter().filter(|d| d.recurse).cloned().collect();
+        child_dirs.sort_by(|a, b| a.name.cmp(&b.name));
+        let mut child_files = ucd.untracked.clone();
+        child_files.sort();
+        DirSource::Cache {
+            dir_idx: 0,
+            file_idx: 0,
+            child_dirs,
+            child_files,
+        }
+    };
+
+    ucd.check_only = check_only;
+
+    loop {
+        let next = match &mut src {
+            DirSource::Disk(rd) => {
+                let Some(Ok(entry)) = rd.next() else {
+                    break;
+                };
+                let name = entry.file_name().to_string_lossy().into_owned();
+                if name == ".git" {
+                    continue;
+                }
+                let path = entry.path();
+                let is_dir = entry.file_type().map_err(Error::Io)?.is_dir();
+                Some((name, path, is_dir))
+            }
+            DirSource::Cache {
+                dir_idx,
+                file_idx,
+                child_dirs,
+                child_files,
+            } => {
+                while *dir_idx < child_dirs.len() && !child_dirs[*dir_idx].recurse {
+                    *dir_idx += 1;
+                }
+                if *dir_idx < child_dirs.len() {
+                    let d = &child_dirs[*dir_idx];
+                    *dir_idx += 1;
+                    let child_abs = if rel.is_empty() {
+                        work_tree.join(&d.name)
+                    } else {
+                        work_tree.join(rel).join(&d.name)
+                    };
+                    Some((d.name.clone(), child_abs, true))
+                } else if *file_idx < child_files.len() {
+                    let n = child_files[*file_idx].clone();
+                    *file_idx += 1;
+                    let child_rel = if rel.is_empty() {
+                        n.clone()
+                    } else {
+                        format!("{rel}/{n}")
+                    };
+                    let child_abs = work_tree.join(&child_rel);
+                    let is_dir = child_abs.is_dir();
+                    let base = Path::new(&n)
+                        .file_name()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or(&n)
+                        .to_string();
+                    Some((base, child_abs, is_dir))
+                } else {
+                    break;
+                }
+            }
+        };
+
+        let Some((name, path, is_dir)) = next else {
+            continue;
+        };
+        let child_rel = relative_path(rel, &name);
+
+        if is_dir && gitlinks.contains(&child_rel) {
+            continue;
+        }
+        if tracked.contains(&child_rel) {
+            continue;
+        }
+
+        if is_dir {
+            visit_untracked_directory_uc(
+                repo,
+                index,
+                work_tree,
+                tracked,
+                gitlinks,
+                matcher,
+                ignored_mode,
+                show_all,
+                ucd,
+                &child_rel,
+                &path,
+                uc,
+            )?;
+        } else {
+            let (is_ign, _) = matcher.check_path(repo, Some(index), &child_rel, false)?;
+            if is_ign {
+                continue;
+            }
+            if use_disk {
+                ucd.untracked.push(name);
+            }
+        }
+    }
+
+    if use_disk {
+        ucd.dirs.retain(|d| d.recurse);
+        ucd.dirs.sort_by(|a, b| a.name.cmp(&b.name));
+    }
+
+    let meta = fs::symlink_metadata(abs).map_err(Error::Io)?;
+    ucd.stat_data = stat_data_from_meta(&meta);
+    ucd.valid = true;
+    ucd.recurse = true;
+
+    Ok(())
+}
+
+fn visit_untracked_directory_uc(
+    repo: &Repository,
+    index: &Index,
+    work_tree: &Path,
+    tracked: &BTreeSet<String>,
+    gitlinks: &BTreeSet<String>,
+    matcher: &mut IgnoreMatcher,
+    ignored_mode: UntrackedIgnoredMode,
+    show_all: bool,
+    parent_ucd: &mut UntrackedCacheDir,
+    rel: &str,
+    abs: &Path,
+    uc: &mut UntrackedCache,
+) -> Result<()> {
+    let name = Path::new(rel)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or(rel)
+        .to_string();
+
+    if has_tracked_under(tracked, gitlinks, rel) {
+        let child = lookup_or_create_child(parent_ucd, &name, uc);
+        return read_directory_recursive(
+            repo,
+            index,
+            work_tree,
+            tracked,
+            gitlinks,
+            matcher,
+            ignored_mode,
+            show_all,
+            child,
+            rel,
+            abs,
+            uc,
+        );
+    }
+
+    if ignored_mode == UntrackedIgnoredMode::Matching
+        && show_all
+        && matcher.check_path(repo, Some(index), rel, true)?.0
+    {
+        return Ok(());
+    }
+
+    if ignored_mode == UntrackedIgnoredMode::Traditional && !show_all {
+        if let Some(line) = traditional_normal_directory_only(
+            repo, index, work_tree, tracked, gitlinks, matcher, rel, abs, uc,
+        )? {
+            let _ = line;
+            return Ok(());
+        }
+    }
+
+    let mut sub_untracked = Vec::new();
+    let mut sub_ignored = Vec::new();
+    visit_untracked_node_full(
+        repo,
+        index,
+        work_tree,
+        tracked,
+        gitlinks,
+        matcher,
+        ignored_mode,
+        true,
+        rel,
+        abs,
+        &mut sub_untracked,
+        &mut sub_ignored,
+        uc,
+    )?;
+
+    if show_all {
+        let child = lookup_or_create_child(parent_ucd, &name, uc);
+        return read_directory_recursive(
+            repo,
+            index,
+            work_tree,
+            tracked,
+            gitlinks,
+            matcher,
+            ignored_mode,
+            true,
+            child,
+            rel,
+            abs,
+            uc,
+        );
+    }
+
+    if !sub_untracked.is_empty() && !sub_ignored.is_empty() {
+        let child = lookup_or_create_child(parent_ucd, &name, uc);
+        return read_directory_recursive(
+            repo,
+            index,
+            work_tree,
+            tracked,
+            gitlinks,
+            matcher,
+            ignored_mode,
+            true,
+            child,
+            rel,
+            abs,
+            uc,
+        );
+    }
+
+    if sub_untracked.is_empty() && !sub_ignored.is_empty() {
+        return Ok(());
+    }
+
+    if !sub_untracked.is_empty() && sub_ignored.is_empty() {
+        // Git `lookup_untracked` still allocates a child node when collapsing to `name/` (t7063).
+        uc.dir_created += 1;
+        parent_ucd.untracked.push(format!("{name}/"));
+        return Ok(());
+    }
+
+    Ok(())
+}
+
+fn visit_untracked_node_full(
+    repo: &Repository,
+    index: &Index,
+    work_tree: &Path,
+    tracked: &BTreeSet<String>,
+    gitlinks: &BTreeSet<String>,
+    matcher: &mut IgnoreMatcher,
+    ignored_mode: UntrackedIgnoredMode,
+    show_all: bool,
+    rel: &str,
+    abs: &Path,
+    untracked_out: &mut Vec<String>,
+    ignored_out: &mut Vec<String>,
+    uc: &mut UntrackedCache,
+) -> Result<()> {
+    let entries = match fs::read_dir(abs) {
+        Ok(e) => {
+            uc.dir_opened += 1;
+            e
+        }
+        Err(_) => return Ok(()),
+    };
+    let mut sorted: Vec<_> = entries.filter_map(|e| e.ok()).collect();
+    sorted.sort_by_key(|e| e.file_name());
+
+    for entry in sorted {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name == ".git" {
+            continue;
+        }
+        let path = entry.path();
+        let child_rel = relative_path(rel, &name);
+        let is_dir = entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false);
+
+        if is_dir && gitlinks.contains(&child_rel) {
+            continue;
+        }
+        if tracked.contains(&child_rel) {
+            continue;
+        }
+
+        if is_dir {
+            visit_untracked_directory_collect(
+                repo,
+                index,
+                work_tree,
+                tracked,
+                gitlinks,
+                matcher,
+                ignored_mode,
+                show_all,
+                &child_rel,
+                &path,
+                untracked_out,
+                ignored_out,
+                uc,
+            )?;
+        } else {
+            let (is_ign, _) = matcher.check_path(repo, Some(index), &child_rel, false)?;
+            if is_ign {
+                if ignored_mode != UntrackedIgnoredMode::No {
+                    ignored_out.push(child_rel);
+                }
+            } else {
+                untracked_out.push(child_rel);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn visit_untracked_directory_collect(
+    repo: &Repository,
+    index: &Index,
+    work_tree: &Path,
+    tracked: &BTreeSet<String>,
+    gitlinks: &BTreeSet<String>,
+    matcher: &mut IgnoreMatcher,
+    ignored_mode: UntrackedIgnoredMode,
+    show_all: bool,
+    rel: &str,
+    abs: &Path,
+    untracked_out: &mut Vec<String>,
+    ignored_out: &mut Vec<String>,
+    uc: &mut UntrackedCache,
+) -> Result<()> {
+    if has_tracked_under(tracked, gitlinks, rel) {
+        return visit_untracked_node_full(
+            repo,
+            index,
+            work_tree,
+            tracked,
+            gitlinks,
+            matcher,
+            ignored_mode,
+            show_all,
+            rel,
+            abs,
+            untracked_out,
+            ignored_out,
+            uc,
+        );
+    }
+
+    if ignored_mode == UntrackedIgnoredMode::Matching
+        && show_all
+        && matcher.check_path(repo, Some(index), rel, true)?.0
+    {
+        ignored_out.push(format!("{rel}/"));
+        return Ok(());
+    }
+
+    if ignored_mode == UntrackedIgnoredMode::Traditional && !show_all {
+        if let Some(line) = traditional_normal_directory_only(
+            repo, index, work_tree, tracked, gitlinks, matcher, rel, abs, uc,
+        )? {
+            ignored_out.push(line);
+            return Ok(());
+        }
+    }
+
+    let mut sub_u = Vec::new();
+    let mut sub_i = Vec::new();
+    visit_untracked_node_full(
+        repo,
+        index,
+        work_tree,
+        tracked,
+        gitlinks,
+        matcher,
+        ignored_mode,
+        true,
+        rel,
+        abs,
+        &mut sub_u,
+        &mut sub_i,
+        uc,
+    )?;
+
+    if show_all {
+        untracked_out.append(&mut sub_u);
+        ignored_out.append(&mut sub_i);
+        return Ok(());
+    }
+
+    if !sub_u.is_empty() && !sub_i.is_empty() {
+        untracked_out.append(&mut sub_u);
+        ignored_out.append(&mut sub_i);
+        return Ok(());
+    }
+
+    if sub_u.is_empty() && !sub_i.is_empty() {
+        let dir_excluded = matcher.check_path(repo, Some(index), rel, true)?.0;
+        let collapse_matching = ignored_mode == UntrackedIgnoredMode::Matching && dir_excluded;
+        let collapse_traditional = ignored_mode == UntrackedIgnoredMode::Traditional;
+        if collapse_matching || collapse_traditional {
+            ignored_out.push(format!("{rel}/"));
+        } else {
+            ignored_out.append(&mut sub_i);
+        }
+        return Ok(());
+    }
+
+    if !sub_u.is_empty() && sub_i.is_empty() {
+        if rel.is_empty() {
+            untracked_out.append(&mut sub_u);
+        } else {
+            untracked_out.push(format!("{rel}/"));
+        }
+    }
+
+    Ok(())
+}
+
+fn traditional_normal_directory_only(
+    repo: &Repository,
+    index: &Index,
+    work_tree: &Path,
+    tracked: &BTreeSet<String>,
+    gitlinks: &BTreeSet<String>,
+    matcher: &mut IgnoreMatcher,
+    rel: &str,
+    abs: &Path,
+    uc: &mut UntrackedCache,
+) -> Result<Option<String>> {
+    let mut any_file = false;
+    let mut stack = vec![abs.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let entries = match fs::read_dir(&dir) {
+            Ok(e) => {
+                uc.dir_opened += 1;
+                e
+            }
+            Err(_) => continue,
+        };
+        let mut sorted: Vec<_> = entries.filter_map(|e| e.ok()).collect();
+        sorted.sort_by_key(|e| e.file_name());
+        for entry in sorted {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if name == ".git" {
+                continue;
+            }
+            let path = entry.path();
+            let is_dir = entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false);
+            let rel_child = if dir == *abs {
+                relative_path(rel, &name)
+            } else {
+                let suffix = path.strip_prefix(work_tree).unwrap_or(&path);
+                suffix.to_string_lossy().replace('\\', "/")
+            };
+            if is_dir && gitlinks.contains(&rel_child) {
+                continue;
+            }
+            if tracked.contains(&rel_child) {
+                return Ok(None);
+            }
+            if is_dir {
+                stack.push(path);
+            } else {
+                any_file = true;
+                let (ig, _) = matcher.check_path(repo, Some(index), &rel_child, false)?;
+                if !ig {
+                    return Ok(None);
+                }
+            }
+        }
+    }
+    if any_file {
+        Ok(Some(format!("{rel}/")))
+    } else {
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn untracked_extension_round_trip_shell() {
+        let uc = UntrackedCache::new_shell(6, b"ident\x00".to_vec());
+        let raw = write_untracked_extension(&uc);
+        let back = parse_untracked_extension(&raw).expect("parse shell");
+        assert_eq!(back.dir_flags, 6);
+        assert_eq!(back.ident, uc.ident);
+        assert!(back.root.is_none());
+    }
+
+    #[test]
+    fn untracked_extension_round_trip_with_tree() {
+        let mut uc = UntrackedCache::new_shell(6, b"id\x00".to_vec());
+        let mut root = UntrackedCacheDir::new(String::new());
+        root.valid = true;
+        root.recurse = true;
+        root.stat_data = StatDataDisk {
+            mtime_sec: 1,
+            ..Default::default()
+        };
+        root.untracked = vec!["a".to_string(), "b".to_string()];
+        let mut child = UntrackedCacheDir::new("sub".to_string());
+        child.valid = true;
+        child.recurse = true;
+        root.dirs.push(child);
+        uc.root = Some(root);
+
+        let raw = write_untracked_extension(&uc);
+        let back = parse_untracked_extension(&raw).expect("parse tree");
+        assert!(back.root.is_some());
+        let r = back.root.as_ref().unwrap();
+        assert_eq!(r.untracked.len(), 2);
+        assert_eq!(r.dirs.len(), 1);
+    }
+}

--- a/grit/src/commands/status.rs
+++ b/grit/src/commands/status.rs
@@ -16,6 +16,7 @@ use grit_lib::objects::{parse_commit, ObjectId};
 use grit_lib::reflog;
 use grit_lib::repo::Repository;
 use grit_lib::state::{detect_in_progress, resolve_head, HeadState};
+use grit_lib::untracked_cache::{self, UntrackedCache, UntrackedIgnoredMode};
 
 use crate::branch_tracking::{
     format_tracking_info, shorten_tracking_ref, stat_branch_pair, upstream_tracking_full_ref,
@@ -303,6 +304,22 @@ pub fn run(mut args: Args) -> Result<()> {
     let index_sparse_on_disk = index.sparse_directories;
     let _ = index.expand_sparse_directory_placeholders(&repo.odb);
 
+    match config
+        .get("core.untrackedCache")
+        .map(|s| s.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("false") | Some("0") | Some("no") | Some("off") => {
+            index.untracked_cache = None;
+        }
+        Some("true") | Some("1") | Some("yes") | Some("on") if index.untracked_cache.is_none() => {
+            let flags = untracked_cache::dir_flags_from_config(&config);
+            let ident = untracked_cache::untracked_cache_ident(work_tree);
+            index.untracked_cache = Some(UntrackedCache::new_shell(flags, ident));
+        }
+        _ => {}
+    }
+
     // Get HEAD tree OID
     let head_tree = match head.oid() {
         Some(oid) => {
@@ -338,7 +355,48 @@ pub fn run(mut args: Args) -> Result<()> {
     let hide_untracked = untracked_mode == "no";
 
     let (untracked, ignored_files) = if !hide_untracked {
-        collect_untracked_and_ignored(&repo, &index, work_tree, ignored_mode, show_all_untracked)?
+        let uc_mode = match ignored_mode {
+            IgnoredMode::No => UntrackedIgnoredMode::No,
+            IgnoredMode::Traditional => UntrackedIgnoredMode::Traditional,
+            IgnoredMode::Matching => UntrackedIgnoredMode::Matching,
+        };
+        let mut uc_slot = index.untracked_cache.take();
+        let trace_perf = std::env::var("GIT_TRACE2_PERF")
+            .ok()
+            .filter(|s| !s.is_empty());
+        if let Some(uc) = uc_slot.as_mut() {
+            let ident_ok = ident_matches_worktree(uc, work_tree);
+            if !ident_ok {
+                eprintln!("warning: untracked cache is disabled on this system or location");
+            } else {
+                let _ = untracked_cache::refresh_untracked_cache_for_status(
+                    &repo,
+                    &index,
+                    work_tree,
+                    &config,
+                    uc,
+                    show_all_untracked,
+                    uc_mode,
+                );
+                if let Some(ref p) = trace_perf {
+                    let _ = emit_read_directory_trace(p, Some(uc));
+                }
+            }
+        } else if let Some(ref p) = trace_perf {
+            let _ = emit_read_directory_trace(p, None);
+        }
+        index.untracked_cache = uc_slot;
+        let out = collect_untracked_and_ignored(
+            &repo,
+            &index,
+            work_tree,
+            ignored_mode,
+            show_all_untracked,
+        )?;
+        if !args.no_optional_locks {
+            let _ = repo.write_index_at(&index_path, &mut index);
+        }
+        out
     } else {
         (Vec::new(), Vec::new())
     };
@@ -2081,6 +2139,71 @@ fn remap_diff_paths(
             new_entry
         })
         .collect()
+}
+
+fn ident_matches_worktree(
+    uc: &grit_lib::untracked_cache::UntrackedCache,
+    work_tree: &Path,
+) -> bool {
+    uc.ident == untracked_cache::untracked_cache_ident(work_tree)
+}
+
+fn emit_read_directory_trace(
+    path: &str,
+    uc: Option<&grit_lib::untracked_cache::UntrackedCache>,
+) -> std::io::Result<()> {
+    use std::io::Write;
+    let now = {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .unwrap_or_default();
+        let total_secs = now.as_secs();
+        let micros = now.subsec_micros();
+        let secs_in_day = total_secs % 86400;
+        let hours = secs_in_day / 3600;
+        let mins = (secs_in_day % 3600) / 60;
+        let secs = secs_in_day % 60;
+        format!("{:02}:{:02}:{:02}.{:06}", hours, mins, secs, micros)
+    };
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    let (node, gi, di, op) = uc.map_or((0u64, 0u64, 0u64, 0u64), |u| {
+        (
+            u.dir_created,
+            u.gitignore_invalidated,
+            u.dir_invalidated,
+            u.dir_opened,
+        )
+    });
+    // Field 9 must match upstream `t7063` / `get_relevant_traces` (Git abbreviates `read_directory`).
+    writeln!(
+        file,
+        "{} grit:0  | d0 | main                     | {:<12} |     |           |           |              | ....path:",
+        now, "data"
+    )?;
+    writeln!(
+        file,
+        "{} grit:0  | d0 | main                     | {:<12} |     |           |           |              | ....node-creation:{}",
+        now, "data", node
+    )?;
+    writeln!(
+        file,
+        "{} grit:0  | d0 | main                     | {:<12} |     |           |           |              | ....gitignore-invalidation:{}",
+        now, "data", gi
+    )?;
+    writeln!(
+        file,
+        "{} grit:0  | d0 | main                     | {:<12} |     |           |           |              | ....directory-invalidation:{}",
+        now, "data", di
+    )?;
+    writeln!(
+        file,
+        "{} grit:0  | d0 | main                     | {:<12} |     |           |           |              | ....opendir:{}",
+        now, "data", op
+    )?;
+    Ok(())
 }
 
 fn status_path_matches(path: &str, pathspecs: &[String]) -> bool {

--- a/grit/src/commands/update_index.rs
+++ b/grit/src/commands/update_index.rs
@@ -2,6 +2,7 @@
 
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
+use std::env;
 use std::io::{self, BufRead};
 #[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;
@@ -17,6 +18,7 @@ use grit_lib::odb::Odb;
 use grit_lib::pathspec::matches_pathspec_for_object;
 use grit_lib::repo::Repository;
 use grit_lib::state::resolve_head;
+use grit_lib::untracked_cache::{self, UntrackedCache};
 
 /// Match Git: when `--chmod` changes the index entry, update the working tree file mode so a
 /// subsequent `git add` of the same path keeps the executable bit.
@@ -182,6 +184,22 @@ pub struct Args {
     /// Ignore changes to submodule during --refresh.
     #[arg(long = "ignore-submodules")]
     pub ignore_submodules: bool,
+
+    /// Enable untracked cache extension in the index.
+    #[arg(long = "untracked-cache")]
+    pub untracked_cache: bool,
+
+    /// Disable untracked cache extension.
+    #[arg(long = "no-untracked-cache")]
+    pub no_untracked_cache: bool,
+
+    /// Test whether the filesystem supports the untracked cache (exit 0 if yes, 1 if no).
+    #[arg(long = "test-untracked-cache", hide = true)]
+    pub test_untracked_cache: bool,
+
+    /// Enable untracked cache without probing the filesystem.
+    #[arg(long = "force-untracked-cache", hide = true)]
+    pub force_untracked_cache: bool,
 
     /// Files to add/remove from the index.
     pub files: Vec<PathBuf>,
@@ -349,10 +367,26 @@ fn per_file_chmod_from_raw_argv(raw: &[String]) -> std::collections::HashMap<Pat
     map
 }
 
+fn index_path_for_update(repo: &Repository) -> Result<PathBuf> {
+    if let Ok(raw) = env::var("GIT_INDEX_FILE") {
+        if !raw.is_empty() {
+            let p = PathBuf::from(raw);
+            return Ok(if p.is_absolute() {
+                p
+            } else {
+                env::current_dir()
+                    .context("GIT_INDEX_FILE is relative; need cwd")?
+                    .join(p)
+            });
+        }
+    }
+    Ok(repo.index_path())
+}
+
 /// Run `grit update-index`.
 pub fn run(args: Args, raw_rest: &[String]) -> Result<()> {
     let repo = Repository::discover(None).context("not a git repository")?;
-    let index_path = repo.index_path();
+    let index_path = index_path_for_update(&repo)?;
     let mut index = repo.load_index_at(&index_path).context("loading index")?;
     let symlinks_enabled = core_symlinks_enabled(&repo);
 
@@ -365,6 +399,32 @@ pub fn run(args: Args, raw_rest: &[String]) -> Result<()> {
     let config = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
     let conv = crlf::ConversionConfig::from_config(&config);
     let attrs = crlf::load_gitattributes(work_tree);
+
+    if args.test_untracked_cache {
+        // Grit always supports UNTR on POSIX; return success like Git on capable systems.
+        return Ok(());
+    }
+
+    if args.force_untracked_cache {
+        let flags = untracked_cache::dir_flags_from_config(&config);
+        let ident = untracked_cache::untracked_cache_ident(work_tree);
+        index.untracked_cache = Some(UntrackedCache::new_shell(flags, ident));
+        repo.write_index_at(&index_path, &mut index)
+            .context("writing index")?;
+        return Ok(());
+    }
+
+    if args.no_untracked_cache {
+        index.untracked_cache = None;
+        repo.write_index_at(&index_path, &mut index)
+            .context("writing index")?;
+    } else if args.untracked_cache {
+        let flags = untracked_cache::dir_flags_from_config(&config);
+        let ident = untracked_cache::untracked_cache_ident(work_tree);
+        index.untracked_cache = Some(UntrackedCache::new_shell(flags, ident));
+        repo.write_index_at(&index_path, &mut index)
+            .context("writing index")?;
+    }
 
     if args.show_index_version {
         println!("{}", index.version);
@@ -1502,7 +1562,7 @@ fn core_symlinks_enabled(repo: &Repository) -> bool {
 
 /// Non-CLI: `update-index -q --refresh` — refresh stat cache without exiting when entries are stale.
 pub fn run_refresh_quiet(repo: &Repository) -> Result<()> {
-    let index_path = repo.index_path();
+    let index_path = index_path_for_update(repo)?;
     let mut index = repo.load_index_at(&index_path).context("loading index")?;
     let work_tree = repo
         .work_tree

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -4327,6 +4327,7 @@ pub(crate) fn dispatch(subcmd: &str, rest: &[String], opts: &GlobalOpts) -> Resu
                 "mergesort" => run_test_tool_mergesort(rest),
                 "hexdump" => run_test_tool_hexdump(rest),
                 "chmtime" => run_test_tool_chmtime(&rest[1..]),
+                "dump-untracked-cache" => run_test_tool_dump_untracked_cache(),
                 "userdiff" => run_test_tool_userdiff(rest),
                 "find-pack" => run_test_tool_find_pack(rest),
                 "ref-store" => run_test_tool_ref_store(rest),
@@ -4859,6 +4860,63 @@ fn run_test_tool_submodule(rest: &[String]) -> Result<()> {
         }
         other => bail!("test-tool submodule: unknown subcommand '{other}'"),
     }
+}
+
+/// `test-tool dump-untracked-cache` — matches `git/t/helper/test-dump-untracked-cache.c`.
+fn run_test_tool_dump_untracked_cache() -> Result<()> {
+    use grit_lib::index::Index;
+    use grit_lib::repo::Repository;
+    use grit_lib::untracked_cache::UntrackedCacheDir;
+
+    let repo = Repository::discover(None).context("not a git repository")?;
+    let index = Index::load(&repo.index_path()).context("read index")?;
+    let Some(uc) = index.untracked_cache.as_ref() else {
+        println!("no untracked cache");
+        return Ok(());
+    };
+
+    println!("info/exclude {}", uc.ss_info_exclude.oid.to_hex());
+    println!("core.excludesfile {}", uc.ss_excludes_file.oid.to_hex());
+    println!("exclude_per_dir {}", uc.exclude_per_dir);
+    println!("flags {:08x}", uc.dir_flags);
+
+    fn dump(ucd: &UntrackedCacheDir, base: &mut String) {
+        let len = base.len();
+        base.push_str(&ucd.name);
+        base.push('/');
+        print!("{} {}", base, ucd.exclude_oid.to_hex());
+        if ucd.recurse {
+            print!(" recurse");
+        }
+        if ucd.check_only {
+            print!(" check_only");
+        }
+        if ucd.valid {
+            print!(" valid");
+        }
+        println!();
+
+        let mut names: Vec<_> = ucd.untracked.iter().cloned().collect();
+        names.sort();
+        for n in &names {
+            println!("{n}");
+        }
+
+        let mut dirs: Vec<_> = ucd.dirs.iter().collect();
+        dirs.sort_by(|a, b| a.name.cmp(&b.name));
+        for d in dirs {
+            dump(d, base);
+        }
+
+        base.truncate(len);
+    }
+
+    if let Some(root) = uc.root.as_ref() {
+        let mut base = String::new();
+        dump(root, &mut base);
+    }
+
+    Ok(())
 }
 
 /// Handle `test-tool chmtime` — get or set file modification times.

--- a/tests/t7063-status-untracked-cache.sh
+++ b/tests/t7063-status-untracked-cache.sh
@@ -5,6 +5,10 @@ test_description='test untracked cache'
 GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME=main
 export GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME
 
+# Upstream Git leaves cwd inside `worktree` after setup; this file relies on that.
+TEST_LIB_INHERIT_CWD=1
+export TEST_LIB_INHERIT_CWD
+
 . ./test-lib.sh
 
 # On some filesystems (e.g. FreeBSD's ext2 and ufs) directory mtime

--- a/tests/test-lib-tap.sh
+++ b/tests/test-lib-tap.sh
@@ -120,19 +120,24 @@ test_expect_success() {
 	fi
 	test_cleanup=:
 	test -z "$verbose" || say "expecting success of $TEST_NUMBER.$test_count '$description': $commands"
-	test_reset_cwd_to_trash
+	if test -z "${TEST_LIB_INHERIT_CWD-}"
+	then
+		test_reset_cwd_to_trash
+	fi
 	test -f "$TRASH_DIRECTORY/.test-exports" && . "$TRASH_DIRECTORY/.test-exports"
-	# Each test starts from the trash root so bodies can use stable relative paths (e.g. `cd
-	# repo`) even when a previous test left cwd inside a subdirectory.
-	cd "$TRASH_DIRECTORY" || exit 1
+	if test -z "${TEST_LIB_INHERIT_CWD-}"
+	then
+		cd "$TRASH_DIRECTORY" || exit 1
+	fi
 	test_run_ "$commands"
 	result=$?
-	# Each test case starts from the trash root; bodies often `cd` into subdirs and must not
-	# leave the harness cwd there (matches git/t/test-lib.sh: only initial cd into trash).
-	cd "$TRASH_DIRECTORY" || {
-		echo >&2 "BUG: cannot cd to TRASH_DIRECTORY=$TRASH_DIRECTORY"
-		result=1
-	}
+	if test -z "${TEST_LIB_INHERIT_CWD-}"
+	then
+		cd "$TRASH_DIRECTORY" || {
+			echo >&2 "BUG: cannot cd to TRASH_DIRECTORY=$TRASH_DIRECTORY"
+			result=1
+		}
+	fi
 	test -f "$TRASH_DIRECTORY/.test-exports" && . "$TRASH_DIRECTORY/.test-exports"
 	if test -f "$_TICK_FILE"
 	then
@@ -211,16 +216,25 @@ test_expect_failure() {
 	fi
 	test_cleanup=:
 	test -z "$verbose" || say "checking known breakage of $TEST_NUMBER.$test_count '$description': $commands"
-	test_reset_cwd_to_trash
+	if test -z "${TEST_LIB_INHERIT_CWD-}"
+	then
+		test_reset_cwd_to_trash
+	fi
 	_exports_file="$TRASH_DIRECTORY/.test-exports"
 	test -f "$_exports_file" && . "$_exports_file"
-	cd "$TRASH_DIRECTORY" || exit 1
+	if test -z "${TEST_LIB_INHERIT_CWD-}"
+	then
+		cd "$TRASH_DIRECTORY" || exit 1
+	fi
 	test_run_ "$commands" expecting_failure
 	result=$?
-	cd "$TRASH_DIRECTORY" || {
-		echo >&2 "BUG: cannot cd to TRASH_DIRECTORY=$TRASH_DIRECTORY"
-		result=1
-	}
+	if test -z "${TEST_LIB_INHERIT_CWD-}"
+	then
+		cd "$TRASH_DIRECTORY" || {
+			echo >&2 "BUG: cannot cd to TRASH_DIRECTORY=$TRASH_DIRECTORY"
+			result=1
+		}
+	fi
 	test -f "$_exports_file" && . "$_exports_file"
 	if test -f "$_TICK_FILE"
 	then

--- a/tests/test-lib.sh
+++ b/tests/test-lib.sh
@@ -1336,10 +1336,16 @@ test_atexit_handler () {
 
 test_eval_inner_ () {
 	local _eval_inner_ret
-	cd "$TRASH_DIRECTORY" || exit 1
+	if test -z "${TEST_LIB_INHERIT_CWD-}"
+	then
+		cd "$TRASH_DIRECTORY" || exit 1
+	fi
 	eval "$1"
 	_eval_inner_ret=$?
-	cd "$TRASH_DIRECTORY" || exit 1
+	if test -z "${TEST_LIB_INHERIT_CWD-}"
+	then
+		cd "$TRASH_DIRECTORY" || exit 1
+	fi
 	return "$_eval_inner_ret"
 }
 

--- a/tests/test-tool
+++ b/tests/test-tool
@@ -1313,6 +1313,16 @@ PY
         ;;
     esac
     ;;
+  dump-untracked-cache)
+    _grit="${GUST_BIN:-$SCRIPT_DIR/../target/release/grit}"
+    if [ ! -x "$_grit" ]; then
+      echo "test-tool dump-untracked-cache: no grit binary (set GUST_BIN)" >&2
+      exit 1
+    fi
+    if [ -n "$global_c_dir" ]; then
+      exec "$_grit" -C "$global_c_dir" test-tool dump-untracked-cache "$@"
+    fi
+    exec "$_grit" test-tool dump-untracked-cache "$@" ;;
   find-pack)
     shift
     exec "$SCRIPT_DIR/../target/release/grit" test-tool find-pack "$@" ;;


### PR DESCRIPTION
- Add EWAH bitmap and untracked_cache module; parse/write UNTR on Index
- Invalidate UNTR on index entry add/remove; update-index flags and GIT_INDEX_FILE
- status: refresh cache from core.untrackedCache, trace2 read_directory perf lines
- test-tool dump-untracked-cache routing; TEST_LIB_INHERIT_CWD for harness cwd
- Refresh test dashboards from harness CSV