### PR TITLE
fix: ls-files core.quotepath false matches Git (t3902-quoted)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -662,7 +662,7 @@ t3705-add-sparse-checkout	t3	yes	20	3	17	false	ok	0
 t3800-mktag	t3	yes	151	144	7	false	ok	0
 t3900-i18n-commit	t3	yes	38	16	22	false	ok	0
 t3901-i18n-patch	t3	yes	20	8	12	false	ok	0
-t3902-quoted	t3	yes	13	12	1	false	ok	0
+t3902-quoted	t3	yes	13	13	0	true	ok	0
 t3902-quoted-ls-tree	t3	yes	8	8	0	true	ok	0
 t3903-stash	t3	yes	142	86	56	false	ok	0
 t3904-stash-patch	t3	yes	10	10	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,642 / 45,142).">
+<meta property="og:description" content="79% of harness tests passing (35,644 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,642 / 45,142).">
+<meta name="twitter:description" content="79% of harness tests passing (35,644 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T18:50:43+00:00" class="gen-time" title="2026-04-09 18:50 UTC">2026-04-09 18:50 UTC</time> · <a href="https://github.com/schacon/grit/commit/815be9929f5bb165898431181acd8e81f722728d" style="color:#58a6ff">815be99</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T18:59:46+00:00" class="gen-time" title="2026-04-09 18:59 UTC">2026-04-09 18:59 UTC</time> · <a href="https://github.com/schacon/grit/commit/866b50433fb011577d74bec690ba8e038dc0b203" style="color:#58a6ff">866b504</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,642</div>
+      <div class="summary-big-val">35,644</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>752 files fully passing</span>
+    <span>754 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -208,18 +208,18 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t2</span>
         <span class="group-desc">Basic commands concerning the working tree</span>
-        <span class="group-meta">29/61 files · 9 skipped · 665/872 tests</span>
+        <span class="group-meta">30/61 files · 9 skipped · 666/872 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:76.3%"></div></div>
-        <span class="group-pct pct-blue">76.3%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:76.4%"></div></div>
+        <span class="group-pct pct-blue">76.4%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t3">
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">55/141 files · 2 skipped · 4,039/5,398 tests</span>
+        <span class="group-meta">56/141 files · 2 skipped · 4,040/5,398 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:74.8%"></div></div>

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35642 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35644 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,642 / 45,142 tests · 1,405 files in scope · 752 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,644 / 45,142 tests · 1,405 files in scope · 754 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T18:50:43+00:00" class="gen-time" title="2026-04-09 18:50 UTC">2026-04-09 18:50 UTC</time> · <a href="https://github.com/schacon/grit/commit/815be9929f5bb165898431181acd8e81f722728d" style="color:#58a6ff">815be99</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T18:59:46+00:00" class="gen-time" title="2026-04-09 18:59 UTC">2026-04-09 18:59 UTC</time> · <a href="https://github.com/schacon/grit/commit/866b50433fb011577d74bec690ba8e038dc0b203" style="color:#58a6ff">866b504</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,642</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,644</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -4767,14 +4767,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:92.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t2" data-tests="3" data-passed="2">
+<tr class="" data-group="t2" data-tests="3" data-passed="3" data-full-pass="1">
   <td class="mono">t2002-checkout-cache-u</td>
   <td>t2</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">3</td>
-  <td class="right">2</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:66.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t2" data-tests="10" data-passed="10" data-full-pass="1">
@@ -6777,14 +6777,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:40.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="13" data-passed="12">
+<tr class="" data-group="t3" data-tests="13" data-passed="13" data-full-pass="1">
   <td class="mono">t3902-quoted</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">13</td>
-  <td class="right">12</td>
+  <td class="right">13</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:92.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="8" data-passed="8" data-full-pass="1">

--- a/grit/src/commands/ls_files.rs
+++ b/grit/src/commands/ls_files.rs
@@ -1253,7 +1253,7 @@ fn is_modified(entry: &IndexEntry, path: &std::path::Path) -> bool {
 /// Return the status tag character for an index entry (used by `-t`).
 /// Format a path for `ls-files` output: C-quote per `core.quotepath` / `core.quotePath`.
 fn format_ls_path(name: &str, use_nul: bool, quote_fully: bool) -> String {
-    if use_nul || !quote_fully {
+    if use_nul {
         return name.to_owned();
     }
     grit_lib::quote_path::quote_c_style(name, quote_fully)

--- a/logs/2026-04-09_t3902-quoted-ls-files-quotepath.md
+++ b/logs/2026-04-09_t3902-quoted-ls-files-quotepath.md
@@ -1,0 +1,19 @@
+# t3902-quoted — ls-files with core.quotepath false
+
+## Issue
+
+Harness `t3902-quoted.sh` failed test 9: after `git config --bool core.quotepath false`, `git ls-files` output did not match `expect.raw` (paths with tabs/LF/double-quote still needed C-style escapes; UTF-8 names should stay literal).
+
+## Root cause
+
+`format_ls_path` in `grit/src/commands/ls_files.rs` returned the raw path whenever `quote_fully` was false, skipping `quote_c_style` entirely. Diff/ls-tree already called `quote_c_style` with `quote_fully` from config; ls-files was wrong.
+
+## Fix
+
+Only skip quoting for `-z` (nul-terminated) output. Otherwise always use `quote_c_style(name, quote_fully)` so `core.quotepath false` matches Git (escape ASCII specials only, not octal UTF-8).
+
+## Validation
+
+- `sh ./tests/t3902-quoted.sh` — 13/13 pass
+- `cargo test -p grit-lib --lib` — pass
+- `./scripts/run-tests.sh t3902-quoted.sh` — updates CSV to 13/13


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`git ls-files` skipped C-style quoting whenever `core.quotepath` was false. Git still escapes tabs, newlines, double quotes, etc.; turning `quotepath` off only stops octal escaping of non-ASCII bytes. That mismatch broke **t3902-quoted** test 9 (raw expected output after `core.quotepath false`).

## Changes

- **`grit/src/commands/ls_files.rs`**: `format_ls_path` now only bypasses quoting for `-z` (nul-terminated) output; otherwise it always calls `quote_c_style(name, quote_fully)`.
- Refreshed harness artifacts for **t3902-quoted** (13/13) and added a short log under `logs/`.

## Validation

- `./scripts/run-tests.sh t3902-quoted.sh` — 13/13
- `cargo test -p grit-lib --lib` — pass
- `cargo check -p grit-rs` — pass

Note: `cargo clippy -p grit-rs -- -D warnings` reports many pre-existing issues across the workspace; not used as a gate here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71db131a-bf64-48a7-abcd-9f596336c5a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71db131a-bf64-48a7-abcd-9f596336c5a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

