### PR TITLE
fix: diff -B binary rewrite parity (t4031)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -709,7 +709,7 @@ t4027-diff-submodule	t4	yes	20	6	14	false	ok	0
 t4028-format-patch-mime-headers	t4	yes	3	3	0	true	ok	0
 t4029-diff-trailing-space	t4	yes	1	1	0	true	ok	0
 t4030-diff-textconv	t4	yes	19	10	9	false	ok	0
-t4031-diff-rewrite-binary	t4	yes	8	3	5	false	ok	0
+t4031-diff-rewrite-binary	t4	yes	8	8	0	true	ok	0
 t4032-diff-inter-hunk-context	t4	yes	37	29	8	false	ok	0
 t4033-diff-patience	t4	yes	11	9	2	false	ok	0
 t4034-diff-words	t4	yes	66	7	59	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.9% of harness tests passing (35,632 / 45,142).">
+<meta property="og:description" content="78.9% of harness tests passing (35,637 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.9% of harness tests passing (35,632 / 45,142).">
+<meta name="twitter:description" content="78.9% of harness tests passing (35,637 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T18:27:56+00:00" class="gen-time" title="2026-04-09 18:27 UTC">2026-04-09 18:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/8a827488252c8a042a20fa92a0379f280402f0d7" style="color:#58a6ff">8a82748</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T18:41:23+00:00" class="gen-time" title="2026-04-09 18:41 UTC">2026-04-09 18:41 UTC</time> · <a href="https://github.com/schacon/grit/commit/70a1fa1b29e5dc10d6ea74249728c87177fec5ab" style="color:#58a6ff">70a1fa1</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,632</div>
+      <div class="summary-big-val">35,637</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>747 files fully passing</span>
+    <span>748 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -230,11 +230,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">72/178 files · 2 skipped · 2,860/4,438 tests</span>
+        <span class="group-meta">73/178 files · 2 skipped · 2,865/4,438 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.4%"></div></div>
-        <span class="group-pct pct-blue">64.4%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.6%"></div></div>
+        <span class="group-pct pct-blue">64.6%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35632 of 45142 tests passing across 1405 harness files (78.9% pass rate).</desc>
+  <desc id="svg-desc">35637 of 45142 tests passing across 1405 harness files (78.9% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.9% pass rate · 35,632 / 45,142 tests · 1,405 files in scope · 747 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.9% pass rate · 35,637 / 45,142 tests · 1,405 files in scope · 748 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="552" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T18:27:56+00:00" class="gen-time" title="2026-04-09 18:27 UTC">2026-04-09 18:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/8a827488252c8a042a20fa92a0379f280402f0d7" style="color:#58a6ff">8a82748</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T18:41:23+00:00" class="gen-time" title="2026-04-09 18:41 UTC">2026-04-09 18:41 UTC</time> · <a href="https://github.com/schacon/grit/commit/70a1fa1b29e5dc10d6ea74249728c87177fec5ab" style="color:#58a6ff">70a1fa1</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,632</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,637</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.9%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -7247,14 +7247,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:52.6%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="8" data-passed="3">
+<tr class="" data-group="t4" data-tests="8" data-passed="8" data-full-pass="1">
   <td class="mono">t4031-diff-rewrite-binary</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">8</td>
-  <td class="right">3</td>
+  <td class="right">8</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:37.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="37" data-passed="29">

--- a/grit/src/commands/diff.rs
+++ b/grit/src/commands/diff.rs
@@ -1848,9 +1848,6 @@ pub fn run(mut args: Args) -> Result<()> {
                 wt_for_content,
                 entry.path(),
             );
-            if is_binary(&old_raw) || is_binary(&new_raw) {
-                continue;
-            }
             if should_break_rewrite_for_stat(&old_raw, &new_raw) {
                 if let Some(pct) = rewrite_dissimilarity_index_percent(&old_raw, &new_raw) {
                     entry.score = Some(pct);
@@ -2108,6 +2105,9 @@ pub fn run(mut args: Args) -> Result<()> {
                 &diff_algo_ctx,
                 diff_algo_cli,
             )?;
+            if args.summary {
+                write_diff_summary(&mut out, &entries, args.break_rewrites, quote_path_fully)?;
+            }
         } else if args.name_only {
             write_name_only(&mut out, &entries, quote_path_fully)?;
         } else if args.name_status {
@@ -3455,10 +3455,11 @@ fn dirstat_damage_for_entry(
         DirstatMode::Lines => {
             if break_rewrites
                 && entry.status == DiffStatus::Modified
-                && !is_binary(&old_raw)
-                && !is_binary(&new_raw)
                 && should_break_rewrite_for_stat(&old_raw, &new_raw)
             {
+                if is_binary(&old_raw) || is_binary(&new_raw) {
+                    return 0;
+                }
                 let ins = count_git_lines(&new_raw) as u64;
                 let del = count_git_lines(&old_raw) as u64;
                 return ins.saturating_add(del);
@@ -4084,10 +4085,11 @@ fn stat_ins_del_for_entry(
     let new_raw = read_content_raw_or_worktree(odb, &entry.new_oid, work_tree, entry.path());
     if break_rewrites
         && entry.status == DiffStatus::Modified
-        && !is_binary(&old_raw)
-        && !is_binary(&new_raw)
         && should_break_rewrite_for_stat(&old_raw, &new_raw)
     {
+        if is_binary(&old_raw) || is_binary(&new_raw) {
+            return (0, 0);
+        }
         return (count_git_lines(&new_raw), count_git_lines(&old_raw));
     }
     let mut old_content = String::from_utf8_lossy(&old_raw).into_owned();
@@ -5168,24 +5170,43 @@ fn write_numstat(
     algo_cli: Option<similar::Algorithm>,
 ) -> Result<()> {
     for entry in entries {
-        let (ins, del) = stat_ins_del_for_entry(
-            odb,
-            entry,
-            work_tree,
-            break_rewrites,
-            line_ignore,
-            ws_mode,
-            algo_ctx,
-            algo_cli,
-        );
+        let old_raw = read_content_raw(odb, &entry.old_oid);
+        let new_raw = read_content_raw_or_worktree(odb, &entry.new_oid, work_tree, entry.path());
+        let binary_rewrite_numstat = break_rewrites
+            && entry.status == DiffStatus::Modified
+            && entry.score.is_some()
+            && (is_binary(&old_raw) || is_binary(&new_raw));
         match entry.status {
             DiffStatus::Renamed | DiffStatus::Copied => {
+                let (ins, del) = stat_ins_del_for_entry(
+                    odb,
+                    entry,
+                    work_tree,
+                    break_rewrites,
+                    line_ignore,
+                    ws_mode,
+                    algo_ctx,
+                    algo_cli,
+                );
                 let old = entry.old_path.as_deref().unwrap_or("");
                 let new = entry.new_path.as_deref().unwrap_or("");
                 let display = format_rename_display(old, new, false);
                 writeln!(out, "{ins}\t{del}\t{display}")?;
             }
+            _ if binary_rewrite_numstat => {
+                writeln!(out, "-\t-\t{}", entry.path())?;
+            }
             _ => {
+                let (ins, del) = stat_ins_del_for_entry(
+                    odb,
+                    entry,
+                    work_tree,
+                    break_rewrites,
+                    line_ignore,
+                    ws_mode,
+                    algo_ctx,
+                    algo_cli,
+                );
                 writeln!(out, "{ins}\t{del}\t{}", entry.path())?;
             }
         }

--- a/grit/src/commands/diff_files.rs
+++ b/grit/src/commands/diff_files.rs
@@ -78,11 +78,6 @@ pub fn run(mut args: Args) -> Result<()> {
                     Err(_) => continue,
                 }
             };
-            if grit_lib::merge_file::is_binary(&old_raw)
-                || grit_lib::merge_file::is_binary(&new_raw)
-            {
-                continue;
-            }
             if should_break_rewrite_for_stat(&old_raw, &new_raw) {
                 if let Some(pct) = rewrite_dissimilarity_index_percent(&old_raw, &new_raw) {
                     entry.score = Some(pct);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes `t4031-diff-rewrite-binary` pass by matching Git’s behavior for **complete rewrites on binary blobs** when `--break-rewrites` (`-B`) is used.

## Changes

- **Dissimilarity / rewrite metadata:** Stop skipping `-B` scoring when either side is binary; `entry.score` is set whenever `should_break_rewrite_for_stat` applies (same for `git diff-files`).
- **`--numstat`:** For modified binary pairs with a rewrite score, emit `-\t-\tpath` like Git (instead of `0\t0`).
- **`--numstat --summary`:** Emit summary lines after numstat when `--summary` is requested (previously summary was dropped on the numstat-only code path).
- **`--stat` / counts:** Binary rewrites still show `Bin N -> M bytes` for the per-file line, but line-based totals stay **0 insertions / 0 deletions** via `stat_ins_del_for_entry`.
- **`dirstat` (lines mode):** Treat binary rewrites as **0** line damage (consistent with Git’s rewrite handling).

## Validation

- `bash tests/t4031-diff-rewrite-binary.sh` — 8/8
- `./scripts/run-tests.sh t4031-diff-rewrite-binary.sh` — 8/8
- `cargo fmt`, `cargo check -p grit-rs`, `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f169bd00-abc5-42a0-bc28-60b5c3c56c9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f169bd00-abc5-42a0-bc28-60b5c3c56c9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

