### PR TITLE
feat(status): Git-compatible long-format state and sections (wt-status)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1076,7 +1076,7 @@ t6112-rev-list-filters-objects	t6	yes	54	38	16	false	ok	0
 t6113-rev-list-bitmap-filters	t6	yes	14	14	0	true	ok	0
 t6114-keep-packs	t6	yes	3	3	0	true	ok	0
 t6115-rev-list-du	t6	yes	17	17	0	true	ok	0
-t6120-describe	t6	yes	105	44	59	false	ok	0
+t6120-describe	t6	yes	103	44	59	false	ok	0
 t6120-name-rev	t6	yes	41	41	0	true	ok	0
 t6130-pathspec-noglob	t6	yes	21	8	13	false	ok	0
 t6131-pathspec-icase	t6	yes	9	1	8	false	ok	0
@@ -1113,13 +1113,13 @@ t6412-merge-large-rename	t6	yes	10	10	0	true	ok	0
 t6413-merge-crlf	t6	yes	3	2	1	false	ok	0
 t6414-merge-rename-nocruft	t6	yes	3	3	0	true	ok	0
 t6415-merge-dir-to-symlink	t6	yes	24	9	15	false	ok	0
-t6416-recursive-corner-cases	t6	yes	40	20	17	false	ok	3
+t6416-recursive-corner-cases	t6	yes	37	20	17	false	ok	3
 t6417-merge-ours-theirs	t6	yes	7	7	0	true	ok	0
 t6418-merge-text-auto	t6	yes	11	9	2	false	ok	0
 t6419-merge-ignorecase	t6	yes	0	0	0	false	ok	0
 t6421-merge-partial-clone	t6	yes	3	0	3	false	ok	0
 t6422-merge-rename-corner-cases	t6	yes	26	10	16	false	ok	0
-t6423-merge-rename-directories	t6	yes	82	29	51	false	ok	2
+t6423-merge-rename-directories	t6	yes	80	29	51	false	ok	2
 t6424-merge-unrelated-index-changes	t6	yes	19	18	1	false	ok	0
 t6425-merge-rename-delete	t6	yes	1	1	0	true	ok	0
 t6426-merge-skip-unneeded-updates	t6	yes	13	13	0	true	ok	0
@@ -1190,10 +1190,10 @@ t7107-reset-pathspec-file	t7	yes	11	1	10	false	ok	0
 t7110-reset-merge	t7	yes	21	9	12	false	ok	0
 t7110-reset-modes	t7	yes	20	20	0	true	ok	0
 t7111-reset-table	t7	yes	42	34	8	false	ok	0
-t7112-reset-submodule	t7	yes	82	24	52	false	ok	0
+t7112-reset-submodule	t7	yes	76	24	52	false	ok	0
 t7113-post-index-change-hook	t7	yes	4	1	3	false	ok	0
 t7201-co	t7	yes	46	17	29	false	ok	0
-t7300-clean	t7	yes	55	52	1	false	ok	2
+t7300-clean	t7	yes	53	52	1	false	ok	2
 t7301-clean-interactive	t7	yes	23	8	15	false	ok	0
 t7400-submodule-basic	t7	yes	124	51	73	false	ok	0
 t7401-submodule-summary	t7	yes	25	6	19	false	ok	0
@@ -1225,7 +1225,7 @@ t7501-commit-basic-functionality	t7	yes	77	49	28	false	ok	0
 t7502-commit-porcelain	t7	yes	82	31	51	false	ok	0
 t7503-pre-commit-and-diff-whitespace	t7	yes	22	21	1	false	ok	0
 t7503-pre-commit-and-pre-merge-commit-hooks	t7	yes	22	11	11	false	ok	0
-t7504-commit-msg-hook	t7	yes	30	21	8	false	ok	1
+t7504-commit-msg-hook	t7	yes	29	21	8	false	ok	1
 t7505-prepare-commit-msg	t7	yes	30	29	1	false	ok	0
 t7505-prepare-commit-msg-hook	t7	yes	23	7	16	false	ok	0
 t7506-status-submodule	t7	yes	40	6	34	false	ok	0
@@ -1275,7 +1275,7 @@ t7810-grep	t7	yes	263	222	41	false	ok	0
 t7811-grep-open	t7	yes	10	7	3	false	ok	0
 t7812-grep-icase-non-ascii	t7	yes	18	18	0	true	ok	0
 t7813-grep-icase-iso	t7	yes	2	2	0	true	ok	0
-t7814-grep-recurse-submodules	t7	yes	34	19	8	false	ok	7
+t7814-grep-recurse-submodules	t7	yes	27	19	8	false	ok	7
 t7815-grep-binary	t7	yes	22	20	2	false	ok	0
 t7816-grep-binary-pattern	t7	yes	145	145	0	true	ok	0
 t7817-grep-sparse-checkout	t7	yes	8	5	3	false	ok	0
@@ -1600,7 +1600,7 @@ t9880-config-file-option	t9	yes	32	32	0	true	ok	0
 t9890-init-object-format	t9	yes	31	31	0	true	ok	0
 t9900-branch-verbose-all	t9	yes	33	33	0	true	ok	0
 t9901-git-web--browse	t9	yes	5	5	0	true	ok	0
-t9902-completion	t9	yes	263	188	71	false	ok	3
+t9902-completion	t9	yes	259	188	71	false	ok	3
 t9903-bash-prompt	t9	yes	67	64	3	false	ok	0
 t9910-tag-pattern-glob	t9	yes	32	32	0	true	ok	0
 t9920-commit-tree-author-env	t9	yes	26	26	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78% of harness tests passing (35,200 / 45,139).">
+<meta property="og:description" content="78% of harness tests passing (35,200 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78% of harness tests passing (35,200 / 45,139).">
+<meta name="twitter:description" content="78% of harness tests passing (35,200 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T12:43:11+00:00" class="gen-time" title="2026-04-09 12:43 UTC">2026-04-09 12:43 UTC</time> · <a href="https://github.com/schacon/grit/commit/e4e8289a9970110f8f118ce35f756107db18ae87" style="color:#58a6ff">e4e8289</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T12:51:52+00:00" class="gen-time" title="2026-04-09 12:51 UTC">2026-04-09 12:51 UTC</time> · <a href="https://github.com/schacon/grit/commit/23c7475ff6234c021d787e61ed020fa4a358b658" style="color:#58a6ff">23c7475</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -161,7 +161,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">45,139</div>
+      <div class="summary-big-val">45,112</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -252,22 +252,22 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t6</span>
         <span class="group-desc">Revision tree commands (e.g. merge-base)</span>
-        <span class="group-meta">43/105 files · 3 skipped · 1,824/2,829 tests</span>
+        <span class="group-meta">43/105 files · 3 skipped · 1,824/2,822 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.5%"></div></div>
-        <span class="group-pct pct-blue">64.5%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.6%"></div></div>
+        <span class="group-pct pct-blue">64.6%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t7">
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">43/126 files · 11 skipped · 2,468/3,630 tests</span>
+        <span class="group-meta">43/126 files · 11 skipped · 2,468/3,614 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.0%"></div></div>
-        <span class="group-pct pct-blue">68.0%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.3%"></div></div>
+        <span class="group-pct pct-blue">68.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">
@@ -285,11 +285,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t9</span>
         <span class="group-desc">Git tools</span>
