### PR TITLE
fix: make t4063-diff-blobs fully pass

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -490,7 +490,7 @@ commit → check it off → move on.
 
 - [ ] `t4069-remerge-diff` █░░░░░░░░░░░░░░░░░░░ 1/16 (15 left) — remerge-diff handling
 - [ ] `t4019-diff-wserror` ████░░░░░░░░░░░░░░░░ 5/21 (16 left) — diff whitespace error detection
-- [ ] `t4063-diff-blobs` ██░░░░░░░░░░░░░░░░░░ 2/18 (16 left) — test direct comparison of blobs via git-diff
+- [x] `t4063-diff-blobs` ████████████████████ 18/18 (0 left) — test direct comparison of blobs via git-diff
 - [x] `t4214-log-graph-octopus` ████████████████████ 17/17 (0 left) — git log --graph of skewed left octopus merge.
 - [ ] `t4103-apply-binary` █████░░░░░░░░░░░░░░░ 7/24 (17 left) — git apply handling binary patches
 

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -744,7 +744,7 @@ t4059-diff-submodule-not-initialized	t4	yes	8	8	0	true	ok	0
 t4060-diff-submodule-option-diff-format	t4	yes	51	29	22	false	ok	0
 t4061-diff-indent	t4	yes	33	2	31	false	ok	0
 t4062-diff-pickaxe	t4	yes	3	3	0	true	ok	0
-t4063-diff-blobs	t4	yes	18	3	15	false	ok	0
+t4063-diff-blobs	t4	yes	18	18	0	true	ok	0
 t4064-diff-oidfind	t4	yes	10	10	0	true	ok	0
 t4065-diff-anchored	t4	yes	7	7	0	true	ok	0
 t4066-diff-emit-delay	t4	yes	2	2	0	true	ok	0
@@ -1193,7 +1193,7 @@ t7111-reset-table	t7	yes	42	34	8	false	ok	0
 t7112-reset-submodule	t7	yes	76	24	52	false	ok	0
 t7113-post-index-change-hook	t7	yes	4	1	3	false	ok	0
 t7201-co	t7	yes	46	17	29	false	ok	0
-t7300-clean	t7	yes	53	52	1	false	ok	2
+t7300-clean	t7	yes	53	52	1	false	ok	0
 t7301-clean-interactive	t7	yes	23	8	15	false	ok	0
 t7400-submodule-basic	t7	yes	124	51	73	false	ok	0
 t7401-submodule-summary	t7	yes	25	6	19	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.8% of harness tests passing (35,530 / 45,112).">
