### PR TITLE
chore: t2108 update-index refresh racy — harness + plan

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -203,7 +203,7 @@ commit → check it off → move on.
 - [ ] `t2200-add-update` █████████████░░░░░░░ 13/19 (6 left) — git add -u
 
 - [ ] `t2500-untracked-overwriting` ████████░░░░░░░░░░░░ 4/10 (6 left) — Test handling of overwriting untracked files
-- [ ] `t2108-update-index-refresh-racy` ░░░░░░░░░░░░░░░░░░░░ 0/6 (6 left) — update-index refresh tests related to racy timestamps
+- [x] `t2108-update-index-refresh-racy` ████████████████████ 6/6 (0 left) — update-index refresh tests related to racy timestamps
 - [ ] `t2017-checkout-orphan` █████████░░░░░░░░░░░ 6/13 (7 left) — git checkout --orphan
 
 - [ ] `t2003-checkout-cache-mkdir` ██████░░░░░░░░░░░░░░ 3/10 (7 left) — git checkout-index --prefix test.

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -511,7 +511,7 @@ t2104-update-index-skip-worktree	t2	yes	7	5	2	false	ok	0
 t2105-update-index-gitfile	t2	yes	4	4	0	true	ok	0
 t2106-update-index-assume-unchanged	t2	yes	2	2	0	true	ok	0
 t2107-update-index-basic	t2	yes	10	10	0	true	ok	0
-t2108-update-index-refresh-racy	t2	yes	6	0	6	false	ok	0
+t2108-update-index-refresh-racy	t2	yes	6	6	0	true	ok	0
 t2200-add-update	t2	yes	19	18	1	false	ok	0
 t2201-add-update-typechange	t2	yes	6	2	4	false	ok	0
 t2202-add-addremove	t2	yes	3	3	0	true	ok	0
@@ -1193,7 +1193,7 @@ t7111-reset-table	t7	yes	42	34	8	false	ok	0
 t7112-reset-submodule	t7	yes	76	24	52	false	ok	0
 t7113-post-index-change-hook	t7	yes	4	1	3	false	ok	0
 t7201-co	t7	yes	46	17	29	false	ok	0
-t7300-clean	t7	yes	53	52	1	false	ok	2
+t7300-clean	t7	yes	53	52	1	false	ok	0
 t7301-clean-interactive	t7	yes	23	8	15	false	ok	0
 t7400-submodule-basic	t7	yes	124	51	73	false	ok	0
 t7401-submodule-summary	t7	yes	25	6	19	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.8% of harness tests passing (35,530 / 45,112).">
+<meta property="og:description" content="78.8% of harness tests passing (35,539 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.8% of harness tests passing (35,530 / 45,112).">
+<meta name="twitter:description" content="78.8% of harness tests passing (35,539 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T16:30:42+00:00" class="gen-time" title="2026-04-09 16:30 UTC">2026-04-09 16:30 UTC</time> · <a href="https://github.com/schacon/grit/commit/7cfe71677eb58eb382a548e40cc0ad9e587d560d" style="color:#58a6ff">7cfe716</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T18:01:10+00:00" class="gen-time" title="2026-04-09 18:01 UTC">2026-04-09 18:01 UTC</time> · <a href="https://github.com/schacon/grit/commit/cbee7d7f221f5433fc3bf9357584a1381a064ebb" style="color:#58a6ff">cbee7d7</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,530</div>
+      <div class="summary-big-val">35,539</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>746 files fully passing</span>
+    <span>749 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -208,11 +208,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t2</span>
         <span class="group-desc">Basic commands concerning the working tree</span>
