### PR TITLE
fix: print git add --dry-run plans on stdout (t2200)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -512,7 +512,7 @@ t2105-update-index-gitfile	t2	yes	4	4	0	true	ok	0
 t2106-update-index-assume-unchanged	t2	yes	2	2	0	true	ok	0
 t2107-update-index-basic	t2	yes	10	10	0	true	ok	0
 t2108-update-index-refresh-racy	t2	yes	6	0	6	false	ok	0
-t2200-add-update	t2	yes	19	18	1	false	ok	0
+t2200-add-update	t2	yes	19	19	0	true	ok	0
 t2201-add-update-typechange	t2	yes	6	2	4	false	ok	0
 t2202-add-addremove	t2	yes	3	3	0	true	ok	0
 t2203-add-intent	t2	yes	19	14	5	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.3% of harness tests passing (35,304 / 45,112).">
+<meta property="og:description" content="78.3% of harness tests passing (35,305 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.3% of harness tests passing (35,304 / 45,112).">
+<meta name="twitter:description" content="78.3% of harness tests passing (35,305 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T15:27:31+00:00" class="gen-time" title="2026-04-09 15:27 UTC">2026-04-09 15:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/8954f0b086547ef9893afc7c773faf6131386c16" style="color:#58a6ff">8954f0b</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T16:37:46+00:00" class="gen-time" title="2026-04-09 16:37 UTC">2026-04-09 16:37 UTC</time> · <a href="https://github.com/schacon/grit/commit/4ac4d9c2fd66918bb5633180c65131719b9e71f4" style="color:#58a6ff">4ac4d9c</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,304</div>
+      <div class="summary-big-val">35,305</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>739 files fully passing</span>
+    <span>740 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -208,11 +208,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t2</span>
         <span class="group-desc">Basic commands concerning the working tree</span>
-        <span class="group-meta">29/61 files · 9 skipped · 664/872 tests</span>
+        <span class="group-meta">30/61 files · 9 skipped · 665/872 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:76.1%"></div></div>
-        <span class="group-pct pct-blue">76.1%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:76.3%"></div></div>
+        <span class="group-pct pct-blue">76.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t3">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35304 of 45112 tests passing across 1405 harness files (78.3% pass rate).</desc>
+  <desc id="svg-desc">35305 of 45112 tests passing across 1405 harness files (78.3% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.3% pass rate · 35,304 / 45,112 tests · 1,405 files in scope · 739 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.3% pass rate · 35,305 / 45,112 tests · 1,405 files in scope · 740 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="548" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T15:27:31+00:00" class="gen-time" title="2026-04-09 15:27 UTC">2026-04-09 15:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/8954f0b086547ef9893afc7c773faf6131386c16" style="color:#58a6ff">8954f0b</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T16:37:46+00:00" class="gen-time" title="2026-04-09 16:37 UTC">2026-04-09 16:37 UTC</time> · <a href="https://github.com/schacon/grit/commit/4ac4d9c2fd66918bb5633180c65131719b9e71f4" style="color:#58a6ff">4ac4d9c</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,304</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,305</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.3%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -5277,14 +5277,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t2" data-tests="19" data-passed="18">
+<tr class="" data-group="t2" data-tests="19" data-passed="19" data-full-pass="1">
   <td class="mono">t2200-add-update</td>
   <td>t2</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">19</td>
-  <td class="right">18</td>
+  <td class="right">19</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:94.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t2" data-tests="6" data-passed="2">

--- a/grit/src/commands/add.rs
+++ b/grit/src/commands/add.rs
@@ -900,7 +900,7 @@ fn update_tracked(
                     );
                     let current = index.get(raw_path, 0);
                     if current.map(|e| e.oid != oid).unwrap_or(false) {
-                        eprintln!("add '{path_str}'");
+                        println!("add '{path_str}'");
                     }
                 }
             } else {
@@ -917,7 +917,7 @@ fn update_tracked(
             }
         } else {
             if args.verbose || args.dry_run {
-                eprintln!("remove '{path_str}'");
+                println!("remove '{path_str}'");
             }
             if !args.dry_run {
                 index.remove(raw_path);
@@ -1287,7 +1287,7 @@ pub(crate) fn stage_file(
             // Don't actually stage, just check if the file exists
             return Ok(());
         }
-        eprintln!("add '{rel_path}'");
+        println!("add '{rel_path}'");
         return Ok(());
     }
 

--- a/logs/2026-04-09_t2200-add-dry-run-stdout.md
+++ b/logs/2026-04-09_t2200-add-dry-run-stdout.md
@@ -1,0 +1,14 @@
+# t2200-add-update: dry-run output on stdout
+
+## Failure
+
+Test 16 `add -n -u should not add but just report` compared `git add -n -u >actual` to an expected file with `add 'check'` and `remove 'top'`. Grit printed those lines on stderr via `eprintln!`, so stdout was empty and `test_cmp` failed.
+
+## Fix
+
+In `grit/src/commands/add.rs`, use `println!` for dry-run `add`/`remove` messages in `update_tracked` and in `stage_file` when `ctx.dry_run` (matches Git: informational dry-run lines go to stdout).
+
+## Verification
+
+- `./scripts/run-tests.sh t2200-add-update.sh` → 19/19 pass
+- `cargo test -p grit-lib --lib` → pass


### PR DESCRIPTION
Match Git's behavior for add -n/-u: planned add/remove lines go to stdout so harness tests can redirect and compare. Index and object store stay unchanged.