### PR TITLE
fix: make t6130-pathspec-noglob pass (log pathspec + wildmatch)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -723,7 +723,7 @@ t4041-diff-submodule-option	t4	yes	47	17	30	false	ok	0
 t4042-diff-textconv-caching	t4	yes	8	7	1	false	ok	0
 t4043-diff-rename-binary	t4	yes	3	2	1	false	ok	0
 t4044-diff-index-unique-abbrev	t4	yes	2	1	1	false	ok	0
-t4045-diff-relative	t4	yes	38	32	6	false	ok	1
+t4045-diff-relative	t4	yes	38	32	6	false	ok	0
 t4046-diff-unmerged	t4	yes	8	3	5	false	ok	0
 t4047-diff-dirstat	t4	yes	41	4	37	false	ok	0
 t4047-diff-numstat	t4	yes	26	26	0	true	ok	0
@@ -1078,7 +1078,7 @@ t6114-keep-packs	t6	yes	3	3	0	true	ok	0
 t6115-rev-list-du	t6	yes	17	17	0	true	ok	0
 t6120-describe	t6	yes	103	44	59	false	ok	0
 t6120-name-rev	t6	yes	41	41	0	true	ok	0
-t6130-pathspec-noglob	t6	yes	21	8	13	false	ok	0
+t6130-pathspec-noglob	t6	yes	21	21	0	true	ok	0
 t6131-pathspec-icase	t6	yes	9	1	8	false	ok	0
 t6132-pathspec-exclude	t6	yes	31	0	31	false	ok	0
 t6133-pathspec-rev-dwim	t6	yes	6	5	1	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.8% of harness tests passing (35,582 / 45,141).">
+<meta property="og:description" content="79% of harness tests passing (35,650 / 45,141).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.8% of harness tests passing (35,582 / 45,141).">
+<meta name="twitter:description" content="79% of harness tests passing (35,650 / 45,141).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T18:12:07+00:00" class="gen-time" title="2026-04-09 18:12 UTC">2026-04-09 18:12 UTC</time> · <a href="https://github.com/schacon/grit/commit/e68f5dd2f3e4e16746c4824798176cdfe2532176" style="color:#58a6ff">e68f5dd</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T18:59:52+00:00" class="gen-time" title="2026-04-09 18:59 UTC">2026-04-09 18:59 UTC</time> · <a href="https://github.com/schacon/grit/commit/32ee381088602cd320b335b4e314d9b117d965db" style="color:#58a6ff">32ee381</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">78.8%</div>
+      <div class="summary-big-val pct-blue">79.0%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,582</div>
+      <div class="summary-big-val">35,650</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:78.8%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>754 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -186,11 +186,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t0</span>
         <span class="group-desc">Absolute basics and global stuff</span>
-        <span class="group-meta">41/64 files · 21 skipped · 4,889/5,136 tests</span>
+        <span class="group-meta">42/64 files · 21 skipped · 4,893/5,136 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:95.2%"></div></div>
-        <span class="group-pct pct-green">95.2%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:95.3%"></div></div>
+        <span class="group-pct pct-green">95.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t1">
@@ -208,11 +208,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t2</span>
         <span class="group-desc">Basic commands concerning the working tree</span>
-        <span class="group-meta">30/61 files · 9 skipped · 665/872 tests</span>
+        <span class="group-meta">31/61 files · 9 skipped · 670/872 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:76.3%"></div></div>
-        <span class="group-pct pct-blue">76.3%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:76.8%"></div></div>
+        <span class="group-pct pct-blue">76.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t3">
@@ -241,22 +241,22 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">29/167 files · 17 skipped · 1,522/4,139 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,568/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:36.8%"></div></div>
-        <span class="group-pct pct-red">36.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.9%"></div></div>
+        <span class="group-pct pct-red">37.9%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
       <div class="group-line1">
         <span class="group-id">t6</span>
         <span class="group-desc">Revision tree commands (e.g. merge-base)</span>