-        <span class="group-meta">29/61 files · 9 skipped · 664/872 tests</span>
+        <span class="group-meta">30/61 files · 9 skipped · 670/872 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:76.1%"></div></div>
-        <span class="group-pct pct-blue">76.1%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:76.8%"></div></div>
+        <span class="group-pct pct-blue">76.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t3">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">46/126 files · 11 skipped · 2,475/3,614 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,478/3,614 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.5%"></div></div>
-        <span class="group-pct pct-blue">68.5%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.6%"></div></div>
+        <span class="group-pct pct-blue">68.6%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35530 of 45112 tests passing across 1405 harness files (78.8% pass rate).</desc>
+  <desc id="svg-desc">35539 of 45112 tests passing across 1405 harness files (78.8% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.8% pass rate · 35,530 / 45,112 tests · 1,405 files in scope · 746 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.8% pass rate · 35,539 / 45,112 tests · 1,405 files in scope · 749 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="552" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T16:30:42+00:00" class="gen-time" title="2026-04-09 16:30 UTC">2026-04-09 16:30 UTC</time> · <a href="https://github.com/schacon/grit/commit/7cfe71677eb58eb382a548e40cc0ad9e587d560d" style="color:#58a6ff">7cfe716</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T18:01:10+00:00" class="gen-time" title="2026-04-09 18:01 UTC">2026-04-09 18:01 UTC</time> · <a href="https://github.com/schacon/grit/commit/cbee7d7f221f5433fc3bf9357584a1381a064ebb" style="color:#58a6ff">cbee7d7</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,530</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,539</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.8%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -5267,14 +5267,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t2" data-tests="6" data-passed="0">
+<tr class="" data-group="t2" data-tests="6" data-passed="6" data-full-pass="1">
   <td class="mono">t2108-update-index-refresh-racy</td>
   <td>t2</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">6</td>
-  <td class="right">0</td>
+  <td class="right">6</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t2" data-tests="19" data-passed="18">
@@ -11717,14 +11717,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:80.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="11" data-passed="10">
+<tr class="" data-group="t7" data-tests="11" data-passed="11" data-full-pass="1">
   <td class="mono">t7012-skip-worktree-writing</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">11</td>
-  <td class="right">10</td>
+  <td class="right">11</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">6</td>
 </tr>
 <tr class="" data-group="t7" data-tests="26" data-passed="26" data-full-pass="1">
@@ -12095,7 +12095,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">52</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.1%"></div></div></td>
-  <td class="right small">2</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="23" data-passed="8">
   <td class="mono">t7301-clean-interactive</td>
@@ -12917,14 +12917,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
   <td class="right small">7</td>
 </tr>
-<tr class="" data-group="t7" data-tests="22" data-passed="20">
+<tr class="" data-group="t7" data-tests="22" data-passed="22" data-full-pass="1">
   <td class="mono">t7815-grep-binary</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">22</td>
-  <td class="right">20</td>
+  <td class="right">22</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="145" data-passed="145" data-full-pass="1">

--- a/logs/2026-04-09_t2108-update-index-refresh-racy.md
+++ b/logs/2026-04-09_t2108-update-index-refresh-racy.md
@@ -1,0 +1,20 @@
+# t2108-update-index-refresh-racy
+
+**Date:** 2026-04-09
+
+## Goal
+
+Make `t2108-update-index-refresh-racy.sh` fully pass (racy mtime behavior for `git update-index --refresh`).
+
+## What we found
+
+- Ran `./scripts/run-tests.sh t2108-update-index-refresh-racy.sh`: **6/6** on branch `cursor/t2108-index-refresh-racy-4d5f`.
+- No Rust changes were required: `grit/src/commands/update_index.rs` already implements Git-aligned behavior:
+  - `index_file_mtime_pair` + `has_racy_timestamp` mirror `read-cache.c` (`is_racy_stat` / `has_racy_timestamp`).
+  - `--refresh` skips rewriting the index when nothing changed and no entry is racy vs index read mtime (first t2108 test).
+  - When racy or stat-updated, the index is written so the magic mtime on `.git/index` is cleared (remaining tests).
+
+## Follow-up
+
+- Refreshed `data/test-files.csv` and dashboards via `run-tests.sh`.
+- Marked task complete in `PLAN.md` and updated `progress.md`.

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   315 |
+| Completed   |   318 |
 | In progress |     5 |
-| Remaining   |   450 |
-| **Total**   |   770 |
+| Remaining   |   448 |
+| **Total**   |   771 |
 
-Task lines in `PLAN.md`: 315 completed (`[x]`), 5 in progress (`[~]`), 450 remaining (`[ ]`).
+Task lines in `PLAN.md`: 318 completed (`[x]`), 5 in progress (`[~]`), 448 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t2108-update-index-refresh-racy` — 6/6 tests pass (`update-index --refresh` / `--really-refresh`: preserve index mtime when nothing racy; rewrite when racy so magic mtime clears; harness CSV/dashboards refreshed)
 - `t5609-clone-branch` — 7/7 tests pass (`clone --branch`: `read_raw_ref` for ref existence so `refs/remotes/origin/HEAD` is set when default branch is packed; reject `--branch` when `refs/heads/<name>` missing on source, including empty repos)
 - `t5802-connect-helper` — 8/8 tests pass (`ext::` sh -c upload-pack argv extraction; `git daemon --inetd` minimal path; streaming unpack zero-byte trees + duplicate `want` dedup; fetch NAK round + tag-following for ext/HTTP; rev-parse `tag^1` peels tags; harness CSV/dashboards refreshed)
 - `t7421-submodule-summary-add` — 5/5 tests pass (`submodule summary`: index↔commit gitlink diff, pathspecs + renamed paths, `rev-parse` first line for abbrev; `submodule update --remote`: local URL fast path updates `refs/remotes/origin/*` + copies objects, stages gitlink in super index)

--- a/test-results.md
+++ b/test-results.md
@@ -1,5 +1,10 @@
 # Test results
 
+**2026-04-09 (t2108 / update-index refresh racy)**
+
+- `cargo test -p grit-lib --lib`: 155 passed
+- `./scripts/run-tests.sh t2108-update-index-refresh-racy.sh`: 6/6 passed
+
 **2026-04-09 (t5609 / clone --branch)**
 
 - `cargo test -p grit-lib --lib`: 152 passed


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Verified `t2108-update-index-refresh-racy.sh` passes **6/6** against current `grit`. No Rust changes were required: `update-index --refresh` / `--really-refresh` already match Git’s racy-timestamp rules (index read mtime vs entry mtimes; skip rewriting the index when nothing is racy).

## Changes

- Refreshed `data/test-files.csv` and dashboards from `./scripts/run-tests.sh t2108-update-index-refresh-racy.sh`
- Marked `t2108-update-index-refresh-racy` complete in `PLAN.md`
- Updated `progress.md`, `test-results.md`, and added `logs/2026-04-09_t2108-update-index-refresh-racy.md`

## Validation

- `cargo test -p grit-lib --lib`: 155 passed
- `./scripts/run-tests.sh t2108-update-index-refresh-racy.sh`: 6/6 passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13ff149f-0d37-413e-a6b7-a9914ca4cdcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13ff149f-0d37-413e-a6b7-a9914ca4cdcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

