### PR TITLE
fix: make t4045-diff-relative pass (relative diff, merge, external diff)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -723,7 +723,7 @@ t4041-diff-submodule-option	t4	yes	47	17	30	false	ok	0
 t4042-diff-textconv-caching	t4	yes	8	7	1	false	ok	0
 t4043-diff-rename-binary	t4	yes	3	2	1	false	ok	0
 t4044-diff-index-unique-abbrev	t4	yes	2	1	1	false	ok	0
-t4045-diff-relative	t4	yes	38	32	6	false	ok	1
+t4045-diff-relative	t4	yes	39	39	0	true	ok	0
 t4046-diff-unmerged	t4	yes	8	3	5	false	ok	0
 t4047-diff-dirstat	t4	yes	41	4	37	false	ok	0
 t4047-diff-numstat	t4	yes	26	26	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.2% of harness tests passing (35,289 / 45,112).">
+<meta property="og:description" content="78.2% of harness tests passing (35,296 / 45,113).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.2% of harness tests passing (35,289 / 45,112).">
+<meta name="twitter:description" content="78.2% of harness tests passing (35,296 / 45,113).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T15:06:57+00:00" class="gen-time" title="2026-04-09 15:06 UTC">2026-04-09 15:06 UTC</time> · <a href="https://github.com/schacon/grit/commit/c4ad2e9f44715e944bf5d633e8117c550d9c487c" style="color:#58a6ff">c4ad2e9</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T16:52:25+00:00" class="gen-time" title="2026-04-09 16:52 UTC">2026-04-09 16:52 UTC</time> · <a href="https://github.com/schacon/grit/commit/d453c985a004bbafaab0d0367914b362de89e59b" style="color:#58a6ff">d453c98</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,11 +157,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,289</div>
+      <div class="summary-big-val">35,296</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">45,112</div>
+      <div class="summary-big-val">45,113</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>733 files fully passing</span>
+    <span>734 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -230,11 +230,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">72/178 files · 2 skipped · 2,716/4,437 tests</span>
+        <span class="group-meta">73/178 files · 2 skipped · 2,723/4,438 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:61.2%"></div></div>
-        <span class="group-pct pct-blue">61.2%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:61.4%"></div></div>
+        <span class="group-pct pct-blue">61.4%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35289 of 45112 tests passing across 1405 harness files (78.2% pass rate).</desc>
+  <desc id="svg-desc">35296 of 45113 tests passing across 1405 harness files (78.2% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.2% pass rate · 35,289 / 45,112 tests · 1,405 files in scope · 733 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.2% pass rate · 35,296 / 45,113 tests · 1,405 files in scope · 734 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="547" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T15:06:57+00:00" class="gen-time" title="2026-04-09 15:06 UTC">2026-04-09 15:06 UTC</time> · <a href="https://github.com/schacon/grit/commit/c4ad2e9f44715e944bf5d633e8117c550d9c487c" style="color:#58a6ff">c4ad2e9</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T16:52:25+00:00" class="gen-time" title="2026-04-09 16:52 UTC">2026-04-09 16:52 UTC</time> · <a href="https://github.com/schacon/grit/commit/d453c985a004bbafaab0d0367914b362de89e59b" style="color:#58a6ff">d453c98</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,289</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n" id="sum-tests">45,113</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,296</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -7387,15 +7387,15 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="38" data-passed="32">
+<tr class="" data-group="t4" data-tests="39" data-passed="39" data-full-pass="1">
   <td class="mono">t4045-diff-relative</td>
   <td>t4</td>
-  <td></td>
-  <td class="right">38</td>
-  <td class="right">32</td>
+  <td><span class="badge ok">full pass</span></td>
+  <td class="right">39</td>
+  <td class="right">39</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:84.2%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="8" data-passed="3">
   <td class="mono">t4046-diff-unmerged</td>

--- a/grit-lib/src/combined_tree_diff.rs
+++ b/grit-lib/src/combined_tree_diff.rs
@@ -198,8 +198,8 @@ fn ll_diff_tree_paths(
             let e_i = tp_entries[i].get(tp_idx[i]);
             parent_neq[i] = tree_entry_pathcmp(e_i, e_imin) != std::cmp::Ordering::Equal;
         }
-        for i in 0..imin {
-            parent_neq[i] = true;
+        for ne in parent_neq.iter_mut().take(imin) {
+            *ne = true;
         }
 
         let p_min = tp_entries[imin].get(tp_idx[imin]);

--- a/grit-lib/src/merge_diff.rs
+++ b/grit-lib/src/merge_diff.rs
@@ -583,15 +583,7 @@ pub fn format_worktree_conflict_combined(
     } else {
         String::from_utf8_lossy(worktree_bytes).into_owned()
     };
-    let wt_for_conflict = if use_conv {
-        wt_text
-            .lines()
-            .map(|l| l.to_uppercase())
-            .collect::<Vec<_>>()
-            .join("\n")
-    } else {
-        wt_text.clone()
-    };
+    let wt_for_conflict = wt_text.clone();
 
     let p1a = abbrev_hex(stage2_oid, abbrev);
     let p2a = abbrev_hex(stage3_oid, abbrev);
@@ -645,11 +637,7 @@ fn conflict_combined_body(wt: &str) -> String {
             }
             if i < lines.len() {
                 let closing = lines[i];
-                if let Some(rest) = closing.strip_prefix(">>>>>>> ") {
-                    body.push_str(&format!("++>>>>>>> {}\n", rest.to_uppercase()));
-                } else {
-                    body.push_str(&format!("++{closing}\n"));
-                }
+                body.push_str(&format!("++{closing}\n"));
                 hunk_new += 1;
             }
             let header = format!(

--- a/grit/src/commands/diff.rs
+++ b/grit/src/commands/diff.rs
@@ -220,6 +220,7 @@ use std::env;
 use std::fs;
 use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 /// ANSI color codes for diff output.
 const RESET: &str = "\x1b[m";
 const BOLD: &str = "\x1b[1m";
@@ -1688,65 +1689,8 @@ pub fn run(mut args: Args) -> Result<()> {
     };
 
     // Apply --relative path prefix stripping.
-    let entries = if !args.no_relative {
-        let prefix = match &args.relative {
-            Some(Some(p)) if !p.is_empty() => {
-                // --relative=<path> — use the given prefix as a literal prefix.
-                // Git does NOT add a trailing '/' — `--relative=sub` matches `subdir/file`.
-                Some(p.clone())
-            }
-            Some(_) => {
-                // bare --relative — infer from CWD relative to work tree
-                if let Some(wt) = work_tree {
-                    if let Ok(cwd) = std::env::current_dir() {
-                        if let Ok(rel) = cwd.strip_prefix(wt) {
-                            let s = rel.to_string_lossy().to_string();
-                            if s.is_empty() {
-                                None
-                            } else {
-                                Some(format!("{s}/"))
-                            }
-                        } else {
-                            None
-                        }
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
-            }
-            None => {
-                // Check diff.relative config
-                use grit_lib::config::ConfigSet;
-                let config = ConfigSet::load(Some(&repo.git_dir), false)
-                    .unwrap_or_else(|_| ConfigSet::new());
-                match config.get("diff.relative") {
-                    Some(val) if matches!(val.to_lowercase().as_str(), "true" | "yes" | "1") => {
-                        // Infer from CWD
-                        if let Some(wt) = work_tree {
-                            if let Ok(cwd) = std::env::current_dir() {
-                                if let Ok(rel) = cwd.strip_prefix(wt) {
-                                    let s = rel.to_string_lossy().to_string();
-                                    if s.is_empty() {
-                                        None
-                                    } else {
-                                        Some(format!("{s}/"))
-                                    }
-                                } else {
-                                    None
-                                }
-                            } else {
-                                None
-                            }
-                        } else {
-                            None
-                        }
-                    }
-                    _ => None,
-                }
-            }
-        };
+    let entries = {
+        let prefix = resolve_diff_relative_prefix(work_tree, &repo.git_dir, &args);
         if let Some(ref pfx) = prefix {
             entries
                 .into_iter()
@@ -1780,8 +1724,6 @@ pub fn run(mut args: Args) -> Result<()> {
         } else {
             entries
         }
-    } else {
-        entries
     };
 
     // Apply orderfile sorting if specified
@@ -1841,6 +1783,23 @@ pub fn run(mut args: Args) -> Result<()> {
         }
     }
 
+    let dirstat_cli_active = !args.dirstat.is_empty() || args.dirstat_by_file.is_some();
+    let (dirstat_opts, dirstat_config_warnings) =
+        resolve_dirstat_options(&args, &repo.git_dir, dirstat_cli_active)?;
+    let relative_prefix_for_paths = resolve_diff_relative_prefix(work_tree, &repo.git_dir, &args);
+    let format_besides_unified_patch = args.shortstat
+        || stat_enabled
+        || args.stat_count.is_some()
+        || args.stat_width.is_some()
+        || args.stat_graph_width.is_some()
+        || args.stat_name_width.is_some()
+        || args.raw
+        || args.numstat
+        || args.name_only
+        || args.name_status
+        || (args.summary && !stat_enabled)
+        || dirstat_opts.is_some();
+
     let merge_in_progress = std::fs::metadata(repo.git_dir.join("MERGE_HEAD")).is_ok();
     let mut conflict_combined_patches: Vec<String> = Vec::new();
     if merge_in_progress && !args.cached && revs.is_empty() && work_tree.is_some() {
@@ -1862,8 +1821,12 @@ pub fn run(mut args: Args) -> Result<()> {
                 7
             };
             if let Some(wt) = work_tree {
-                for path in &conflict_paths {
-                    let key = path.as_bytes();
+                for display_path in &conflict_paths {
+                    let repo_path = repo_relative_path_for_relative_display(
+                        display_path,
+                        relative_prefix_for_paths.as_deref(),
+                    );
+                    let key = repo_path.as_bytes();
                     let Some(e1) = index.get(key, 1) else {
                         continue;
                     };
@@ -1873,13 +1836,13 @@ pub fn run(mut args: Args) -> Result<()> {
                     let Some(e3) = index.get(key, 3) else {
                         continue;
                     };
-                    let file_path = wt.join(path);
+                    let file_path = wt.join(&repo_path);
                     let wt_bytes = std::fs::read(&file_path).unwrap_or_default();
                     conflict_combined_patches.push(format_worktree_conflict_combined(
                         &repo.git_dir,
                         &config,
                         &repo.odb,
-                        path,
+                        display_path,
                         &e1.oid,
                         &e2.oid,
                         &e3.oid,
@@ -1888,13 +1851,19 @@ pub fn run(mut args: Args) -> Result<()> {
                     ));
                 }
             }
-            entries.retain(|e| {
-                if conflict_paths.iter().any(|p| p == e.path()) {
-                    e.status != DiffStatus::Unmerged && e.status != DiffStatus::Modified
-                } else {
-                    true
-                }
-            });
+            // Git keeps index↔worktree `U`/`M` lines for `--raw` / `--name-only` during conflicts;
+            // combined `diff --cc` replaces them only when unified patch is the sole format.
+            let strip_conflict_index_lines =
+                emit_unified_patch && !args.no_patch && !format_besides_unified_patch;
+            if strip_conflict_index_lines {
+                entries.retain(|e| {
+                    if conflict_paths.iter().any(|p| p == e.path()) {
+                        e.status != DiffStatus::Unmerged && e.status != DiffStatus::Modified
+                    } else {
+                        true
+                    }
+                });
+            }
         }
     }
 
@@ -1976,22 +1945,6 @@ pub fn run(mut args: Args) -> Result<()> {
 
     // `--quiet` alone suppresses stdout, but it still must honor `--exit-code` (below). `-s` /
     // `--no-patch` suppresses the unified patch without implying `--quiet`.
-    let dirstat_cli_active = !args.dirstat.is_empty() || args.dirstat_by_file.is_some();
-    let (dirstat_opts, dirstat_config_warnings) =
-        resolve_dirstat_options(&args, &repo.git_dir, dirstat_cli_active)?;
-
-    let format_besides_unified_patch = args.shortstat
-        || stat_enabled
-        || args.stat_count.is_some()
-        || args.stat_width.is_some()
-        || args.stat_graph_width.is_some()
-        || args.stat_name_width.is_some()
-        || args.raw
-        || args.numstat
-        || args.name_only
-        || args.name_status
-        || (args.summary && !stat_enabled)
-        || dirstat_opts.is_some();
     let quiet_suppresses_stdout = args.quiet && !format_besides_unified_patch;
 
     for w in &dirstat_config_warnings {
@@ -2112,6 +2065,14 @@ pub fn run(mut args: Args) -> Result<()> {
             if show_unified {
                 let diff_config = grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true)
                     .unwrap_or_default();
+                let external_diff_cmd = std::env::var("GIT_EXTERNAL_DIFF")
+                    .ok()
+                    .filter(|s| !s.trim().is_empty())
+                    .or_else(|| {
+                        diff_config
+                            .get("diff.external")
+                            .filter(|s| !s.trim().is_empty())
+                    });
                 write_patch_with_prefix(
                     &mut out,
                     &repo,
@@ -2138,6 +2099,9 @@ pub fn run(mut args: Args) -> Result<()> {
                     &diff_algo_ctx,
                     diff_algo_cli,
                     args.cached,
+                    args.no_ext_diff,
+                    external_diff_cmd.as_deref(),
+                    relative_prefix_for_paths.as_deref(),
                 )?;
             }
         }
@@ -3426,6 +3390,102 @@ fn write_dirstat(
     Ok(())
 }
 
+/// Prefix for `--relative` / `diff.relative` path stripping (trailing `/` except empty root).
+///
+/// `--no-relative` disables only the `diff.relative` config; explicit `--relative` on the CLI
+/// still applies (matches Git, t4045).
+fn resolve_diff_relative_prefix(
+    work_tree: Option<&Path>,
+    git_dir: &Path,
+    args: &Args,
+) -> Option<String> {
+    let from_cli = match &args.relative {
+        Some(Some(p)) if !p.is_empty() => Some(p.clone()),
+        Some(_) => {
+            if let Some(wt) = work_tree {
+                if let Ok(cwd) = std::env::current_dir() {
+                    if let Ok(rel) = cwd.strip_prefix(wt) {
+                        let s = rel.to_string_lossy().to_string();
+                        if s.is_empty() {
+                            None
+                        } else {
+                            Some(format!("{s}/"))
+                        }
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        }
+        None => None,
+    };
+    if from_cli.is_some() {
+        return from_cli;
+    }
+    if args.no_relative {
+        return None;
+    }
+    let config = ConfigSet::load(Some(git_dir), false).unwrap_or_else(|_| ConfigSet::new());
+    match config.get("diff.relative") {
+        Some(val) if matches!(val.to_lowercase().as_str(), "true" | "yes" | "1") => {
+            if let Some(wt) = work_tree {
+                if let Ok(cwd) = std::env::current_dir() {
+                    if let Ok(rel) = cwd.strip_prefix(wt) {
+                        let s = rel.to_string_lossy().to_string();
+                        if s.is_empty() {
+                            None
+                        } else {
+                            Some(format!("{s}/"))
+                        }
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Map a `--relative`-stripped display path back to the repository-relative path for index I/O.
+fn repo_relative_path_for_relative_display(display: &str, prefix: Option<&str>) -> String {
+    let Some(pfx) = prefix.filter(|s| !s.is_empty()) else {
+        return display.to_owned();
+    };
+    if pfx.ends_with('/') {
+        format!("{pfx}{display}")
+    } else {
+        format!("{pfx}/{display}")
+    }
+}
+
+/// Repository-relative path for attributes / worktree reads when `--relative` stripped display paths.
+fn repo_path_for_diff_entry(entry: &DiffEntry, relative_prefix: Option<&str>) -> String {
+    match relative_prefix {
+        Some(p) if !p.is_empty() => repo_relative_path_for_relative_display(entry.path(), Some(p)),
+        _ => entry.path().to_owned(),
+    }
+}
+
+/// Repo-relative path for one diff side label (`old_path` / `new_path` are display paths after `--relative`).
+fn repo_path_for_diff_side(display_path: &str, relative_prefix: Option<&str>) -> String {
+    if display_path == "/dev/null" {
+        return display_path.to_owned();
+    }
+    match relative_prefix {
+        Some(p) if !p.is_empty() => repo_relative_path_for_relative_display(display_path, Some(p)),
+        _ => display_path.to_owned(),
+    }
+}
+
 fn parse_rev_and_paths(args: &[String], has_separator: bool) -> (Vec<String>, Vec<String>) {
     if let Some(sep) = args.iter().position(|a| a == "--") {
         let revs = args[..sep].to_vec();
@@ -3954,6 +4014,73 @@ fn write_diff_header_with_prefix(
     Ok(())
 }
 
+/// Run `GIT_EXTERNAL_DIFF` / `diff.external` when set (Git-compatible argv: path, file, hex, mode ×2).
+///
+/// Matches Git's `prepare_shell_cmd` + `run_command` with `use_shell=1`.
+fn run_external_diff_for_patch(
+    out: &mut impl Write,
+    cmd_line: &str,
+    display_path: &str,
+    old_raw: &[u8],
+    new_raw: &[u8],
+    old_oid: &ObjectId,
+    new_oid: &ObjectId,
+    old_mode: &str,
+    new_mode: &str,
+) -> Result<()> {
+    let cmd_line = cmd_line.trim();
+    if cmd_line.is_empty() {
+        bail!("empty external diff command");
+    }
+    let old_tmp = tempfile::NamedTempFile::new().context("temp file for external diff (old)")?;
+    let new_tmp = tempfile::NamedTempFile::new().context("temp file for external diff (new)")?;
+    fs::write(old_tmp.path(), old_raw)?;
+    fs::write(new_tmp.path(), new_raw)?;
+    let old_hex = old_oid.to_hex();
+    let new_hex = new_oid.to_hex();
+    const SHELL_META: &[char] = &[
+        '|', '&', ';', '<', '>', '(', ')', '$', '`', '\\', '"', '\'', ' ', '\t', '\n', '*', '?',
+        '[', '#', '~', '=', '%',
+    ];
+    let needs_c = cmd_line.chars().any(|c| SHELL_META.contains(&c));
+    let mut cmd = Command::new("sh");
+    if needs_c {
+        let c_script = format!("{cmd_line} \"$@\"");
+        cmd.arg("-c")
+            .arg(&c_script)
+            .arg(cmd_line)
+            .arg(display_path)
+            .arg(old_tmp.path())
+            .arg(&old_hex)
+            .arg(old_mode)
+            .arg(new_tmp.path())
+            .arg(&new_hex)
+            .arg(new_mode);
+    } else {
+        cmd.arg(cmd_line)
+            .arg(display_path)
+            .arg(old_tmp.path())
+            .arg(&old_hex)
+            .arg(old_mode)
+            .arg(new_tmp.path())
+            .arg(&new_hex)
+            .arg(new_mode);
+    }
+    let mut child = cmd
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .with_context(|| format!("failed to spawn external diff {cmd_line:?}"))?;
+    let mut stdout = child.stdout.take().context("external diff stdout")?;
+    io::copy(&mut stdout, out)?;
+    let status = child.wait().context("waiting for external diff")?;
+    if !status.success() {
+        bail!("external diff exited with {status}");
+    }
+    Ok(())
+}
+
 fn write_patch_with_prefix(
     out: &mut impl Write,
     repo: &Repository,
@@ -3980,10 +4107,14 @@ fn write_patch_with_prefix(
     algo_ctx: &DiffAlgoContext,
     algo_cli: Option<similar::Algorithm>,
     cached: bool,
+    no_ext_diff: bool,
+    external_diff_cmd: Option<&str>,
+    relative_prefix: Option<&str>,
 ) -> Result<()> {
     for entry in entries {
         let old_path = entry.old_path.as_deref().unwrap_or("/dev/null");
         let new_path = entry.new_path.as_deref().unwrap_or("/dev/null");
+        let path_for_attrs = repo_path_for_diff_entry(entry, relative_prefix);
 
         if let Some(fmt) = submodule_fmt {
             if entry.old_mode == "160000" || entry.new_mode == "160000" {
@@ -4009,7 +4140,37 @@ fn write_patch_with_prefix(
                         work_tree,
                         true,
                         submodule_ignore,
-                        entry.path(),
+                        &path_for_attrs,
+                    )?;
+                    continue;
+                }
+            }
+        }
+
+        let old_wt_path = repo_path_for_diff_side(old_path, relative_prefix);
+        let old_content_raw = if entry.old_oid == zero_oid() {
+            read_content_raw_or_worktree(odb, &entry.old_oid, work_tree, &old_wt_path)
+        } else {
+            read_content_raw(odb, &entry.old_oid)
+        };
+        let wt_path = path_for_attrs.clone();
+        let new_content_raw =
+            read_content_raw_or_worktree(odb, &entry.new_oid, work_tree, &wt_path);
+
+        if !no_ext_diff {
+            if let Some(ext) = external_diff_cmd.filter(|s| !s.is_empty()) {
+                if entry.status != DiffStatus::Unmerged {
+                    let display = entry.path();
+                    run_external_diff_for_patch(
+                        out,
+                        ext,
+                        display,
+                        &old_content_raw,
+                        &new_content_raw,
+                        &entry.old_oid,
+                        &entry.new_oid,
+                        &entry.old_mode,
+                        &entry.new_mode,
                     )?;
                     continue;
                 }
@@ -4068,10 +4229,6 @@ fn write_patch_with_prefix(
         }
 
         // Check for binary content
-        let old_content_raw = read_content_raw(odb, &entry.old_oid);
-        let new_content_raw =
-            read_content_raw_or_worktree(odb, &entry.new_oid, work_tree, new_path);
-
         // `git diff --cached` for a newly staged empty file: header + index line only, no hunks
         // (t1501-work-tree `diff-TREE-cached.expected`).
         if cached && entry.status == DiffStatus::Added && new_content_raw.is_empty() {
@@ -4089,8 +4246,8 @@ fn write_patch_with_prefix(
             continue;
         }
 
-        let path_for_attrs = entry.path();
-        let textconv_patch = use_textconv && diff_textconv_active(git_dir, config, path_for_attrs);
+        let textconv_patch =
+            use_textconv && diff_textconv_active(git_dir, config, path_for_attrs.as_str());
         if !textconv_patch && (is_binary(&old_content_raw) || is_binary(&new_content_raw)) {
             if show_binary {
                 // --binary: output a "GIT binary patch" block
@@ -4118,7 +4275,7 @@ fn write_patch_with_prefix(
                 odb,
                 git_dir,
                 config,
-                path_for_attrs,
+                path_for_attrs.as_str(),
                 &old_content_raw,
                 &entry.old_oid,
                 true,
@@ -4133,7 +4290,7 @@ fn write_patch_with_prefix(
                 odb,
                 git_dir,
                 config,
-                path_for_attrs,
+                path_for_attrs.as_str(),
                 &new_content_raw,
                 &entry.new_oid,
                 true,
@@ -4217,13 +4374,12 @@ fn write_patch_with_prefix(
                 write!(out, "{patch}")?;
             }
         } else {
-            let rel_for_attrs = entry.path();
-            let algo = diff_algorithm_for_path(rel_for_attrs, algo_cli, algo_ctx);
+            let algo = diff_algorithm_for_path(path_for_attrs.as_str(), algo_cli, algo_ctx);
             let func_matcher = matcher_for_path_parsed(
                 algo_ctx.config.as_ref(),
                 &algo_ctx.attrs.rules,
                 &algo_ctx.attrs.macros,
-                rel_for_attrs,
+                path_for_attrs.as_str(),
                 algo_ctx.ignore_case_attrs,
             )
             .unwrap_or(None);

--- a/tests/t4045-diff-relative.sh
+++ b/tests/t4045-diff-relative.sh
@@ -223,7 +223,7 @@ test_expect_success 'diff --relative --name-only with change in subdir' '
 	test_cmp expected out
 '
 
-test_expect_failure 'diff --relative with change in subdir' '
+test_expect_success 'diff --relative with change in subdir' '
 	git switch br3 &&
 	br1_blob=$(git rev-parse --short --verify br1:subdir/file0) &&
 	br3_blob=$(git rev-parse --short --verify br3:subdir/file0) &&


### PR DESCRIPTION
- Treat --no-relative as disabling diff.relative config only; explicit --relative still applies
- During merge conflicts, keep U/M index lines for --name-only/--raw; strip only for patch-only output
- Resolve combined conflict patches and worktree reads using repo paths when paths are --relative-stripped
- Implement GIT_EXTERNAL_DIFF / diff.external via sh (Git-compatible argv)
- Stop uppercasing conflict marker bodies in format_worktree_conflict_combined
- Flip t4045 unmerged case to test_expect_success; refresh harness CSV and dashboards