### PR TITLE
test: t13210-rev-list-count-all harness at 33/33

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -378,7 +378,7 @@ t13150-diff-stat-insertions-deletions	t1	yes	42	40	2	false	ok	0
 t13180-log-patch-stat	t1	yes	35	34	1	false	ok	0
 t13190-log-format-body	t1	yes	36	36	0	true	ok	0
 t13200-rev-list-walk-options	t1	yes	35	35	0	true	ok	0
-t13210-rev-list-count-all	t1	yes	33	31	2	false	ok	0
+t13210-rev-list-count-all	t1	yes	33	33	0	true	ok	0
 t13220-rev-parse-worktree	t1	yes	36	36	0	true	ok	0
 t13230-rev-parse-upstream	t1	yes	35	35	0	true	ok	0
 t13240-config-get-all-values	t1	yes	32	32	0	true	ok	0
@@ -1193,7 +1193,7 @@ t7111-reset-table	t7	yes	42	34	8	false	ok	0
 t7112-reset-submodule	t7	yes	76	24	52	false	ok	0
 t7113-post-index-change-hook	t7	yes	4	1	3	false	ok	0
 t7201-co	t7	yes	46	17	29	false	ok	0
-t7300-clean	t7	yes	53	52	1	false	ok	2
+t7300-clean	t7	yes	53	52	1	false	ok	0
 t7301-clean-interactive	t7	yes	23	8	15	false	ok	0
 t7400-submodule-basic	t7	yes	124	51	73	false	ok	0
 t7401-submodule-summary	t7	yes	25	6	19	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.8% of harness tests passing (35,530 / 45,112).">
+<meta property="og:description" content="78.8% of harness tests passing (35,535 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.8% of harness tests passing (35,530 / 45,112).">
+<meta name="twitter:description" content="78.8% of harness tests passing (35,535 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T16:30:42+00:00" class="gen-time" title="2026-04-09 16:30 UTC">2026-04-09 16:30 UTC</time> · <a href="https://github.com/schacon/grit/commit/7cfe71677eb58eb382a548e40cc0ad9e587d560d" style="color:#58a6ff">7cfe716</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T17:58:25+00:00" class="gen-time" title="2026-04-09 17:58 UTC">2026-04-09 17:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/cbee7d7f221f5433fc3bf9357584a1381a064ebb" style="color:#58a6ff">cbee7d7</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,530</div>
+      <div class="summary-big-val">35,535</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>746 files fully passing</span>
+    <span>749 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -197,11 +197,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">273/368 files · 8 skipped · 11,695/12,747 tests</span>
+        <span class="group-meta">274/368 files · 8 skipped · 11,697/12,747 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:91.7%"></div></div>
-        <span class="group-pct pct-green">91.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:91.8%"></div></div>
+        <span class="group-pct pct-green">91.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t2">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">46/126 files · 11 skipped · 2,475/3,614 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,478/3,614 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.5%"></div></div>
-        <span class="group-pct pct-blue">68.5%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.6%"></div></div>
+        <span class="group-pct pct-blue">68.6%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35530 of 45112 tests passing across 1405 harness files (78.8% pass rate).</desc>
+  <desc id="svg-desc">35535 of 45112 tests passing across 1405 harness files (78.8% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.8% pass rate · 35,530 / 45,112 tests · 1,405 files in scope · 746 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.8% pass rate · 35,535 / 45,112 tests · 1,405 files in scope · 749 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="552" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T16:30:42+00:00" class="gen-time" title="2026-04-09 16:30 UTC">2026-04-09 16:30 UTC</time> · <a href="https://github.com/schacon/grit/commit/7cfe71677eb58eb382a548e40cc0ad9e587d560d" style="color:#58a6ff">7cfe716</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T17:58:25+00:00" class="gen-time" title="2026-04-09 17:58 UTC">2026-04-09 17:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/cbee7d7f221f5433fc3bf9357584a1381a064ebb" style="color:#58a6ff">cbee7d7</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,530</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,535</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.8%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -3937,14 +3937,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="33" data-passed="31">
+<tr class="" data-group="t1" data-tests="33" data-passed="33" data-full-pass="1">
   <td class="mono">t13210-rev-list-count-all</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">33</td>
-  <td class="right">31</td>
+  <td class="right">33</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:93.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="36" data-passed="36" data-full-pass="1">
@@ -11717,14 +11717,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:80.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="11" data-passed="10">
+<tr class="" data-group="t7" data-tests="11" data-passed="11" data-full-pass="1">
   <td class="mono">t7012-skip-worktree-writing</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">11</td>
-  <td class="right">10</td>
+  <td class="right">11</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">6</td>
 </tr>
 <tr class="" data-group="t7" data-tests="26" data-passed="26" data-full-pass="1">
@@ -12095,7 +12095,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">52</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.1%"></div></div></td>
-  <td class="right small">2</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="23" data-passed="8">
   <td class="mono">t7301-clean-interactive</td>
@@ -12917,14 +12917,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
   <td class="right small">7</td>
 </tr>
-<tr class="" data-group="t7" data-tests="22" data-passed="20">
+<tr class="" data-group="t7" data-tests="22" data-passed="22" data-full-pass="1">
   <td class="mono">t7815-grep-binary</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">22</td>
-  <td class="right">20</td>
+  <td class="right">22</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="145" data-passed="145" data-full-pass="1">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t13210-rev-list-count-all.sh` already passes all 33 tests against current `grit` (`rev-list --count`, `--all`, range syntax, `--max-count`, `--skip`, full 40-char hashes).

This change refreshes `data/test-files.csv` and the generated dashboards from `./scripts/run-tests.sh t13210-rev-list-count-all.sh` so the project records **33/33** and **0 failures**.

## Verification

- `./scripts/run-tests.sh t13210-rev-list-count-all.sh` → 33/33
- `cargo test -p grit-lib --lib` → pass

## Note

`cargo clippy -D warnings` reports many pre-existing issues in the workspace; not addressed here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-719f23b2-e039-4c06-8709-0f801450c32a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-719f23b2-e039-4c06-8709-0f801450c32a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

