### PR TITLE
fix: make t7418-submodule-sparse-gitmodules fully pass

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -821,7 +821,7 @@ commit → check it off → move on.
 - [ ] `t7103-reset-bare` ████████████░░░░░░░░ 8/13 (5 left) — git reset in a bare repository
 - [ ] `t7603-merge-reduce-heads` ████████████░░░░░░░░ 8/13 (5 left) — git merge
 
-- [ ] `t7418-submodule-sparse-gitmodules` ██████░░░░░░░░░░░░░░ 3/9 (6 left) — Test reading/writing .gitmodules when not in the working tree
+- [x] `t7418-submodule-sparse-gitmodules` — Test reading/writing .gitmodules when not in the working tree (9/9)
 
 - [ ] `t7701-repack-unpack-unreachable` ██████░░░░░░░░░░░░░░ 3/9 (6 left) — git repack works correctly
 - [x] `t7011-skip-worktree-reading` — skip-worktree bit test (15/15)

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1193,7 +1193,7 @@ t7111-reset-table	t7	yes	42	34	8	false	ok	0
 t7112-reset-submodule	t7	yes	76	24	52	false	ok	0
 t7113-post-index-change-hook	t7	yes	4	1	3	false	ok	0
 t7201-co	t7	yes	46	17	29	false	ok	0
-t7300-clean	t7	yes	53	52	1	false	ok	2
+t7300-clean	t7	yes	53	52	1	false	ok	0
 t7301-clean-interactive	t7	yes	23	8	15	false	ok	0
 t7400-submodule-basic	t7	yes	124	51	73	false	ok	0
 t7401-submodule-summary	t7	yes	25	6	19	false	ok	0
@@ -1209,7 +1209,7 @@ t7413-submodule-is-active	t7	yes	10	2	8	false	ok	0
 t7414-submodule-mistakes	t7	yes	5	5	0	true	ok	0
 t7416-submodule-dash-url	t7	yes	18	9	9	false	ok	0
 t7417-submodule-path-url	t7	yes	5	5	0	true	ok	0
-t7418-submodule-sparse-gitmodules	t7	yes	9	5	4	false	ok	0
+t7418-submodule-sparse-gitmodules	t7	yes	9	9	0	true	ok	0
 t7419-submodule-set-branch	t7	yes	9	9	0	true	ok	0
 t7420-submodule-set-url	t7	yes	3	2	1	false	ok	0
 t7421-submodule-summary-add	t7	yes	5	5	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.8% of harness tests passing (35,530 / 45,112).">