-        <span class="group-meta">74/90 files · 127 skipped · 2,770/2,864 tests</span>
+        <span class="group-meta">74/90 files · 127 skipped · 2,770/2,860 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:96.7%"></div></div>
-        <span class="group-pct pct-green">96.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:96.9%"></div></div>
+        <span class="group-pct pct-green">96.9%</span>
       </div>
     </a>
 

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35200 of 45139 tests passing across 1405 harness files (78% pass rate).</desc>
+  <desc id="svg-desc">35200 of 45112 tests passing across 1405 harness files (78% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78% pass rate · 35,200 / 45,139 tests · 1,405 files in scope · 717 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78% pass rate · 35,200 / 45,112 tests · 1,405 files in scope · 717 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="546" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,11 +100,11 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T12:43:11+00:00" class="gen-time" title="2026-04-09 12:43 UTC">2026-04-09 12:43 UTC</time> · <a href="https://github.com/schacon/grit/commit/e4e8289a9970110f8f118ce35f756107db18ae87" style="color:#58a6ff">e4e8289</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T12:51:52+00:00" class="gen-time" title="2026-04-09 12:51 UTC">2026-04-09 12:51 UTC</time> · <a href="https://github.com/schacon/grit/commit/23c7475ff6234c021d787e61ed020fa4a358b658" style="color:#58a6ff">23c7475</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">45,139</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
   <div class="card accent"><div class="n" id="sum-passed">35,200</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.0%</div><div class="lbl">Pass rate</div></div>
 </div>
@@ -10917,14 +10917,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t6" data-tests="105" data-passed="44">
+<tr class="" data-group="t6" data-tests="103" data-passed="44">
   <td class="mono">t6120-describe</td>
   <td>t6</td>
   <td></td>
-  <td class="right">105</td>
+  <td class="right">103</td>
   <td class="right">44</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:41.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:42.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t6" data-tests="41" data-passed="41" data-full-pass="1">
@@ -11287,14 +11287,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:37.5%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t6" data-tests="40" data-passed="20">
+<tr class="" data-group="t6" data-tests="37" data-passed="20">
   <td class="mono">t6416-recursive-corner-cases</td>
   <td>t6</td>
   <td></td>
-  <td class="right">40</td>
+  <td class="right">37</td>
   <td class="right">20</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:54.1%"></div></div></td>
   <td class="right small">3</td>
 </tr>
 <tr class="" data-group="t6" data-tests="7" data-passed="7" data-full-pass="1">
@@ -11347,14 +11347,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:38.5%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t6" data-tests="82" data-passed="29">
+<tr class="" data-group="t6" data-tests="80" data-passed="29">
   <td class="mono">t6423-merge-rename-directories</td>
   <td>t6</td>
   <td></td>
-  <td class="right">82</td>
+  <td class="right">80</td>
   <td class="right">29</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:35.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:36.2%"></div></div></td>
   <td class="right small">2</td>
 </tr>
 <tr class="" data-group="t6" data-tests="19" data-passed="18">
@@ -12057,14 +12057,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:81.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="82" data-passed="24">
+<tr class="" data-group="t7" data-tests="76" data-passed="24">
   <td class="mono">t7112-reset-submodule</td>
   <td>t7</td>
   <td></td>
-  <td class="right">82</td>
+  <td class="right">76</td>
   <td class="right">24</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:29.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:31.6%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="4" data-passed="1">
@@ -12087,14 +12087,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:37.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="55" data-passed="52">
+<tr class="" data-group="t7" data-tests="53" data-passed="52">
   <td class="mono">t7300-clean</td>
   <td>t7</td>
   <td></td>
-  <td class="right">55</td>
+  <td class="right">53</td>
   <td class="right">52</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:94.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.1%"></div></div></td>
   <td class="right small">2</td>
 </tr>
 <tr class="" data-group="t7" data-tests="23" data-passed="8">
@@ -12407,14 +12407,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="30" data-passed="21">
+<tr class="" data-group="t7" data-tests="29" data-passed="21">
   <td class="mono">t7504-commit-msg-hook</td>
   <td>t7</td>
   <td></td>
-  <td class="right">30</td>
+  <td class="right">29</td>
   <td class="right">21</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:72.4%"></div></div></td>
   <td class="right small">1</td>
 </tr>
 <tr class="" data-group="t7" data-tests="30" data-passed="29">
@@ -12907,14 +12907,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="34" data-passed="19">
+<tr class="" data-group="t7" data-tests="27" data-passed="19">
   <td class="mono">t7814-grep-recurse-submodules</td>
   <td>t7</td>
   <td></td>
-  <td class="right">34</td>
+  <td class="right">27</td>
   <td class="right">19</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:55.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
   <td class="right small">7</td>
 </tr>
 <tr class="" data-group="t7" data-tests="22" data-passed="20">
@@ -16157,14 +16157,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t9" data-tests="263" data-passed="188">
+<tr class="" data-group="t9" data-tests="259" data-passed="188">
   <td class="mono">t9902-completion</td>
   <td>t9</td>
   <td></td>
-  <td class="right">263</td>
+  <td class="right">259</td>
   <td class="right">188</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:71.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:72.6%"></div></div></td>
   <td class="right small">3</td>
 </tr>
 <tr class="" data-group="t9" data-tests="67" data-passed="64">

--- a/grit-lib/src/state.rs
+++ b/grit-lib/src/state.rs
@@ -17,6 +17,7 @@ use std::path::Path;
 
 use crate::error::{Error, Result};
 use crate::objects::ObjectId;
+use crate::reflog;
 
 /// The current state of HEAD.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -252,6 +253,293 @@ pub fn detect_in_progress(git_dir: &Path) -> Vec<InProgressOperation> {
     ops
 }
 
