### PR TITLE
fix: t0041-usage porcelain revision errors for contains/merged

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -33,7 +33,7 @@ t0033-safe-directory	t0	yes	22	20	2	false	ok	0
 t0034-root-safe-directory	t0	yes	0	0	0	false	ok	0
 t0035-safe-bare-repository	t0	yes	12	9	3	false	ok	0
 t0040-parse-options	t0	yes	94	85	9	false	ok	0
-t0041-usage	t0	yes	16	8	8	false	ok	0
+t0041-usage	t0	yes	16	16	0	true	ok	0
 t0050-filesystem	t0	yes	11	9	2	false	ok	2
 t0051-windows-named-pipe	t0	skip	1	0	0	false	ok	0
 t0052-simple-ipc	t0	yes	9	9	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.9% of harness tests passing (35,632 / 45,142).">
+<meta property="og:description" content="79% of harness tests passing (35,640 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.9% of harness tests passing (35,632 / 45,142).">
+<meta name="twitter:description" content="79% of harness tests passing (35,640 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T18:27:56+00:00" class="gen-time" title="2026-04-09 18:27 UTC">2026-04-09 18:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/8a827488252c8a042a20fa92a0379f280402f0d7" style="color:#58a6ff">8a82748</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T19:01:39+00:00" class="gen-time" title="2026-04-09 19:01 UTC">2026-04-09 19:01 UTC</time> · <a href="https://github.com/schacon/grit/commit/70a1fa1b29e5dc10d6ea74249728c87177fec5ab" style="color:#58a6ff">70a1fa1</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">78.9%</div>
+      <div class="summary-big-val pct-blue">79.0%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,632</div>
+      <div class="summary-big-val">35,640</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:78.9%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>747 files fully passing</span>
+    <span>748 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -186,11 +186,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t0</span>
         <span class="group-desc">Absolute basics and global stuff</span>
-        <span class="group-meta">40/64 files · 21 skipped · 4,885/5,134 tests</span>
+        <span class="group-meta">41/64 files · 21 skipped · 4,893/5,134 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:95.1%"></div></div>
-        <span class="group-pct pct-green">95.1%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:95.3%"></div></div>
+        <span class="group-pct pct-green">95.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t1">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35632 of 45142 tests passing across 1405 harness files (78.9% pass rate).</desc>
+  <desc id="svg-desc">35640 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.9% pass rate · 35,632 / 45,142 tests · 1,405 files in scope · 747 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,640 / 45,142 tests · 1,405 files in scope · 748 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="552" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T18:27:56+00:00" class="gen-time" title="2026-04-09 18:27 UTC">2026-04-09 18:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/8a827488252c8a042a20fa92a0379f280402f0d7" style="color:#58a6ff">8a82748</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:01:39+00:00" class="gen-time" title="2026-04-09 19:01 UTC">2026-04-09 19:01 UTC</time> · <a href="https://github.com/schacon/grit/commit/70a1fa1b29e5dc10d6ea74249728c87177fec5ab" style="color:#58a6ff">70a1fa1</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,632</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">78.9%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,640</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -487,14 +487,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.4%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t0" data-tests="16" data-passed="8">
+<tr class="" data-group="t0" data-tests="16" data-passed="16" data-full-pass="1">
   <td class="mono">t0041-usage</td>
   <td>t0</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">16</td>
-  <td class="right">8</td>
+  <td class="right">16</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t0" data-tests="11" data-passed="9">

--- a/grit/src/commands/branch.rs
+++ b/grit/src/commands/branch.rs
@@ -6,10 +6,12 @@ use grit_lib::config::{ConfigFile, ConfigScope, ConfigSet};
 use grit_lib::diff::zero_oid;
 use grit_lib::merge_base::count_symmetric_ahead_behind;
 use grit_lib::merge_base::is_ancestor;