+<meta property="og:description" content="78.8% of harness tests passing (35,537 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.8% of harness tests passing (35,530 / 45,112).">
+<meta name="twitter:description" content="78.8% of harness tests passing (35,537 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T16:30:42+00:00" class="gen-time" title="2026-04-09 16:30 UTC">2026-04-09 16:30 UTC</time> · <a href="https://github.com/schacon/grit/commit/7cfe71677eb58eb382a548e40cc0ad9e587d560d" style="color:#58a6ff">7cfe716</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T18:26:55+00:00" class="gen-time" title="2026-04-09 18:26 UTC">2026-04-09 18:26 UTC</time> · <a href="https://github.com/schacon/grit/commit/cbee7d7f221f5433fc3bf9357584a1381a064ebb" style="color:#58a6ff">cbee7d7</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,530</div>
+      <div class="summary-big-val">35,537</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>746 files fully passing</span>
+    <span>749 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">46/126 files · 11 skipped · 2,475/3,614 tests</span>
+        <span class="group-meta">49/126 files · 11 skipped · 2,482/3,614 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.5%"></div></div>
-        <span class="group-pct pct-blue">68.5%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
+        <span class="group-pct pct-blue">68.7%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35530 of 45112 tests passing across 1405 harness files (78.8% pass rate).</desc>
+  <desc id="svg-desc">35537 of 45112 tests passing across 1405 harness files (78.8% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.8% pass rate · 35,530 / 45,112 tests · 1,405 files in scope · 746 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.8% pass rate · 35,537 / 45,112 tests · 1,405 files in scope · 749 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="552" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T16:30:42+00:00" class="gen-time" title="2026-04-09 16:30 UTC">2026-04-09 16:30 UTC</time> · <a href="https://github.com/schacon/grit/commit/7cfe71677eb58eb382a548e40cc0ad9e587d560d" style="color:#58a6ff">7cfe716</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T18:26:55+00:00" class="gen-time" title="2026-04-09 18:26 UTC">2026-04-09 18:26 UTC</time> · <a href="https://github.com/schacon/grit/commit/cbee7d7f221f5433fc3bf9357584a1381a064ebb" style="color:#58a6ff">cbee7d7</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,530</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,537</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.8%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -11717,14 +11717,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:80.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="11" data-passed="10">
+<tr class="" data-group="t7" data-tests="11" data-passed="11" data-full-pass="1">
   <td class="mono">t7012-skip-worktree-writing</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">11</td>
-  <td class="right">10</td>
+  <td class="right">11</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">6</td>
 </tr>
 <tr class="" data-group="t7" data-tests="26" data-passed="26" data-full-pass="1">
@@ -12095,7 +12095,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">52</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.1%"></div></div></td>
-  <td class="right small">2</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="23" data-passed="8">
   <td class="mono">t7301-clean-interactive</td>
@@ -12247,14 +12247,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="9" data-passed="5">
+<tr class="" data-group="t7" data-tests="9" data-passed="9" data-full-pass="1">
   <td class="mono">t7418-submodule-sparse-gitmodules</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">9</td>
-  <td class="right">5</td>
+  <td class="right">9</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:55.6%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="9" data-passed="9" data-full-pass="1">
@@ -12917,14 +12917,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
   <td class="right small">7</td>
 </tr>
-<tr class="" data-group="t7" data-tests="22" data-passed="20">
+<tr class="" data-group="t7" data-tests="22" data-passed="22" data-full-pass="1">
   <td class="mono">t7815-grep-binary</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">22</td>
-  <td class="right">20</td>
+  <td class="right">22</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="145" data-passed="145" data-full-pass="1">

--- a/grit/src/commands/read_tree.rs
+++ b/grit/src/commands/read_tree.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 use grit_lib::config::ConfigSet;
 use grit_lib::crlf;
 use grit_lib::ignore::IgnoreMatcher;
-use grit_lib::index::{Index, IndexEntry, MODE_EXECUTABLE, MODE_SYMLINK};
+use grit_lib::index::{Index, IndexEntry, MODE_EXECUTABLE, MODE_GITLINK, MODE_SYMLINK};
 use grit_lib::objects::{parse_commit, parse_tree, ObjectId, ObjectKind};
 use grit_lib::refs::resolve_ref;
 use grit_lib::repo::Repository;
@@ -821,6 +821,21 @@ fn apply_sparse_checkout(git_dir: &Path, index: &mut Index) -> Result<()> {
     Ok(())
 }
 
+/// Submodule gitlink (`160000`): ensure an empty directory exists at `rel` under `work_tree`.
+///
+/// Git does not populate submodule contents during `read-tree -u` (same as clone); the recorded
+/// OID names a commit in the submodule ODB, not a blob in the superproject.
+fn ensure_gitlink_placeholder_dir(work_tree: &Path, rel: &str) -> Result<()> {
+    let full_path = work_tree.join(rel);
+    if full_path.is_file() || full_path.is_symlink() {
+        let _ = std::fs::remove_file(&full_path);
+    } else if full_path.is_dir() && !full_path.join(".git").exists() {
+        let _ = std::fs::remove_dir_all(&full_path);
+    }
+    let _ = std::fs::create_dir_all(&full_path);
+    Ok(())
+}
+
 /// True if the working tree already has this index entry (blob/symlink) at `abs_path`.
 ///
 /// When `read-tree -u` refreshes after files were removed from disk, the index may still
@@ -900,11 +915,17 @@ fn checkout_index_entries(repo: &Repository, old_index: &Index, new_index: &Inde
         }
         let path_str = String::from_utf8_lossy(&entry.path).into_owned();
         let abs_path = work_tree.join(&path_str);
-        if old_stage0
-            .get(&entry.path)
-            .is_some_and(|old_entry| same_blob(old_entry, entry))
+        if entry.mode != MODE_GITLINK
+            && old_stage0
+                .get(&entry.path)
+                .is_some_and(|old_entry| same_blob(old_entry, entry))
             && checkout_entry_present_on_disk(&abs_path, entry.mode)
         {
+            continue;
+        }
+
+        if entry.mode == MODE_GITLINK {
+            ensure_gitlink_placeholder_dir(&work_tree, &path_str)?;
             continue;
         }
 

--- a/grit/src/commands/submodule.rs
+++ b/grit/src/commands/submodule.rs
@@ -216,10 +216,11 @@ fn run_with_top_opts(top: SubmoduleTopOpts, args: Args) -> Result<()> {
         }
     }
 }
