### PR TITLE
fix: Git-compatible diff-index -z raw output (t4009-diff-rename-4)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -682,7 +682,7 @@ t4005-diff-rename-2	t4	yes	4	1	3	false	ok	0
 t4006-diff-mode	t4	yes	7	6	1	false	ok	0
 t4007-rename-3	t4	yes	13	6	7	false	ok	0
 t4008-diff-break-rewrite	t4	yes	14	5	9	false	ok	0
-t4009-diff-rename-4	t4	yes	7	4	3	false	ok	0
+t4009-diff-rename-4	t4	yes	7	7	0	true	ok	0
 t4010-diff-pathspec	t4	yes	17	17	0	true	ok	0
 t4011-diff-symlink	t4	yes	8	7	1	false	ok	0
 t4011-diff-tree	t4	yes	110	109	1	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.8% of harness tests passing (35,535 / 45,112).">
+<meta property="og:description" content="78.8% of harness tests passing (35,582 / 45,141).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.8% of harness tests passing (35,535 / 45,112).">
+<meta name="twitter:description" content="78.8% of harness tests passing (35,582 / 45,141).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T17:58:25+00:00" class="gen-time" title="2026-04-09 17:58 UTC">2026-04-09 17:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/cbee7d7f221f5433fc3bf9357584a1381a064ebb" style="color:#58a6ff">cbee7d7</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T18:12:07+00:00" class="gen-time" title="2026-04-09 18:12 UTC">2026-04-09 18:12 UTC</time> · <a href="https://github.com/schacon/grit/commit/e68f5dd2f3e4e16746c4824798176cdfe2532176" style="color:#58a6ff">e68f5dd</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,11 +157,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,535</div>
+      <div class="summary-big-val">35,582</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">45,112</div>
+      <div class="summary-big-val">45,141</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>749 files fully passing</span>
+    <span>754 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -208,44 +208,44 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t2</span>
         <span class="group-desc">Basic commands concerning the working tree</span>
