### PR TITLE
fix: make t7110-reset-merge fully pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1187,7 +1187,7 @@ t7104-reset-hard	t7	yes	3	3	0	true	ok	0
 t7105-reset-patch	t7	yes	13	6	7	false	ok	0
 t7106-reset-unborn-branch	t7	yes	7	7	0	true	ok	0
 t7107-reset-pathspec-file	t7	yes	11	1	10	false	ok	0
-t7110-reset-merge	t7	yes	21	9	12	false	ok	0
+t7110-reset-merge	t7	yes	21	21	0	true	ok	0
 t7110-reset-modes	t7	yes	20	20	0	true	ok	0
 t7111-reset-table	t7	yes	42	34	8	false	ok	0
 t7112-reset-submodule	t7	yes	76	24	52	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.9% of harness tests passing (35,632 / 45,142).">
+<meta property="og:description" content="79% of harness tests passing (35,645 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.9% of harness tests passing (35,632 / 45,142).">
+<meta name="twitter:description" content="79% of harness tests passing (35,645 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T18:27:56+00:00" class="gen-time" title="2026-04-09 18:27 UTC">2026-04-09 18:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/8a827488252c8a042a20fa92a0379f280402f0d7" style="color:#58a6ff">8a82748</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T19:17:37+00:00" class="gen-time" title="2026-04-09 19:17 UTC">2026-04-09 19:17 UTC</time> · <a href="https://github.com/schacon/grit/commit/30b340a923efca70b8f5cd76e96bbd5b55f896de" style="color:#58a6ff">30b340a</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">78.9%</div>
+      <div class="summary-big-val pct-blue">79.0%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,632</div>
+      <div class="summary-big-val">35,645</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:78.9%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>747 files fully passing</span>
+    <span>749 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">29/167 files · 17 skipped · 1,541/4,139 tests</span>
+        <span class="group-meta">30/167 files · 17 skipped · 1,542/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.2%"></div></div>
-        <span class="group-pct pct-red">37.2%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.3%"></div></div>
+        <span class="group-pct pct-red">37.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,497/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.1%"></div></div>
+        <span class="group-pct pct-blue">69.1%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35632 of 45142 tests passing across 1405 harness files (78.9% pass rate).</desc>
+  <desc id="svg-desc">35645 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.9% pass rate · 35,632 / 45,142 tests · 1,405 files in scope · 747 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,645 / 45,142 tests · 1,405 files in scope · 749 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="552" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T18:27:56+00:00" class="gen-time" title="2026-04-09 18:27 UTC">2026-04-09 18:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/8a827488252c8a042a20fa92a0379f280402f0d7" style="color:#58a6ff">8a82748</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:17:37+00:00" class="gen-time" title="2026-04-09 19:17 UTC">2026-04-09 19:17 UTC</time> · <a href="https://github.com/schacon/grit/commit/30b340a923efca70b8f5cd76e96bbd5b55f896de" style="color:#58a6ff">30b340a</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,632</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">78.9%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,645</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -9337,14 +9337,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="3" data-passed="2">
+<tr class="" data-group="t5" data-tests="3" data-passed="3" data-full-pass="1">
   <td class="mono">t5501-fetch-push-alternates</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">3</td>
-  <td class="right">2</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:66.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="7" data-passed="2">
@@ -12027,14 +12027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:9.1%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="21" data-passed="9">
+<tr class="" data-group="t7" data-tests="21" data-passed="21" data-full-pass="1">
   <td class="mono">t7110-reset-merge</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">21</td>
-  <td class="right">9</td>
+  <td class="right">21</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:42.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="20" data-passed="20" data-full-pass="1">

--- a/grit/src/commands/read_tree.rs
+++ b/grit/src/commands/read_tree.rs
@@ -549,6 +549,23 @@ fn two_way_merge(
     Ok(out)
 }
 