-use grit_lib::objects::{parse_commit, ObjectId, ObjectKind};
+use grit_lib::objects::{parse_commit, ObjectId};
 use grit_lib::refs;
 use grit_lib::repo::Repository;
 use grit_lib::rev_parse::{resolve_revision, resolve_upstream_symbolic_name, symbolic_full_name};
+
+use crate::porcelain_rev::{resolve_porcelain_commitish_filter, resolve_porcelain_merged_commit};
 use grit_lib::state::{resolve_head, HeadState};
 use grit_lib::stripspace::{process as stripspace_process, Mode as StripspaceMode};
 use std::collections::HashSet;
@@ -420,7 +422,7 @@ fn list_branches(repo: &Repository, head: &HeadState, args: &Args) -> Result<()>
                     .oid()
                     .ok_or_else(|| anyhow::anyhow!("HEAD does not point to a valid commit"))?
             } else {
-                resolve_revision_must_be_commit(repo, merged_val)?
+                resolve_porcelain_merged_commit(repo, merged_val)?
             };
             for b in &branches {
                 if is_ancestor(repo, b.oid, target_oid).unwrap_or(false) {
@@ -438,7 +440,7 @@ fn list_branches(repo: &Repository, head: &HeadState, args: &Args) -> Result<()>
                 .oid()
                 .ok_or_else(|| anyhow::anyhow!("HEAD does not point to a valid commit"))?
         } else {
-            resolve_revision_must_be_commit(repo, no_merged_val)?
+            resolve_porcelain_merged_commit(repo, no_merged_val)?
         };
         branches.retain(|b| !is_ancestor(repo, b.oid, target_oid).unwrap_or(true));
     }
@@ -448,7 +450,7 @@ fn list_branches(repo: &Repository, head: &HeadState, args: &Args) -> Result<()>
         let contain_oids: Vec<ObjectId> = args
             .contains
             .iter()
-            .map(|r| resolve_revision_must_be_commit(repo, r))
+            .map(|r| resolve_porcelain_commitish_filter(repo, r))
             .collect::<Result<_>>()?;
         branches.retain(|b| {
             contain_oids
@@ -459,7 +461,7 @@ fn list_branches(repo: &Repository, head: &HeadState, args: &Args) -> Result<()>
 
     // Apply --no-contains filter
     for no_contains_rev in &args.no_contains {
-        let no_contains_oid = resolve_revision_must_be_commit(repo, no_contains_rev)?;
+        let no_contains_oid = resolve_porcelain_commitish_filter(repo, no_contains_rev)?;
         branches.retain(|b| !is_ancestor(repo, no_contains_oid, b.oid).unwrap_or(true));
     }
 
@@ -576,24 +578,6 @@ fn list_branches(repo: &Repository, head: &HeadState, args: &Args) -> Result<()>
     }
 
     Ok(())
-}
-
-/// Resolve a revision and require the peeled object to be a commit (Git `branch --contains` rules).
-///
-/// On failure, prints Git-compatible messages to stderr and exits with code 129.
-fn resolve_revision_must_be_commit(repo: &Repository, spec: &str) -> Result<ObjectId> {
-    let oid = resolve_revision(repo, spec)?;
-    let object = repo.odb.read(&oid)?;
-    let hex = oid.to_hex();
-    let kind_msg = match object.kind {
-        ObjectKind::Commit => return Ok(oid),
-        ObjectKind::Tree => "tree",
-        ObjectKind::Blob => "blob",
-        ObjectKind::Tag => "tag",
-    };
-    eprintln!("error: object {hex} is a {kind_msg}, not a commit");
-    eprintln!("error: no such commit {hex}");
-    std::process::exit(129);
 }
 
 /// Sort branches by the given key.

