### PR TITLE
fix: make t7105-reset-patch pass (git reset -p)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1184,7 +1184,7 @@ t7101-reset-empty-subdirs	t7	yes	10	10	0	true	ok	0
 t7102-reset	t7	yes	38	23	15	false	ok	0
 t7103-reset-bare	t7	yes	13	10	3	false	ok	0
 t7104-reset-hard	t7	yes	3	3	0	true	ok	0
-t7105-reset-patch	t7	yes	13	6	7	false	ok	0
+t7105-reset-patch	t7	yes	13	13	0	true	ok	0
 t7106-reset-unborn-branch	t7	yes	7	7	0	true	ok	0
 t7107-reset-pathspec-file	t7	yes	11	1	10	false	ok	0
 t7110-reset-merge	t7	yes	21	9	12	false	ok	0
@@ -1193,7 +1193,7 @@ t7111-reset-table	t7	yes	42	34	8	false	ok	0
 t7112-reset-submodule	t7	yes	76	24	52	false	ok	0
 t7113-post-index-change-hook	t7	yes	4	1	3	false	ok	0
 t7201-co	t7	yes	46	17	29	false	ok	0
-t7300-clean	t7	yes	53	52	1	false	ok	2
+t7300-clean	t7	yes	53	52	1	false	ok	0
 t7301-clean-interactive	t7	yes	23	8	15	false	ok	0
 t7400-submodule-basic	t7	yes	124	51	73	false	ok	0
 t7401-submodule-summary	t7	yes	25	6	19	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.8% of harness tests passing (35,530 / 45,112).">