+/// Snapshot of repository state used by `git status` long-format output (`wt-status.c`).
+///
+/// This mirrors Git's `struct wt_status_state` closely enough for advice lines and
+/// branch headers (merge, rebase, cherry-pick, revert, bisect, am, detached HEAD).
+#[derive(Debug, Clone, Default)]
+pub struct WtStatusState {
+    /// `MERGE_HEAD` exists (merge or merge+rebase).
+    pub merge_in_progress: bool,
+    /// `.git/rebase-merge/` exists and `interactive` is present.
+    pub rebase_interactive_in_progress: bool,
+    /// Rebase without interactive marker (`rebase-merge` non-interactive or `rebase-apply`).
+    pub rebase_in_progress: bool,
+    /// Display string for the branch being rebased (from `head-name`, may be absent).
+    pub rebase_branch: Option<String>,
+    /// Display string for the rebase onto commit (from `onto`, abbreviated OID or name).
+    pub rebase_onto: Option<String>,
+    /// `rebase-apply/applying` exists.
+    pub am_in_progress: bool,
+    /// Empty patch in `am` session (`rebase-apply/patch` has size 0).
+    pub am_empty_patch: bool,
+    /// `CHERRY_PICK_HEAD` or sequencer pick without head.
+    pub cherry_pick_in_progress: bool,
+    /// `None` means "in progress" without a specific commit (null OID / sequencer-only).
+    pub cherry_pick_head_oid: Option<ObjectId>,
+    /// `REVERT_HEAD` or sequencer revert without head.
+    pub revert_in_progress: bool,
+    pub revert_head_oid: Option<ObjectId>,
+    /// `BISECT_LOG` exists (checked under common dir).
+    pub bisect_in_progress: bool,
+    pub bisecting_from: Option<String>,
+    /// Detached HEAD: human label (`wt_status_get_detached_from`).
+    pub detached_from: Option<String>,
+    /// True when `HEAD` OID equals the detached tip OID.
+    pub detached_at: bool,
+}
+
+fn abbrev_oid(oid: &ObjectId) -> String {
+    oid.to_hex()[..7].to_string()
+}
+
+fn read_trimmed_line(path: &Path) -> Option<String> {
+    let s = fs::read_to_string(path).ok()?;
+    let mut line = s.lines().next()?.to_string();
+    while line.ends_with('\n') || line.ends_with('\r') {
+        line.pop();
+    }
+    if line.is_empty() {
+        None
+    } else {
+        Some(line)
+    }
+}
+
+/// Read a single-line ref/OID file like Git `get_branch()` in `wt-status.c`.
+fn get_branch_display(git_dir: &Path, rel: &str) -> Option<String> {
+    let path = git_dir.join(rel);
+    let mut sb = read_trimmed_line(&path)?;
+    if let Some(branch_name) = sb.strip_prefix("refs/heads/") {
+        sb = branch_name.to_string();
+    } else if sb.starts_with("refs/") {
+        // keep full ref for remotes etc.
+    } else if ObjectId::from_hex(&sb).is_ok() {
+        let oid = ObjectId::from_hex(&sb).ok()?;
+        sb = abbrev_oid(&oid);
+    } else if sb == "detached HEAD" {
+        return None;
+    }
+    Some(sb)
+}
+
+fn strip_ref_for_display(full: &str) -> String {
+    if let Some(s) = full.strip_prefix("refs/tags/") {
+        return s.to_string();
+    }
+    if let Some(s) = full.strip_prefix("refs/remotes/") {
+        return s.to_string();
+    }
+    if let Some(s) = full.strip_prefix("refs/heads/") {
+        return s.to_string();
+    }
+    full.to_string()
+}
+
+fn tag_name_for_oid(git_dir: &Path, oid: ObjectId) -> Option<String> {
+    let tags = crate::refs::list_refs(git_dir, "refs/tags/").ok()?;
+    let mut names: Vec<String> = tags
+        .into_iter()
+        .filter(|(_, o)| *o == oid)
+        .map(|(name, _)| name.strip_prefix("refs/tags/").unwrap_or(&name).to_string())
+        .collect();
+    if names.is_empty() {
+        return None;
+    }
+    names.sort();
+    names.into_iter().next()
+}
+
+fn dwim_detach_label(git_dir: &Path, target: &str, noid: ObjectId) -> String {
+    if target == "HEAD" {
+        return abbrev_oid(&noid);
+    }
+    if target.starts_with("refs/") {
+        if let Ok(oid) = crate::refs::resolve_ref(git_dir, target) {
+            if oid == noid {
+                return strip_ref_for_display(target);
+            }
+        }
+    }
+    for candidate in [
+        format!("refs/heads/{target}"),
+        format!("refs/tags/{target}"),
+        format!("refs/remotes/{target}"),
+    ] {
+        if let Ok(oid) = crate::refs::resolve_ref(git_dir, &candidate) {
+            if oid == noid {
+                return strip_ref_for_display(&candidate);
+            }
+        }
+    }
+    if target.len() == 40 {
+        if let Ok(oid) = ObjectId::from_hex(target) {
+            if oid == noid {
+                return abbrev_oid(&noid);
+            }
+        }
+    }
+    if !target.is_empty()
+        && target.chars().all(|c| c.is_ascii_hexdigit())
+        && target.len() <= 40
+        && noid.to_hex().starts_with(target)
+    {
+        if let Some(tag) = tag_name_for_oid(git_dir, noid) {
+            return tag;
+        }
+    }
+    abbrev_oid(&noid)
+}
+
+fn wt_status_get_detached_from(git_dir: &Path, head_oid: ObjectId) -> Option<(String, bool)> {
+    let entries = reflog::read_reflog(git_dir, "HEAD").ok()?;
+    for entry in entries.iter().rev() {
+        let msg = entry.message.trim();
+        let Some(rest) = msg.strip_prefix("checkout: moving from ") else {
+            continue;
+        };
+        let Some(idx) = rest.rfind(" to ") else {
+            continue;
+        };
+        let target = rest[idx + 4..].trim();
+        let noid = entry.new_oid;
+        let label = dwim_detach_label(git_dir, target, noid);
+        let detached_at = head_oid == noid;
+        return Some((label, detached_at));
+    }
+    None
+}
+
+fn wt_status_check_rebase(git_dir: &Path, state: &mut WtStatusState) -> bool {
+    let apply = git_dir.join("rebase-apply");
+    if apply.is_dir() {
+        if apply.join("applying").exists() {
+            state.am_in_progress = true;
+            let patch = apply.join("patch");
+            if let Ok(meta) = patch.metadata() {
+                if meta.len() == 0 {
+                    state.am_empty_patch = true;
+                }
+            }
+        } else {
+            state.rebase_in_progress = true;
+            state.rebase_branch = get_branch_display(git_dir, "rebase-apply/head-name");
+            state.rebase_onto = get_branch_display(git_dir, "rebase-apply/onto");
+        }
+        return true;
+    }
+    let merge = git_dir.join("rebase-merge");
+    if merge.is_dir() {
+        if merge.join("interactive").exists() {
+            state.rebase_interactive_in_progress = true;
+        } else {
+            state.rebase_in_progress = true;
+        }
+        state.rebase_branch = get_branch_display(git_dir, "rebase-merge/head-name");
+        state.rebase_onto = get_branch_display(git_dir, "rebase-merge/onto");
+        return true;
+    }
+    false
+}
+
+fn sequencer_first_replay(git_dir: &Path) -> Option<bool> {
+    let path = git_dir.join("sequencer").join("todo");
+    if !path.is_file() {
+        return None;
+    }
+    let content = fs::read_to_string(&path).ok()?;
+    for line in content.lines() {
+        let t = line.trim();
+        if t.is_empty() || t.starts_with('#') {
+            continue;
+        }
+        let mut parts = t.split_whitespace();
+        let cmd = parts.next()?;
+        return Some(matches!(cmd, "pick" | "p" | "revert" | "r"));
+    }
+    None
+}
+
+/// Fill [`WtStatusState`] the same way Git `wt_status_get_state` does (without sparse checkout %).
+///
+/// `get_detached_from` matches Git's third parameter: when true and `head` is detached, populate
+/// `detached_from` / `detached_at` from the `HEAD` reflog.
+pub fn wt_status_get_state(
+    git_dir: &Path,
+    head: &HeadState,
+    get_detached_from: bool,
+) -> Result<WtStatusState> {
+    let mut state = WtStatusState::default();
+
+    if git_dir.join("MERGE_HEAD").exists() {
+        wt_status_check_rebase(git_dir, &mut state);
+        state.merge_in_progress = true;
+    } else if wt_status_check_rebase(git_dir, &mut state) {
+        // rebase/am state already filled
+    } else if let Some(oid) = read_cherry_pick_head(git_dir)? {
+        state.cherry_pick_in_progress = true;
+        state.cherry_pick_head_oid = Some(oid);
+    }
+
+    let bisect_base = crate::refs::common_dir(git_dir).unwrap_or_else(|| git_dir.to_path_buf());
+    if bisect_base.join("BISECT_LOG").exists() {
+        state.bisect_in_progress = true;
+        state.bisecting_from = get_branch_display(&bisect_base, "BISECT_START");
+    }
+
+    if let Some(oid) = read_revert_head(git_dir)? {
+        state.revert_in_progress = true;
+        state.revert_head_oid = Some(oid);
+    }
+
+    if let Some(is_pick) = sequencer_first_replay(git_dir) {
+        if is_pick && !state.cherry_pick_in_progress {
+            state.cherry_pick_in_progress = true;
+            state.cherry_pick_head_oid = None;
+        } else if !is_pick && !state.revert_in_progress {
+            state.revert_in_progress = true;
+            state.revert_head_oid = None;
+        }
+    }
+
+    if get_detached_from {
+        if let HeadState::Detached { oid } = head {
+            if let Some((label, at)) = wt_status_get_detached_from(git_dir, *oid) {
+                state.detached_from = Some(label);
+                state.detached_at = at;
+            }
+        }
+    }
+
+    Ok(state)
+}
+
+/// Whether a split commit is in progress during interactive rebase (`wt-status.c` `split_commit_in_progress`).
+pub fn split_commit_in_progress(git_dir: &Path, head: &HeadState) -> bool {
+    let HeadState::Detached { oid: head_oid } = head else {
+        return false;
+    };
+    let Some(amend_line) = read_trimmed_line(&git_dir.join("rebase-merge/amend")) else {
+        return false;
+    };
+    let Some(orig_line) = read_trimmed_line(&git_dir.join("rebase-merge/orig-head")) else {
+        return false;
+    };
+    let Ok(amend_oid) = ObjectId::from_hex(amend_line.trim()) else {
+        return false;
+    };
+    let Ok(orig_head_oid) = ObjectId::from_hex(orig_line.trim()) else {
+        return false;
+    };
+    if amend_line == orig_line {
+        head_oid != &amend_oid
+    } else if let Ok(Some(cur_orig)) = read_orig_head(git_dir) {
+        cur_orig != orig_head_oid
+    } else {
+        false
+    }
+}
+
 /// Build a complete [`RepoState`] snapshot for a repository.
 ///
 /// # Parameters
