### PR TITLE
docs: t3703-add-magic-pathspec fully passing (harness + plan)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -270,7 +270,7 @@ commit → check it off → move on.
 - [ ] `t3401-rebase-and-am-rename` ████████████░░░░░░░░ 6/10 (4 left) — git rebase + directory rename tests
 - [x] `t3419-rebase-patch-id` ████████████████████ 8/8 (0 left) — git rebase - test patch id computation
 - [x] `t3429-rebase-edit-todo` ████████████████████ 7/7 (0 left) — rebase should reread the todo file if an exec modifies it
-- [ ] `t3703-add-magic-pathspec` ██████░░░░░░░░░░░░░░ 2/6 (4 left) — magic pathspec tests using git-add
+- [x] `t3703-add-magic-pathspec` ████████████████████ 6/6 (0 left) — magic pathspec tests using git-add
 - [ ] `t3601-rm-pathspec-file` ████░░░░░░░░░░░░░░░░ 1/5 (4 left) — rm --pathspec-from-file
 - [ ] `t3909-stash-pathspec-file` ████░░░░░░░░░░░░░░░░ 1/5 (4 left) — stash --pathspec-from-file
 - [x] `t3417-rebase-whitespace-fix` ████████████████████ 4/4 (0 left) — git rebase --whitespace=fix

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -656,7 +656,7 @@ t3700-add	t3	yes	58	44	14	false	ok	0
 t3700-add-pathspec-file	t3	yes	24	24	0	true	ok	0
 t3701-add-interactive	t3	yes	130	31	99	false	ok	0
 t3702-add-edit	t3	yes	3	1	2	false	ok	0
-t3703-add-magic-pathspec	t3	yes	6	4	2	false	ok	0
+t3703-add-magic-pathspec	t3	yes	6	6	0	true	ok	0
 t3704-add-pathspec-file	t3	yes	11	11	0	true	ok	0
 t3705-add-sparse-checkout	t3	yes	20	3	17	false	ok	0
 t3800-mktag	t3	yes	151	144	7	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.9% of harness tests passing (35,632 / 45,142).">