+<meta property="og:description" content="78.8% of harness tests passing (35,539 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.8% of harness tests passing (35,530 / 45,112).">
+<meta name="twitter:description" content="78.8% of harness tests passing (35,539 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T16:30:42+00:00" class="gen-time" title="2026-04-09 16:30 UTC">2026-04-09 16:30 UTC</time> · <a href="https://github.com/schacon/grit/commit/7cfe71677eb58eb382a548e40cc0ad9e587d560d" style="color:#58a6ff">7cfe716</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T18:38:16+00:00" class="gen-time" title="2026-04-09 18:38 UTC">2026-04-09 18:38 UTC</time> · <a href="https://github.com/schacon/grit/commit/f9ea624972d94eb7291489345f3d4b54c182b54f" style="color:#58a6ff">f9ea624</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,530</div>
+      <div class="summary-big-val">35,539</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>746 files fully passing</span>
+    <span>748 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">46/126 files · 11 skipped · 2,475/3,614 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,484/3,614 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.5%"></div></div>
-        <span class="group-pct pct-blue">68.5%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
+        <span class="group-pct pct-blue">68.7%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35530 of 45112 tests passing across 1405 harness files (78.8% pass rate).</desc>
+  <desc id="svg-desc">35539 of 45112 tests passing across 1405 harness files (78.8% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.8% pass rate · 35,530 / 45,112 tests · 1,405 files in scope · 746 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.8% pass rate · 35,539 / 45,112 tests · 1,405 files in scope · 748 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="552" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T16:30:42+00:00" class="gen-time" title="2026-04-09 16:30 UTC">2026-04-09 16:30 UTC</time> · <a href="https://github.com/schacon/grit/commit/7cfe71677eb58eb382a548e40cc0ad9e587d560d" style="color:#58a6ff">7cfe716</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T18:38:16+00:00" class="gen-time" title="2026-04-09 18:38 UTC">2026-04-09 18:38 UTC</time> · <a href="https://github.com/schacon/grit/commit/f9ea624972d94eb7291489345f3d4b54c182b54f" style="color:#58a6ff">f9ea624</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,530</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,539</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.8%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -11997,14 +11997,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="13" data-passed="6">
+<tr class="" data-group="t7" data-tests="13" data-passed="13" data-full-pass="1">
   <td class="mono">t7105-reset-patch</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">13</td>
-  <td class="right">6</td>
+  <td class="right">13</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:46.2%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="7" data-passed="7" data-full-pass="1">
@@ -12095,7 +12095,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">52</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.1%"></div></div></td>
-  <td class="right small">2</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="23" data-passed="8">
   <td class="mono">t7301-clean-interactive</td>
@@ -12917,14 +12917,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
   <td class="right small">7</td>
 </tr>
-<tr class="" data-group="t7" data-tests="22" data-passed="20">
+<tr class="" data-group="t7" data-tests="22" data-passed="22" data-full-pass="1">
   <td class="mono">t7815-grep-binary</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">22</td>
-  <td class="right">20</td>
+  <td class="right">22</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="145" data-passed="145" data-full-pass="1">

--- a/grit/src/commands/checkout.rs
+++ b/grit/src/commands/checkout.rs
@@ -3004,22 +3004,8 @@ pub(crate) fn checkout_patch(
 
                 let path_str = String::from_utf8_lossy(&ie.path).to_string();
 
-                // Apply path filter if specified
-                if !filter_paths.is_empty() {
-                    let matches = filter_paths.iter().any(|fp| {
-                        if is_glob_pattern(fp) {
-                            glob_matches(fp, &path_str)
-                        } else if fp.is_empty() || fp == "." {
-                            true
-                        } else if fp.ends_with('/') {
-                            path_str.starts_with(fp.as_str())
-                        } else {
-                            path_str == *fp || path_str.starts_with(&format!("{fp}/"))
-                        }
-                    });
-                    if !matches {
-                        continue;
-                    }
+                if !patch_path_filter_matches(&path_str, &filter_paths) {
+                    continue;
                 }
 
                 let abs_path = work_tree.join(&path_str);
@@ -3056,19 +3042,8 @@ pub(crate) fn checkout_patch(
                 }
                 let path_str = String::from_utf8_lossy(&flat_entry.path).to_string();
 
-                if !filter_paths.is_empty() {
-                    let matches = filter_paths.iter().any(|fp| {
-                        if is_glob_pattern(fp) {
-                            glob_matches(fp, &path_str)
-                        } else if fp.is_empty() || fp == "." {
-                            true
-                        } else {
-                            path_str == *fp || path_str.starts_with(&format!("{fp}/"))
-                        }
-                    });
-                    if !matches {
-                        continue;
-                    }
+                if !patch_path_filter_matches(&path_str, &filter_paths) {
+                    continue;
                 }
 
                 let abs_path = work_tree.join(&path_str);
@@ -4360,8 +4335,26 @@ fn glob_matches_inner(pattern: &[u8], path: &[u8]) -> bool {
     pi == pattern.len()
 }
 
-/// Resolve a pathspec to a repository-relative path.
-fn resolve_pathspec(spec: &str, work_tree: &Path, cwd: &Path) -> String {
+/// True when `path_str` matches any of the `filter_paths` from interactive patch commands.
+pub(crate) fn patch_path_filter_matches(path_str: &str, filter_paths: &[String]) -> bool {
+    if filter_paths.is_empty() {
+        return true;
+    }
+    filter_paths.iter().any(|fp| {
+        if is_glob_pattern(fp) {
+            glob_matches(fp, path_str)
+        } else if fp.is_empty() || fp == "." {
+            true
+        } else if fp.ends_with('/') {
+            path_str.starts_with(fp.as_str())
+        } else {
+            path_str == *fp || path_str.starts_with(&format!("{fp}/"))
+        }
+    })
+}
+
+/// Resolve a pathspec to a repository-relative path (used by `checkout -p` / `reset -p`).
+pub(crate) fn resolve_pathspec(spec: &str, work_tree: &Path, cwd: &Path) -> String {
     // Handle :/ prefix (repo root)
     if spec == ":/" || spec.starts_with(":/") {
         let rest = &spec[2..];

--- a/grit/src/commands/reset.rs
+++ b/grit/src/commands/reset.rs
@@ -21,8 +21,12 @@ use grit_lib::objects::{parse_commit, parse_tree, ObjectId, ObjectKind};
 use grit_lib::odb::Odb;
 use grit_lib::refs::{append_reflog, resolve_ref, write_ref};
 use grit_lib::repo::Repository;
-use grit_lib::rev_parse::{abbreviate_object_id, resolve_revision_as_commit};
+use grit_lib::rev_parse::{
+    abbreviate_object_id, resolve_revision, resolve_revision_as_commit,
+    revision_spec_contains_ancestry_navigation, split_treeish_colon,
+};
 use grit_lib::state::{resolve_head, HeadState};
+use similar::{Algorithm, TextDiff};
 
 /// The zero OID for reflog entries when there is no previous value.
 fn zero_oid() -> ObjectId {
@@ -215,7 +219,7 @@ pub fn run(mut args: Args) -> Result<()> {
 
     let repo = Repository::discover(None).context("not a git repository")?;
 
-    // Handle -p (patch mode) by delegating to `git checkout-index`-like interactive unstaging
+    // Handle -p (patch mode): interactive partial unstaging / index application vs a treeish.
     if args.patch {
         return reset_patch(&repo, &args.rest);
     }
@@ -428,51 +432,219 @@ fn write_reset_reflog(
     }
 }
 
-/// Interactive patch-mode reset: present each staged hunk and ask whether
-/// to unstage it. This is the `git reset -p` flow.
-fn reset_patch(repo: &Repository, _rest: &[String]) -> Result<()> {
+/// Map `rev-parse` failures to the same stderr shape as `git reset -p`.
+fn map_reset_patch_rev_error(spec: &str, err: grit_lib::error::Error) -> anyhow::Error {
+    let s = err.to_string();
+    if s.contains("Could not parse object") {
+        anyhow::anyhow!("fatal: Could not parse object '{spec}'.")
+    } else if s.contains("ambiguous argument") {
+        err.into()
+    } else if s.contains("unknown revision") || s.contains("ObjectNotFound") {
+        anyhow::anyhow!(
+            "fatal: ambiguous argument '{spec}': unknown revision or path not in the working tree.\n\
+Use '--' to separate paths from revisions, like this:\n\
+'git <command> [<revision>...] -- [<file>...]'"
+        )
+    } else {
+        err.into()
+    }
+}
+
+/// Whether `token` looks like a short/full hex object id (for `reset -p` error propagation).
+fn looks_like_hex_object_id(token: &str) -> bool {
+    let t = token.trim();
+    (4..=40).contains(&t.len()) && t.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// First positional for `reset -p`: same DWIM as path-less `reset` (commit-ish vs pathspec), plus
+/// explicit treeish forms (`rev:path`, `...^{tree}`) that are not commit-ish.
+fn resolve_reset_patch_first_arg(repo: &Repository, first: &str) -> Result<Option<String>> {
+    let explicit_treeish = split_treeish_colon(first).is_some() || first.contains("^{");
+    if explicit_treeish {
+        return resolve_revision(repo, first)
+            .map(|_| Some(first.to_owned()))
+            .map_err(|e| map_reset_patch_rev_error(first, e));
+    }
+
+    if let Some(spec) = resolve_reset_first_arg_as_commit(repo, first) {
+        return Ok(Some(spec));
+    }
+    if revision_spec_contains_ancestry_navigation(first) {
+        return Ok(Some(first.to_owned()));
+    }
+    if looks_like_hex_object_id(first) {
+        return resolve_revision(repo, first)
+            .map(|_| Some(first.to_owned()))
+            .map_err(|e| map_reset_patch_rev_error(first, e));
+    }
+    Ok(None)
+}
+
+/// Split `rest` for `reset -p` into `(treeish_spec, pathspecs)` (Git-compatible).
+fn split_reset_patch_args(repo: &Repository, rest: &[String]) -> Result<(String, Vec<String>)> {
+    if rest.is_empty() {
+        return Ok(("HEAD".to_owned(), vec![]));
+    }
+
+    let mut i = 0usize;
+    while i < rest.len() {
+        let a = rest[i].as_str();
+        if matches!(
+            a,
+            "--soft"
+                | "--mixed"
+                | "--hard"
+                | "--merge"
+                | "--keep"
+                | "-q"
+                | "--quiet"
+                | "-N"
+                | "--intent-to-add"
+                | "--no-refresh"
+                | "--refresh"
+        ) {
+            i += 1;
+            continue;
+        }
+        break;
+    }
+    let rest = if i > 0 { &rest[i..] } else { rest };
+    if rest.is_empty() {
+        return Ok(("HEAD".to_owned(), vec![]));
+    }
+
+    if let Some(sep) = rest
+        .iter()
+        .position(|a| a == "--" || a == "--end-of-options")
+    {
+        let commit_spec = if sep == 0 {
+            "HEAD".to_owned()
+        } else {
+            rest[0].clone()
+        };
+        let paths = rest[sep + 1..].to_vec();
+        if sep == 0 {
+            return Ok((commit_spec, paths));
+        }
+        let treeish = resolve_reset_patch_first_arg(repo, &commit_spec)?;
+        let spec = treeish.unwrap_or(commit_spec);
+        return Ok((spec, paths));
+    }
+
+    let first = &rest[0];
+    let treeish = resolve_reset_patch_first_arg(repo, first)?;
+    if let Some(spec) = treeish {
+        let paths: Vec<String> = rest[1..]
+            .iter()
+            .filter(|a| {
+                !matches!(
+                    a.as_str(),
+                    "--soft"
+                        | "--mixed"
+                        | "--hard"
+                        | "--merge"
+                        | "--keep"
+                        | "-q"
+                        | "--quiet"
+                        | "-N"
+                        | "--intent-to-add"
+                        | "--no-refresh"
+                        | "--refresh"
+                )
+            })
+            .cloned()
+            .collect();
+        Ok((spec, paths))
+    } else {
+        Ok(("HEAD".to_owned(), rest.to_vec()))
+    }
+}
+
+/// Peel a resolved object to a tree OID (`commit` → its root tree).
+fn tree_oid_for_treeish(repo: &Repository, oid: ObjectId) -> Result<ObjectId> {
+    let obj = repo.odb.read(&oid)?;
+    match obj.kind {
+        ObjectKind::Tree => Ok(oid),
+        ObjectKind::Commit => Ok(parse_commit(&obj.data)?.tree),
+        _ => bail!("object {oid} is not a commit or tree"),
+    }
+}
+
+/// Resolve the tree OID for `git reset -p [<treeish>]`. Rejects `rev:path` blob forms.
+fn validate_reset_patch_treeish(repo: &Repository, treeish_spec: &str) -> Result<ObjectId> {
+    if let Some((lhs, rhs)) = split_treeish_colon(treeish_spec) {
+        if !lhs.is_empty() && !rhs.is_empty() {
+            let oid = resolve_revision(repo, treeish_spec)
+                .map_err(|e| map_reset_patch_rev_error(treeish_spec, e))?;
+            let obj = repo
+                .odb
+                .read(&oid)
+                .with_context(|| format!("reading object for '{treeish_spec}'"))?;
+            if obj.kind == ObjectKind::Blob {
+                bail!("fatal: Could not parse object '{treeish_spec}'.");
+            }
+        }
+    }
+    let oid = resolve_revision(repo, treeish_spec)
+        .map_err(|e| map_reset_patch_rev_error(treeish_spec, e))?;
+    tree_oid_for_treeish(repo, oid)
+}
+
+/// Interactive patch-mode reset (`git reset -p`): partial index updates toward `treeish`.
+fn reset_patch(repo: &Repository, rest: &[String]) -> Result<()> {
     use std::io::{self, BufRead, Write};
 
-    let head = resolve_head(&repo.git_dir)?;
-    let index_path = repo.index_path();
-    let mut index = repo.load_index_at(&index_path).context("loading index")?;
+    let work_tree = repo
+        .work_tree
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("this operation must be run in a work tree"))?;
 
-    // Get HEAD tree entries (empty if unborn)
-    let tree_entries = if let Some(oid) = head.oid() {
-        let tree_oid = commit_to_tree(repo, oid)?;
-        tree_to_flat_entries(repo, &tree_oid, "")?
-    } else {
-        Vec::new()
-    };
-    let tree_map: HashMap<Vec<u8>, IndexEntry> = tree_entries
+    let (treeish_spec, path_args) = split_reset_patch_args(repo, rest)?;
+    let cwd = std::env::current_dir().context("resolving cwd")?;
+    let filter_paths: Vec<String> = path_args
+        .iter()
+        .map(|p| crate::commands::checkout::resolve_pathspec(p, work_tree, &cwd))
+        .collect();
+
+    let target_tree_oid = validate_reset_patch_treeish(repo, &treeish_spec)?;
+    let target_entries = tree_to_flat_entries(repo, &target_tree_oid, "")?;
+    let target_map: HashMap<Vec<u8>, IndexEntry> = target_entries
         .into_iter()
         .map(|e| (e.path.clone(), e))
         .collect();
 
-    // Find staged entries that differ from HEAD
+    let index_path = repo.index_path();
+    let mut index = repo.load_index_at(&index_path).context("loading index")?;
+
     let mut staged_paths: Vec<Vec<u8>> = Vec::new();
     for entry in &index.entries {
         if entry.stage() != 0 {
             continue;
         }
-        let in_tree = tree_map.get(&entry.path);
+        let path_str = String::from_utf8_lossy(&entry.path);
+        if !crate::commands::checkout::patch_path_filter_matches(&path_str, &filter_paths) {
+            continue;
+        }
+        let in_tree = target_map.get(&entry.path);
         let differs = match in_tree {
             Some(te) => te.oid != entry.oid || te.mode != entry.mode,
-            None => true, // new file
+            None => true,
         };
         if differs {
             staged_paths.push(entry.path.clone());
         }
     }
-    // Also find paths deleted from index (in tree but not in index)
-    for path in tree_map.keys() {
+    for path in target_map.keys() {
         if !index
             .entries
             .iter()
             .any(|e| e.path == *path && e.stage() == 0)
             && !staged_paths.contains(path)
         {
-            staged_paths.push(path.clone());
+            let path_str = String::from_utf8_lossy(path);
+            if crate::commands::checkout::patch_path_filter_matches(&path_str, &filter_paths) {
+                staged_paths.push(path.clone());
+            }
         }
     }
 
@@ -480,28 +652,204 @@ fn reset_patch(repo: &Repository, _rest: &[String]) -> Result<()> {
         return Ok(());
     }
 
+    staged_paths.sort();
+
     let stdin = io::stdin();
     let mut reader = stdin.lock();
+    let mut out = io::stdout();
 
-    for path in &staged_paths {
-        let path_str = String::from_utf8_lossy(path);
-        let action = if tree_map.contains_key(path) {
+    for path in staged_paths {
+        let path_str = String::from_utf8_lossy(&path).into_owned();
+
+        let index_blob = index.get(&path, 0).map(|e| e.oid);
+        let tree_entry = target_map.get(&path);
+        let tree_oid = tree_entry.map(|e| e.oid);
+        let tree_mode = tree_entry.map(|e| e.mode);
+
+        // Myers diff with **old = target tree**, **new = index** so the printed patch and
+        // `blend_line_diff_by_hunk_ranges` match Git (`reset -p` applies the tree side when a hunk
+        // is accepted).
+        let (index_bytes, tree_bytes) = match (index_blob, tree_oid) {
+            (Some(ib), Some(to)) => {
+                let iobj = repo.odb.read(&ib)?;
+                let tobj = repo.odb.read(&to)?;
+                if iobj.kind != ObjectKind::Blob || tobj.kind != ObjectKind::Blob {
+                    continue;
+                }
+                (iobj.data, tobj.data)
+            }
+            (Some(ib), None) => {
+                let iobj = repo.odb.read(&ib)?;
+                if iobj.kind != ObjectKind::Blob {
+                    continue;
+                }
+                (iobj.data, Vec::new())
+            }
+            (None, Some(to)) => {
+                let tobj = repo.odb.read(&to)?;
+                if tobj.kind != ObjectKind::Blob {
+                    continue;
+                }
+                (Vec::new(), tobj.data)
+            }
+            (None, None) => continue,
+        };
+
+        let tree_str = String::from_utf8_lossy(&tree_bytes);
+        let index_str = String::from_utf8_lossy(&index_bytes);
+        let text_diff = TextDiff::configure()
+            .algorithm(Algorithm::Myers)
+            .diff_lines(tree_str.as_ref(), index_str.as_ref());
+        let ops: Vec<_> = text_diff.ops().to_vec();
+        let has_change = ops
+            .iter()
+            .any(|o| !matches!(o, similar::DiffOp::Equal { .. }));
+        if !has_change {
+            continue;
+        }
+
+        let n_ops = ops.len();
+        let mut hunk_ranges: Vec<(usize, usize)> = vec![(0, n_ops)];
+        let mut accepted = vec![false; hunk_ranges.len()];
+        let mut hunk_cursor = 0usize;
+
+        let verb = if treeish_spec == "HEAD" || treeish_spec == "@" {
             "Unstage"
         } else {
-            "Unstage addition of"
+            "Apply"
         };
-        print!("{}  {}? ([y]es/[n]o) ", action, path_str);
-        io::stdout().flush()?;
-        let mut line = String::new();
-        reader.read_line(&mut line)?;
-        let answer = line.trim().to_lowercase();
-        if answer == "y" || answer == "yes" {
-            // Reset this path to tree version
-            index.remove(path);
-            if let Some(te) = tree_map.get(path) {
-                index.add_or_replace(te.clone());
+
+        'hunk_loop: loop {
+            let n_hunks = hunk_ranges.len();
+            if hunk_cursor >= n_hunks {
+                break;
+            }
+
+            let display_idx = hunk_cursor + 1;
+            let (s, e) = hunk_ranges[hunk_cursor];
+            let hunk_only = crate::commands::stash::partial_unified_for_op_range(
+                path_str.as_str(),
+                &tree_bytes,
+                &index_bytes,
+                &ops[s..e],
+                3,
+            );
+
+            writeln!(out, "diff --git a/{path_str} b/{path_str}").ok();
+            write!(out, "--- a/{path_str}\n+++ b/{path_str}\n").ok();
+            write!(out, "{hunk_only}").ok();
+            write!(
+                out,
+                "({display_idx}/{n_hunks}) {verb} this hunk to index [y,n,q,a,d,s,e,?]? "
+            )
+            .ok();
+            out.flush().ok();
+
+            let mut line = String::new();
+            if reader.read_line(&mut line).unwrap_or(0) == 0 {
+                break;
+            }
+            let answer = line.trim();
+            match answer {
+                "y" | "Y" => {
+                    accepted[hunk_cursor] = true;
+                    hunk_cursor += 1;
+                }
+                "n" | "N" => {
+                    hunk_cursor += 1;
+                }
+                "a" | "A" => {
+                    for j in hunk_cursor..n_hunks {
+                        accepted[j] = true;
+                    }
+                    break 'hunk_loop;
+                }
+                "d" | "D" => {
+                    break 'hunk_loop;
+                }
+                "q" | "Q" => {
+                    break;
+                }
+                "s" | "S" => {
+                    if !crate::commands::stash::split_hunk_at_first_gap(
+                        &mut hunk_ranges,
+                        hunk_cursor,
+                        &ops,
+                    ) {
+                        continue 'hunk_loop;
+                    }
+                    let n = hunk_ranges.len();
+                    accepted.resize(n, false);
+                    continue 'hunk_loop;
+                }
+                _ => {
+                    hunk_cursor += 1;
+                }
             }
         }
+
+        if !accepted.iter().any(|&a| a) {
+            continue;
+        }
+
+        let blended = crate::commands::checkout::blend_line_diff_by_hunk_ranges(
+            &tree_bytes,
+            &index_bytes,
+            &hunk_ranges,
+            &accepted,
+        );
+        let blended_bytes = blended.into_bytes();
+
+        if blended_bytes == index_bytes {
+            continue;
+        }
+
+        index.remove(&path);
+        if blended_bytes.is_empty() {
+            if let Some(te) = tree_entry {
+                if te.mode == MODE_GITLINK {
+                    index.add_or_replace(te.clone());
+                }
+            }
+            continue;
+        }
+
+        let blob_oid = Odb::hash_object_data(ObjectKind::Blob, &blended_bytes);
+        let mode = tree_mode.unwrap_or(0o100644);
+        let path_bytes = path.clone();
+        let abs_file = work_tree.join(&path_str);
+        let (cs, cns, ms, mns, dev, ino, fsz) = if let Ok(m) = std::fs::symlink_metadata(&abs_file)
+        {
+            use std::os::unix::fs::MetadataExt as _;
+            (
+                m.ctime() as u32,
+                m.ctime_nsec() as u32,
+                m.mtime() as u32,
+                m.mtime_nsec() as u32,
+                m.dev() as u32,
+                m.ino() as u32,
+                m.size() as u32,
+            )
+        } else {
+            (0, 0, 0, 0, 0, 0, blended_bytes.len() as u32)
+        };
+        let entry = IndexEntry {
+            ctime_sec: cs,
+            ctime_nsec: cns,
+            mtime_sec: ms,
+            mtime_nsec: mns,
+            dev,
+            ino,
+            mode,
+            uid: 0,
+            gid: 0,
+            size: fsz,
+            oid: blob_oid,
+            flags: path_bytes.len().min(0xFFF) as u16,
+            flags_extended: None,
+            path: path_bytes,
+        };
+        index.add_or_replace(entry);
     }
 
     repo.write_index_at(&index_path, &mut index)

--- a/grit/src/commands/stash.rs
+++ b/grit/src/commands/stash.rs
@@ -1164,7 +1164,7 @@ fn do_stash_patch_push(
 }
 
 /// Build unified hunk text (`@@` …) for a slice of Myers line-diff ops (HEAD vs current worktree).
-fn partial_unified_for_op_range(
+pub(crate) fn partial_unified_for_op_range(
     path: &str,
     head_bytes: &[u8],
     work_bytes: &[u8],
@@ -1235,7 +1235,7 @@ fn partial_unified_for_op_range(
 
 /// Split after the first change block, at the following line-equality (`Equal`) ops, when more
 /// changes exist after that context (same idea as Git `add -p` / stash `s`).
-fn split_hunk_at_first_gap(
+pub(crate) fn split_hunk_at_first_gap(
     ranges: &mut Vec<(usize, usize)>,
     hunk_cursor: usize,
     ops: &[similar::DiffOp],

--- a/logs/2026-04-09_t7105-reset-patch.md
+++ b/logs/2026-04-09_t7105-reset-patch.md
@@ -1,10 +1,8 @@
 # t7105-reset-patch
 
-## Goal
+- Replaced per-file yes/no `reset -p` with hunk-level flow matching Git: Myers diff **target tree → index**, stash-style hunk splitting, `blend_line_diff_by_hunk_ranges` for partial index updates.
+- Treeish parsing: `split_reset_patch_args` mirrors `reset` DWIM (so `dir` is a pathspec, not a tree); explicit `rev:path` / `^{` use `resolve_revision`; short hex uses rev-parse errors.
+- Blob `HEAD^:path` → `fatal: Could not parse object`; unknown `aaaaaaaa` → ambiguous argument message.
+- Factored `patch_path_filter_matches` + `pub(crate) resolve_pathspec` in checkout; exported stash `partial_unified_for_op_range` / `split_hunk_at_first_gap`.
 
-Ensure `tests/t7105-reset-patch.sh` passes fully under the harness (`grit` as `git`).
-
-## Result
-
-- `./scripts/run-tests.sh t7105-reset-patch.sh` → **13/13** pass (no Rust changes required on this branch; implementation already satisfied the file).
-- Refreshed `data/test-files.csv` and dashboards; marked task complete in `PLAN.md` and updated `progress.md` counts.
+Tests: `./scripts/run-tests.sh t7105-reset-patch.sh` — 13/13 pass.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements proper `git reset -p` behavior so `tests/t7105-reset-patch.sh` passes (13/13).

## Changes

- **Hunk-level patch mode**: Diff **target tree → index** (matches Git’s displayed patch direction), prompt per hunk with `Unstage` for `HEAD`/`@`/default and `Apply` for other treeishes; use the same hunk machinery as stash (`partial_unified_for_op_range`, `split_hunk_at_first_gap`) and `blend_line_diff_by_hunk_ranges` for partial index updates.
- **Arguments**: `split_reset_patch_args` mirrors non-patch `reset` DWIM so tokens like `dir` are pathspecs, not treeishes; explicit `rev:path` and `^{…}` forms go through `resolve_revision`.
- **Errors**: Blob treeish `HEAD^:path` → `fatal: Could not parse object '…'`; unknown short hex → Git-style ambiguous argument message.
- **Refactor**: `patch_path_filter_matches` + `pub(crate) resolve_pathspec` in `checkout.rs`; `partial_unified_for_op_range` / `split_hunk_at_first_gap` are `pub(crate)` in `stash.rs` for reuse.

## Validation

- `./scripts/run-tests.sh t7105-reset-patch.sh` — all tests pass
- `cargo test -p grit-lib --lib`
- `cargo check -p grit-rs` (no warnings from touched crates)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c3e83fd6-5193-49ec-99f5-6afd0e3f774c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c3e83fd6-5193-49ec-99f5-6afd0e3f774c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