+<meta property="og:description" content="78.8% of harness tests passing (35,547 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.8% of harness tests passing (35,530 / 45,112).">
+<meta name="twitter:description" content="78.8% of harness tests passing (35,547 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T16:30:42+00:00" class="gen-time" title="2026-04-09 16:30 UTC">2026-04-09 16:30 UTC</time> · <a href="https://github.com/schacon/grit/commit/7cfe71677eb58eb382a548e40cc0ad9e587d560d" style="color:#58a6ff">7cfe716</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T18:21:06+00:00" class="gen-time" title="2026-04-09 18:21 UTC">2026-04-09 18:21 UTC</time> · <a href="https://github.com/schacon/grit/commit/f9ea624972d94eb7291489345f3d4b54c182b54f" style="color:#58a6ff">f9ea624</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,530</div>
+      <div class="summary-big-val">35,547</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>746 files fully passing</span>
+    <span>748 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -230,11 +230,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">72/178 files · 2 skipped · 2,866/4,437 tests</span>
+        <span class="group-meta">73/178 files · 2 skipped · 2,881/4,437 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.6%"></div></div>
-        <span class="group-pct pct-blue">64.6%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.9%"></div></div>
+        <span class="group-pct pct-blue">64.9%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">
@@ -263,7 +263,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">46/126 files · 11 skipped · 2,475/3,614 tests</span>
+        <span class="group-meta">47/126 files · 11 skipped · 2,477/3,614 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.5%"></div></div>

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35530 of 45112 tests passing across 1405 harness files (78.8% pass rate).</desc>
+  <desc id="svg-desc">35547 of 45112 tests passing across 1405 harness files (78.8% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.8% pass rate · 35,530 / 45,112 tests · 1,405 files in scope · 746 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.8% pass rate · 35,547 / 45,112 tests · 1,405 files in scope · 748 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="552" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T16:30:42+00:00" class="gen-time" title="2026-04-09 16:30 UTC">2026-04-09 16:30 UTC</time> · <a href="https://github.com/schacon/grit/commit/7cfe71677eb58eb382a548e40cc0ad9e587d560d" style="color:#58a6ff">7cfe716</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T18:21:06+00:00" class="gen-time" title="2026-04-09 18:21 UTC">2026-04-09 18:21 UTC</time> · <a href="https://github.com/schacon/grit/commit/f9ea624972d94eb7291489345f3d4b54c182b54f" style="color:#58a6ff">f9ea624</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,530</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,547</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.8%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -7597,14 +7597,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="18" data-passed="3">
+<tr class="" data-group="t4" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t4063-diff-blobs</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">3</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:16.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="10" data-passed="10" data-full-pass="1">
@@ -12095,7 +12095,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">52</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.1%"></div></div></td>
-  <td class="right small">2</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="23" data-passed="8">
   <td class="mono">t7301-clean-interactive</td>
@@ -12917,14 +12917,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
   <td class="right small">7</td>
 </tr>
-<tr class="" data-group="t7" data-tests="22" data-passed="20">
+<tr class="" data-group="t7" data-tests="22" data-passed="22" data-full-pass="1">
   <td class="mono">t7815-grep-binary</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">22</td>
-  <td class="right">20</td>
+  <td class="right">22</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="145" data-passed="145" data-full-pass="1">

--- a/grit-lib/src/rev_parse.rs
+++ b/grit-lib/src/rev_parse.rs
@@ -972,27 +972,111 @@ fn peel_to_tree(repo: &Repository, oid: ObjectId) -> Result<ObjectId> {
 
 /// Navigate a tree to find an object at a given path.
 fn resolve_tree_path(repo: &Repository, tree_oid: &ObjectId, path: &str) -> Result<ObjectId> {
+    let (oid, _) = walk_tree_to_blob_entry(repo, tree_oid, path)?;
+    Ok(oid)
+}
+
+/// Resolved blob (non-tree) at `treeish:path` for diff plumbing.
+///
+/// Returns the repository-relative path, blob OID, and Git mode string (e.g. `"100644"`).
+#[derive(Debug, Clone)]
+pub struct TreeishBlobAtPath {
+    /// Path used in `diff --git` / `---` / `+++` headers (tree path, `/`-separated).
+    pub path: String,
+    /// Object id of the blob.
+    pub oid: ObjectId,
+    /// File mode as in tree objects (`100644`, `100755`, `120000`, …).
+    pub mode: String,
+}
+
+/// Resolve `rev:path` to the blob at that path in the tree reached from `rev`.
+///
+/// Fails when `spec` is not `treeish:path`, when the path is missing, or when the
+/// target is a tree or gitlink rather than a blob/symlink blob.
+pub fn resolve_treeish_blob_at_path(repo: &Repository, spec: &str) -> Result<TreeishBlobAtPath> {
+    let (before, after) = split_treeish_colon(spec)
+        .filter(|(_, path)| !path.is_empty())
+        .ok_or_else(|| Error::InvalidRef(format!("'{spec}' is not a treeish:path revision")))?;
+
+    let rev_oid = match resolve_revision_impl(repo, before, true, false, true, true, false, false) {
+        Ok(o) => o,
+        Err(Error::ObjectNotFound(s)) if s == before => {
+            return Err(Error::Message(format!(
+                "fatal: invalid object name '{before}'."
+            )));
+        }
+        Err(Error::Message(msg)) if msg.contains("ambiguous argument") => {
+            return Err(Error::Message(format!(
+                "fatal: invalid object name '{before}'."
+            )));
+        }
+        Err(e) => return Err(e),
+    };
+
+    let tree_oid = peel_to_tree(repo, rev_oid)?;
+    let clean_path = match normalize_colon_path_for_tree(repo, after) {
+        Ok(p) => p,
+        Err(Error::InvalidRef(msg)) if msg == "outside repository" => {
+            let wt = repo
+                .work_tree
+                .as_ref()
+                .and_then(|p| p.canonicalize().ok())
+                .map(|p| p.display().to_string())
+                .unwrap_or_default();
+            return Err(Error::Message(format!(
+                "fatal: '{after}' is outside repository at '{wt}'"
+            )));
+        }
+        Err(e) => return Err(e),
+    };
+
+    let (oid, mode_str) = walk_tree_to_blob_entry(repo, &tree_oid, &clean_path)?;
+    Ok(TreeishBlobAtPath {
+        path: clean_path,
+        oid,
+        mode: mode_str,
+    })
+}
+
+/// Walk from `tree_oid` to the leaf named by `path` and return blob OID + mode string.
+fn walk_tree_to_blob_entry(
+    repo: &Repository,
+    tree_oid: &ObjectId,
+    path: &str,
+) -> Result<(ObjectId, String)> {
     let obj = repo.odb.read(tree_oid)?;
     let entries = crate::objects::parse_tree(&obj.data)?;
     let components: Vec<&str> = path.split('/').filter(|c| !c.is_empty()).collect();
     if components.is_empty() {
-        return Ok(*tree_oid);
+        return Err(Error::InvalidRef(format!(
+            "path '{path}' does not name a blob in tree {tree_oid}"
+        )));
     }
+
     let first = components[0];
     let rest: Vec<&str> = components[1..].to_vec();
     for entry in entries {
         let name = String::from_utf8_lossy(&entry.name);
         if name == first {
             if rest.is_empty() {
-                return Ok(entry.oid);
-            } else {
-                return resolve_tree_path(repo, &entry.oid, &rest.join("/"));
+                if entry.mode == crate::index::MODE_TREE {
+                    return Err(Error::InvalidRef(format!("'{path}' is a tree, not a blob")));
+                }
+                if entry.mode == crate::index::MODE_GITLINK {
+                    return Err(Error::InvalidRef(format!(
+                        "'{path}' is a gitlink, not a blob"
+                    )));
+                }
+                return Ok((entry.oid, entry.mode_str()));
             }
+            if entry.mode != crate::index::MODE_TREE {
+                return Err(Error::ObjectNotFound(path.to_owned()));
+            }
+            return walk_tree_to_blob_entry(repo, &entry.oid, &rest.join("/"));
         }
     }
     Err(Error::ObjectNotFound(format!(
-        "path '{}' not found in tree {}",
-        path, tree_oid
+        "path '{path}' not found in tree {tree_oid}"
     )))
 }
 

--- a/grit/src/commands/diff.rs
+++ b/grit/src/commands/diff.rs
@@ -40,7 +40,8 @@ use grit_lib::odb::Odb;
 use grit_lib::repo::Repository;
 use grit_lib::rev_list::{rev_list, RevListOptions};
 use grit_lib::rev_parse::{
-    abbreviate_object_id, resolve_revision, show_prefix, split_treeish_colon,
+    abbreviate_object_id, resolve_revision, resolve_treeish_blob_at_path, show_prefix,
+    split_treeish_colon, TreeishBlobAtPath,
 };
 use grit_lib::userdiff::matcher_for_path_parsed;
 use regex::Regex;
@@ -219,6 +220,8 @@ fn submodule_commit_subject_line(c: &grit_lib::objects::CommitData) -> String {
 use std::env;
 use std::fs;
 use std::io::{self, IsTerminal, Write};
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 /// ANSI color codes for diff output.
 const RESET: &str = "\x1b[m";
@@ -1084,14 +1087,15 @@ pub fn run(mut args: Args) -> Result<()> {
         }
         Err(e) => return Err(e.into()),
     };
+    let merged_attrs = Arc::new(merged_attrs);
     let diff_config = grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true)
         .unwrap_or_else(|_| grit_lib::config::ConfigSet::new());
     let ignore_case_attrs = diff_config
         .get("core.ignorecase")
         .is_some_and(|v| matches!(v.to_ascii_lowercase().as_str(), "true" | "yes" | "1"));
     let diff_algo_ctx = DiffAlgoContext {
-        attrs: Arc::new(merged_attrs),
-        config: Arc::new(diff_config),
+        attrs: Arc::clone(&merged_attrs),
+        config: Arc::new(diff_config.clone()),
         ignore_case_attrs,
     };
     let diff_algo_cli = parse_cli_diff_algorithm_from_argv();
@@ -1133,10 +1137,52 @@ pub fn run(mut args: Args) -> Result<()> {
             &args,
             &revs[0],
             &paths[0],
+            None::<&str>,
             &src_prefix,
             &dst_prefix,
             patch_context,
+            Arc::clone(&merged_attrs),
+            diff_config.clone(),
+            ignore_case_attrs,
+            diff_algo_cli,
+            &cwd,
+            quote_path_fully,
         );
+    }
+
+    // `git diff <blob-oid> <file>` — raw object id vs path (t4063: prefers filename in headers).
+    if revs.len() == 1 && paths.len() == 1 && !args.cached {
+        if split_treeish_colon(&revs[0]).is_none() {
+            if let Some(wt) = repo.work_tree.as_ref() {
+                if fs::symlink_metadata(wt.join(&paths[0])).is_ok() {
+                    let oid = resolve_revision(&repo, &revs[0]).ok();
+                    let is_blob = oid.is_some_and(|o| {
+                        repo.odb
+                            .read(&o)
+                            .map(|obj| obj.kind == ObjectKind::Blob)
+                            .unwrap_or(false)
+                    });
+                    if is_blob {
+                        return run_diff_blob_vs_file(
+                            &repo,
+                            &args,
+                            &revs[0],
+                            &paths[0],
+                            Some(paths[0].as_str()),
+                            &src_prefix,
+                            &dst_prefix,
+                            patch_context,
+                            Arc::clone(&merged_attrs),
+                            diff_config.clone(),
+                            ignore_case_attrs,
+                            diff_algo_cli,
+                            &cwd,
+                            quote_path_fully,
+                        );
+                    }
+                }
+            }
+        }
     }
 
     // `git diff <path> <path>` — compare a worktree file to another path (e.g. outside the repo).