+<meta property="og:description" content="78.9% of harness tests passing (35,635 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.9% of harness tests passing (35,632 / 45,142).">
+<meta name="twitter:description" content="78.9% of harness tests passing (35,635 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T18:27:56+00:00" class="gen-time" title="2026-04-09 18:27 UTC">2026-04-09 18:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/8a827488252c8a042a20fa92a0379f280402f0d7" style="color:#58a6ff">8a82748</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T18:43:01+00:00" class="gen-time" title="2026-04-09 18:43 UTC">2026-04-09 18:43 UTC</time> · <a href="https://github.com/schacon/grit/commit/30b340a923efca70b8f5cd76e96bbd5b55f896de" style="color:#58a6ff">30b340a</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,632</div>
+      <div class="summary-big-val">35,635</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>747 files fully passing</span>
+    <span>749 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -219,7 +219,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">54/141 files · 2 skipped · 4,037/5,398 tests</span>
+        <span class="group-meta">55/141 files · 2 skipped · 4,039/5,398 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:74.8%"></div></div>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">29/167 files · 17 skipped · 1,541/4,139 tests</span>
+        <span class="group-meta">30/167 files · 17 skipped · 1,542/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.2%"></div></div>
-        <span class="group-pct pct-red">37.2%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.3%"></div></div>
+        <span class="group-pct pct-red">37.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35632 of 45142 tests passing across 1405 harness files (78.9% pass rate).</desc>
+  <desc id="svg-desc">35635 of 45142 tests passing across 1405 harness files (78.9% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.9% pass rate · 35,632 / 45,142 tests · 1,405 files in scope · 747 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.9% pass rate · 35,635 / 45,142 tests · 1,405 files in scope · 749 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="552" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T18:27:56+00:00" class="gen-time" title="2026-04-09 18:27 UTC">2026-04-09 18:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/8a827488252c8a042a20fa92a0379f280402f0d7" style="color:#58a6ff">8a82748</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T18:43:01+00:00" class="gen-time" title="2026-04-09 18:43 UTC">2026-04-09 18:43 UTC</time> · <a href="https://github.com/schacon/grit/commit/30b340a923efca70b8f5cd76e96bbd5b55f896de" style="color:#58a6ff">30b340a</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,632</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,635</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.9%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -6717,14 +6717,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:33.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="6" data-passed="4">
+<tr class="" data-group="t3" data-tests="6" data-passed="6" data-full-pass="1">
   <td class="mono">t3703-add-magic-pathspec</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">6</td>
-  <td class="right">4</td>
+  <td class="right">6</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:66.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="11" data-passed="11" data-full-pass="1">
@@ -9337,14 +9337,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="3" data-passed="2">
+<tr class="" data-group="t5" data-tests="3" data-passed="3" data-full-pass="1">
   <td class="mono">t5501-fetch-push-alternates</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">3</td>
-  <td class="right">2</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:66.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="7" data-passed="2">

--- a/logs/2026-04-09_t3703-add-magic-pathspec.md
+++ b/logs/2026-04-09_t3703-add-magic-pathspec.md
@@ -1,0 +1,17 @@
+# t3703-add-magic-pathspec
+
+**Date:** 2026-04-09
+
+## Outcome
+
+`./scripts/run-tests.sh t3703-add-magic-pathspec.sh` reports **6/6** passing on branch `cursor/t3703-add-magic-pathspec-3ff7`. No Rust changes were required in this session; implementation was already sufficient.
+
+## Tests covered
+
+- `:/` from subdirectory (paths relative to repo root)
+- `:/anothersub`, `:/non-existent` (must fail)
+- Optional `COLON_DIR` prereq: files named like magic pathspecs require `./` prefix
+
+## Follow-up
+
+- Committed harness refresh (`data/test-files.csv`, dashboards) and `PLAN.md` / `progress.md` alignment.

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   316 |
+| Completed   |   321 |
 | In progress |     5 |
-| Remaining   |   449 |
-| **Total**   |   770 |
+| Remaining   |   445 |
+| **Total**   |   771 |
 
-Task lines in `PLAN.md`: 316 completed (`[x]`), 5 in progress (`[~]`), 449 remaining (`[ ]`).
+Task lines in `PLAN.md`: 321 completed (`[x]`), 5 in progress (`[~]`), 445 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t3703-add-magic-pathspec` — 6/6 tests pass (`git add -n` with `:/` top-level pathspec from subdir, `:/<path>` prefix, missing path failure, `./` disambiguation when a file shadows magic `:(icase)` / `:/` names; harness CSV/dashboards refreshed)
 - `t4063-diff-blobs` — 18/18 tests pass (`diff`: blob↔blob and `rev:path` pairs without treating blobs as trees; `HEAD:one..HEAD:two` range split; `rev:path` vs worktree file uses tree path + modes + `write_patch_with_prefix`; raw blob OID vs existing file uses filename as old path; `rev_parse::resolve_treeish_blob_at_path` for tree walks)
 - `t5605-clone-local` — 23/23 tests pass (streaming pack unpack for 0-byte objects; local clone without `--shared` no longer writes source `alternates`; `--no-hardlinks` / `file://` copy-only objects; `--upload-pack` local-path rejection + env prefix for grit `upload-pack`; corrupt loose ref validation before ref copy; `fetch` no-op when `remote.*.url` is a bundle file; bundle clone HEAD/default-branch parity with Git for `bundle create tip` without `HEAD` line)
 - `t5609-clone-branch` — 7/7 tests pass (`clone --branch`: `read_raw_ref` for ref existence so `refs/remotes/origin/HEAD` is set when default branch is packed; reject `--branch` when `refs/heads/<name>` missing on source, including empty repos)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t3703-add-magic-pathspec` already passes all harness tests (6/6). This change refreshes `data/test-files.csv` and dashboards from `./scripts/run-tests.sh t3703-add-magic-pathspec.sh`, marks the task complete in `PLAN.md`, updates `progress.md` counts, and adds a short log under `logs/`.

## Verification

```bash
./scripts/run-tests.sh t3703-add-magic-pathspec.sh
```

## Notes

No Rust changes in this PR; pathspec/`git add` behavior for `:/`, missing paths, and `./` disambiguation for colon-named files was already aligned with Git.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60a76c65-a618-4e39-938a-27a3264a7a81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60a76c65-a618-4e39-938a-27a3264a7a81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

