### PR TITLE
fix: make t0014-alias fully pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -13,7 +13,7 @@ t0009-git-dir-validation	t0	yes	6	6	0	true	ok	0
 t0010-racy-git	t0	yes	10	10	0	true	ok	0
 t0012-help	t0	yes	123	119	4	false	ok	0
 t0013-sha1dc	t0	skip	0	0	0	false	ok	0
-t0014-alias	t0	yes	21	20	1	false	ok	1
+t0014-alias	t0	yes	21	21	0	true	ok	1
 t0017-env-helper	t0	yes	5	5	0	true	ok	0
 t0018-advice	t0	yes	6	6	0	true	ok	0
 t0019-json-writer	t0	yes	16	16	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.9% of harness tests passing (35,632 / 45,142).">
+<meta property="og:description" content="78.9% of harness tests passing (35,633 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.9% of harness tests passing (35,632 / 45,142).">
+<meta name="twitter:description" content="78.9% of harness tests passing (35,633 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T18:27:56+00:00" class="gen-time" title="2026-04-09 18:27 UTC">2026-04-09 18:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/8a827488252c8a042a20fa92a0379f280402f0d7" style="color:#58a6ff">8a82748</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T18:53:09+00:00" class="gen-time" title="2026-04-09 18:53 UTC">2026-04-09 18:53 UTC</time> · <a href="https://github.com/schacon/grit/commit/70a1fa1b29e5dc10d6ea74249728c87177fec5ab" style="color:#58a6ff">70a1fa1</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,632</div>
+      <div class="summary-big-val">35,633</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>747 files fully passing</span>
+    <span>748 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -186,11 +186,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t0</span>
         <span class="group-desc">Absolute basics and global stuff</span>