-use grit_lib::config::{ConfigFile, ConfigScope};
+use grit_lib::config::{canonical_key, ConfigFile, ConfigScope};
 use grit_lib::diff::{diff_index_to_tree, DiffEntry, DiffStatus};
 use grit_lib::error::Error as LibError;
 use grit_lib::index::MODE_GITLINK;
+use grit_lib::merge_diff::blob_oid_at_path;
 use grit_lib::objects::{parse_commit, parse_tree, ObjectId, ObjectKind};
 use grit_lib::pathspec::matches_pathspec;
 use grit_lib::refs;
@@ -599,6 +600,10 @@ pub struct SummaryArgs {
     #[arg(long)]
     pub files: bool,
 
+    /// Skip submodules with `submodule.<name>.ignore=all` (Git `--for-status`; used by status).
+    #[arg(long = "for-status")]
+    pub for_status: bool,
+
     /// Limit how many commits `log` shows for each submodule (`-n`; Git `--summary-limit`).
     #[arg(short = 'n', long = "summary-limit")]
     pub summary_limit: Option<i32>,
@@ -653,6 +658,8 @@ pub(crate) struct SubmoduleInfo {
     pub(crate) shallow: Option<bool>,
     pub(crate) update: Option<String>,
     pub(crate) branch: Option<String>,
+    /// `submodule.<name>.ignore` from `.gitmodules` (e.g. `all`, `dirty`), when set.
+    pub(crate) ignore: Option<String>,
 }
 
 /// Update submodule working trees to the commits recorded in the superproject index.
@@ -1091,6 +1098,7 @@ fn parse_gitmodules_with_repo(
         shallow: Option<bool>,
         update: Option<String>,
         branch: Option<String>,
+        ignore: Option<String>,
     }
     let mut modules: BTreeMap<String, ModuleFields> = BTreeMap::new();
 
@@ -1127,6 +1135,7 @@ fn parse_gitmodules_with_repo(
                 }
                 "update" => entry_val.update = entry.value.clone(),
                 "branch" => entry_val.branch = entry.value.clone(),
+                "ignore" => entry_val.ignore = entry.value.clone(),
                 _ => {}
             }
         }
@@ -1142,6 +1151,7 @@ fn parse_gitmodules_with_repo(
                 shallow: f.shallow,
                 update: f.update,
                 branch: f.branch,
+                ignore: f.ignore,
             });
         }
     }
@@ -1827,9 +1837,43 @@ fn attach_existing_submodule_worktree(
     Ok(())
 }
 