-        <span class="group-meta">29/61 files · 9 skipped · 664/872 tests</span>
+        <span class="group-meta">30/61 files · 9 skipped · 665/872 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:76.1%"></div></div>
-        <span class="group-pct pct-blue">76.1%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:76.3%"></div></div>
+        <span class="group-pct pct-blue">76.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t3">
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">54/141 files · 2 skipped · 3,954/5,369 tests</span>
+        <span class="group-meta">55/141 files · 2 skipped · 3,983/5,398 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:73.6%"></div></div>
-        <span class="group-pct pct-blue">73.6%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:73.8%"></div></div>
+        <span class="group-pct pct-blue">73.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">72/178 files · 2 skipped · 2,866/4,437 tests</span>
+        <span class="group-meta">73/178 files · 2 skipped · 2,869/4,437 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.6%"></div></div>
-        <span class="group-pct pct-blue">64.6%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.7%"></div></div>
+        <span class="group-pct pct-blue">64.7%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">28/167 files · 17 skipped · 1,520/4,139 tests</span>
+        <span class="group-meta">29/167 files · 17 skipped · 1,522/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:36.7%"></div></div>
-        <span class="group-pct pct-red">36.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:36.8%"></div></div>
+        <span class="group-pct pct-red">36.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">48/126 files · 11 skipped · 2,478/3,614 tests</span>
+        <span class="group-meta">49/126 files · 11 skipped · 2,490/3,614 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.6%"></div></div>
-        <span class="group-pct pct-blue">68.6%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.9%"></div></div>
+        <span class="group-pct pct-blue">68.9%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35535 of 45112 tests passing across 1405 harness files (78.8% pass rate).</desc>
+  <desc id="svg-desc">35582 of 45141 tests passing across 1405 harness files (78.8% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.8% pass rate · 35,535 / 45,112 tests · 1,405 files in scope · 749 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.8% pass rate · 35,582 / 45,141 tests · 1,405 files in scope · 754 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="552" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T17:58:25+00:00" class="gen-time" title="2026-04-09 17:58 UTC">2026-04-09 17:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/cbee7d7f221f5433fc3bf9357584a1381a064ebb" style="color:#58a6ff">cbee7d7</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T18:12:07+00:00" class="gen-time" title="2026-04-09 18:12 UTC">2026-04-09 18:12 UTC</time> · <a href="https://github.com/schacon/grit/commit/e68f5dd2f3e4e16746c4824798176cdfe2532176" style="color:#58a6ff">e68f5dd</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,535</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n" id="sum-tests">45,141</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,582</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.8%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -5277,14 +5277,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t2" data-tests="19" data-passed="18">
+<tr class="" data-group="t2" data-tests="19" data-passed="19" data-full-pass="1">
   <td class="mono">t2200-add-update</td>
   <td>t2</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">19</td>
-  <td class="right">18</td>
+  <td class="right">19</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:94.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t2" data-tests="6" data-passed="2">
@@ -6867,15 +6867,15 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="0" data-passed="0">
+<tr class="" data-group="t3" data-tests="29" data-passed="29" data-full-pass="1">
   <td class="mono">t3910-mac-os-precompose</td>
   <td>t3</td>
-  <td></td>
-  <td class="right">0</td>
-  <td class="right">0</td>
+  <td><span class="badge ok">full pass</span></td>
+  <td class="right">29</td>
+  <td class="right">29</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="18" data-passed="6">
   <td class="mono">t3920-crlf-messages</td>
@@ -6977,14 +6977,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:35.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="7" data-passed="4">
+<tr class="" data-group="t4" data-tests="7" data-passed="7" data-full-pass="1">
   <td class="mono">t4009-diff-rename-4</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">7</td>
-  <td class="right">4</td>
+  <td class="right">7</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:57.1%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="17" data-passed="17" data-full-pass="1">
@@ -9257,14 +9257,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:42.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="3" data-passed="1">
+<tr class="" data-group="t5" data-tests="3" data-passed="3" data-full-pass="1">
   <td class="mono">t5405-send-pack-rewind</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">3</td>
-  <td class="right">1</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:33.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="3" data-passed="2">
@@ -11777,14 +11777,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="17" data-passed="5">
+<tr class="" data-group="t7" data-tests="17" data-passed="17" data-full-pass="1">
   <td class="mono">t7060-wtstatus</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">17</td>
-  <td class="right">5</td>
+  <td class="right">17</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:29.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="26" data-passed="26" data-full-pass="1">

--- a/grit/src/commands/diff_index.rs
+++ b/grit/src/commands/diff_index.rs
@@ -309,16 +309,20 @@ pub fn run(mut args: Args) -> Result<()> {
                 }
             }
         } else {
-            let terminator = if options.nul_terminated { "\0" } else { "\n" };
             let stdout = std::io::stdout();
             let mut out = stdout.lock();
             for entry in &diff_entries {
-                let line = render_raw_diff_entry(entry, &repo, options.abbrev, !options.cached)?;
                 if options.nul_terminated {
-                    // In -z mode, the colon-prefixed status line ends with NUL,
-                    // then path(s) follow separated/terminated by NUL
-                    write!(out, "{}{}", line, terminator)?;
+                    write_raw_diff_entry_z(
+                        &mut out,
+                        entry,
+                        &repo,
+                        options.abbrev,
+                        !options.cached,
+                    )?;
                 } else {
+                    let line =
+                        render_raw_diff_entry(entry, &repo, options.abbrev, !options.cached)?;
                     writeln!(out, "{}", line)?;
                 }
             }
@@ -1183,6 +1187,70 @@ fn raw_change_to_diff_entry(change: &RawChange) -> DiffEntry {
         new_oid: change.new.map_or_else(zero_oid, |s| s.oid),
         score: None,
     }
+}
+
+/// Write one `diff-index` raw record in Git's `-z` format.
+///
+/// The colon-prefixed status line ends with a NUL byte (no tab before paths).
+/// For renames/copies, old and new paths are each NUL-terminated. For other
+/// statuses, a single path is NUL-terminated.
+fn write_raw_diff_entry_z(
+    out: &mut impl Write,
+    entry: &DiffEntry,
+    repo: &Repository,
+    abbrev: Option<usize>,
+    diff_index_uncached: bool,
+) -> Result<()> {
+    let width = abbrev.unwrap_or(40).clamp(4, 40);
+
+    let (old_oid_disp, new_oid_disp) = if diff_index_uncached && entry.status == DiffStatus::Added {
+        ("0".repeat(width), "0".repeat(width))
+    } else {
+        let old_oid = if entry.old_oid == zero_oid() {
+            "0".repeat(width)
+        } else {
+            match abbrev {
+                Some(min_len) => abbreviate_object_id(repo, entry.old_oid, min_len)?,
+                None => entry.old_oid.to_hex(),
+            }
+        };
+        let new_oid = if entry.new_oid == zero_oid() {
+            "0".repeat(width)
+        } else {
+            match abbrev {
+                Some(min_len) => abbreviate_object_id(repo, entry.new_oid, min_len)?,
+                None => entry.new_oid.to_hex(),
+            }
+        };
+        (old_oid, new_oid)
+    };
+
+    let status_str = match (entry.status, entry.score) {
+        (DiffStatus::Renamed, Some(s)) => format!("R{s:03}"),
+        (DiffStatus::Copied, Some(s)) => format!("C{s:03}"),
+        _ => entry.status.letter().to_string(),
+    };
+
+    write!(
+        out,
+        ":{} {} {} {} {}",
+        entry.old_mode, entry.new_mode, old_oid_disp, new_oid_disp, status_str
+    )?;
+    out.write_all(b"\0")?;
+
+    match entry.status {
+        DiffStatus::Renamed | DiffStatus::Copied => {
+            out.write_all(entry.old_path.as_deref().unwrap_or("").as_bytes())?;
+            out.write_all(b"\0")?;
+            out.write_all(entry.new_path.as_deref().unwrap_or("").as_bytes())?;
+            out.write_all(b"\0")?;
+        }
+        _ => {
+            out.write_all(entry.path().as_bytes())?;
+            out.write_all(b"\0")?;
+        }
+    }
+    Ok(())
 }
 
 /// Render a DiffEntry in raw format.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`grit diff-index -z` was emitting a single NUL-terminated line that still used tab-separated paths after the colon header, which does not match Git’s diff-raw `-z` encoding. The harness in `t4009-diff-rename-4` compares against Git’s format after normalizing scores and OIDs.

## Changes

- **`diff-index` raw `-z` output**: NUL-terminate the colon-prefixed status line (no tab before paths). For renames/copies, write old path and new path as separate NUL-terminated fields.
- **Harness refresh**: Updated `data/test-files.csv` and generated dashboards after `./scripts/run-tests.sh t4009-diff-rename-4.sh` (7/7 pass).

## Validation

- `./scripts/run-tests.sh t4009-diff-rename-4.sh`
- `cargo test -p grit-lib --lib`
- `cargo check -p grit-rs`

Note: `cargo clippy -p grit-rs -- -D warnings` fails on this repo due to many pre-existing `grit-lib` clippy errors; the touched crate checks clean with `cargo check`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac39f0ce-4668-4bb9-b68f-66398868e154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac39f0ce-4668-4bb9-b68f-66398868e154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

