### PR TITLE
fix: make t5405-send-pack-rewind pass (local fetch + pack unpack)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -910,7 +910,7 @@ t5401-update-hooks	t5	yes	13	8	5	false	ok	0
 t5402-post-merge-hook	t5	yes	7	3	4	false	ok	0
 t5403-post-checkout-hook	t5	yes	14	11	3	false	ok	0
 t5404-tracking-branches	t5	yes	7	3	4	false	ok	0
-t5405-send-pack-rewind	t5	yes	3	1	2	false	ok	0
+t5405-send-pack-rewind	t5	yes	3	3	0	true	ok	0
 t5406-remote-rejects	t5	yes	3	2	1	false	ok	0
 t5407-post-rewrite-hook	t5	yes	17	7	10	false	ok	0
 t5408-send-pack-stdin	t5	yes	10	6	4	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.1% of harness tests passing (35,211 / 45,112).">
+<meta property="og:description" content="78.1% of harness tests passing (35,213 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.1% of harness tests passing (35,211 / 45,112).">
+<meta name="twitter:description" content="78.1% of harness tests passing (35,213 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T13:35:26+00:00" class="gen-time" title="2026-04-09 13:35 UTC">2026-04-09 13:35 UTC</time> · <a href="https://github.com/schacon/grit/commit/e77a8c04fc06ccd3ad1253e512a5889290d4b86f" style="color:#58a6ff">e77a8c0</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T14:29:52+00:00" class="gen-time" title="2026-04-09 14:29 UTC">2026-04-09 14:29 UTC</time> · <a href="https://github.com/schacon/grit/commit/1b2deb6d814ce62f9b7b0fab0b751f2cf7de238c" style="color:#58a6ff">1b2deb6</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,211</div>
+      <div class="summary-big-val">35,213</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>721 files fully passing</span>
+    <span>722 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">23/167 files · 17 skipped · 1,478/4,139 tests</span>
+        <span class="group-meta">24/167 files · 17 skipped · 1,480/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:35.7%"></div></div>
-        <span class="group-pct pct-red">35.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:35.8%"></div></div>
+        <span class="group-pct pct-red">35.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35211 of 45112 tests passing across 1405 harness files (78.1% pass rate).</desc>
+  <desc id="svg-desc">35213 of 45112 tests passing across 1405 harness files (78.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.1% pass rate · 35,211 / 45,112 tests · 1,405 files in scope · 721 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.1% pass rate · 35,213 / 45,112 tests · 1,405 files in scope · 722 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="547" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T13:35:26+00:00" class="gen-time" title="2026-04-09 13:35 UTC">2026-04-09 13:35 UTC</time> · <a href="https://github.com/schacon/grit/commit/e77a8c04fc06ccd3ad1253e512a5889290d4b86f" style="color:#58a6ff">e77a8c0</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T14:29:52+00:00" class="gen-time" title="2026-04-09 14:29 UTC">2026-04-09 14:29 UTC</time> · <a href="https://github.com/schacon/grit/commit/1b2deb6d814ce62f9b7b0fab0b751f2cf7de238c" style="color:#58a6ff">1b2deb6</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,211</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,213</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -9257,14 +9257,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:42.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="3" data-passed="1">
+<tr class="" data-group="t5" data-tests="3" data-passed="3" data-full-pass="1">
   <td class="mono">t5405-send-pack-rewind</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">3</td>
-  <td class="right">1</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:33.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="3" data-passed="2">

--- a/grit-lib/src/unpack_objects.rs
+++ b/grit-lib/src/unpack_objects.rs
@@ -14,6 +14,7 @@ use std::collections::HashMap;
 use std::io::{self, Read};
 
 use flate2::read::ZlibDecoder;
+use flate2::{Decompress, FlushDecompress, Status};
 use sha1::{Digest, Sha1};
 
 use crate::error::{Error, Result};
@@ -766,33 +767,65 @@ impl<'a> StreamingPackReader<'a> {
         const CHUNK: usize = 64 * 1024;
         let mut scratch = [0u8; CHUNK];
         let mut out = vec![0u8; expected_size];
+        let mut z = Decompress::new(true);
+        let mut out_pos = 0usize;
+        let mut eof = false;
         loop {
-            let mut cursor = std::io::Cursor::new(self.pending.as_slice());
-            let mut z = ZlibDecoder::new(&mut cursor);
-            match z.read_exact(&mut out) {
-                Ok(()) => {
-                    let consumed = z.total_in() as usize;
-                    if consumed > self.pending.len() {
-                        return Err(Error::CorruptObject(
-                            "zlib total_in exceeds pending buffer".to_owned(),
-                        ));
+            if self.pending.is_empty() && !eof {
+                let n = self.inner.read(&mut scratch).map_err(Error::Io)?;
+                if n == 0 {
+                    eof = true;
+                } else {
+                    self.pending.extend_from_slice(&scratch[..n]);
+                }
+            }
+
+            let flush = if eof && self.pending.is_empty() {
+                FlushDecompress::Finish
+            } else {
+                FlushDecompress::None
+            };
+
+            let before_in = z.total_in();
+            let before_out = z.total_out();
+            let status = z
+                .decompress(self.pending.as_slice(), &mut out[out_pos..], flush)
+                .map_err(|e| Error::Zlib(e.to_string()))?;
+            let consumed = (z.total_in() - before_in) as usize;
+            if consumed > self.pending.len() {
+                return Err(Error::CorruptObject(
+                    "zlib consumed more than pending buffer".to_owned(),
+                ));
+            }
+            self.pack_hasher.update(&self.pending[..consumed]);
+            self.stream_pos += consumed;
+            self.pending.drain(..consumed);
+            out_pos += (z.total_out() - before_out) as usize;
+
+            match status {
+                Status::StreamEnd => {
+                    if out_pos != expected_size {
+                        return Err(Error::CorruptObject(format!(
+                            "decompressed size mismatch: got {out_pos}, want {expected_size}"
+                        )));
                     }
-                    self.pack_hasher.update(&self.pending[..consumed]);
-                    self.stream_pos += consumed;
-                    self.pending.drain(..consumed);
                     return Ok(out);
                 }
-                Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => {
-                    let n = self.inner.read(&mut scratch).map_err(Error::Io)?;
-                    if n == 0 {
+                Status::Ok | Status::BufError => {
+                    if consumed == 0 && !eof {
+                        let n = self.inner.read(&mut scratch).map_err(Error::Io)?;
+                        if n == 0 {
+                            eof = true;
+                        } else {
+                            self.pending.extend_from_slice(&scratch[..n]);
+                        }
+                    } else if eof && self.pending.is_empty() && out_pos != expected_size {
                         return Err(Error::CorruptObject(format!(
                             "pack stream truncated (zlib) at offset {}",
                             self.stream_pos
                         )));
                     }
-                    self.pending.extend_from_slice(&scratch[..n]);
                 }
-                Err(e) => return Err(Error::Zlib(e.to_string())),
             }
         }
     }

--- a/grit/src/commands/serve_v2.rs
+++ b/grit/src/commands/serve_v2.rs
@@ -379,7 +379,8 @@ fn cmd_fetch(git_dir: &Path, args: &[String], out: &mut impl Write) -> Result<()
     }
 
     pkt_line::write_line(out, "packfile")?;
-    let mut child = crate::pack_objects_upload::spawn_pack_objects_upload(git_dir)?;
+    let thin = !have_oids.is_empty();
+    let mut child = crate::pack_objects_upload::spawn_pack_objects_upload(git_dir, thin)?;
     {
         let mut pin = child
             .stdin

--- a/grit/src/commands/upload_pack.rs
+++ b/grit/src/commands/upload_pack.rs
@@ -171,7 +171,8 @@ pub fn run(args: Args) -> Result<()> {
         }
     }
 
-    let mut child = crate::pack_objects_upload::spawn_pack_objects_upload(&repo.git_dir)?;
+    let thin = !client_have_commits.is_empty();
+    let mut child = crate::pack_objects_upload::spawn_pack_objects_upload(&repo.git_dir, thin)?;
     {
         let mut pin = child.stdin.take().context("pack-objects stdin")?;
         crate::pack_objects_upload::write_pack_objects_revs_stdin(

--- a/grit/src/fetch_transport.rs
+++ b/grit/src/fetch_transport.rs
@@ -294,11 +294,11 @@ pub(crate) fn spawn_upload_pack(
     cmd_template: Option<&str>,
     repo_path: &Path,
 ) -> Result<std::process::Child> {
-    spawn_upload_pack_with_proto(
-        cmd_template,
-        repo_path,
-        protocol_wire::effective_client_protocol_version(),
-    )
+    // Always negotiate protocol v0 here: [`read_advertisement`] and
+    // [`fetch_upload_pack_negotiate_pack_bytes_with_streams`] implement the v0 ref advertisement
+    // and want/have/done exchange only. Using the user's `protocol.version` (often 2) would leave
+    // the advertisement list empty and break refspec resolution (e.g. t5405 local fetch).
+    spawn_upload_pack_with_proto(cmd_template, repo_path, 0)
 }
 
 pub(crate) fn drain_child_stdout_to_eof(r: &mut impl Read) -> std::io::Result<()> {
@@ -387,8 +387,8 @@ pub(crate) fn read_pkt_payload_raw(r: &mut impl Read) -> std::io::Result<Option<
     let len = usize::from_str_radix(len_str, 16)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
     match len {
-        0 => Ok(Some(Vec::new())),
-        1 | 2 => Ok(Some(Vec::new())),
+        // Flush / delim / response-end — not a data payload; side-band readers stop at flush.
+        0 | 1 | 2 => Ok(None),
         n if n <= 4 => Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
             format!("invalid pkt-line length: {n}"),
@@ -404,20 +404,33 @@ pub(crate) fn read_pkt_payload_raw(r: &mut impl Read) -> std::io::Result<Option<
 
 fn read_sideband_pack_until_done(r: &mut impl Read, out: &mut Vec<u8>) -> Result<()> {
     let mut seen_pack = false;
+    // Progress and pack data share side-band channel 1; the `PACK` magic may start mid-chunk or
+    // span chunk boundaries (65515-byte framing), so scan a small carry buffer until we find it.
+    let mut pending: Vec<u8> = Vec::new();
     loop {
         let Some(payload) = read_pkt_payload_raw(r)? else {
             break;
         };
+        // `read_pkt_payload_raw` returns `None` on flush/EOF; empty payloads should not occur.
         if payload.is_empty() {
-            if seen_pack {
-                break;
-            }
             continue;
         }
         match payload[0] {
             1 => {
-                seen_pack = true;
-                out.extend_from_slice(&payload[1..]);
+                let data = &payload[1..];
+                if !seen_pack {
+                    pending.extend_from_slice(data);
+                    if let Some(pos) = pending.windows(4).position(|w| w == b"PACK") {
+                        seen_pack = true;
+                        out.extend_from_slice(&pending[pos..]);
+                        pending.clear();
+                    } else if pending.len() > 3 {
+                        let keep_from = pending.len() - 3;
+                        pending.drain(..keep_from);
+                    }
+                } else {
+                    out.extend_from_slice(data);
+                }
             }
             2 | 3 => {}
             _ => {

--- a/grit/src/file_upload_pack_v2.rs
+++ b/grit/src/file_upload_pack_v2.rs
@@ -352,8 +352,7 @@ fn read_pkt_payload_raw(r: &mut impl Read) -> std::io::Result<Option<Vec<u8>>> {
     let len = usize::from_str_radix(len_str, 16)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
     match len {
-        0 => Ok(Some(Vec::new())),
-        1 | 2 => Ok(Some(Vec::new())),
+        0 | 1 | 2 => Ok(None),
         n if n <= 4 => Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
             format!("invalid pkt-line length: {n}"),

--- a/grit/src/http_smart.rs
+++ b/grit/src/http_smart.rs
@@ -278,9 +278,6 @@ fn read_sideband_pack_until_done(r: &mut impl Read, out: &mut Vec<u8>) -> Result
             break;
         };
         if payload.is_empty() {
-            if seen_pack {
-                break;
-            }
             continue;
         }
         match payload[0] {

--- a/grit/src/pack_objects_upload.rs
+++ b/grit/src/pack_objects_upload.rs
@@ -19,7 +19,10 @@ fn resolve_hook_path(git_dir: &Path, hook: &str) -> PathBuf {
 }
 
 /// Build and spawn `git pack-objects` (via hook or `grit pack-objects`).
-pub fn spawn_pack_objects_upload(git_dir: &Path) -> Result<Child> {
+///
+/// When `thin` is true, omit objects the client already has (requires matching `have` lines).
+/// For a fetch/clone with no common objects, pass `false` so the pack is self-contained.
+pub fn spawn_pack_objects_upload(git_dir: &Path, thin: bool) -> Result<Child> {
     let protected = ConfigSet::load_protected(true).unwrap_or_default();
     let hook_raw = protected.get("uploadpack.packobjectshook");
     let grit = grit_executable();
@@ -32,18 +35,21 @@ pub fn spawn_pack_objects_upload(git_dir: &Path) -> Result<Child> {
             .arg(&hook_resolved)
             .arg("git")
             .arg("pack-objects")
-            .arg("--revs")
-            .arg("--thin")
-            .arg("--stdout")
+            .arg("--revs");
+        if thin {
+            c.arg("--thin");
+        }
+        c.arg("--stdout")
             .arg("--progress")
             .arg("--delta-base-offset");
         c
     } else {
         let mut c = Command::new(&grit);
-        c.arg("pack-objects")
-            .arg("--revs")
-            .arg("--thin")
-            .arg("--stdout")
+        c.arg("pack-objects").arg("--revs");
+        if thin {
+            c.arg("--thin");
+        }
+        c.arg("--stdout")
             .arg("--progress")
             .arg("--delta-base-offset");
         c

--- a/logs/2026-04-09_t5405-send-pack-rewind.md
+++ b/logs/2026-04-09_t5405-send-pack-rewind.md
@@ -1,0 +1,24 @@
+# t5405-send-pack-rewind
+
+## Symptom
+
+`git fetch .. main:main` failed with `could not find remote ref 'refs/heads/main'` (protocol v2 advertisement misread as v0) or, after forcing v0, `pack trailing checksum mismatch` on unpack.
+
+## Fixes
+
+1. **`fetch_transport::spawn_upload_pack`**: Always spawn `upload-pack` with protocol v0 (`GIT_PROTOCOL` unset). The negotiation path uses v0 ref ads + want/have/done; default `protocol.version=2` left the advertised ref list empty.
+
+2. **`read_pkt_payload_raw`**: Return `None` for flush/delim/special pkt-lines (`len` 0–2), not `Some([])`, so side-band readers stop at the post-pack flush instead of reading the next pkt-line into the pack buffer.
+
+3. **`read_sideband_pack_until_done`**: Skip channel-1 progress until `PACK` magic; handle magic split across side-band chunks via a small pending buffer.
+
+4. **`pack_objects_upload::spawn_pack_objects_upload`**: Pass `thin: bool`; omit `--thin` when there are no client `have` commits (empty clone / first fetch), matching Git so the pack is self-contained.
+
+5. **`StreamingPackReader::decompress`** (`unpack_objects.rs`): Use `flate2::Decompress` with explicit consumed input length so the pack SHA-1 matches Git when zlib streams do not end on read chunk boundaries (e.g. empty file blob in t5405).
+
+## Validation
+
+- `sh tests/t5405-send-pack-rewind.sh` — 3/3
+- `./scripts/run-tests.sh t5405-send-pack-rewind.sh` — 3/3
+- `cargo test -p grit-lib --lib` — pass
+- `cargo clippy -p grit-lib -p grit-rs` — pass

--- a/progress.md
+++ b/progress.md
@@ -15,6 +15,7 @@ Task lines in `PLAN.md`: 308 completed (`[x]`), 5 in progress (`[~]`), 456 remai
 
 ## Recently completed
 
+- `t5405-send-pack-rewind` — 3/3 tests pass (local `upload-pack` negotiation: force protocol v0 for ref ads; side-band reader stops on flush pkt-lines; skip progress until `PACK`; thin pack only with `have` lines; `unpack_objects` zlib input consumption matches Git for pack checksum)
 - `t3423-rebase-reword` — 3/3 tests pass (`rebase -i`: parse `reword`/`r` in todo; run commit editor with `prepare-commit-msg` source `reword`; `rebase --continue` after conflict uses `rebase-merge/message` template; noop-fast-forward path restricted to `pick` only so `reword` still opens editor)
 - `t3417-rebase-whitespace-fix` — 4/4 tests pass (`rebase --whitespace=fix`: apply `fix_blob_bytes` to merged index after three-way merge; noop pick path rebuilds tree + commit when whitespace fix is active; harness CSV refreshed)
 - `t7011-skip-worktree-reading` — 15/15 tests pass (`update-index` skip-worktree no-op / `--remove` clears entry; `--remove` on missing untracked path is silent; `reset` preserves skip-worktree; `diff-index` skips worktree for skip-worktree; `commit` pathspec rejects skip-worktree)


### PR DESCRIPTION
Force protocol v0 for spawned upload-pack so ref advertisements match the v0 want/have negotiation path. Treat flush pkt-lines as boundaries in binary side-band reads, strip progress until PACK (including split magic), and omit pack-objects --thin when the client sent no haves. Fix streaming pack zlib decompression to hash exactly the compressed bytes so checksums match Git for small/empty blobs.