-        <span class="group-meta">40/64 files · 21 skipped · 4,885/5,134 tests</span>
+        <span class="group-meta">41/64 files · 21 skipped · 4,886/5,134 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:95.1%"></div></div>
-        <span class="group-pct pct-green">95.1%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:95.2%"></div></div>
+        <span class="group-pct pct-green">95.2%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t1">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35632 of 45142 tests passing across 1405 harness files (78.9% pass rate).</desc>
+  <desc id="svg-desc">35633 of 45142 tests passing across 1405 harness files (78.9% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.9% pass rate · 35,632 / 45,142 tests · 1,405 files in scope · 747 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.9% pass rate · 35,633 / 45,142 tests · 1,405 files in scope · 748 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="552" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T18:27:56+00:00" class="gen-time" title="2026-04-09 18:27 UTC">2026-04-09 18:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/8a827488252c8a042a20fa92a0379f280402f0d7" style="color:#58a6ff">8a82748</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T18:53:09+00:00" class="gen-time" title="2026-04-09 18:53 UTC">2026-04-09 18:53 UTC</time> · <a href="https://github.com/schacon/grit/commit/70a1fa1b29e5dc10d6ea74249728c87177fec5ab" style="color:#58a6ff">70a1fa1</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,632</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,633</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.9%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -287,14 +287,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t0" data-tests="21" data-passed="20">
+<tr class="" data-group="t0" data-tests="21" data-passed="21" data-full-pass="1">
   <td class="mono">t0014-alias</td>
   <td>t0</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">21</td>
-  <td class="right">20</td>
+  <td class="right">21</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:95.2%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
 <tr class="" data-group="t0" data-tests="5" data-passed="5" data-full-pass="1">

--- a/grit/src/commands/grep.rs
+++ b/grit/src/commands/grep.rs
@@ -38,7 +38,11 @@ fn grep_output_path(repo: &Repository, full_worktree_relative: &str) -> String {
 }
 
 /// Arguments for `grit grep`.
+///
+/// Git uses `-h` for `--no-filename`, not for short help (see `main` dispatch). Clap's default
+/// `-h`/`--help` would steal `-h` and break `git grep -h` / t0014-alias.
 #[derive(Debug, ClapArgs)]
+#[command(disable_help_flag = true)]
 pub struct Args {
     /// Show line numbers.
     #[arg(short = 'n', long = "line-number")]

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -4219,7 +4219,14 @@ pub(crate) fn dispatch(subcmd: &str, rest: &[String], opts: &GlobalOpts) -> Resu
             commands::index_pack::run(parse_cmd_args(subcmd, &argv))
         }
         "init" => commands::init::run(parse_cmd_args(subcmd, rest), opts.bare),
-        "interpret-trailers" => commands::interpret_trailers::run_from_argv(rest),
+        "interpret-trailers" => {
+            if rest.len() == 1 && (rest[0] == "-h" || rest[0] == "--help") {
+                if let Some(syn) = upstream_help_builtin_synopsis::synopsis_for_builtin(subcmd) {
+                    print_upstream_synopsis_and_exit(subcmd, syn, 129);
+                }
+            }
+            commands::interpret_trailers::run_from_argv(rest)
+        }
         "last-modified" => commands::last_modified::run(parse_cmd_args(subcmd, rest)),
         "log" => {
             let rest = preprocess_log_pickaxe_args(preprocess_log_args(rest));

--- a/grit/upstream_help_synopsis.rs
+++ b/grit/upstream_help_synopsis.rs
@@ -380,6 +380,9 @@ git hash-object [-t <type>] [-w] --stdin-paths [--no-filters]"#),
         "index-pack" => Some(r#"git index-pack [-v] [-o <index-file>] [--[no-]rev-index] <pack-file>
 git index-pack --stdin [--fix-thin] [--keep] [-v] [-o <index-file>]
 		  [--[no-]rev-index] [<pack-file>]"#),
+        "interpret-trailers" => Some(r#"git interpret-trailers [--in-place] [--trim-empty]
+			[(--trailer (<key>|<key-alias>)[(=|:)<value>])...]
+			[--parse] [<file>...]"#),
         "ls-files" => Some(r#"git ls-files [-z] [-t] [-v] [-f]
 		[-c|--cached] [-d|--deleted] [-o|--others] [-i|--ignored]
 		[-s|--stage] [-u|--unmerged] [-k|--killed] [-m|--modified]

--- a/logs/2026-04-09_t0014-alias.md
+++ b/logs/2026-04-09_t0014-alias.md
@@ -1,0 +1,11 @@
+# t0014-alias
+
+## Failures
+
+1. `git grep -h`: clap reserved `-h` for help on `grep::Args`, so the lone `-h` path never reached the Git-compatible `--no-filename` / synopsis handling in `dispatch`. Fix: `#[command(disable_help_flag = true)]` on `grep::Args`.
+
+2. `git interpret-trailers -h`: manual argv parser rejected `-h` with no upstream synopsis in the generator. Fix: add `interpret-trailers` to `generate-upstream-help-synopsis.py`, regenerate `grit/upstream_help_synopsis.rs`, and short-circuit `-h`/`--help` in `dispatch` like other builtins.
+
+## Verification
+
+- `./scripts/run-tests.sh t0014-alias.sh` → 21/21 pass.

--- a/scripts/generate-upstream-help-synopsis.py
+++ b/scripts/generate-upstream-help-synopsis.py
@@ -89,6 +89,7 @@ BUILTINS = [
     "get-tar-commit-id",
     "hash-object",
     "index-pack",
+    "interpret-trailers",
     "ls-files",
     "ls-remote",
     "ls-tree",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t0014-alias` was failing on **cannot alias-shadow regular builtins** because two commands did not produce non-empty stdout for `git <cmd> -h` when compared under `test_might_fail`.

## Changes

1. **`git grep`**: Clap's default `-h` (help) on `grep::Args` intercepted `-h` before the existing Git-compatible path in `dispatch` could treat a lone `-h` as short synopsis / `--no-filename`. Added `#[command(disable_help_flag = true)]` so `-h` follows Git semantics; `--help` still goes through `parse_cmd_args` and prints help (exit 0).

2. **`git interpret-trailers`**: The manual argv parser rejected `-h`. Added `interpret-trailers` to `scripts/generate-upstream-help-synopsis.py`, regenerated `grit/upstream_help_synopsis.rs`, and short-circuit `-h`/`--help` in `dispatch` to the upstream synopsis (exit 129), matching other builtins.

Harness: `./scripts/run-tests.sh t0014-alias.sh` → **21/21** pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2cf0c8f5-810b-418c-937b-836e4f714028"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2cf0c8f5-810b-418c-937b-836e4f714028"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