--- a/grit/src/commands/for_each_ref.rs
+++ b/grit/src/commands/for_each_ref.rs
@@ -13,6 +13,11 @@ use grit_lib::objects::{
 use grit_lib::refs::read_head;
 use grit_lib::repo::Repository;
 use grit_lib::rev_parse::resolve_revision;
+
+use crate::porcelain_rev::{
+    resolve_porcelain_commitish_filter, resolve_porcelain_merged_commit,
+    resolve_porcelain_points_at,
+};
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::fs;
@@ -572,21 +577,15 @@ fn parse_packed_refs(git_dir: &Path) -> Result<Vec<(String, ObjectId)>> {
 
 fn apply_filters(repo: &Repository, opts: &Options, refs: &mut Vec<RefEntry>) -> Result<()> {
     if let Some(points_spec) = &opts.points_at {
-        let points_oid = resolve_revision(repo, points_spec)?;
-        // `resolve_revision` accepts a full 40-hex OID even when the object is
-        // absent (matching `git rev-parse`). For `--points-at`, Grit requires
-        // the object to exist so invalid targets are rejected (see t13070).
-        repo.odb
-            .read(&points_oid)
-            .map_err(|_| anyhow::anyhow!("object {points_oid} not found"))?;
+        let points_oid = resolve_porcelain_points_at(repo, points_spec, true)?;
         refs.retain(|entry| {
             entry.oid == Some(points_oid)
                 || entry.oid.and_then(|oid| peel_to_non_tag(repo, oid).ok()) == Some(points_oid)
         });
     }
 
-    let merged_base = resolve_optional_commitish(repo, opts.merged.as_ref())?;
-    let no_merged_base = resolve_optional_commitish(repo, opts.no_merged.as_ref())?;
+    let merged_base = resolve_optional_merged_commitish(repo, opts.merged.as_ref())?;
+    let no_merged_base = resolve_optional_merged_commitish(repo, opts.no_merged.as_ref())?;
     if let Some(base) = merged_base {
         refs.retain(|entry| {
             entry
@@ -607,8 +606,8 @@ fn apply_filters(repo: &Repository, opts: &Options, refs: &mut Vec<RefEntry>) ->
         });
     }
 
-    let contains_base = resolve_optional_commitish(repo, opts.contains.as_ref())?;
-    let no_contains_base = resolve_optional_commitish(repo, opts.no_contains.as_ref())?;
+    let contains_base = resolve_optional_contains_commitish(repo, opts.contains.as_ref())?;
+    let no_contains_base = resolve_optional_contains_commitish(repo, opts.no_contains.as_ref())?;
     if let Some(base) = contains_base {
         refs.retain(|entry| {
             entry
@@ -632,13 +631,24 @@ fn apply_filters(repo: &Repository, opts: &Options, refs: &mut Vec<RefEntry>) ->
     Ok(())
 }
 
-fn resolve_optional_commitish(
+fn resolve_optional_merged_commitish(
     repo: &Repository,
     raw: Option<&Option<String>>,
 ) -> Result<Option<ObjectId>> {
     match raw {
         None => Ok(None),
-        Some(Some(spec)) => Ok(Some(resolve_revision(repo, spec)?)),
+        Some(Some(spec)) => Ok(Some(resolve_porcelain_merged_commit(repo, spec)?)),
+        Some(None) => Ok(Some(resolve_porcelain_merged_commit(repo, "HEAD")?)),
+    }
+}
+
+fn resolve_optional_contains_commitish(
+    repo: &Repository,
+    raw: Option<&Option<String>>,
+) -> Result<Option<ObjectId>> {
+    match raw {
+        None => Ok(None),
+        Some(Some(spec)) => Ok(Some(resolve_porcelain_commitish_filter(repo, spec)?)),
         Some(None) => Ok(Some(resolve_revision(repo, "HEAD")?)),
     }
 }

--- a/grit/src/commands/tag.rs
+++ b/grit/src/commands/tag.rs
@@ -12,6 +12,8 @@ use grit_lib::reflog::reflog_path;
 use grit_lib::refs::append_reflog;
 use grit_lib::repo::Repository;
 use grit_lib::rev_parse::resolve_revision;
+
+use crate::porcelain_rev::{resolve_porcelain_commitish_filter, resolve_porcelain_points_at};
 use grit_lib::state::resolve_head;
 use std::fs;
 use std::io::{self, Write};
@@ -405,22 +407,19 @@ fn list_tags(
 
     // Filter by --contains
     if let Some(rev) = contains {
-        let target =
-            resolve_revision(repo, rev).with_context(|| format!("not a valid commit: '{rev}'"))?;
+        let target = resolve_porcelain_commitish_filter(repo, rev)?;
         tags.retain(|(_, tag_oid)| tag_contains(repo, tag_oid, &target));
     }
 
     // Filter by --no-contains
     if let Some(rev) = no_contains {
-        let target =
-            resolve_revision(repo, rev).with_context(|| format!("not a valid commit: '{rev}'"))?;
+        let target = resolve_porcelain_commitish_filter(repo, rev)?;
         tags.retain(|(_, tag_oid)| !tag_contains(repo, tag_oid, &target));
     }
 
     // Filter by --points-at
     if let Some(rev) = points_at {
-        let target =
-            resolve_revision(repo, rev).with_context(|| format!("not a valid object: '{rev}'"))?;
+        let target = resolve_porcelain_points_at(repo, rev, false)?;
         tags.retain(|(_, tag_oid)| tag_points_at(repo, tag_oid, &target));
     }
 

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -32,6 +32,7 @@ mod ident;
 mod pack_objects_upload;
 pub mod pathspec;
 pub mod pkt_line;
+mod porcelain_rev;
 mod precompose;
 pub mod protocol;
 mod protocol_wire;

--- a/grit/src/porcelain_rev.rs
+++ b/grit/src/porcelain_rev.rs
@@ -1,0 +1,194 @@
+//! Revision resolution helpers for porcelain commands that must match Git's error shapes.
+//!
+//! Some Git commands resolve commitishes **without** index path DWIM (`README` is not
+//! `HEAD:README`). Filter options use `error: malformed object name …` and exit **129**; some
+//! listing modes use `fatal: malformed object name …` and exit **128** (handled via
+//! [`grit_lib::error::Error::Message`]).
+
+use anyhow::Result;
+use grit_lib::error::Error as LibError;
+use grit_lib::objects::ObjectId;
+use grit_lib::objects::{tag_object_line_oid, ObjectKind};
+use grit_lib::repo::Repository;
+use grit_lib::rev_parse::resolve_revision_without_index_dwim;
+
+use crate::explicit_exit::ExplicitExit;
+
+fn malformed_object_name_plain(spec: &str) -> String {
+    spec.to_owned()
+}
+
+fn malformed_object_name_quoted(spec: &str) -> String {
+    format!("'{spec}'")
+}
+
+/// Print Git-compatible lines for a non-commit object and exit 129 (`branch` / `tag --contains`).
+pub fn exit_wrong_type_not_commit(hex: &str, kind: ObjectKind) -> Result<ObjectId> {
+    let kind_msg = match kind {
+        ObjectKind::Tree => "tree",
+        ObjectKind::Blob => "blob",
+        ObjectKind::Tag => "tag",
+        ObjectKind::Commit => "commit",
+    };
+    Err(anyhow::Error::new(ExplicitExit {
+        code: 129,
+        message: format!(
+            "error: object {hex} is a {kind_msg}, not a commit\nerror: no such commit {hex}"
+        ),
+    }))
+}
+
+/// Resolve `spec` for `tag --contains` / `--no-contains`, `branch --contains` / `--no-contains`,
+/// and `for-each-ref` contains filters (plain `error: malformed object name`, exit 129).
+pub fn resolve_porcelain_commitish_filter(repo: &Repository, spec: &str) -> Result<ObjectId> {
+    let oid = resolve_revision_without_index_dwim(repo, spec).map_err(|_| {
+        anyhow::Error::new(ExplicitExit {
+            code: 129,
+            message: format!(
+                "error: malformed object name {}",
+                malformed_object_name_plain(spec)
+            ),
+        })
+    })?;
+
+    if spec.len() == 40 && spec.chars().all(|c| c.is_ascii_hexdigit()) {
+        if repo.odb.read(&oid).is_err() {
+            let hex = oid.to_hex();
+            return Err(anyhow::Error::new(ExplicitExit {
+                code: 129,
+                message: format!("error: no such commit {hex}"),
+            }));
+        }
+    }
+
+    let object = match repo.odb.read(&oid) {
+        Ok(o) => o,
+        Err(_) => {
+            let hex = oid.to_hex();
+            return Err(anyhow::Error::new(ExplicitExit {
+                code: 129,
+                message: format!("error: no such commit {hex}"),
+            }));
+        }
+    };
+
+    match object.kind {
+        ObjectKind::Commit => Ok(oid),
+        _ => exit_wrong_type_not_commit(&oid.to_hex(), object.kind),
+    }
+}
+
+/// Resolve `spec` for `tag --points-at` and `for-each-ref --points-at` (quoted malformed names,
+/// exit 129).
+///
+/// When `verify_full_hex_oid_exists` is false, a syntactically valid 40-hex OID is accepted even
+/// if the object is missing (matches `git tag --points-at`). When true, a missing object is an
+/// error (Grit `for-each-ref` regression coverage in t13070).
+pub fn resolve_porcelain_points_at(
+    repo: &Repository,
+    spec: &str,
+    verify_full_hex_oid_exists: bool,
+) -> Result<ObjectId> {
+    let oid = resolve_revision_without_index_dwim(repo, spec).map_err(|_| {
+        anyhow::Error::new(ExplicitExit {
+            code: 129,
+            message: format!(
+                "error: malformed object name {}",
+                malformed_object_name_quoted(spec)
+            ),
+        })
+    })?;
+
+    if spec.len() == 40 && spec.chars().all(|c| c.is_ascii_hexdigit()) {
+        if verify_full_hex_oid_exists && repo.odb.read(&oid).is_err() {
+            return Err(anyhow::anyhow!("object {oid} not found"));
+        }
+        return Ok(oid);
+    }
+
+    if repo.odb.read(&oid).is_err() {
+        return Err(anyhow::Error::new(ExplicitExit {
+            code: 129,
+            message: format!(
+                "error: malformed object name {}",
+                malformed_object_name_quoted(spec)
+            ),
+        }));
+    }
+
+    Ok(oid)
+}
+
+/// Wrong-type / missing-object errors for `--merged` / `--no-merged` (exit 129).
+fn merged_must_point_to_commit_exit(hex: &str, kind: ObjectKind) -> Result<ObjectId> {
+    let kind_msg = match kind {
+        ObjectKind::Tree => "tree",
+        ObjectKind::Blob => "blob",
+        ObjectKind::Tag => "tag",
+        ObjectKind::Commit => "commit",
+    };
+    Err(anyhow::Error::new(ExplicitExit {
+        code: 129,
+        message: format!(
+            "error: object {hex} is a {kind_msg}, not a commit\nerror: option `merged' must point to a commit"
+        ),
+    }))
+}
+
+/// Resolve a commit for `branch --merged` / `--no-merged` and `for-each-ref` merged filters.
+///
+/// Uses no index DWIM. Unresolvable names yield `fatal: malformed object name` (exit 128). Missing
+/// full hex, missing peeled objects, or non-commit targets yield Git's `merged` option errors (exit
+/// 129). Annotated tags peel to their target commit.
+pub fn resolve_porcelain_merged_commit(repo: &Repository, spec: &str) -> Result<ObjectId> {
+    let oid = resolve_revision_without_index_dwim(repo, spec).map_err(|_| {
+        anyhow::Error::new(LibError::Message(format!(
+            "fatal: malformed object name {spec}"
+        )))
+    })?;
+
+    if spec.len() == 40 && spec.chars().all(|c| c.is_ascii_hexdigit()) {
+        if repo.odb.read(&oid).is_err() {
+            return Err(anyhow::Error::new(ExplicitExit {
+                code: 129,
+                message: "error: option `merged' must point to a commit".to_owned(),
+            }));
+        }
+    }
+
+    let object = match repo.odb.read(&oid) {
+        Ok(o) => o,
+        Err(_) => {
+            return Err(anyhow::Error::new(ExplicitExit {
+                code: 129,
+                message: "error: option `merged' must point to a commit".to_owned(),
+            }));
+        }
+    };
+
+    match object.kind {
+        ObjectKind::Commit => Ok(oid),
+        ObjectKind::Tag => {
+            let inner_oid = tag_object_line_oid(&object.data).ok_or_else(|| {
+                anyhow::Error::new(ExplicitExit {
+                    code: 129,
+                    message: "error: option `merged' must point to a commit".to_owned(),
+                })
+            })?;
+            let inner = match repo.odb.read(&inner_oid) {
+                Ok(o) => o,
+                Err(_) => {
+                    return Err(anyhow::Error::new(ExplicitExit {
+                        code: 129,
+                        message: "error: option `merged' must point to a commit".to_owned(),
+                    }));
+                }
+            };
+            match inner.kind {
+                ObjectKind::Commit => Ok(inner_oid),
+                _ => merged_must_point_to_commit_exit(&inner_oid.to_hex(), inner.kind),
+            }
+        }
+        _ => merged_must_point_to_commit_exit(&oid.to_hex(), object.kind),
+    }
+}

--- a/logs/2026-04-09_t0041-usage.md
+++ b/logs/2026-04-09_t0041-usage.md
@@ -1,0 +1,21 @@
+# t0041-usage
+
+## Goal
+
+Make `tests/t0041-usage.sh` pass: invalid `--contains` / `--no-contains` arguments must print `error: malformed object name …` (not `fatal: ambiguous argument …`) and must not print usage; exit code 129 via `ExplicitExit`.
+
+## Changes
+
+- Added `grit/src/porcelain_rev.rs` with:
+  - `resolve_revision_without_index_dwim` for filter args (no index path DWIM).
+  - `resolve_porcelain_commitish_filter` for tag/branch/for-each-ref contains filters.
+  - `resolve_porcelain_merged_commit` for `--merged` / `--no-merged` (fatal malformed + merged option errors).
+  - `resolve_porcelain_points_at` with flag: `tag --points-at` allows missing full hex like git; `for-each-ref --points-at` still rejects missing OID (t13070).
+- Wired `branch`, `tag`, `for-each-ref` to these helpers.
+
+## Verification
+
+- `sh tests/t0041-usage.sh -v` — 16/16
+- `sh tests/t13070-for-each-ref-points-at.sh -q` — 32/32
+- `./scripts/run-tests.sh t0041-usage.sh`
+- `cargo test -p grit-lib --lib`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Invalid `--contains` / `--no-contains` arguments for `tag`, `branch`, and `for-each-ref` now match Git: `error: malformed object name …` on stderr (no usage), exit **129**, using `resolve_revision_without_index_dwim` so index path DWIM does not apply.

`--merged` / `--no-merged` use fatal malformed names where appropriate and Git-style `merged` option errors for wrong/missing commit targets. Annotated tags peel to their commit for merged filters.

`--points-at` is split: `tag --points-at` allows a syntactically valid 40-hex OID even if missing (like upstream `git tag`); `for-each-ref --points-at` still rejects a missing full OID so t13070 keeps passing.

## Test plan

- `./scripts/run-tests.sh t0041-usage.sh` (16/16)
- `sh tests/t13070-for-each-ref-points-at.sh` (32/32)
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e6863b4-43f9-4bb6-a98f-47bbf0d7a080"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e6863b4-43f9-4bb6-a98f-47bbf0d7a080"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