+/// Whether `.gitmodules` may be created or updated in the work tree (`git/submodule.c:is_writing_gitmodules_ok`).
+fn is_writing_gitmodules_ok(repo: &Repository, work_tree: &Path) -> bool {
+    let gm = work_tree.join(".gitmodules");
+    if gm.exists() {
+        return true;
+    }
+    let Ok(index) = repo.load_index() else {
+        return false;
+    };
+    if index.get(b".gitmodules", 0).is_some() {
+        return false;
+    }
+    let Ok(head) = resolve_head(&repo.git_dir) else {
+        return false;
+    };
+    let Some(commit_oid) = head.oid().copied() else {
+        return true;
+    };
+    let Ok(obj) = repo.odb.read(&commit_oid) else {
+        return false;
+    };
+    if obj.kind != ObjectKind::Commit {
+        return false;
+    }
+    let Ok(c) = parse_commit(&obj.data) else {
+        return false;
+    };
+    blob_oid_at_path(&repo.odb, &c.tree, ".gitmodules").is_none()
+}
+
 fn run_add(args: &AddArgs) -> Result<()> {
     let repo = Repository::discover(None).context("not a git repository")?;
     let work_tree = repo.work_tree.as_ref().context("bare repository")?;
+
+    if !is_writing_gitmodules_ok(&repo, work_tree) {
+        bail!("please make sure that the .gitmodules file is in the working tree");
+    }
 
     // Derive path from URL if not provided.
     let path = match &args.path {
@@ -2738,6 +2782,38 @@ fn submodule_work_tree_for_summary(work_tree: &Path, logical_path: &str) -> Path
     direct
 }
 
+/// True when `submodule.<name>.ignore` is `all` in local config or in `.gitmodules` (Git `prepare_submodule_summary`).
+fn submodule_ignore_all_for_summary(
+    local_cfg: Option<&ConfigFile>,
+    modules: &[SubmoduleInfo],
+    sm_path: &str,
+) -> bool {
+    let Some(m) = modules
+        .iter()
+        .find(|mm| mm.path == sm_path || mm.name == sm_path)
+    else {
+        return false;
+    };
+    let key = format!("submodule.{}.ignore", m.name);
+    if let Some(cfg) = local_cfg {
+        if let Ok(canon) = canonical_key(&key) {
+            if cfg
+                .entries
+                .iter()
+                .rev()
+                .find(|e| e.key == canon)
+                .and_then(|e| e.value.as_deref())
+                .is_some_and(|v| v.eq_ignore_ascii_case("all"))
+            {
+                return true;
+            }
+        }
+    }
+    m.ignore
+        .as_deref()
+        .is_some_and(|v| v.eq_ignore_ascii_case("all"))
+}
+
 fn run_summary(args: &SummaryArgs, _quiet: bool) -> Result<()> {
     if args.summary_limit == Some(0) {
         return Ok(());
@@ -2779,6 +2855,15 @@ fn run_summary(args: &SummaryArgs, _quiet: bool) -> Result<()> {
         .load_index()
         .context("load index for submodule summary")?;
 
+    let (modules_for_ignore, local_cfg_for_ignore) = if args.for_status {
+        (
+            parse_gitmodules_with_repo(work_tree, Some(&repo)).unwrap_or_default(),
+            parse_local_config(&repo.git_dir).ok(),
+        )
+    } else {
+        (Vec::new(), None)
+    };
+
     let entries: Vec<DiffEntry> = if args.files {
         if args.cached {
             bail!("options '--cached' and '--files' cannot be used together");
@@ -2816,7 +2901,50 @@ fn run_summary(args: &SummaryArgs, _quiet: bool) -> Result<()> {
         out.sort_by(|a, b| a.path().cmp(b.path()));
         out
     } else {
-        diff_index_to_tree(&repo.odb, &index, base_tree_oid.as_ref())?
+        let mut entries = diff_index_to_tree(&repo.odb, &index, base_tree_oid.as_ref())?;
+        // Git `submodule summary` uses `diff-index --ignore-submodules=dirty`: when the index
+        // gitlink matches `HEAD^{tree}` but the submodule worktree HEAD differs (e.g. after
+        // `pull` before `submodule update`), still report the range (`t7418`).
+        if !args.cached {
+            if let Some(tree_oid) = base_tree_oid.as_ref() {
+                let mut extra: Vec<DiffEntry> = Vec::new();
+                for ie in &index.entries {
+                    if ie.stage() != 0 || ie.mode != MODE_GITLINK || ie.skip_worktree() {
+                        continue;
+                    }
+                    let path_str = String::from_utf8_lossy(&ie.path).into_owned();
+                    let Some(te_oid) = blob_oid_at_path(&repo.odb, tree_oid, &path_str) else {
+                        continue;
+                    };
+                    if te_oid != ie.oid {
+                        continue;
+                    }
+                    let sub_path = submodule_work_tree_for_summary(work_tree, &path_str);
+                    if !sub_path.join(".git").exists() {
+                        continue;
+                    }
+                    let Some(sub_head) = grit_lib::diff::read_submodule_head_oid(&sub_path) else {
+                        continue;
+                    };
+                    if sub_head == ie.oid {
+                        continue;
+                    }
+                    extra.push(DiffEntry {
+                        status: DiffStatus::Modified,
+                        old_path: Some(path_str.clone()),
+                        new_path: Some(path_str),
+                        old_mode: format!("{:o}", MODE_GITLINK),
+                        new_mode: format!("{:o}", MODE_GITLINK),
+                        old_oid: ie.oid,
+                        new_oid: sub_head,
+                        score: None,
+                    });
+                }
+                entries.extend(extra);
+                entries.sort_by(|a, b| a.path().cmp(b.path()));
+            }
+        }
+        entries
     };
 
     let stdout = io::stdout();
@@ -2828,6 +2956,17 @@ fn run_summary(args: &SummaryArgs, _quiet: bool) -> Result<()> {
         }
         let sm_path = summary_display_path(e);
         if !pathspec_selected(&pathspecs, sm_path) {
+            continue;
+        }
+
+        if args.for_status
+            && e.status != DiffStatus::Added
+            && submodule_ignore_all_for_summary(
+                local_cfg_for_ignore.as_ref(),
+                &modules_for_ignore,
+                sm_path,
+            )
+        {
             continue;
         }
 

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -4364,7 +4364,7 @@ pub(crate) fn dispatch(subcmd: &str, rest: &[String], opts: &GlobalOpts) -> Resu
                 "rot13-filter" => commands::test_tool_rot13_filter::run(&rest[1..]),
                 "path-utils" => run_test_tool_path_utils(&rest[1..]),
                 "subprocess" => run_test_tool_subprocess(&rest[1..]),
-                "submodule" => run_test_tool_submodule(&rest[1..]),
+                "submodule" => run_test_tool_submodule(rest),
                 "config" => run_test_tool_config(&rest[1..]),
                 "parse-options" => {
                     let args = preprocess_test_tool_args(rest)?;
@@ -4964,6 +4964,11 @@ fn run_test_tool_path_utils(rest: &[String]) -> Result<()> {
 
 /// Handle `test-tool submodule` subcommands.
 fn run_test_tool_submodule(rest: &[String]) -> Result<()> {
+    let args = preprocess_test_tool_args(rest)?;
+    if args.first().map(|s| s.as_str()) != Some("submodule") {
+        bail!("internal error: test-tool submodule dispatcher");
+    }
+    let rest = &args[1..];
     let subcmd = rest.first().map(|s| s.as_str()).unwrap_or("");
     match subcmd {
         "resolve-relative-url" => {
@@ -4981,8 +4986,191 @@ fn run_test_tool_submodule(rest: &[String]) -> Result<()> {
             println!("{result}");
             Ok(())
         }
+        "config-list" => {
+            let key = rest
+                .get(1)
+                .map(|s| s.as_str())
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("usage: test-tool submodule config-list <key>"))?;
+            let repo =
+                grit_lib::repo::Repository::discover(None).context("not a git repository")?;
+            let work_tree = repo.work_tree.as_ref().context("bare repository")?;
+            let wanted =
+                grit_lib::config::canonical_key(key).map_err(|e| anyhow::anyhow!("{e}"))?;
+            let (content, path_for_parse) =
+                gitmodules_file_content_for_test_tool(&repo, work_tree)?;
+            let cfg = grit_lib::config::ConfigFile::parse(
+                &path_for_parse,
+                &content,
+                grit_lib::config::ConfigScope::Local,
+            )
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+            for e in &cfg.entries {
+                if e.key == wanted {
+                    if let Some(v) = &e.value {
+                        println!("{v}");
+                    }
+                }
+            }
+            Ok(())
+        }
+        "config-set" => {
+            let key = rest.get(1).map(|s| s.as_str()).unwrap_or("");
+            let value = rest.get(2).map(|s| s.as_str()).unwrap_or("");
+            if key.is_empty() {
+                bail!("usage: test-tool submodule config-set <key> <value>");
+            }
+            let repo =
+                grit_lib::repo::Repository::discover(None).context("not a git repository")?;
+            let work_tree = repo.work_tree.as_ref().context("bare repository")?;
+            if !is_writing_gitmodules_ok_for_test_tool(&repo, work_tree) {
+                bail!("please make sure that the .gitmodules file is in the working tree");
+            }
+            let path = work_tree.join(".gitmodules");
+            let mut cfg = if path.exists() {
+                let content = std::fs::read_to_string(&path).context("reading .gitmodules")?;
+                grit_lib::config::ConfigFile::parse(
+                    &path,
+                    &content,
+                    grit_lib::config::ConfigScope::Local,
+                )?
+            } else {
+                grit_lib::config::ConfigFile::parse(
+                    &path,
+                    "",
+                    grit_lib::config::ConfigScope::Local,
+                )?
+            };
+            cfg.set(key, value).map_err(|e| anyhow::anyhow!("{e}"))?;
+            cfg.write().map_err(|e| anyhow::anyhow!("{e}"))?;
+            Ok(())
+        }
+        "config-unset" => {
+            let key = rest.get(1).map(|s| s.as_str()).unwrap_or("");
+            if key.is_empty() {
+                bail!("usage: test-tool submodule config-unset <key>");
+            }
+            let repo =
+                grit_lib::repo::Repository::discover(None).context("not a git repository")?;
+            let work_tree = repo.work_tree.as_ref().context("bare repository")?;
+            if !is_writing_gitmodules_ok_for_test_tool(&repo, work_tree) {
+                bail!("please make sure that the .gitmodules file is in the working tree");
+            }
+            let path = work_tree.join(".gitmodules");
+            if !path.exists() {
+                return Ok(());
+            }
+            let content = std::fs::read_to_string(&path).context("reading .gitmodules")?;
+            let mut cfg = grit_lib::config::ConfigFile::parse(
+                &path,
+                &content,
+                grit_lib::config::ConfigScope::Local,
+            )?;
+            let _ = cfg.unset(key).map_err(|e| anyhow::anyhow!("{e}"))?;
+            cfg.write().map_err(|e| anyhow::anyhow!("{e}"))?;
+            Ok(())
+        }
+        "config-writeable" => {
+            if rest.len() != 1 {
+                bail!("usage: test-tool submodule config-writeable");
+            }
+            let repo =
+                grit_lib::repo::Repository::discover(None).context("not a git repository")?;
+            let work_tree = repo.work_tree.as_ref().context("bare repository")?;
+            if is_writing_gitmodules_ok_for_test_tool(&repo, work_tree) {
+                Ok(())
+            } else {
+                bail!(".gitmodules is not writable in this state");
+            }
+        }
         other => bail!("test-tool submodule: unknown subcommand '{other}'"),
     }
+}
+
+/// `.gitmodules` text and a path used only for parsing / round-trip (Git `config_from_gitmodules`).
+fn gitmodules_file_content_for_test_tool(
+    repo: &grit_lib::repo::Repository,
+    work_tree: &Path,
+) -> Result<(String, PathBuf)> {
+    use grit_lib::merge_diff::blob_oid_at_path;
+    use grit_lib::objects::{parse_commit, ObjectKind};
+    use grit_lib::state::resolve_head;
+
+    let path = work_tree.join(".gitmodules");
+    if path.exists() {
+        let content = std::fs::read_to_string(&path).context("reading .gitmodules")?;
+        return Ok((content, path));
+    }
+    let index = repo.load_index().context("failed to load index")?;
+    if let Some(ie) = index.get(b".gitmodules", 0) {
+        let obj = repo
+            .odb
+            .read(&ie.oid)
+            .context("failed to read .gitmodules blob from ODB")?;
+        if obj.kind != ObjectKind::Blob {
+            return Ok((String::new(), path));
+        }
+        let content = String::from_utf8(obj.data).context("failed to decode .gitmodules blob")?;
+        return Ok((content, path));
+    }
+    let head = resolve_head(&repo.git_dir).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let Some(commit_oid) = head.oid().copied() else {
+        return Ok((String::new(), path));
+    };
+    let obj = repo.odb.read(&commit_oid).context("reading HEAD commit")?;
+    if obj.kind != ObjectKind::Commit {
+        return Ok((String::new(), path));
+    }
+    let commit = parse_commit(&obj.data).context("parsing HEAD commit")?;
+    let Some(blob_oid) = blob_oid_at_path(&repo.odb, &commit.tree, ".gitmodules") else {
+        return Ok((String::new(), path));
+    };
+    let blob = repo
+        .odb
+        .read(&blob_oid)
+        .context("reading .gitmodules blob from HEAD tree")?;
+    if blob.kind != ObjectKind::Blob {
+        return Ok((String::new(), path));
+    }
+    let content = String::from_utf8(blob.data).context("failed to decode .gitmodules blob")?;
+    Ok((content, path))
+}
+
+/// Matches Git `is_writing_gitmodules_ok` (`git/submodule.c`).
+fn is_writing_gitmodules_ok_for_test_tool(
+    repo: &grit_lib::repo::Repository,
+    work_tree: &Path,
+) -> bool {
+    use grit_lib::merge_diff::blob_oid_at_path;
+    use grit_lib::objects::{parse_commit, ObjectKind};
+    use grit_lib::state::resolve_head;
+
+    let gm = work_tree.join(".gitmodules");
+    if gm.exists() {
+        return true;
+    }
+    let Ok(index) = repo.load_index() else {
+        return false;
+    };
+    if index.get(b".gitmodules", 0).is_some() {
+        return false;
+    }
+    let Ok(head) = resolve_head(&repo.git_dir) else {
+        return false;
+    };
+    let Some(commit_oid) = head.oid().copied() else {
+        return true;
+    };
+    let Ok(obj) = repo.odb.read(&commit_oid) else {
+        return false;
+    };
+    if obj.kind != ObjectKind::Commit {
+        return false;
+    }
+    let Ok(c) = parse_commit(&obj.data) else {
+        return false;
+    };
+    blob_oid_at_path(&repo.odb, &c.tree, ".gitmodules").is_none()
 }
 
 /// Handle `test-tool chmtime` — get or set file modification times.

--- a/logs/2026-04-09_t7418-submodule-sparse-gitmodules.md
+++ b/logs/2026-04-09_t7418-submodule-sparse-gitmodules.md
@@ -1,0 +1,27 @@
+# t7418-submodule-sparse-gitmodules
+
+## Summary
+
+Made `tests/t7418-submodule-sparse-gitmodules.sh` pass 9/9.
+
+## Changes
+
+1. **`read-tree -u`**: Treat `160000` gitlink index entries like clone — ensure an empty directory only; do not read the gitlink OID as a blob in the superproject ODB (fixes sparse checkout after clone).
+
+2. **`test-tool submodule`**: Implemented `config-list`, `config-set`, `config-unset`, `config-writeable` in `grit` (read `.gitmodules` from worktree, index, or `HEAD` tree; write guard matches Git `is_writing_gitmodules_ok`). Wired `tests/test-tool` to delegate `submodule` to grit (with `-C`).
+
+3. **`submodule summary`**: Added `--for-status`; skip when `submodule.<name>.ignore=all` in `.gitmodules` or `config`; merge in gitlink paths where index matches `HEAD^{tree}` but submodule worktree HEAD differs (parity with `diff-index --ignore-submodules=dirty`).
+
+4. **`submodule add`**: Fail early when writing `.gitmodules` is unsafe (same guard as Git).
+
+5. **Tracking**: `PLAN.md`, `progress.md`, `test-results.md`, harness CSV/dashboards via `run-tests.sh`.
+
+## Validation
+
+- `cargo fmt`, `cargo clippy --fix --allow-dirty -p grit-rs`
+- `cargo test -p grit-lib --lib`
+- `./scripts/run-tests.sh t7418-submodule-sparse-gitmodules.sh`
+
+## Git
+
+Branch: `cursor/t7418-submodule-sparse-gitmodules-7843` — commit and push to origin.

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   315 |
+| Completed   |   318 |
 | In progress |     5 |
-| Remaining   |   450 |
-| **Total**   |   770 |
+| Remaining   |   448 |
+| **Total**   |   771 |
 
-Task lines in `PLAN.md`: 315 completed (`[x]`), 5 in progress (`[~]`), 450 remaining (`[ ]`).
+Task lines in `PLAN.md`: 318 completed (`[x]`), 5 in progress (`[~]`), 448 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t7418-submodule-sparse-gitmodules` — 9/9 tests pass (`read-tree -u`: gitlink checkout as empty dir, not blob read; `test-tool submodule` config-list/set/unset/writeable + harness delegation; `submodule summary --for-status`: ignore=all + index-vs-tree-out-of-sync gitlinks like `diff-index --ignore-submodules=dirty`; `submodule add`: `is_writing_gitmodules_ok` guard)
 - `t5609-clone-branch` — 7/7 tests pass (`clone --branch`: `read_raw_ref` for ref existence so `refs/remotes/origin/HEAD` is set when default branch is packed; reject `--branch` when `refs/heads/<name>` missing on source, including empty repos)
 - `t5802-connect-helper` — 8/8 tests pass (`ext::` sh -c upload-pack argv extraction; `git daemon --inetd` minimal path; streaming unpack zero-byte trees + duplicate `want` dedup; fetch NAK round + tag-following for ext/HTTP; rev-parse `tag^1` peels tags; harness CSV/dashboards refreshed)
 - `t7421-submodule-summary-add` — 5/5 tests pass (`submodule summary`: index↔commit gitlink diff, pathspecs + renamed paths, `rev-parse` first line for abbrev; `submodule update --remote`: local URL fast path updates `refs/remotes/origin/*` + copies objects, stages gitlink in super index)

--- a/test-results.md
+++ b/test-results.md
@@ -1,5 +1,10 @@
 # Test results
 
+**2026-04-09 (t7418 / submodule sparse .gitmodules)**
+
+- `cargo test -p grit-lib --lib`: 155 passed
+- `./scripts/run-tests.sh t7418-submodule-sparse-gitmodules.sh`: 9/9 passed
+
 **2026-04-09 (t5609 / clone --branch)**
 
 - `cargo test -p grit-lib --lib`: 152 passed

--- a/tests/test-tool
+++ b/tests/test-tool
@@ -1327,6 +1327,17 @@ PY
       exec "$_grit" -C "$global_c_dir" test-tool rot13-filter "$@"
     fi
     exec "$_grit" test-tool rot13-filter "$@" ;;
+  submodule)
+    shift
+    _grit="${GUST_BIN:-$SCRIPT_DIR/grit}"
+    if [ ! -x "$_grit" ]; then
+      echo "test-tool submodule: no grit binary (set GUST_BIN or build: tests/grit)" >&2
+      exit 1
+    fi
+    if [ -n "$global_c_dir" ]; then
+      exec "$_grit" -C "$global_c_dir" test-tool submodule "$@"
+    fi
+    exec "$_grit" test-tool submodule "$@" ;;
   *)
     exec git test-tool "$@" ;;
 esac


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This completes `t7418-submodule-sparse-gitmodules` (9/9): sparse checkout hiding `.gitmodules`, reading/writing rules, submodule init/update/summary/add.

## Key changes

- **`read-tree -u`**: Gitlink (`160000`) entries no longer go through the superproject ODB as blobs; an empty placeholder directory is ensured (submodule commits live in the submodule ODB).
- **`test-tool submodule`**: Implemented `config-list`, `config-set`, `config-unset`, and `config-writeable` in grit (read `.gitmodules` from worktree, index, or `HEAD` tree; write guard matches Git `is_writing_gitmodules_ok`). The harness `tests/test-tool` shell stub now delegates `submodule` to grit so `-C` works.
- **`submodule summary`**: Added `--for-status` (skip when `submodule.<name>.ignore=all`) and merged in gitlink changes when the index matches `HEAD^{tree}` but the submodule worktree HEAD differs—matching `git diff-index --ignore-submodules=dirty` (needed after `pull` before `submodule update`).
- **`submodule add`**: Fails with the same “please make sure that the .gitmodules file is in the working tree” guard when `.gitmodules` exists only in the index/HEAD.

## Validation

- `cargo fmt`, `cargo clippy --fix --allow-dirty -p grit-rs`
- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t7418-submodule-sparse-gitmodules.sh`

## Tracking

`PLAN.md`, `progress.md`, `test-results.md`, harness CSV, dashboards, and `logs/2026-04-09_t7418-submodule-sparse-gitmodules.md` updated.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a9bb209-318a-4f18-ba9a-ef67f1748abe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a9bb209-318a-4f18-ba9a-ef67f1748abe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