@@ -1396,7 +1442,9 @@ pub fn run(mut args: Args) -> Result<()> {
 
     let mut _symmetric = false;
     if revs.len() == 1 {
-        if let Some((left, right)) = revs[0].split_once("...") {
+        if let Some((left_spec, right_spec)) = try_treeish_blob_range(&revs[0]) {
+            revs = vec![left_spec, right_spec];
+        } else if let Some((left, right)) = revs[0].split_once("...") {
             let left = if left.is_empty() { "HEAD" } else { left };
             let right = if right.is_empty() { "HEAD" } else { right };
             let left_oid = resolve_revision(&repo, left)
@@ -1503,10 +1551,28 @@ pub fn run(mut args: Args) -> Result<()> {
                 diff_tree_to_worktree(&repo.odb, Some(&tree_oid), wt, &index)?
             }
             (_, 2) => {
-                // Two revisions: tree-to-tree diff
-                let tree1 = commit_or_tree_oid(&repo, &revs[0])?;
-                let tree2 = commit_or_tree_oid(&repo, &revs[1])?;
-                diff_trees(&repo.odb, Some(&tree1), Some(&tree2), "")?
+                match (
+                    blob_side_for_blob_diff_spec(&repo, &revs[0])?,
+                    blob_side_for_blob_diff_spec(&repo, &revs[1])?,
+                ) {
+                    (Some(a), Some(b)) => {
+                        vec![DiffEntry {
+                            status: DiffStatus::Modified,
+                            old_path: Some(a.path),
+                            new_path: Some(b.path),
+                            old_mode: a.mode,
+                            new_mode: b.mode,
+                            old_oid: a.oid,
+                            new_oid: b.oid,
+                            score: None,
+                        }]
+                    }
+                    _ => {
+                        let tree1 = commit_or_tree_oid(&repo, &revs[0])?;
+                        let tree2 = commit_or_tree_oid(&repo, &revs[1])?;
+                        diff_trees(&repo.odb, Some(&tree1), Some(&tree2), "")?
+                    }
+                }
             }
             _ => {
                 bail!("too many revisions");
@@ -2150,93 +2216,206 @@ pub fn run(mut args: Args) -> Result<()> {
     Ok(())
 }
 
-/// `git diff <rev>:<path> <file>` — blob at revision vs worktree file (used by tests).
+/// `git diff <rev>:<path> <file>` — blob at revision vs worktree file (t4063-diff-blobs).
 fn run_diff_blob_vs_file(
     repo: &Repository,
     args: &Args,
     rev_path: &str,
     file_path: &str,
+    display_old_blob_as: Option<&str>,
     src_prefix: &str,
     dst_prefix: &str,
     patch_context: usize,
+    merged_attrs: Arc<grit_lib::attributes::ParsedGitAttributes>,
+    diff_config: grit_lib::config::ConfigSet,
+    ignore_case_attrs: bool,
+    diff_algo_cli: Option<similar::Algorithm>,
+    cwd: &Path,
+    quote_path_fully: bool,
 ) -> Result<()> {
     let wt = repo
         .work_tree
         .as_ref()
         .ok_or_else(|| anyhow::anyhow!("this operation must be run in a work tree"))?;
     let abs = wt.join(file_path);
-    let blob_oid = resolve_revision(repo, rev_path)
-        .with_context(|| format!("unknown revision: '{rev_path}'"))?;
-    let obj = repo
-        .odb
-        .read(&blob_oid)
-        .with_context(|| format!("reading object {blob_oid}"))?;
-    if obj.kind != ObjectKind::Blob {
-        bail!("object '{blob_oid}' does not name a blob");
-    }
-    let blob_text = String::from_utf8_lossy(&obj.data);
-    let disk_bytes = fs::read(&abs).unwrap_or_default();
-    let disk_text = String::from_utf8_lossy(&disk_bytes);
 
-    let context_lines = patch_context;
-
-    let has_diff = blob_text != disk_text;
-    if !has_diff {
-        if args.exit_code || args.quiet {
-            return Ok(());
+    let (old_path, old_mode, old_oid) = if split_treeish_colon(rev_path).is_some() {
+        let tree_side = resolve_treeish_blob_at_path(repo, rev_path)
+            .with_context(|| format!("unknown revision: '{rev_path}'"))?;
+        (tree_side.path, tree_side.mode, tree_side.oid)
+    } else {
+        let oid = resolve_revision(repo, rev_path)
+            .with_context(|| format!("unknown revision: '{rev_path}'"))?;
+        let obj = repo
+            .odb
+            .read(&oid)
+            .with_context(|| format!("reading object {oid}"))?;
+        if obj.kind != ObjectKind::Blob {
+            bail!("object '{oid}' does not name a blob");
         }
+        let label = display_old_blob_as
+            .map(str::to_owned)
+            .unwrap_or_else(|| oid.to_hex());
+        (label, "100644".to_owned(), oid)
+    };
+
+    let wt_mode = worktree_file_mode_octal(&abs);
+    let disk_oid = Odb::hash_object_data(ObjectKind::Blob, &fs::read(&abs).unwrap_or_default());
+
+    let entries = vec![DiffEntry {
+        status: DiffStatus::Modified,
+        old_path: Some(old_path),
+        new_path: Some(file_path.to_owned()),
+        old_mode,
+        new_mode: wt_mode,
+        old_oid,
+        new_oid: disk_oid,
+        score: None,
+    }];
+    let entry = &entries[0];
+
+    let has_diff = entry.old_oid != entry.new_oid || entry.old_mode != entry.new_mode;
+    if !has_diff {
         return Ok(());
     }
 
     if args.check {
-        bail!("--check is not supported with <rev>:<path> <file>");
+        let mut out: Box<dyn Write> = if let Some(ref p) = args.output_path {
+            let resolved = if p.is_absolute() {
+                p.clone()
+            } else {
+                cwd.join(p)
+            };
+            Box::new(
+                std::fs::OpenOptions::new()
+                    .create(true)
+                    .truncate(true)
+                    .write(true)
+                    .open(&resolved)
+                    .with_context(|| {
+                        format!("failed to open output file {}", resolved.display())
+                    })?,
+            )
+        } else {
+            Box::new(io::stdout())
+        };
+        let attr_rules: Option<Vec<AttrRule>> = Some(load_gitattributes(&repo.git_dir));
+        let config_for_attrs = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+        let has_ws_errors = check_whitespace_errors(
+            &mut out,
+            &entries,
+            &repo.odb,
+            Some(wt.as_ref()),
+            attr_rules.as_deref(),
+            &config_for_attrs,
+        )?;
+        if has_ws_errors {
+            if args.exit_code {
+                std::process::exit(3);
+            }
+            std::process::exit(2);
+        }
+        if args.exit_code || args.quiet {
+            std::process::exit(1);
+        }
+        return Ok(());
     }
 
-    let mut out = io::stdout().lock();
-    let show_blob_patch = !args.quiet && !args.no_patch;
-    if show_blob_patch {
-        let old_label = format!("{src_prefix}{rev_path}");
-        let new_label = format!("{dst_prefix}{file_path}");
-        let patch = unified_diff(
-            blob_text.as_ref(),
-            disk_text.as_ref(),
-            &old_label,
-            &new_label,
-            context_lines,
-        );
-        let use_color = match args.color.as_deref() {
-            Some("always") => true,
-            Some("never") => false,
-            Some("auto") | None => io::stdout().is_terminal(),
-            Some(_) => false,
-        };
-        if use_color {
-            for line in patch.lines() {
-                if line.starts_with("@@") {
-                    writeln!(out, "{CYAN}{line}{RESET}")?;
-                } else if line.starts_with('+') && !line.starts_with("+++") {
-                    writeln!(out, "{GREEN}{line}{RESET}")?;
-                } else if line.starts_with('-') && !line.starts_with("---") {
-                    writeln!(out, "{RED}{line}{RESET}")?;
-                } else if line.starts_with("diff ")
-                    || line.starts_with("---")
-                    || line.starts_with("+++")
-                {
-                    writeln!(out, "{BOLD}{line}{RESET}")?;
-                } else {
-                    writeln!(out, "{line}")?;
-                }
+    let diff_algo_ctx = DiffAlgoContext {
+        attrs: merged_attrs,
+        config: Arc::new(diff_config.clone()),
+        ignore_case_attrs,
+    };
+    let inter_hunk_context = args
+        .inter_hunk_context
+        .or_else(|| {
+            diff_config
+                .get("diff.interhunkcontext")
+                .and_then(|s| s.parse().ok())
+        })
+        .unwrap_or(0);
+    let patch_abbrev = if args.full_index {
+        40usize
+    } else if let Some(n) = args.abbrev {
+        n.max(4).min(40)
+    } else {
+        7
+    };
+    let use_color = match args.color.as_deref() {
+        Some("always") => true,
+        Some("never") => false,
+        Some("auto") | None => {
+            if args.output_path.is_some() {
+                false
+            } else {
+                io::stdout().is_terminal()
             }
-        } else {
-            write!(out, "{patch}")?;
         }
+        Some(_) => false,
+    };
+    let suppress_blank_empty = diff_config
+        .get("diff.suppressBlankEmpty")
+        .map(|v| v == "true")
+        .unwrap_or(false);
+
+    let mut out: Box<dyn Write> = if let Some(ref p) = args.output_path {
+        let resolved = if p.is_absolute() {
+            p.clone()
+        } else {
+            cwd.join(p)
+        };
+        Box::new(
+            std::fs::OpenOptions::new()
+                .create(true)
+                .truncate(true)
+                .write(true)
+                .open(&resolved)
+                .with_context(|| format!("failed to open output file {}", resolved.display()))?,
+        )
+    } else {
+        Box::new(io::stdout())
+    };
+
+    let word_diff = args.word_diff.is_some() || args.color_words;
+    let show_patch = !args.quiet && !args.no_patch;
+    if show_patch {
+        write_patch_with_prefix(
+            &mut out,
+            repo,
+            &entries,
+            &repo.odb,
+            &repo.git_dir,
+            &diff_config,
+            patch_context,
+            use_color,
+            word_diff,
+            Some(wt.as_ref()),
+            suppress_blank_empty,
+            patch_abbrev,
+            inter_hunk_context,
+            args.binary,
+            args.break_rewrites,
+            args.irreversible_delete,
+            !args.no_textconv,
+            src_prefix,
+            dst_prefix,
+            args.submodule.as_deref(),
+            submodule_ignore_flags_from_diff_arg(
+                args.ignore_submodules.as_deref().unwrap_or("none"),
+            ),
+            None,
+            &diff_algo_ctx,
+            diff_algo_cli,
+            false,
+        )?;
+    }
+
+    if args.summary {
+        write_diff_summary(&mut out, &entries, args.break_rewrites, quote_path_fully)?;
     }
 
     if (args.exit_code || args.quiet) && has_diff {
         std::process::exit(1);
-    }
-    if has_diff && !args.exit_code && show_blob_patch {
-        // differences were printed; match `git diff` non-exit-code behavior (exit 0)
     }
     Ok(())
 }
@@ -3508,6 +3687,92 @@ fn resolve_packed_ref(git_dir: &std::path::Path, refname: &str) -> Option<String
         if name == refname {
             return Some(oid.to_owned());
         }
+    }
+    None
+}
+
+/// When `spec` is `treeish:path`, resolve the blob and path; otherwise `None`.
+fn blob_side_for_treeish_path_spec(
+    repo: &Repository,
+    spec: &str,
+) -> Result<Option<TreeishBlobAtPath>> {
+    match split_treeish_colon(spec) {
+        Some((_, path)) if !path.is_empty() => Ok(Some(resolve_treeish_blob_at_path(repo, spec)?)),
+        _ => Ok(None),
+    }
+}
+
+/// Resolve `spec` to a blob side for `git diff` when comparing two blobs (raw OID or `rev:path`).
+fn blob_side_for_blob_diff_spec(
+    repo: &Repository,
+    spec: &str,
+) -> Result<Option<TreeishBlobAtPath>> {
+    if let Some(side) = blob_side_for_treeish_path_spec(repo, spec)? {
+        return Ok(Some(side));
+    }
+    let oid = match resolve_revision(repo, spec) {
+        Ok(o) => o,
+        Err(_) => return Ok(None),
+    };
+    let obj = match repo.odb.read(&oid) {
+        Ok(o) => o,
+        Err(_) => return Ok(None),
+    };
+    if obj.kind != ObjectKind::Blob {
+        return Ok(None);
+    }
+    Ok(Some(TreeishBlobAtPath {
+        path: oid.to_hex(),
+        oid,
+        mode: "100644".to_owned(),
+    }))
+}
+
+/// Octal mode string for a worktree file (`120000` symlink, `100755` executable, else `100644`).
+fn worktree_file_mode_octal(path: &Path) -> String {
+    if let Ok(meta) = fs::symlink_metadata(path) {
+        if meta.file_type().is_symlink() {
+            return "120000".to_owned();
+        }
+        #[cfg(unix)]
+        {
+            let mode = meta.permissions().mode();
+            if mode & 0o111 != 0 {
+                return "100755".to_owned();
+            }
+        }
+    }
+    "100644".to_owned()
+}
+
+/// If both sides are `rev:path` with `..` between path segments, return the two specs (Git: t4063).
+fn try_treeish_blob_range(spec: &str) -> Option<(String, String)> {
+    let bytes = spec.as_bytes();
+    let mut i = 0usize;
+    let mut peel_depth = 0usize;
+    while i + 1 < bytes.len() {
+        if bytes[i] == b'^' && bytes[i + 1] == b'{' {
+            peel_depth += 1;
+            i += 2;
+            continue;
+        }
+        if peel_depth > 0 {
+            if bytes[i] == b'}' {
+                peel_depth -= 1;
+            }
+            i += 1;
+            continue;
+        }
+        if bytes[i] == b'.' && bytes.get(i + 1) == Some(&b'.') {
+            let left = &spec[..i];
+            let right = &spec[i + 2..];
+            if split_treeish_colon(left).is_some_and(|(_, p)| !p.is_empty())
+                && split_treeish_colon(right).is_some_and(|(_, p)| !p.is_empty())
+            {
+                return Some((left.to_owned(), right.to_owned()));
+            }
+        }
+        i += 1;
     }
     None
 }

--- a/logs/2026-04-09_t4063-diff-blobs.md
+++ b/logs/2026-04-09_t4063-diff-blobs.md
@@ -1,0 +1,19 @@
+# t4063-diff-blobs
+
+## Goal
+
+Make `tests/t4063-diff-blobs.sh` fully pass (direct blob / `rev:path` comparisons in `git diff`).
+
+## Changes
+
+- **grit-lib `rev_parse`**: Added `resolve_treeish_blob_at_path` (+ `TreeishBlobAtPath`) to resolve `treeish:path` to blob OID, tree-relative path string, and octal mode from tree entries. Refactored internal tree walk to return mode.
+- **grit `diff`**:
+  - Split `HEAD:one..HEAD:two`-style specs *before* `A..B` revision expansion so they become two `treeish:path` tokens.
+  - Two-revision path: if both sides resolve to blobs (raw OID or `rev:path`), build a single `DiffEntry` and use existing patch pipeline; else tree-to-tree via `commit_or_tree_oid`.
+  - `rev:path` vs worktree file: build `DiffEntry` with tree modes + hashed worktree blob OID; emit via `write_patch_with_prefix` (correct `diff --git`, `index`, mode lines).
+  - `blob_oid` vs existing file: early branch when first arg resolves to a blob and second exists on disk; old path label uses the filename when Git would (t4063).
+
+## Verification
+
+- `./scripts/run-tests.sh t4063-diff-blobs.sh` → 18/18
+- `cargo test -p grit-lib --lib` → pass

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   315 |
+| Completed   |   316 |
 | In progress |     5 |
-| Remaining   |   450 |
+| Remaining   |   449 |
 | **Total**   |   770 |
 
-Task lines in `PLAN.md`: 315 completed (`[x]`), 5 in progress (`[~]`), 450 remaining (`[ ]`).
+Task lines in `PLAN.md`: 316 completed (`[x]`), 5 in progress (`[~]`), 449 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t4063-diff-blobs` — 18/18 tests pass (`diff`: blob↔blob and `rev:path` pairs without treating blobs as trees; `HEAD:one..HEAD:two` range split; `rev:path` vs worktree file uses tree path + modes + `write_patch_with_prefix`; raw blob OID vs existing file uses filename as old path; `rev_parse::resolve_treeish_blob_at_path` for tree walks)
 - `t5609-clone-branch` — 7/7 tests pass (`clone --branch`: `read_raw_ref` for ref existence so `refs/remotes/origin/HEAD` is set when default branch is packed; reject `--branch` when `refs/heads/<name>` missing on source, including empty repos)
 - `t5802-connect-helper` — 8/8 tests pass (`ext::` sh -c upload-pack argv extraction; `git daemon --inetd` minimal path; streaming unpack zero-byte trees + duplicate `want` dedup; fetch NAK round + tag-following for ext/HTTP; rev-parse `tag^1` peels tags; harness CSV/dashboards refreshed)
 - `t7421-submodule-summary-add` — 5/5 tests pass (`submodule summary`: index↔commit gitlink diff, pathspecs + renamed paths, `rev-parse` first line for abbrev; `submodule update --remote`: local URL fast path updates `refs/remotes/origin/*` + copies objects, stages gitlink in super index)

--- a/test-results.md
+++ b/test-results.md
@@ -1,5 +1,10 @@
 # Test results
 
+**2026-04-09 (t4063 / diff blobs)**
+
+- `cargo test -p grit-lib --lib`: 155 passed
+- `./scripts/run-tests.sh t4063-diff-blobs.sh`: 18/18 passed
+
 **2026-04-09 (t5609 / clone --branch)**
 
 - `cargo test -p grit-lib --lib`: 152 passed


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible `git diff` for comparing blobs directly: raw object IDs, `rev:path` pairs, `HEAD:a..HEAD:b` range form, and `rev:path` vs worktree file (including mode lines and the blob-OID vs file filename preference from t4063).

## Key changes

- **`grit-lib`**: `resolve_treeish_blob_at_path` resolves `treeish:path` to blob OID, repository-relative path, and tree entry mode.
- **`grit diff`**: Split `treeish:path..treeish:path` before generic `A..B` handling; two-revision blob pairs produce a synthetic `DiffEntry`; blob vs file uses the normal patch pipeline.

## Verification

- `./scripts/run-tests.sh t4063-diff-blobs.sh` — 18/18
- `cargo test -p grit-lib --lib` — pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3251b81f-c33a-4c59-a01c-3ee2379860ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3251b81f-c33a-4c59-a01c-3ee2379860ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