@@ -318,14 +606,30 @@ pub fn read_merge_msg(git_dir: &Path) -> Result<Option<String>> {
     }
 }
 
-/// Read CHERRY_PICK_HEAD.
+/// Read CHERRY_PICK_HEAD when it contains a valid 40-hex OID; `None` if missing, empty, or invalid
+/// (Git ignores malformed `CHERRY_PICK_HEAD` for the "commit $abbrev" line; sequencer still applies).
 pub fn read_cherry_pick_head(git_dir: &Path) -> Result<Option<ObjectId>> {
-    read_single_oid_file(&git_dir.join("CHERRY_PICK_HEAD"))
+    read_oid_head_file_optional(&git_dir.join("CHERRY_PICK_HEAD"))
 }
 
-/// Read REVERT_HEAD.
+/// Read REVERT_HEAD when it contains a valid OID; `None` if missing, empty, or invalid.
 pub fn read_revert_head(git_dir: &Path) -> Result<Option<ObjectId>> {
-    read_single_oid_file(&git_dir.join("REVERT_HEAD"))
+    read_oid_head_file_optional(&git_dir.join("REVERT_HEAD"))
+}
+
+fn read_oid_head_file_optional(path: &Path) -> Result<Option<ObjectId>> {
+    match fs::read_to_string(path) {
+        Ok(content) => {
+            let trimmed = content.trim();
+            if trimmed.is_empty() {
+                Ok(None)
+            } else {
+                Ok(ObjectId::from_hex(trimmed).ok())
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(Error::Io(e)),
+    }
 }
 
 /// Read ORIG_HEAD.

--- a/grit/src/commands/status.rs
+++ b/grit/src/commands/status.rs
@@ -15,7 +15,10 @@ use grit_lib::index::{Index, IndexEntry, MODE_GITLINK, MODE_TREE};
 use grit_lib::objects::{parse_commit, ObjectId};
 use grit_lib::reflog;
 use grit_lib::repo::Repository;
-use grit_lib::state::{detect_in_progress, resolve_head, HeadState};
+use grit_lib::rev_parse::abbreviate_object_id;
+use grit_lib::state::{
+    resolve_head, split_commit_in_progress, wt_status_get_state, HeadState, WtStatusState,
+};
 
 use crate::branch_tracking::{
     format_tracking_info, shorten_tracking_ref, stat_branch_pair, upstream_tracking_full_ref,
@@ -202,7 +205,7 @@ pub fn run(mut args: Args) -> Result<()> {
         .ok_or_else(|| anyhow::anyhow!("this operation must be run in a work tree"))?;
 
     let head = resolve_head(&repo.git_dir)?;
-    let in_progress = detect_in_progress(&repo.git_dir);
+    let wt_state = wt_status_get_state(&repo.git_dir, &head, true)?;
 
     // Load full config for status.displayCommentPrefix and advice.statusHints
     let config = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_else(|_| ConfigSet::new());
@@ -479,7 +482,7 @@ pub fn run(mut args: Args) -> Result<()> {
             &args,
             colopts,
             effective_no_ahead_behind,
-            &in_progress,
+            &wt_state,
             &index,
             index_sparse_on_disk,
             &staged_long,
@@ -1651,7 +1654,10 @@ pub(crate) fn write_status_branch_header(
                 show_hints && !omit_diverged_pull_hint,
             )?;
             if !tracking.is_empty() {
-                for line in tracking.trim_end().lines() {
+                for line in tracking.trim().lines() {
+                    if line.is_empty() {
+                        continue;
+                    }
                     cpw(out, cp, line)?;
                 }
                 cpw(out, cp, "")?;
@@ -1694,7 +1700,197 @@ fn cpw(out: &mut impl Write, prefix: &str, line: &str) -> Result<()> {
     Ok(())
 }
 
-/// Long format (default).
+fn status_unique_abbrev(repo: &Repository, oid: ObjectId) -> String {
+    abbreviate_object_id(repo, oid, 7).unwrap_or_else(|_| oid.to_hex()[..7].to_string())
+}
+
+fn long_status_unmerged_label(mask: u8) -> &'static str {
+    match mask {
+        1 => "both deleted:",
+        2 => "added by us:",
+        3 => "deleted by them:",
+        4 => "added by them:",
+        5 => "deleted by us:",
+        6 => "both added:",
+        7 => "both modified:",
+        _ => "unmerged:",
+    }
+}
+
+fn long_status_unmerged_label_width() -> usize {
+    (1u8..=7)
+        .map(|m| long_status_unmerged_label(m).len())
+        .max()
+        .unwrap_or(0)
+        + 1
+}
+
+fn long_status_print_unmerged_header(
+    out: &mut impl Write,
+    cp: &str,
+    show_hints: bool,
+    unmerged: &[(String, u8)],
+    show_unstage_hint: bool,
+    head: &HeadState,
+) -> Result<()> {
+    cpw(out, cp, "Unmerged paths:")?;
+    if !show_hints {
+        return Ok(());
+    }
+    let mut both_deleted = false;
+    let mut del_mod_conflict = false;
+    let mut not_deleted = false;
+    for (_, mask) in unmerged {
+        match *mask {
+            0 => {}
+            1 => both_deleted = true,
+            3 | 5 => del_mod_conflict = true,
+            _ => not_deleted = true,
+        }
+    }
+    if show_unstage_hint {
+        if head.oid().is_some() {
+            cpw(
+                out,
+                cp,
+                "  (use \"git restore --staged <file>...\" to unstage)",
+            )?;
+        } else {
+            cpw(out, cp, "  (use \"git rm --cached <file>...\" to unstage)")?;
+        }
+    }
+    if !both_deleted {
+        if !del_mod_conflict {
+            cpw(out, cp, "  (use \"git add <file>...\" to mark resolution)")?;
+        } else {
+            cpw(
+                out,
+                cp,
+                "  (use \"git add/rm <file>...\" as appropriate to mark resolution)",
+            )?;
+        }
+    } else if !del_mod_conflict && !not_deleted {
+        cpw(out, cp, "  (use \"git rm <file>...\" to mark resolution)")?;
+    } else {
+        cpw(
+            out,
+            cp,
+            "  (use \"git add/rm <file>...\" as appropriate to mark resolution)",
+        )?;
+    }
+    Ok(())
+}
+
+fn long_status_abbrev_oid_in_line(repo: &Repository, line: &str) -> String {
+    let parts: Vec<&str> = line.splitn(3, ' ').collect();
+    if parts.len() < 2 {
+        return line.to_string();
+    }
+    let cmd = parts[0];
+    if matches!(cmd, "exec" | "x" | "label" | "l") {
+        return line.to_string();
+    }
+    let oid_s = parts[1];
+    if oid_s.len() != 40 || !oid_s.chars().all(|c| c.is_ascii_hexdigit()) {
+        return line.to_string();
+    }
+    if grit_lib::rev_parse::resolve_revision(repo, oid_s).is_err() {
+        return line.to_string();
+    }
+    format!(
+        "{} {} {}",
+        cmd,
+        &oid_s[..7],
+        parts.get(2).copied().unwrap_or("")
+    )
+}
+
+fn long_status_read_rebase_todo_lines(
+    repo: &Repository,
+    git_dir: &Path,
+    rel: &str,
+) -> Result<Option<Vec<String>>> {
+    let path = git_dir.join(rel);
+    let Ok(content) = fs::read_to_string(&path) else {
+        return Ok(None);
+    };
+    let mut out = Vec::new();
+    for line in content.lines() {
+        let t = line.trim();
+        if t.is_empty() || t.starts_with('#') {
+            continue;
+        }
+        out.push(long_status_abbrev_oid_in_line(repo, t));
+    }
+    Ok(Some(out))
+}
+
+fn long_status_print_rebase_information(
+    out: &mut impl Write,
+    cp: &str,
+    show_hints: bool,
+    repo: &Repository,
+    git_dir: &Path,
+) -> Result<()> {
+    let have_done =
+        long_status_read_rebase_todo_lines(repo, git_dir, "rebase-merge/done")?.unwrap_or_default();
+    let todo_path = git_dir.join("rebase-merge/git-rebase-todo");
+    let yet_to_do =
+        match long_status_read_rebase_todo_lines(repo, git_dir, "rebase-merge/git-rebase-todo")? {
+            Some(v) => v,
+            None if todo_path.exists() => {
+                cpw(out, cp, "git-rebase-todo is missing.")?;
+                Vec::new()
+            }
+            None => Vec::new(),
+        };
+    const NR_SHOW: usize = 2;
+    if have_done.is_empty() {
+        cpw(out, cp, "No commands done.")?;
+    } else {
+        let n = have_done.len();
+        if n == 1 {
+            cpw(out, cp, &format!("Last command done (1 command done):"))?;
+        } else {
+            cpw(out, cp, &format!("Last commands done ({n} commands done):"))?;
+        }
+        let start = if n > NR_SHOW { n - NR_SHOW } else { 0 };
+        for line in have_done.iter().skip(start) {
+            cpw(out, cp, &format!("   {line}"))?;
+        }
+        if n > NR_SHOW && show_hints {
+            let path = git_dir.join("rebase-merge/done");
+            cpw(out, cp, &format!("  (see more in file {})", path.display()))?;
+        }
+    }
+    if yet_to_do.is_empty() {
+        cpw(out, cp, "No commands remaining.")?;
+    } else {
+        let n = yet_to_do.len();
+        if n == 1 {
+            cpw(out, cp, "Next command to do (1 remaining command):")?;
+        } else {
+            cpw(
+                out,
+                cp,
+                &format!("Next commands to do ({n} remaining commands):"),
+            )?;
+        }
+        for line in yet_to_do.iter().take(NR_SHOW) {
+            cpw(out, cp, &format!("   {line}"))?;
+        }
+        if show_hints {
+            cpw(
+                out,
+                cp,
+                "  (use \"git rebase --edit-todo\" to view and edit)",
+            )?;
+        }
+    }
+    Ok(())
+}
+
+/// Long format (default), matching Git `wt-status.c` layout and advice text.
 fn format_long(
     out: &mut impl Write,
     head: &HeadState,
@@ -1703,7 +1899,7 @@ fn format_long(
     _args: &Args,
     colopts: ColOpts,
     effective_no_ahead_behind: bool,
-    in_progress: &[grit_lib::state::InProgressOperation],
+    state: &WtStatusState,
     expanded_index: &Index,
     index_sparse_on_disk: bool,
     staged: &[grit_lib::diff::DiffEntry],
@@ -1712,15 +1908,12 @@ fn format_long(
     ignored_files: &[String],
     hide_untracked: bool,
 ) -> Result<()> {
-    // Determine comment prefix
-    let comment_prefix = match config.get("status.displayCommentPrefix") {
+    let comment_prefix: &str = match config.get("status.displayCommentPrefix") {
         Some(v) if v == "true" || v == "yes" || v == "on" || v == "1" => "# ",
         _ => "",
     };
     let cp = comment_prefix;
 
-    // Determine if hints should be shown.
-    // `GIT_ADVICE` globally overrides per-advice config knobs.
     let config_hints = match config.get("advice.statusHints") {
         Some(v) if v == "false" || v == "no" || v == "off" || v == "0" => false,
         _ => true,
@@ -1730,22 +1923,252 @@ fn format_long(
         .and_then(|v| parse_bool_str(&v))
         .unwrap_or(config_hints);
 
-    write_status_branch_header(
-        out,
-        head,
-        repo,
-        cp,
-        show_hints,
-        effective_no_ahead_behind,
-        false,
-        None,
-    )?;
+    match head {
+        HeadState::Branch {
+            short_name,
+            oid: Some(_),
+            ..
+        } => {
+            cpw(out, cp, &format!("On branch {short_name}"))?;
+            let tracking = format_tracking_info(
+                repo,
+                short_name,
+                if effective_no_ahead_behind {
+                    AheadBehindMode::Quick
+                } else {
+                    AheadBehindMode::Full
+                },
+                show_hints,
+            )?;
+            if !tracking.is_empty() {
+                for line in tracking.trim().lines() {
+                    if line.is_empty() {
+                        continue;
+                    }
+                    cpw(out, cp, line)?;
+                }
+                cpw(out, cp, "")?;
+            }
+        }
+        HeadState::Branch {
+            short_name,
+            oid: None,
+            ..
+        } => {
+            cpw(out, cp, &format!("On branch {short_name}"))?;
+            cpw(out, cp, "")?;
+            cpw(out, cp, "No commits yet")?;
+            cpw(out, cp, "")?;
+        }
+        HeadState::Detached { oid } => {
+            if state.rebase_interactive_in_progress {
+                let onto = state.rebase_onto.as_deref().unwrap_or("");
+                cpw(
+                    out,
+                    cp,
+                    &format!("interactive rebase in progress; onto {onto}"),
+                )?;
+            } else if state.rebase_in_progress && !state.am_in_progress {
+                let onto = state.rebase_onto.as_deref().unwrap_or("");
+                cpw(out, cp, &format!("rebase in progress; onto {onto}"))?;
+            } else if let Some(df) = state.detached_from.as_deref() {
+                if state.detached_at {
+                    cpw(out, cp, &format!("HEAD detached at {df}"))?;
+                } else {
+                    cpw(out, cp, &format!("HEAD detached from {df}"))?;
+                }
+            } else {
+                let short = &oid.to_hex()[..7];
+                cpw(out, cp, &format!("HEAD detached at {short}"))?;
+            }
+        }
+        HeadState::Invalid => {
+            cpw(out, cp, "Not currently on any branch.")?;
+        }
+    }
 
-    // In-progress operations
-    for op in in_progress {
+    let git_dir = &repo.git_dir;
+    let merge_msg_exists = git_dir.join("MERGE_MSG").exists();
+
+    if state.merge_in_progress {
+        if state.rebase_interactive_in_progress {
+            long_status_print_rebase_information(out, cp, show_hints, repo, git_dir)?;
+            cpw(out, cp, "")?;
+        }
+        if long_status_has_unmerged(expanded_index) {
+            cpw(out, cp, "You have unmerged paths.")?;
+            if show_hints {
+                cpw(out, cp, "  (fix conflicts and run \"git commit\")")?;
+                cpw(out, cp, "  (use \"git merge --abort\" to abort the merge)")?;
+            }
+            cpw(out, cp, "")?;
+        } else {
+            cpw(out, cp, "All conflicts fixed but you are still merging.")?;
+            if show_hints {
+                cpw(out, cp, "  (use \"git commit\" to conclude merge)")?;
+            }
+            cpw(out, cp, "")?;
+        }
+    } else if state.am_in_progress {
+        cpw(out, cp, "You are in the middle of an am session.")?;
+        if state.am_empty_patch {
+            cpw(out, cp, "The current patch is empty.")?;
+        }
+        if show_hints {
+            if !state.am_empty_patch {
+                cpw(
+                    out,
+                    cp,
+                    "  (fix conflicts and then run \"git am --continue\")",
+                )?;
+            }
+            cpw(out, cp, "  (use \"git am --skip\" to skip this patch)")?;
+            if state.am_empty_patch {
+                cpw(
+                    out,
+                    cp,
+                    "  (use \"git am --allow-empty\" to record this patch as an empty commit)",
+                )?;
+            }
+            cpw(
+                out,
+                cp,
+                "  (use \"git am --abort\" to restore the original branch)",
+            )?;
+        }
         cpw(out, cp, "")?;
-        cpw(out, cp, &format!("You are currently {}.", op.description()))?;
-        cpw(out, cp, &format!("  ({})", op.hint()))?;
+    } else if state.rebase_in_progress || state.rebase_interactive_in_progress {
+        long_status_print_rebase_information(out, cp, show_hints, repo, git_dir)?;
+        let has_um = long_status_has_unmerged(expanded_index);
+        if has_um {
+            long_status_print_rebase_state(out, cp, state)?;
+            if show_hints {
+                cpw(
+                    out,
+                    cp,
+                    "  (fix conflicts and then run \"git rebase --continue\")",
+                )?;
+                cpw(out, cp, "  (use \"git rebase --skip\" to skip this patch)")?;
+                cpw(
+                    out,
+                    cp,
+                    "  (use \"git rebase --abort\" to check out the original branch)",
+                )?;
+            }
+            cpw(out, cp, "")?;
+        } else if state.rebase_in_progress || merge_msg_exists {
+            long_status_print_rebase_state(out, cp, state)?;
+            if show_hints {
+                cpw(
+                    out,
+                    cp,
+                    "  (all conflicts fixed: run \"git rebase --continue\")",
+                )?;
+            }
+            cpw(out, cp, "")?;
+        } else if split_commit_in_progress(git_dir, head) {
+            long_status_print_splitting(out, cp, show_hints, state)?;
+        } else {
+            long_status_print_editing(out, cp, show_hints, state)?;
+        }
+    } else if state.cherry_pick_in_progress {
+        if let Some(oid) = state.cherry_pick_head_oid {
+            let abbrev = status_unique_abbrev(repo, oid);
+            cpw(
+                out,
+                cp,
+                &format!("You are currently cherry-picking commit {abbrev}."),
+            )?;
+        } else {
+            cpw(out, cp, "Cherry-pick currently in progress.")?;
+        }
+        if show_hints {
+            if long_status_has_unmerged(expanded_index) {
+                cpw(
+                    out,
+                    cp,
+                    "  (fix conflicts and run \"git cherry-pick --continue\")",
+                )?;
+            } else if state.cherry_pick_head_oid.is_none() {
+                cpw(
+                    out,
+                    cp,
+                    "  (run \"git cherry-pick --continue\" to continue)",
+                )?;
+            } else {
+                cpw(
+                    out,
+                    cp,
+                    "  (all conflicts fixed: run \"git cherry-pick --continue\")",
+                )?;
+            }
+            cpw(
+                out,
+                cp,
+                "  (use \"git cherry-pick --skip\" to skip this patch)",
+            )?;
+            cpw(
+                out,
+                cp,
+                "  (use \"git cherry-pick --abort\" to cancel the cherry-pick operation)",
+            )?;
+        }
+        cpw(out, cp, "")?;
+    } else if state.revert_in_progress {
+        if let Some(oid) = state.revert_head_oid {
+            let abbrev = status_unique_abbrev(repo, oid);
+            cpw(
+                out,
+                cp,
+                &format!("You are currently reverting commit {abbrev}."),
+            )?;
+        } else {
+            cpw(out, cp, "Revert currently in progress.")?;
+        }
+        if show_hints {
+            if long_status_has_unmerged(expanded_index) {
+                cpw(
+                    out,
+                    cp,
+                    "  (fix conflicts and run \"git revert --continue\")",
+                )?;
+            } else if state.revert_head_oid.is_none() {
+                cpw(out, cp, "  (run \"git revert --continue\" to continue)")?;
+            } else {
+                cpw(
+                    out,
+                    cp,
+                    "  (all conflicts fixed: run \"git revert --continue\")",
+                )?;
+            }
+            cpw(out, cp, "  (use \"git revert --skip\" to skip this patch)")?;
+            cpw(
+                out,
+                cp,
+                "  (use \"git revert --abort\" to cancel the revert operation)",
+            )?;
+        }
+        cpw(out, cp, "")?;
+    }
+
+    if state.bisect_in_progress {
+        if let Some(from) = state.bisecting_from.as_deref() {
+            cpw(
+                out,
+                cp,
+                &format!("You are currently bisecting, started from branch '{from}'."),
+            )?;
+        } else {
+            cpw(out, cp, "You are currently bisecting.")?;
+        }
+        if show_hints {
+            cpw(
+                out,
+                cp,
+                "  (use \"git bisect reset\" to get back to the original branch)",
+            )?;
+        }
+        cpw(out, cp, "")?;
     }
 
     if let Some(msg) = sparse_checkout_banner(config, expanded_index, index_sparse_on_disk) {
@@ -1754,25 +2177,45 @@ fn format_long(
         cpw(out, cp, "")?;
     }
 
-    // Track whether we've printed any section (to know if we need a separator)
-    let mut has_section = false;
+    let unmerged_map = unmerged_paths_and_mask(expanded_index);
+    let mut unmerged_paths: Vec<(String, u8)> =
+        unmerged_map.iter().map(|(p, m)| (p.clone(), *m)).collect();
 
-    // Staged changes
-    if !staged.is_empty() {
-        has_section = true;
+    let staged_normal: Vec<&DiffEntry> = staged
+        .iter()
+        .filter(|e| e.status != DiffStatus::Unmerged)
+        .collect();
+    let unstaged_normal: Vec<&DiffEntry> = unstaged
+        .iter()
+        .filter(|e| e.status != DiffStatus::Unmerged && !unmerged_map.contains_key(e.path()))
+        .collect();
+
+    let has_unmerged = !unmerged_paths.is_empty();
+    let committable = state.merge_in_progress && !has_unmerged && !staged_normal.is_empty();
+    let show_staged_unstage_hints = show_hints
+        && head.oid().is_some()
+        && !((state.merge_in_progress || state.cherry_pick_in_progress) && !has_unmerged);
+    let unlisted_untracked_line = hide_untracked
+        && !has_unmerged
+        && !staged_normal.is_empty()
+        && (state.merge_in_progress
+            || state.cherry_pick_in_progress
+            || state.revert_in_progress
+            || state.rebase_in_progress
+            || state.rebase_interactive_in_progress);
+
+    let dirty_like_git_worktree = !unstaged_normal.is_empty() || has_unmerged;
+
+    if !staged_normal.is_empty() {
         cpw(out, cp, "Changes to be committed:")?;
-        if show_hints {
-            if head.oid().is_some() {
-                cpw(
-                    out,
-                    cp,
-                    "  (use \"git restore --staged <file>...\" to unstage)",
-                )?;
-            } else {
-                cpw(out, cp, "  (use \"git rm --cached <file>...\" to unstage)")?;
-            }
+        if show_staged_unstage_hints {
+            cpw(
+                out,
+                cp,
+                "  (use \"git restore --staged <file>...\" to unstage)",
+            )?;
         }
-        for entry in staged {
+        for entry in &staged_normal {
             let label = match entry.status {
                 DiffStatus::Added => "new file",
                 DiffStatus::Deleted => "deleted",
@@ -1787,27 +2230,57 @@ fn format_long(
         cpw(out, cp, "")?;
     }
 
-    // Unstaged changes
-    if !unstaged.is_empty() {
-        if has_section {
-            // blank line already printed after previous section
-        } else {
-            has_section = true;
+    if !unmerged_paths.is_empty() {
+        unmerged_paths.sort_by(|a, b| a.0.cmp(&b.0));
+        let show_unstage_unmerged = !state.merge_in_progress
+            && !state.cherry_pick_in_progress
+            && (state.rebase_in_progress
+                || state.rebase_interactive_in_progress
+                || state.revert_in_progress);
+        long_status_print_unmerged_header(
+            out,
+            cp,
+            show_hints,
+            &unmerged_paths,
+            show_unstage_unmerged,
+            head,
+        )?;
+        let label_w = long_status_unmerged_label_width();
+        for (path, mask) in &unmerged_paths {
+            let how = long_status_unmerged_label(*mask);
+            let pad = label_w.saturating_sub(how.len());
+            let spaces: String = std::iter::repeat(' ').take(pad).collect();
+            cpw(out, cp, &format!("\t{how}{spaces}{path}"))?;
         }
+        cpw(out, cp, "")?;
+    }
+
+    if !unstaged_normal.is_empty() {
+        let has_deleted = unstaged_normal
+            .iter()
+            .any(|e| e.status == DiffStatus::Deleted);
         cpw(out, cp, "Changes not staged for commit:")?;
         if show_hints {
-            cpw(
-                out,
-                cp,
-                "  (use \"git add <file>...\" to update what will be committed)",
-            )?;
+            if has_deleted {
+                cpw(
+                    out,
+                    cp,
+                    "  (use \"git add/rm <file>...\" to update what will be committed)",
+                )?;
+            } else {
+                cpw(
+                    out,
+                    cp,
+                    "  (use \"git add <file>...\" to update what will be committed)",
+                )?;
+            }
             cpw(
                 out,
                 cp,
                 "  (use \"git restore <file>...\" to discard changes in working directory)",
             )?;
         }
-        for entry in unstaged {
+        for entry in &unstaged_normal {
             let label = match entry.status {
                 DiffStatus::Deleted => "deleted",
                 DiffStatus::Modified => "modified",
@@ -1819,13 +2292,7 @@ fn format_long(
         cpw(out, cp, "")?;
     }
 
-    // Untracked files
     if !untracked.is_empty() {
-        if has_section {
-            // blank line already printed after previous section
-        } else {
-            has_section = true;
-        }
         cpw(out, cp, "Untracked files:")?;
         if show_hints {
             cpw(
@@ -1846,11 +2313,7 @@ fn format_long(
         cpw(out, cp, "")?;
     }
 
-    // Ignored files
     if !ignored_files.is_empty() {
-        if has_section {
-            // blank line already printed after previous section
-        }
         cpw(out, cp, "Ignored files:")?;
         if show_hints {
             cpw(
@@ -1871,8 +2334,7 @@ fn format_long(
         cpw(out, cp, "")?;
     }
 
-    // "Untracked files not listed" message when -uno is used
-    if hide_untracked {
+    if unlisted_untracked_line {
         if show_hints {
             cpw(
                 out,
@@ -1882,51 +2344,146 @@ fn format_long(
         } else {
             cpw(out, cp, "Untracked files not listed")?;
         }
-    }
-
-    // Footer messages
-    if staged.is_empty() && unstaged.is_empty() && untracked.is_empty() {
-        if hide_untracked {
-            // When hiding untracked, don't say "working tree clean"
-        } else if !ignored_files.is_empty() {
-            cpw(
-                out,
-                cp,
-                "nothing to commit but untracked files present (use \"git add\" to track)",
-            )?;
-        } else {
-            cpw(out, cp, "nothing to commit, working tree clean")?;
+    } else if !committable {
+        // `dirty_like_git_worktree` matches Git `wt_status_check_worktree_changes` use in
+        // the footer (untracked-only uses a different message).
+        if dirty_like_git_worktree {
+            if show_hints {
+                cpw(
+                    out,
+                    cp,
+                    "no changes added to commit (use \"git add\" and/or \"git commit -a\")",
+                )?;
+            } else {
+                cpw(out, cp, "no changes added to commit")?;
+            }
+        } else if staged_normal.is_empty() && unstaged_normal.is_empty() && untracked.is_empty() {
+            if hide_untracked {
+                if show_hints {
+                    cpw(
+                        out,
+                        cp,
+                        "nothing to commit (use -u to show untracked files)",
+                    )?;
+                } else {
+                    cpw(out, cp, "nothing to commit")?;
+                }
+            } else if !ignored_files.is_empty() {
+                cpw(
+                    out,
+                    cp,
+                    "nothing to commit but untracked files present (use \"git add\" to track)",
+                )?;
+            } else {
+                cpw(out, cp, "nothing to commit, working tree clean")?;
+            }
+        } else if !staged_normal.is_empty() && unstaged_normal.is_empty() && untracked.is_empty() {
+            // only staged: no footer
+        } else if staged_normal.is_empty() && unstaged_normal.is_empty() && !untracked.is_empty() {
+            if show_hints {
+                cpw(
+                    out,
+                    cp,
+                    "nothing added to commit but untracked files present (use \"git add\" to track)",
+                )?;
+            } else {
+                cpw(
+                    out,
+                    cp,
+                    "nothing added to commit but untracked files present",
+                )?;
+            }
         }
-    } else if !staged.is_empty() && unstaged.is_empty() && untracked.is_empty() {
-        // Only staged changes — no footer needed (git doesn't print one)
-    } else if staged.is_empty() && !unstaged.is_empty() && untracked.is_empty() {
-        cpw(
-            out,
-            cp,
-            "no changes added to commit (use \"git add\" and/or \"git commit -a\")",
-        )?;
-    } else if staged.is_empty() && unstaged.is_empty() && !untracked.is_empty() {
+    } else if staged_normal.is_empty() && unstaged_normal.is_empty() && untracked.is_empty() {
         if show_hints {
             cpw(
                 out,
                 cp,
-                "nothing added to commit but untracked files present (use \"git add\" to track)",
+                "nothing to commit (use -u to show untracked files)",
             )?;
         } else {
-            cpw(
-                out,
-                cp,
-                "nothing added to commit but untracked files present",
-            )?;
+            cpw(out, cp, "nothing to commit")?;
         }
-    } else if staged.is_empty() {
+    }
+
+    Ok(())
+}
+
+fn long_status_has_unmerged(index: &Index) -> bool {
+    index
+        .entries
+        .iter()
+        .any(|e| e.stage() > 0 && e.stage() <= 3)
+}
+
+fn long_status_print_rebase_state(
+    out: &mut impl Write,
+    cp: &str,
+    state: &WtStatusState,
+) -> Result<()> {
+    let branch = state.rebase_branch.as_deref().unwrap_or("");
+    let onto = state.rebase_onto.as_deref().unwrap_or("");
+    cpw(
+        out,
+        cp,
+        &format!("You are currently rebasing branch '{branch}' on '{onto}'."),
+    )
+}
+
+fn long_status_print_splitting(
+    out: &mut impl Write,
+    cp: &str,
+    show_hints: bool,
+    state: &WtStatusState,
+) -> Result<()> {
+    let branch = state.rebase_branch.as_deref().unwrap_or("");
+    let onto = state.rebase_onto.as_deref().unwrap_or("");
+    cpw(
+        out,
+        cp,
+        &format!(
+            "You are currently splitting a commit while rebasing branch '{branch}' on '{onto}'."
+        ),
+    )?;
+    if show_hints {
         cpw(
             out,
             cp,
-            "no changes added to commit (use \"git add\" and/or \"git commit -a\")",
+            "  (Once your working directory is clean, run \"git rebase --continue\")",
         )?;
     }
+    cpw(out, cp, "")?;
+    Ok(())
+}
 
+fn long_status_print_editing(
+    out: &mut impl Write,
+    cp: &str,
+    show_hints: bool,
+    state: &WtStatusState,
+) -> Result<()> {
+    let branch = state.rebase_branch.as_deref().unwrap_or("");
+    let onto = state.rebase_onto.as_deref().unwrap_or("");
+    cpw(
+        out,
+        cp,
+        &format!(
+            "You are currently editing a commit while rebasing branch '{branch}' on '{onto}'."
+        ),
+    )?;
+    if show_hints {
+        cpw(
+            out,
+            cp,
+            "  (use \"git commit --amend\" to amend the current commit)",
+        )?;
+        cpw(
+            out,
+            cp,
+            "  (use \"git rebase --continue\" once you are satisfied with your changes)",
+        )?;
+    }
+    cpw(out, cp, "")?;
     Ok(())
 }
 


### PR DESCRIPTION
- Add WtStatusState + wt_status_get_state (merge/rebase/am/cherry/revert/bisect, detached)
- Rewrite format_long: merge/rebase/cherry/revert hints, unmerged paths, footers, -uno lines
- Tolerate invalid CHERRY_PICK_HEAD/REVERT_HEAD; fix reflog scan for detached HEAD labels
- read_cherry_pick_head/read_revert_head return None on malformed hex