-        <span class="group-meta">47/105 files · 3 skipped · 1,830/2,822 tests</span>
+        <span class="group-meta">48/105 files · 3 skipped · 1,843/2,822 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.8%"></div></div>
-        <span class="group-pct pct-blue">64.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:65.3%"></div></div>
+        <span class="group-pct pct-blue">65.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t7">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35582 of 45141 tests passing across 1405 harness files (78.8% pass rate).</desc>
+  <desc id="svg-desc">35650 of 45141 tests passing across 1405 harness files (79% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.8% pass rate · 35,582 / 45,141 tests · 1,405 files in scope · 754 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,650 / 45,141 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="552" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T18:12:07+00:00" class="gen-time" title="2026-04-09 18:12 UTC">2026-04-09 18:12 UTC</time> · <a href="https://github.com/schacon/grit/commit/e68f5dd2f3e4e16746c4824798176cdfe2532176" style="color:#58a6ff">e68f5dd</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T18:59:52+00:00" class="gen-time" title="2026-04-09 18:59 UTC">2026-04-09 18:59 UTC</time> · <a href="https://github.com/schacon/grit/commit/32ee381088602cd320b335b4e314d9b117d965db" style="color:#58a6ff">32ee381</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,141</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,582</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">78.8%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,650</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -887,14 +887,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:44.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t0" data-tests="7" data-passed="3">
+<tr class="" data-group="t0" data-tests="7" data-passed="7" data-full-pass="1">
   <td class="mono">t0411-clone-from-partial</td>
   <td>t0</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">7</td>
-  <td class="right">3</td>
+  <td class="right">7</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:42.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t0" data-tests="548" data-passed="536">
@@ -5307,14 +5307,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t2" data-tests="19" data-passed="14">
+<tr class="" data-group="t2" data-tests="19" data-passed="19" data-full-pass="1">
   <td class="mono">t2203-add-intent</td>
   <td>t2</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">19</td>
-  <td class="right">14</td>
+  <td class="right">19</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:73.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t2" data-tests="47" data-passed="47" data-full-pass="1">
@@ -7395,7 +7395,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">32</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:84.2%"></div></div></td>
-  <td class="right small">1</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="8" data-passed="3">
   <td class="mono">t4046-diff-unmerged</td>
@@ -9577,14 +9577,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:33.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="5" data-passed="1">
+<tr class="" data-group="t5" data-tests="5" data-passed="5" data-full-pass="1">
   <td class="mono">t5525-fetch-tagopt</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">5</td>
-  <td class="right">1</td>
+  <td class="right">5</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:20.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="56" data-passed="16">
@@ -10117,14 +10117,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:78.6%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="115" data-passed="38">
+<tr class="" data-group="t5" data-tests="115" data-passed="71">
   <td class="mono">t5601-clone</td>
   <td>t5</td>
   <td></td>
   <td class="right">115</td>
-  <td class="right">38</td>
+  <td class="right">71</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:33.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:61.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="3" data-passed="3" data-full-pass="1">
@@ -10157,14 +10157,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:64.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="23" data-passed="14">
+<tr class="" data-group="t5" data-tests="23" data-passed="23" data-full-pass="1">
   <td class="mono">t5605-clone-local</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">23</td>
-  <td class="right">14</td>
+  <td class="right">23</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:60.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="21" data-passed="20">
@@ -10937,14 +10937,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t6" data-tests="21" data-passed="8">
+<tr class="" data-group="t6" data-tests="21" data-passed="21" data-full-pass="1">
   <td class="mono">t6130-pathspec-noglob</td>
   <td>t6</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">21</td>
-  <td class="right">8</td>
+  <td class="right">21</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:38.1%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t6" data-tests="9" data-passed="1">

--- a/grit-lib/src/pathspec.rs
+++ b/grit-lib/src/pathspec.rs
@@ -264,32 +264,12 @@ pub fn pathspecs_allow_bloom(specs: &[String]) -> bool {
 }
 
 /// True if `path` is matched by `spec` (Git pathspec syntax, including magic and globals).
+///
+/// Same as [`matches_pathspec_with_context`] with default file context (no directory-only
+/// semantics for literal `dir/` pathspecs).
 #[must_use]
 pub fn pathspec_matches(spec: &str, path: &str) -> bool {
-    let (elem_magic, raw_pattern) = parse_element_magic(spec);
-    let magic = combine_magic(elem_magic);
-
-    if magic.literal && magic.glob {
-        // Git dies; treat as non-match for robustness.
-        return false;
-    }
-
-    if magic.exclude {
-        // Exclude pathspecs are handled by higher layers; do not match positively here.
-        return false;
-    }
-
-    let pattern = strip_top_magic(raw_pattern);
-    let path_for_match = if let Some(prefix) = magic.prefix.as_deref() {
-        if !path.starts_with(prefix) {
-            return false;
-        }
-        &path[prefix.len()..]
-    } else {
-        path
-    };
-
-    pathspec_matches_tail(pattern, path_for_match, magic)
+    matches_pathspec_with_context(spec, path, PathspecMatchContext::default())
 }
 
 fn pathspec_matches_tail(pattern: &str, path: &str, magic: PathspecMagic) -> bool {
@@ -313,14 +293,10 @@ fn pathspec_matches_tail(pattern: &str, path: &str, magic: PathspecMagic) -> boo
     let path_bytes = path.as_bytes();
     let simple = simple_length(pattern);
 
-    if simple < pattern.len() {
-        if wildmatch(pattern_bytes, path_bytes, wm_flags) {
-            return true;
-        }
-    } else if ps_str_eq(pattern, path, magic.icase) {
+    // Git `match_pathspec_item`: exact / directory prefix before `git_fnmatch`.
+    if ps_str_eq(pattern, path, magic.icase) {
         return true;
     }
-
     if let Some(prefix) = pattern.strip_suffix('/') {
         if ps_str_eq(prefix, path, magic.icase) {
             return true;
@@ -329,11 +305,35 @@ fn pathspec_matches_tail(pattern: &str, path: &str, magic: PathspecMagic) -> boo
         if path_starts_with(path, &prefix_slash, magic.icase) {
             return true;
         }
-        return false;
+    } else {
+        let prefix_slash = format!("{pattern}/");
+        if path_starts_with(path, &prefix_slash, magic.icase) {
+            return true;
+        }
     }
 
-    let prefix_slash = format!("{pattern}/");
-    path == pattern || path_starts_with(path, &prefix_slash, magic.icase)
+    // Wildcard: require literal bytes up to `simple_length`, then wildmatch the tail only.
+    if simple < pattern.len() {
+        if path_bytes.len() < simple {
+            return false;
+        }
+        let path_lit = &path_bytes[..simple];
+        let pat_lit = &pattern_bytes[..simple];
+        let same = if magic.icase {
+            path_lit.eq_ignore_ascii_case(pat_lit)
+        } else {
+            path_lit == pat_lit
+        };
+        if !same {
+            return false;
+        }
+        let pat_rest = &pattern[simple..];
+        let path_rest = &path[simple..];
+        return wildmatch(pat_rest.as_bytes(), path_rest.as_bytes(), wm_flags);
+    }
+
+    ps_str_eq(pattern, path, magic.icase)
+        || path_starts_with(path, &format!("{pattern}/"), magic.icase)
 }
 
 fn ps_str_eq(a: &str, b: &str, icase: bool) -> bool {
@@ -382,7 +382,9 @@ pub fn matches_pathspec(spec: &str, path: &str) -> bool {
     matches_pathspec_with_context(spec, path, PathspecMatchContext::default())
 }
 
-/// Like [`matches_pathspec`], but uses `ctx` for trailing-`/` literal pathspecs.
+/// Like [`matches_pathspec`], but uses `ctx` for trailing-`/` literal pathspecs and for
+/// wildcard pathspecs where the pattern continues after a directory boundary (Git
+/// `matches_pathspec` + directory semantics).
 #[must_use]
 pub fn matches_pathspec_with_context(spec: &str, path: &str, ctx: PathspecMatchContext) -> bool {
     let spec_nfc: Cow<'_, str> = if pathspec_precompose_enabled() {
@@ -403,37 +405,67 @@ pub fn matches_pathspec_with_context(spec: &str, path: &str, ctx: PathspecMatchC
         return true;
     }
 
-    if trimmed.contains('*') || trimmed.contains('?') || trimmed.contains('[') {
-        let flags = if trimmed.contains("**") {
-            WM_PATHNAME
-        } else {
-            0
-        };
-        if wildmatch(trimmed.as_bytes(), path.as_bytes(), flags) {
-            return true;
-        }
-        if (ctx.is_directory || ctx.is_git_submodule)
-            && !path.is_empty()
-            && trimmed.len() > path.len()
-            && trimmed.as_bytes().get(path.len()) == Some(&b'/')
-            && trimmed.starts_with(path)
-        {
-            return true;
-        }
+    let (elem_magic, raw_pattern) = parse_element_magic(trimmed);
+    let magic = combine_magic(elem_magic);
+
+    if magic.literal && magic.glob {
+        return false;
+    }
+    if magic.exclude {
         return false;
     }
 
-    if let Some(prefix) = trimmed.strip_suffix('/') {
-        if path.starts_with(&format!("{prefix}/")) {
-            return true;
+    let pattern = strip_top_magic(raw_pattern);
+    let path_for_match = if let Some(prefix) = magic.prefix.as_deref() {
+        if !path.starts_with(prefix) {
+            return false;
         }
-        if path == prefix {
-            return ctx.is_directory || ctx.is_git_submodule;
+        &path[prefix.len()..]
+    } else {
+        path
+    };
+
+    if magic.literal {
+        if let Some(prefix) = pattern.strip_suffix('/') {
+            if path_for_match.starts_with(&format!("{prefix}/")) {
+                return true;
+            }
+            if path_for_match == prefix {
+                return ctx.is_directory || ctx.is_git_submodule;
+            }
+            return false;
         }
-        return false;
+        return path_for_match == pattern || path_for_match.starts_with(&format!("{pattern}/"));
     }
 
-    path == trimmed || path.starts_with(&format!("{trimmed}/"))
+    // No wildcards and trailing `/`: directory-only semantics (Git `matches_pathspec`).
+    if let Some(prefix) = pattern.strip_suffix('/') {
+        if simple_length(pattern) == pattern.len() {
+            if path_for_match.starts_with(&format!("{prefix}/")) {
+                return true;
+            }
+            if path_for_match == prefix {
+                return ctx.is_directory || ctx.is_git_submodule;
+            }
+            return false;
+        }
+    }
+
+    if pathspec_matches_tail(pattern, path_for_match, magic) {
+        return true;
+    }
+
+    if (ctx.is_directory || ctx.is_git_submodule)
+        && !path_for_match.is_empty()
+        && pattern.len() > path_for_match.len()
+        && pattern.as_bytes().get(path_for_match.len()) == Some(&b'/')
+        && pattern.starts_with(path_for_match)
+        && simple_length(pattern) < pattern.len()
+    {
+        return true;
+    }
+
+    false
 }
 
 /// Parse a Git mode string (e.g. `100644`, `040000`) into a [`PathspecMatchContext`].
@@ -515,6 +547,12 @@ pub fn wildmatch_flags_icase_glob(icase: bool, glob: bool) -> u32 {
 #[cfg(test)]
 mod tree_entry_pathspec_tests {
     use super::*;
+
+    #[test]
+    fn t6130_bracket_filename_matches_pathspec() {
+        assert!(matches_pathspec("f[o][o]", "f[o][o]"));
+        assert!(matches_pathspec(":(glob)f[o][o]", "f[o][o]"));
+    }
 
     #[test]
     fn literal_prefix_and_exact() {

--- a/grit-lib/src/wildmatch.rs
+++ b/grit-lib/src/wildmatch.rs
@@ -22,7 +22,9 @@ fn is_glob_special(c: u8) -> bool {
     matches!(c, b'*' | b'?' | b'[' | b'\\')
 }
 
-/// Core recursive matching function — closely follows the C dowild().
+/// Core recursive matching function — closely follows the C `dowild()` for-loop
+/// (`for (; *p; text++, p++)`), including advancing `text` only once per iteration
+/// after `[` / `?` / literals (not inside `do_bracket` before the pattern `]` is consumed).
 fn dowild(p: &[u8], text: &[u8], flags: u32) -> i32 {
     let mut pi = 0;
     let mut ti = 0;
@@ -56,17 +58,14 @@ fn dowild(p: &[u8], text: &[u8], flags: u32) -> i32 {
                 if t_ch_fold != lit {
                     return WM_NOMATCH;
                 }
-                ti += 1;
-                pi += 1;
             }
             b'?' => {
                 if (flags & WM_PATHNAME) != 0 && t_ch == b'/' {
                     return WM_NOMATCH;
                 }
-                ti += 1;
-                pi += 1;
             }
             b'*' => {
+                let star_start = pi;
                 // Determine if this is ** and whether it matches slashes.
                 let prev_p = pi; // position of first *
                 pi += 1;
@@ -114,14 +113,9 @@ fn dowild(p: &[u8], text: &[u8], flags: u32) -> i32 {
                 if !match_slash && p[pi] == b'/' {
                     if let Some(pos) = text[ti..].iter().position(|&b| b == b'/') {
                         ti += pos;
-                        // The slash is consumed by continuing the outer loop
-                        // (pi already points at '/', ti at '/')
-                        // Actually, follow C: text points at slash, then the
-                        // top-level for loop increments both. We need to match
-                        // the / explicitly:
-                        // In C: text = slash, then break to continue the for loop
-                        // which does text++, p++. So both advance past '/'.
-                        // We can just continue the outer loop from here.
+                        // Git: leave `text` at `/`, then the for-loop does `text++, p++`.
+                        ti += 1;
+                        pi = star_start + 2;
                         continue;
                     } else {
                         return WM_ABORT_ALL;
@@ -188,7 +182,6 @@ fn dowild(p: &[u8], text: &[u8], flags: u32) -> i32 {
                 if result != WM_MATCH {
                     return result;
                 }
-                ti += 1;
             }
             _ => {
                 let mut p_fold = p_ch;
@@ -198,9 +191,14 @@ fn dowild(p: &[u8], text: &[u8], flags: u32) -> i32 {
                 if t_ch_fold != p_fold {
                     return WM_NOMATCH;
                 }
-                ti += 1;
-                pi += 1;
             }
+        }
+
+        // C `for` increment: `text++, p++` after each iteration. `do_bracket` leaves `pi`
+        // past `]`; other branches leave `pi` on the byte that was matched.
+        ti += 1;
+        if p_ch != b'[' {
+            pi += 1;
         }
     }
 
@@ -390,6 +388,8 @@ mod tests {
     fn bracket() {
         assert!(wildmatch(b"*[al]?", b"ball", 0));
         assert!(!wildmatch(b"[ten]", b"ten", 0));
+        assert!(wildmatch(b"[o][o]", b"oo", 0));
+        assert!(!wildmatch(b"[o][o]", b"[o][o]", 0));
     }
 
     #[test]

--- a/grit/src/commands/log.rs
+++ b/grit/src/commands/log.rs
@@ -4559,9 +4559,9 @@ fn commit_touches_paths(
     Ok(false)
 }
 
-/// Check if a file path matches a pathspec (prefix match or exact match).
+/// Check if a file path matches a pathspec (Git magic + `GIT_*_PATHSPECS` globals).
 fn path_matches(path: &str, pathspec: &str) -> bool {
-    crate::pathspec::pathspec_matches(pathspec, path)
+    grit_lib::pathspec::matches_pathspec(pathspec, path)
 }
 
 /// Extract unix timestamp from an author/committer line.

--- a/logs/2026-04-09-t6130-pathspec-noglob.md
+++ b/logs/2026-04-09-t6130-pathspec-noglob.md
@@ -1,0 +1,6 @@
+# t6130-pathspec-noglob
+
+- **Root cause:** `git log` path filtering used `crate::pathspec::pathspec_matches`, which ignores `GIT_*_PATHSPECS`, `:(glob)` / `:(literal)`, and Git’s `simple_length` + `wildmatch` tail semantics.
+- **Fix:** `log.rs` now uses `grit_lib::pathspec::matches_pathspec`. `grit-lib` `matches_pathspec_with_context` delegates to the same magic-aware tail matcher as `pathspec_matches`; `pathspec_matches_tail` matches Git’s literal-prefix + wildmatch-rest behavior.
+- **wildmatch:** Reworked `dowild` loop increments to mirror Git’s C `for` (bracket handling + `*` + `/` with `WM_PATHNAME`).
+- **Tests:** `./scripts/run-tests.sh t6130-pathspec-noglob.sh` → 21/21; `cargo test -p grit-lib --lib`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **`git log` path filtering** now uses `grit_lib::pathspec::matches_pathspec` instead of the binary’s simplified `crate::pathspec::pathspec_matches`, so `--literal-pathspecs`, `GIT_LITERAL_PATHSPECS`, `:(glob)`, `:(literal)`, `**/` behavior, etc. match Git (fixes `t6130-pathspec-noglob.sh`).
- **`grit-lib` pathspec tail matching** follows Git’s pattern: exact / directory prefix checks, then a literal prefix of length `simple_length` and `wildmatch` on the remainder only.
- **`wildmatch` `dowild`** loop structure was aligned with Git’s C implementation (bracket handling and `*` + `/` with `WM_PATHNAME`).

## Testing

- `./scripts/run-tests.sh t6130-pathspec-noglob.sh` — 21/21
- `cargo test -p grit-lib --lib`

## Notes

Harness dashboards and `data/test-files.csv` were refreshed by the test run.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ba99f84-62a7-44e3-9ea1-e212ca7aec69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ba99f84-62a7-44e3-9ea1-e212ca7aec69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