+/// First phase of `git reset --keep`: carry the current index forward across a fast-forward
+/// from `HEAD^{tree}` to `target^{tree}` using Git's two-way merge rules (`twoway_merge`).
+///
+/// This matches `reset_index(..., KEEP)` in Git's `builtin/reset.c`, which runs before HEAD is
+/// updated and before the second `oneway_merge` phase.
+pub(crate) fn reset_keep_twoway_index(
+    repo: &Repository,
+    current_index: &Index,
+    head_tree_oid: ObjectId,
+    target_tree_oid: ObjectId,
+) -> Result<Index> {
+    let prot = PathProtection::load(&repo.git_dir);
+    let head_map = tree_to_map(tree_to_index_entries(repo, &head_tree_oid, "", prot)?);
+    let target_map = tree_to_map(tree_to_index_entries(repo, &target_tree_oid, "", prot)?);
+    two_way_merge(repo, current_index, &head_map, &target_map)
+}
+
 /// When the index matches tree A (ours), Git also requires the working tree file to match
 /// the index for cases marked "up-to-date" in `t1000-read-tree-m-3way.sh`.
 fn require_uptodate(repo: &Repository, entry: &IndexEntry) -> Result<()> {

--- a/grit/src/commands/reset.rs
+++ b/grit/src/commands/reset.rs
@@ -1061,73 +1061,65 @@ fn reset_commit(
         bail!("fatal: mixed reset is not allowed in a bare repository");
     }
 
-    // For --keep, we need to check safety before making any changes.
+    // `--keep` refuses while a merge is in progress or the index has unmerged
+    // entries (Git: `die_if_unmerged_cache` before touching the index).
     if mode == ResetMode::Keep {
+        die_if_unmerged_or_merge_head(repo)?;
         check_keep_safety(repo, &head, &target_oid)?;
     }
 
-    // `--merge` matches Git's twoway merge reset: refuse when the working tree
-    // or index is out of sync with HEAD on paths that differ between HEAD and
-    // the target (e.g. cherry-pick --abort after a local edit to an unrelated
-    // file). When HEAD already matches the target, this is a no-op check.
+    // `--merge` uses Git's one-way merge into the index: staged differences from
+    // HEAD on paths that will change are discarded, but the working tree must
+    // still match the pre-reset index on those paths (`verify_uptodate`).
     if mode == ResetMode::Merge {
-        check_keep_safety(repo, &head, &target_oid)?;
+        check_merge_reset_worktree(repo, &head, &target_oid)?;
     }
 
     // Get the old OID for reflog and ORIG_HEAD.
     let old_oid = head.oid().copied().unwrap_or_else(zero_oid);
+    let pre_reset_head_oid = head.oid().copied();
 
     // Save ORIG_HEAD before moving HEAD.
     if head.oid().is_some() {
         write_orig_head(&repo.git_dir, &old_oid)?;
     }
 
-    // Update HEAD (and the branch it points to, if on a branch).
-    update_head_ref(&repo.git_dir, &head, &target_oid)?;
-
-    // Write reflog entries.
-    write_reset_reflog(repo, &head, &old_oid, &target_oid, commit_spec);
-
-    // Clean up merge/cherry-pick state files on non-soft reset.
-    if mode != ResetMode::Soft {
-        let _ = std::fs::remove_file(repo.git_dir.join("MERGE_HEAD"));
-        let _ = std::fs::remove_file(repo.git_dir.join("MERGE_MSG"));
-        let _ = std::fs::remove_file(repo.git_dir.join("MERGE_MODE"));
-        if !extra.skip_sequencer_head_cleanup {
-            let _ = std::fs::remove_file(repo.git_dir.join("CHERRY_PICK_HEAD"));
-            let _ = std::fs::remove_file(repo.git_dir.join("REVERT_HEAD"));
-        }
-    }
-
     if mode == ResetMode::Soft {
+        update_head_ref(&repo.git_dir, &head, &target_oid)?;
+        write_reset_reflog(repo, &head, &old_oid, &target_oid, commit_spec);
         // Soft: HEAD moved, index and working tree unchanged.
         return Ok(());
     }
 
-    // Mixed / hard / keep: reset index from the commit's tree.
-    let tree_oid = commit_to_tree(repo, &target_oid)?;
-    let tree_entries = tree_to_flat_entries(repo, &tree_oid, "")?;
-
+    // Git updates the index before moving HEAD for mixed/hard/keep/merge (`reset_index` runs
+    // before `reset_refs` in builtin/reset.c).
     let index_path = repo.index_path();
     let old_index = repo
         .load_index_at(&index_path)
         .context("loading old index")?;
-    let mut new_index = Index::new();
-    new_index.entries = tree_entries;
-    new_index.sort();
-    // Git keeps cache-entry flags (assume-unchanged, skip-worktree) across mixed/hard/merge
-    // index rebuilds so sparse/skip-worktree paths stay marked (t7011).
-    preserve_index_cache_flags_from(&old_index, &mut new_index);
 
-    if mode == ResetMode::Hard || mode == ResetMode::Keep || mode == ResetMode::Merge {
-        // Hard/Keep/Merge require a working tree
-        if repo.work_tree.is_none() {
-            bail!("fatal: this operation must be run in a work tree");
+    let mut new_index = match mode {
+        ResetMode::Merge => {
+            let head_oid = pre_reset_head_oid.ok_or_else(|| {
+                anyhow::anyhow!("fatal: could not resolve HEAD for reset --merge")
+            })?;
+            build_merge_reset_index(repo, &old_index, head_oid, &target_oid)?
         }
-        if repo.work_tree.is_some() {
-            let wt = repo.work_tree.as_deref().expect("worktree checked above");
-            if mode == ResetMode::Merge || mode == ResetMode::Keep {
-                let obstruction = find_untracked_obstruction(wt, &old_index, &new_index);
+        ResetMode::Keep => {
+            let head_oid = pre_reset_head_oid
+                .ok_or_else(|| anyhow::anyhow!("fatal: could not resolve HEAD for reset --keep"))?;
+            let head_tree_oid = commit_to_tree(repo, &head_oid)?;
+            let target_tree_oid = commit_to_tree(repo, &target_oid)?;
+            let mut phase1 = crate::commands::read_tree::reset_keep_twoway_index(
+                repo,
+                &old_index,
+                head_tree_oid,
+                target_tree_oid,
+            )?;
+            preserve_index_cache_flags_from(&old_index, &mut phase1);
+            if repo.work_tree.is_some() {
+                let wt = repo.work_tree.as_deref().expect("worktree");
+                let obstruction = find_untracked_obstruction(wt, &old_index, &phase1);
                 if let Some((path, is_dir)) = obstruction {
                     if is_dir {
                         bail!("Updating '{}' would lose untracked files in it", path);
@@ -1135,13 +1127,56 @@ fn reset_commit(
                         bail!("Updating '{}' would lose untracked files.", path);
                     }
                 }
+                // Selective checkout like Git's single `unpack_trees` pass: when the twoway result
+                // keeps the same blob as the pre-reset index, do not overwrite a dirty work tree.
+                checkout_merge_reset_worktree(repo, &old_index, &mut phase1)?;
             }
-            checkout_index_to_worktree(
-                repo,
-                &old_index,
-                &mut new_index,
-                Some((&target_oid, Some(commit_spec))),
-            )?;
+            build_merge_reset_index(repo, &phase1, head_oid, &target_oid)?
+        }
+        _ => {
+            let tree_oid = commit_to_tree(repo, &target_oid)?;
+            let tree_entries = tree_to_flat_entries(repo, &tree_oid, "")?;
+            let mut idx = Index::new();
+            idx.entries = tree_entries;
+            idx.sort();
+            idx
+        }
+    };
+    // Git keeps cache-entry flags (assume-unchanged, skip-worktree) across mixed/hard/merge
+    // index rebuilds so sparse/skip-worktree paths stay marked (t7011).
+    preserve_index_cache_flags_from(&old_index, &mut new_index);
+
+    if mode == ResetMode::Hard || mode == ResetMode::Keep || mode == ResetMode::Merge {
+        if repo.work_tree.is_none() {
+            bail!("fatal: this operation must be run in a work tree");
+        }
+        if let Some(wt) = repo.work_tree.as_deref() {
+            match mode {
+                ResetMode::Merge => {
+                    let obstruction = find_untracked_obstruction(wt, &old_index, &new_index);
+                    if let Some((path, is_dir)) = obstruction {
+                        if is_dir {
+                            bail!("Updating '{}' would lose untracked files in it", path);
+                        } else {
+                            bail!("Updating '{}' would lose untracked files.", path);
+                        }
+                    }
+                    checkout_merge_reset_worktree(repo, &old_index, &mut new_index)?;
+                }
+                ResetMode::Keep => {
+                    // Working tree was synced to the twoway-merge index inside the `Keep` arm
+                    // above; Git's second `reset_index(MIXED)` only adjusts the index.
+                }
+                ResetMode::Hard => {
+                    checkout_index_to_worktree(
+                        repo,
+                        &old_index,
+                        &mut new_index,
+                        Some((&target_oid, Some(commit_spec))),
+                    )?;
+                }
+                _ => {}
+            }
         }
         if !quiet {
             print_head_message(repo, &target_oid)?;
@@ -1180,7 +1215,240 @@ fn reset_commit(
     repo.write_index_at(&index_path, &mut new_index)
         .context("writing index")?;
     crate::commands::sparse_checkout::reapply_sparse_checkout_if_configured(repo)?;
+
+    update_head_ref(&repo.git_dir, &head, &target_oid)?;
+    write_reset_reflog(repo, &head, &old_oid, &target_oid, commit_spec);
+
+    let _ = std::fs::remove_file(repo.git_dir.join("MERGE_HEAD"));
+    let _ = std::fs::remove_file(repo.git_dir.join("MERGE_MSG"));
+    let _ = std::fs::remove_file(repo.git_dir.join("MERGE_MODE"));
+    if !extra.skip_sequencer_head_cleanup {
+        let _ = std::fs::remove_file(repo.git_dir.join("CHERRY_PICK_HEAD"));
+        let _ = std::fs::remove_file(repo.git_dir.join("REVERT_HEAD"));
+    }
+
     Ok(())
+}
+
+/// Refuse `reset --keep` when a merge is in progress (Git: `die_if_unmerged_cache`).
+fn die_if_unmerged_or_merge_head(repo: &Repository) -> Result<()> {
+    if repo.git_dir.join("MERGE_HEAD").exists() {
+        bail!("Cannot do a keep reset in the middle of a merge.");
+    }
+    let index_path = repo.index_path();
+    let index = repo.load_index_at(&index_path).context("loading index")?;
+    if index.entries.iter().any(|e| e.stage() != 0) {
+        bail!("Cannot do a keep reset in the middle of a merge.");
+    }
+    Ok(())
+}
+
+/// For `reset --merge`, Git's `oneway_merge` / `merged_entry` checks run per path where the
+/// **index** (stage 0) differs from the **target tree** — not only where HEAD and target trees
+/// differ (staged edits to paths that are identical in HEAD vs target must still be validated).
+fn check_merge_reset_worktree(
+    repo: &Repository,
+    head: &HeadState,
+    target_oid: &ObjectId,
+) -> Result<()> {
+    let head_oid = match head.oid() {
+        Some(oid) => *oid,
+        None => return Ok(()),
+    };
+
+    if head_oid == *target_oid {
+        return Ok(());
+    }
+
+    let target_tree_oid = commit_to_tree(repo, target_oid)?;
+    let target_entries = tree_to_flat_entries(repo, &target_tree_oid, "")?;
+    let target_map: HashMap<Vec<u8>, &IndexEntry> =
+        target_entries.iter().map(|e| (e.path.clone(), e)).collect();
+
+    let index_path = repo.index_path();
+    let index = repo.load_index_at(&index_path).context("loading index")?;
+    let index_map: HashMap<Vec<u8>, &IndexEntry> = index
+        .entries
+        .iter()
+        .filter(|e| e.stage() == 0)
+        .map(|e| (e.path.clone(), e))
+        .collect();
+
+    let mut unmerged_paths: HashSet<Vec<u8>> = HashSet::new();
+    let mut unmerged_only_paths: HashSet<Vec<u8>> = HashSet::new();
+    for e in &index.entries {
+        if e.stage() != 0 {
+            unmerged_paths.insert(e.path.clone());
+        }
+    }
+    for p in &unmerged_paths {
+        if !index_map.contains_key(p) {
+            unmerged_only_paths.insert(p.clone());
+        }
+    }
+
+    let work_tree = match &repo.work_tree {
+        Some(p) => p.clone(),
+        None => return Ok(()),
+    };
+
+    let mut all_paths: HashSet<Vec<u8>> = HashSet::new();
+    all_paths.extend(index_map.keys().cloned());
+    all_paths.extend(target_map.keys().cloned());
+    all_paths.extend(unmerged_paths.iter().cloned());
+
+    for path in all_paths {
+        if unmerged_only_paths.contains(&path) {
+            continue;
+        }
+
+        let path_str = String::from_utf8_lossy(&path);
+        let idx_e = index_map.get(&path);
+        let tgt_e = target_map.get(&path);
+        let abs_path = work_tree.join(path_str.as_ref());
+
+        match (idx_e, tgt_e) {
+            (None, Some(_)) => {
+                if abs_path.exists() || abs_path.is_symlink() {
+                    bail!(
+                        "Entry '{}' would be overwritten by merge. Cannot merge.",
+                        path_str
+                    );
+                }
+            }
+            (Some(ie), None) => {
+                merge_reset_verify_worktree_matches_index(repo, ie, &abs_path, path_str.as_ref())?;
+            }
+            (Some(ie), Some(te)) => {
+                if ie.oid == te.oid && ie.mode == te.mode {
+                    continue;
+                }
+                merge_reset_verify_worktree_matches_index(repo, ie, &abs_path, path_str.as_ref())?;
+            }
+            (None, None) => {}
+        }
+    }
+
+    Ok(())
+}
+
+fn merge_reset_verify_worktree_matches_index(
+    repo: &Repository,
+    idx_e: &IndexEntry,
+    abs_path: &Path,
+    path_str: &str,
+) -> Result<()> {
+    if idx_e.mode == MODE_SYMLINK {
+        if !abs_path.is_symlink() {
+            bail!("Entry '{}' not uptodate. Cannot merge.", path_str);
+        }
+        let target = std::fs::read_link(abs_path)?;
+        let obj = repo.odb.read(&idx_e.oid)?;
+        let expected = String::from_utf8_lossy(&obj.data);
+        if target.to_string_lossy() != expected.as_ref() {
+            bail!("Entry '{}' not uptodate. Cannot merge.", path_str);
+        }
+        return Ok(());
+    }
+    if !abs_path.is_file() {
+        bail!("Entry '{}' not uptodate. Cannot merge.", path_str);
+    }
+    let content = std::fs::read(abs_path)?;
+    if hash_blob_content(&content) != idx_e.oid {
+        bail!("Entry '{}' not uptodate. Cannot merge.", path_str);
+    }
+    Ok(())
+}
+
+/// Build the post-`reset --merge` index using Git's `oneway_merge` rules.
+fn build_merge_reset_index(
+    repo: &Repository,
+    old_index: &Index,
+    head_oid: ObjectId,
+    target_oid: &ObjectId,
+) -> Result<Index> {
+    if head_oid == *target_oid {
+        let has_unmerged = old_index.entries.iter().any(|e| e.stage() != 0);
+        if !has_unmerged {
+            let mut idx = Index::new();
+            for e in &old_index.entries {
+                if e.stage() == 0 {
+                    idx.entries.push(e.clone());
+                }
+            }
+            idx.sort();
+            return Ok(idx);
+        }
+    }
+
+    let head_tree_oid = commit_to_tree(repo, &head_oid)?;
+    let target_tree_oid = commit_to_tree(repo, target_oid)?;
+
+    let head_entries = tree_to_flat_entries(repo, &head_tree_oid, "")?;
+    let target_entries = tree_to_flat_entries(repo, &target_tree_oid, "")?;
+
+    let head_map: HashMap<Vec<u8>, &IndexEntry> =
+        head_entries.iter().map(|e| (e.path.clone(), e)).collect();
+    let target_map: HashMap<Vec<u8>, &IndexEntry> =
+        target_entries.iter().map(|e| (e.path.clone(), e)).collect();
+
+    let mut unique_paths: Vec<Vec<u8>> = Vec::new();
+    for e in &old_index.entries {
+        if unique_paths.last().map(|p| p != &e.path).unwrap_or(true) {
+            unique_paths.push(e.path.clone());
+        }
+    }
+
+    let old_paths_set: HashSet<Vec<u8>> = unique_paths.iter().cloned().collect();
+
+    let mut result_entries: Vec<IndexEntry> = Vec::new();
+
+    for path in &unique_paths {
+        let path_entries: Vec<&IndexEntry> = old_index
+            .entries
+            .iter()
+            .filter(|e| e.path == *path)
+            .collect();
+        let has_unmerged = path_entries.iter().any(|e| e.stage() != 0);
+
+        if has_unmerged {
+            match (head_map.get(path), target_map.get(path)) {
+                (Some(h), Some(t)) if h.oid == t.oid && h.mode == t.mode => {
+                    result_entries.push((*t).clone());
+                }
+                (_, Some(t)) => {
+                    result_entries.push((*t).clone());
+                }
+                _ => {}
+            }
+            continue;
+        }
+
+        let old0 = path_entries.iter().find(|e| e.stage() == 0).copied();
+        match (old0, target_map.get(path)) {
+            (Some(old), Some(t)) if old.oid == t.oid && old.mode == t.mode => {
+                result_entries.push(old.clone());
+            }
+            (_, Some(t)) => {
+                result_entries.push((*t).clone());
+            }
+            (Some(_), None) => {}
+            (None, None) => {}
+        }
+    }
+
+    for path in target_map.keys() {
+        if !old_paths_set.contains(path) {
+            if let Some(t) = target_map.get(path) {
+                result_entries.push((*t).clone());
+            }
+        }
+    }
+
+    let mut new_index = Index::new();
+    new_index.entries = result_entries;
+    new_index.sort();
+    Ok(new_index)
 }
 
 /// Check if `--keep` is safe: refuse if there are local uncommitted changes
@@ -1547,9 +1815,9 @@ fn tree_to_flat_entries(
     Ok(result)
 }
 
-/// Like [`checkout_index_to_worktree`] but for `reset --merge` after sequencer
-/// rollback: keep local modifications to paths whose staged (target) blob is
-/// unchanged from the pre-reset index, matching Git's twoway merge behavior.
+/// Like [`checkout_index_to_worktree`] but for `reset --merge`: preserve local edits when the
+/// new index still records the same blob/mode as `old_index` stage 0 but the work tree differs
+/// (Git `oneway_merge` stat reuse path).
 fn checkout_merge_reset_worktree(
     repo: &Repository,
     old_index: &Index,

--- a/logs/2026-04-09-t7110-reset-merge.md
+++ b/logs/2026-04-09-t7110-reset-merge.md
@@ -1,0 +1,17 @@
+# t7110-reset-merge
+
+## Summary
+
+Aligned `grit reset --merge` and `grit reset --keep` with Git’s `builtin/reset.c` + `unpack_trees` behavior so `tests/t7110-reset-merge.sh` passes (21/21).
+
+## Changes
+
+- **Index order**: Update index before moving HEAD for non-soft resets (matches Git).
+- **`--keep`**: `die_if_unmerged_or_merge_head`; two-phase index (`reset_keep_twoway_index` → `build_merge_reset_index`); selective worktree sync after twoway via `checkout_merge_reset_worktree`; no second full checkout after oneway.
+- **`--merge`**: `check_merge_reset_worktree` validates index vs target tree (including staged-only differences); `build_merge_reset_index` implements one-way merge rules; unmerged-only paths and `HEAD == target` with conflicts handled.
+- **`read_tree.rs`**: exported `reset_keep_twoway_index` for the twoway phase.
+
+## Validation
+
+- `./scripts/run-tests.sh t7110-reset-merge.sh` → 21/21
+- `cargo test -p grit-lib --lib`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible `reset --merge` and `reset --keep` so `tests/t7110-reset-merge.sh` passes (21/21).

## Details

- **Non-soft reset order**: Update the index before moving `HEAD`, matching `git/builtin/reset.c`.
- **`--keep`**: Reject when `MERGE_HEAD` exists or the index has unmerged entries. Run Git’s two-phase index update: twoway merge (`reset_keep_twoway_index` in `read_tree.rs`) then one-way merge into the target tree. After the twoway phase, sync the worktree selectively (`checkout_merge_reset_worktree`) so paths that still match the pre-reset blob keep local edits; the second phase only adjusts the index.
- **`--merge`**: Pre-check worktree vs index for every path where stage 0 differs from the target tree (not only HEAD↔target tree diffs). Build the new index with one-way merge semantics; resolve unmerged entries to the target tree; when `HEAD` already equals the target but conflicts remain, still run the unmerged resolution path.
- **Harness**: Refreshed `data/test-files.csv` and dashboards via `./scripts/run-tests.sh t7110-reset-merge.sh`.

## Validation

- `./scripts/run-tests.sh t7110-reset-merge.sh`
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad417dbf-fbf6-4963-a463-8033b3db35a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad417dbf-fbf6-4963-a463-8033b3db35a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

