### PR TITLE
fix: ls-files --recurse-submodules (t3007)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -340,7 +340,7 @@ commit → check it off → move on.
 - [x] `t3511-cherry-pick-x` ████████████████████ 22/22 (0 left) — Test cherry-pick -x and -s
 - [ ] `t3202-show-branch` ██░░░░░░░░░░░░░░░░░░ 4/27 (23 left) — test show-branch
 - [ ] `t3431-rebase-fork-point` ██░░░░░░░░░░░░░░░░░░ 3/26 (23 left) — git rebase --fork-point test
-- [ ] `t3007-ls-files-recurse-submodules` ░░░░░░░░░░░░░░░░░░░░ 1/24 (23 left) — Test ls-files recurse-submodules feature
+- [x] `t3007-ls-files-recurse-submodules` — Test ls-files recurse-submodules feature
 
 - [ ] `t3311-notes-merge-fanout` ░░░░░░░░░░░░░░░░░░░░ 1/24 (23 left) — Test notes merging at various fanout levels
 - [ ] `t3418-rebase-continue` ████░░░░░░░░░░░░░░░░ 6/30 (24 left) — git rebase --continue tests

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -537,7 +537,7 @@ t3003-ls-files-exclude	t3	yes	7	7	0	true	ok	0
 t3004-ls-files-basic	t3	yes	6	6	0	true	ok	0
 t3005-ls-files-relative	t3	yes	4	4	0	true	ok	0
 t3006-ls-files-long	t3	yes	3	3	0	true	ok	0
-t3007-ls-files-recurse-submodules	t3	yes	24	7	17	false	ok	0
+t3007-ls-files-recurse-submodules	t3	yes	24	24	0	true	ok	0
 t3008-ls-files-lazy-init-name-hash	t3	yes	1	1	0	true	ok	0
 t3009-ls-files-others-nonsubmodule	t3	yes	2	1	1	false	ok	0
 t3010-ls-files-killed-modified	t3	yes	6	3	3	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.9% of harness tests passing (35,632 / 45,142).">
+<meta property="og:description" content="79% of harness tests passing (35,657 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.9% of harness tests passing (35,632 / 45,142).">
+<meta name="twitter:description" content="79% of harness tests passing (35,657 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T18:27:56+00:00" class="gen-time" title="2026-04-09 18:27 UTC">2026-04-09 18:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/8a827488252c8a042a20fa92a0379f280402f0d7" style="color:#58a6ff">8a82748</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T19:23:50+00:00" class="gen-time" title="2026-04-09 19:23 UTC">2026-04-09 19:23 UTC</time> · <a href="https://github.com/schacon/grit/commit/815be9929f5bb165898431181acd8e81f722728d" style="color:#58a6ff">815be99</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">78.9%</div>
+      <div class="summary-big-val pct-blue">79.0%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,632</div>
+      <div class="summary-big-val">35,657</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:78.9%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>747 files fully passing</span>
+    <span>752 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -197,7 +197,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">273/368 files · 8 skipped · 11,692/12,747 tests</span>
+        <span class="group-meta">274/368 files · 8 skipped · 11,693/12,747 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-green" style="width:91.7%"></div></div>
@@ -219,11 +219,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">54/141 files · 2 skipped · 4,037/5,398 tests</span>
+        <span class="group-meta">56/141 files · 2 skipped · 4,056/5,398 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:74.8%"></div></div>
-        <span class="group-pct pct-blue">74.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:75.1%"></div></div>
+        <span class="group-pct pct-blue">75.1%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">29/167 files · 17 skipped · 1,541/4,139 tests</span>
+        <span class="group-meta">31/167 files · 17 skipped · 1,546/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.2%"></div></div>
-        <span class="group-pct pct-red">37.2%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.4%"></div></div>
+        <span class="group-pct pct-red">37.4%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35632 of 45142 tests passing across 1405 harness files (78.9% pass rate).</desc>
+  <desc id="svg-desc">35657 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.9% pass rate · 35,632 / 45,142 tests · 1,405 files in scope · 747 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,657 / 45,142 tests · 1,405 files in scope · 752 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="552" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T18:27:56+00:00" class="gen-time" title="2026-04-09 18:27 UTC">2026-04-09 18:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/8a827488252c8a042a20fa92a0379f280402f0d7" style="color:#58a6ff">8a82748</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:23:50+00:00" class="gen-time" title="2026-04-09 19:23 UTC">2026-04-09 19:23 UTC</time> · <a href="https://github.com/schacon/grit/commit/815be9929f5bb165898431181acd8e81f722728d" style="color:#58a6ff">815be99</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,632</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">78.9%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,657</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -3327,14 +3327,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:93.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="32" data-passed="31">
+<tr class="" data-group="t1" data-tests="32" data-passed="32" data-full-pass="1">
   <td class="mono">t12620-rev-parse-resolve-ref</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">32</td>
-  <td class="right">31</td>
+  <td class="right">32</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:96.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="33" data-passed="32">
@@ -5527,14 +5527,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="24" data-passed="7">
+<tr class="" data-group="t3" data-tests="24" data-passed="24" data-full-pass="1">
   <td class="mono">t3007-ls-files-recurse-submodules</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">24</td>
-  <td class="right">7</td>
+  <td class="right">24</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:29.2%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="1" data-passed="1" data-full-pass="1">
@@ -6577,14 +6577,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="65" data-passed="63">
+<tr class="" data-group="t3" data-tests="65" data-passed="65" data-full-pass="1">
   <td class="mono">t3510-cherry-pick</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">65</td>
-  <td class="right">63</td>
+  <td class="right">65</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:96.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="55" data-passed="45">
@@ -8737,14 +8737,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:91.5%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="14" data-passed="10">
+<tr class="" data-group="t5" data-tests="14" data-passed="14" data-full-pass="1">
   <td class="mono">t5004-archive-corner-cases</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">14</td>
-  <td class="right">10</td>
+  <td class="right">14</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:71.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="26" data-passed="24">
@@ -9337,14 +9337,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="3" data-passed="2">
+<tr class="" data-group="t5" data-tests="3" data-passed="3" data-full-pass="1">
   <td class="mono">t5501-fetch-push-alternates</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">3</td>
-  <td class="right">2</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:66.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="7" data-passed="2">

--- a/grit-lib/src/config.rs
+++ b/grit-lib/src/config.rs
@@ -1525,10 +1525,14 @@ impl ConfigSet {
                 Self::merge_with_includes(&mut set, &f, proc, 0, &ctx)?;
             }
 
-            // Worktree config
+            // Worktree config — Git only reads `config.worktree` when
+            // `extensions.worktreeConfig` is enabled in the common repository `config`.
+            let common_dir = crate::repo::common_git_dir_for_config(gd);
             let wt_path = gd.join("config.worktree");
-            if let Ok(Some(f)) = ConfigFile::from_path(&wt_path, ConfigScope::Worktree) {
-                Self::merge_with_includes(&mut set, &f, proc, 0, &ctx)?;
+            if crate::repo::worktree_config_enabled(&common_dir) {
+                if let Ok(Some(f)) = ConfigFile::from_path(&wt_path, ConfigScope::Worktree) {
+                    Self::merge_with_includes(&mut set, &f, proc, 0, &ctx)?;
+                }
             }
         }
 

--- a/grit-lib/src/lib.rs
+++ b/grit-lib/src/lib.rs
@@ -99,6 +99,7 @@ pub mod simple_ipc {
 }
 pub mod state;
 pub mod stripspace;
+pub mod submodule_config;
 pub mod submodule_gitdir;
 pub mod test_tool_progress;
 pub mod textconv_cache;

--- a/grit-lib/src/pathspec.rs
+++ b/grit-lib/src/pathspec.rs
@@ -263,6 +263,64 @@ pub fn pathspecs_allow_bloom(specs: &[String]) -> bool {
         .all(|s| !s.is_empty() && bloom_lookup_prefix_with_cwd(s, None).is_some())
 }
 
+/// Whether `path` is included when Git applies a pathspec list with optional `:(exclude)` entries.
+///
+/// A path is rejected if any exclude pathspec matches it. When at least one non-exclude pathspec is
+/// present, the path must also match one of those positives (`OR` semantics).
+#[must_use]
+pub fn path_allowed_by_pathspec_list(specs: &[String], path: &str) -> bool {
+    let mut has_positive = false;
+    let mut positive_match = false;
+    for s in specs {
+        let (elem, raw_pattern) = parse_element_magic(s);
+        let magic = combine_magic(elem);
+        if magic.exclude {
+            if path_matches_pathspec_tail(raw_pattern, path, magic) {
+                return false;
+            }
+            continue;
+        }
+        has_positive = true;
+        if pathspec_matches(s, path) {
+            positive_match = true;
+        }
+    }
+    !has_positive || positive_match
+}
+
+/// True when `spec` is an exclude pathspec (`:(exclude)…`) that matches `path`.
+#[must_use]
+pub fn pathspec_exclude_matches(spec: &str, path: &str) -> bool {
+    let (elem, raw_pattern) = parse_element_magic(spec);
+    let magic = combine_magic(elem);
+    if !magic.exclude {
+        return false;
+    }
+    path_matches_pathspec_tail(raw_pattern, path, magic)
+}
+
+/// True when `spec` matches `path` for pathspec bookkeeping (positive match or exclude hit).
+#[must_use]
+pub fn pathspec_contributes_match(spec: &str, path: &str) -> bool {
+    pathspec_matches(spec, path) || pathspec_exclude_matches(spec, path)
+}
+
+fn path_matches_pathspec_tail(raw_pattern: &str, path: &str, magic: PathspecMagic) -> bool {
+    if magic.literal && magic.glob {
+        return false;
+    }
+    let pattern = strip_top_magic(raw_pattern);
+    let path_for_match = if let Some(prefix) = magic.prefix.as_deref() {
+        if !path.starts_with(prefix) {
+            return false;
+        }
+        &path[prefix.len()..]
+    } else {
+        path
+    };
+    pathspec_matches_tail(pattern, path_for_match, magic)
+}
+
 /// True if `path` is matched by `spec` (Git pathspec syntax, including magic and globals).
 #[must_use]
 pub fn pathspec_matches(spec: &str, path: &str) -> bool {
@@ -565,6 +623,27 @@ mod tree_entry_pathspec_tests {
                 is_git_submodule: true,
                 ..Default::default()
             }
+        ));
+    }
+}
+
+#[cfg(test)]
+mod pathspec_list_tests {
+    use super::*;
+
+    #[test]
+    fn exclude_removes_paths_matching_icase_positive() {
+        let specs = vec![
+            ":(icase)*.txt".to_string(),
+            ":(exclude)submodule/subsub/*".to_string(),
+        ];
+        assert!(path_allowed_by_pathspec_list(
+            &specs,
+            "submodule/g.txt"
+        ));
+        assert!(!path_allowed_by_pathspec_list(
+            &specs,
+            "submodule/subsub/e.txt"
         ));
     }
 }

--- a/grit-lib/src/repo.rs
+++ b/grit-lib/src/repo.rs
@@ -381,6 +381,10 @@ impl Repository {
     /// Like [`Repository::load_index`], but reads from an explicit index file path
     /// (e.g. `GIT_INDEX_FILE` or a worktree-specific index).
     pub fn load_index_at(&self, path: &std::path::Path) -> Result<Index> {
+        let cfg = ConfigSet::load(Some(&self.git_dir), true).unwrap_or_default();
+        if let Some(res) = cfg.get_bool("index.sparse") {
+            res.map_err(Error::ConfigError)?;
+        }
         let mut idx = Index::load_expand_sparse_optional(path, &self.odb)?;
         if let Some(ref wt) = self.work_tree {
             crate::sparse_checkout::clear_skip_worktree_from_present_files(

--- a/grit-lib/src/submodule_config.rs
+++ b/grit-lib/src/submodule_config.rs
@@ -1,0 +1,132 @@
+//! Submodule registration and activation (Git `submodule.c` parity for tooling).
+//!
+//! Used by `ls-files --recurse-submodules` to decide when to enter a gitlink.
+
+use std::path::Path;
+
+use crate::config::{ConfigFile, ConfigScope, ConfigSet};
+use crate::index::Index;
+use crate::odb::Odb;
+use crate::pathspec::pathspec_matches;
+
+/// Maps a submodule work tree path (as in the index / `.gitmodules`) to its submodule section name.
+#[derive(Debug, Clone)]
+pub struct SubmoduleRegistration {
+    /// `submodule.<name>` section name from `.gitmodules`.
+    pub name: String,
+    /// Normalized `submodule.<name>.path` (forward slashes, no trailing slash).
+    pub path: String,
+}
+
+/// Load `.gitmodules` mappings: path → submodule name.
+///
+/// Reads the work tree file when present; otherwise falls back to the `.gitmodules` blob at stage 0
+/// in `index` (sparse checkout / absent file), using `odb` to load the blob.
+pub fn load_submodule_registrations(
+    work_tree: &Path,
+    index: Option<&Index>,
+    odb: Option<&Odb>,
+) -> Vec<SubmoduleRegistration> {
+    let gitmodules_path = work_tree.join(".gitmodules");
+    let content = if gitmodules_path.exists() {
+        let Some(s) = std::fs::read_to_string(&gitmodules_path).ok() else {
+            return Vec::new();
+        };
+        s
+    } else if let (Some(ix), Some(db)) = (index, odb) {
+        let Some(ie) = ix.get(b".gitmodules", 0) else {
+            return Vec::new();
+        };
+        let Ok(obj) = db.read(&ie.oid) else {
+            return Vec::new();
+        };
+        if obj.kind != crate::objects::ObjectKind::Blob {
+            return Vec::new();
+        }
+        let Some(s) = String::from_utf8(obj.data).ok() else {
+            return Vec::new();
+        };
+        s
+    } else {
+        return Vec::new();
+    };
+
+    let Ok(config) = ConfigFile::parse(&gitmodules_path, &content, ConfigScope::Local) else {
+        return Vec::new();
+    };
+    #[derive(Default)]
+    struct Fields {
+        path: Option<String>,
+        url: Option<String>,
+    }
+    let mut by_name: std::collections::BTreeMap<String, Fields> = std::collections::BTreeMap::new();
+    for entry in &config.entries {
+        let key = &entry.key;
+        if !key.starts_with("submodule.") {
+            continue;
+        }
+        let rest = &key["submodule.".len()..];
+        let Some(dot) = rest.rfind('.') else {
+            continue;
+        };
+        let name = &rest[..dot];
+        let var = &rest[dot + 1..];
+        let slot = by_name.entry(name.to_string()).or_default();
+        match var {
+            "path" => slot.path = entry.value.clone(),
+            "url" => slot.url = entry.value.clone(),
+            _ => {}
+        }
+    }
+
+    let mut out = Vec::new();
+    for (name, f) in by_name {
+        if let (Some(path), Some(_url)) = (f.path, f.url) {
+            let path = path.replace('\\', "/");
+            let path = path.trim_end_matches('/').to_string();
+            if !path.is_empty() {
+                out.push(SubmoduleRegistration { name, path });
+            }
+        }
+    }
+    out
+}
+
+/// Returns the `.gitmodules` submodule section name for a gitlink path, if registered.
+pub fn submodule_name_for_path<'a>(
+    registrations: &'a [SubmoduleRegistration],
+    path: &str,
+) -> Option<&'a str> {
+    let path = path.replace('\\', "/");
+    registrations
+        .iter()
+        .find(|r| r.path == path)
+        .map(|r| r.name.as_str())
+}
+
+/// Git `is_submodule_active` / `is_tree_submodule_active` for `ls-files --recurse-submodules`.
+///
+/// Returns false when `module_name` is `None` (path not listed in `.gitmodules`).
+#[must_use]
+pub fn is_submodule_active(
+    config: &ConfigSet,
+    module_name: Option<&str>,
+    submodule_path: &str,
+) -> bool {
+    let Some(name) = module_name else {
+        return false;
+    };
+
+    let active_key = format!("submodule.{name}.active");
+    if let Some(res) = config.get_bool(&active_key) {
+        return res.unwrap_or(false);
+    }
+
+    let patterns = config.get_all("submodule.active");
+    if !patterns.is_empty() {
+        return patterns.iter().any(|p| pathspec_matches(p, submodule_path));
+    }
+
+    let url_key = format!("submodule.{name}.url");
+    config.get(&url_key).is_some()
+}

--- a/grit/src/commands/ls_files.rs
+++ b/grit/src/commands/ls_files.rs
@@ -9,8 +9,11 @@ use std::path::Component;
 use std::path::{Path, PathBuf};
 
 use grit_lib::ignore::IgnoreMatcher;
-use grit_lib::index::IndexEntry;
-use grit_lib::repo::Repository;
+use grit_lib::index::{Index, IndexEntry};
+use grit_lib::repo::{resolve_dot_git, Repository};
+use grit_lib::submodule_config::{
+    is_submodule_active, load_submodule_registrations, submodule_name_for_path,
+};
 use grit_lib::unicode_normalization::{precompose_utf8_path, precompose_utf8_segment};
 
 use crate::explicit_exit::ExplicitExit;
@@ -200,6 +203,10 @@ pub fn run(args: Args) -> Result<()> {
         anyhow::bail!("fatal: options 'ls-files --with-tree' and '-s/-u' cannot be used together");
     }
 
+    if args.recurse_submodules && args.error_unmatch {
+        anyhow::bail!("fatal: ls-files --recurse-submodules does not support --error-unmatch");
+    }
+
     let stdout = io::stdout();
     let mut out = stdout.lock();
 
@@ -244,7 +251,10 @@ pub fn run(args: Args) -> Result<()> {
             .with_context(|| format!("overlay tree '{treeish}' on index"))?;
     }
 
-    pathspec_filter = expand_ls_files_globs(pathspec_filter, work_tree, &index, precompose_walk);
+    if !args.recurse_submodules {
+        pathspec_filter =
+            expand_ls_files_globs(pathspec_filter, work_tree, &index, precompose_walk);
+    }
 
     // For `--error-unmatch`, Git matches pathspecs separately against index output vs untracked
     // output (`-c` vs `-o`). A pathspec that only hits tracked files does not satisfy `-o`.
@@ -279,190 +289,259 @@ pub fn run(args: Args) -> Result<()> {
 
     let attrs_for_eol = grit_lib::crlf::load_gitattributes(work_tree);
 
-    let mut last_dedup_path: Option<Vec<u8>> = None;
-    for entry in &index.entries {
-        if entry.overlay_tree_skip_output() {
-            continue;
-        }
-        // Filter by pathspec
-        if !pathspec_filter.is_empty() {
-            let idx = pathspec_filter
-                .iter()
-                .position(|spec| spec.matches(&entry.path));
-            match idx {
-                Some(i) => matched_index[i] = true,
-                None => continue,
-            }
-        }
-
-        // Unmerged: stage != 0
-        if args.unmerged && entry.stage() == 0 {
-            continue;
-        }
-        // --ignored with --cached: only show tracked files that are ignored
-        if args.ignored && show_cached && !args.others {
-            let path_str = String::from_utf8_lossy(&entry.path);
-            // Pass None for index so tracked files aren't auto-skipped
-            let excluded = if let Some(ref mut m) = matcher {
-                m.check_path(&repo, None, &path_str, false)
-                    .map(|(ig, _)| ig)
-                    .unwrap_or(false)
-            } else {
-                false
-            };
-            if !excluded {
-                continue;
-            }
-        }
-
-        // --deleted / --modified: show entries that are deleted or modified on disk.
-        // Applies to every index stage (including unmerged); matches git ls-files.c.
-        // When both -d and -m are set, show if EITHER condition is true.
-        if (args.deleted || args.modified) && !show_cached {
-            if entry.skip_worktree() {
-                continue;
-            }
-            let full = work_tree.join(std::str::from_utf8(&entry.path).unwrap_or(""));
-            let is_deleted = !full.exists();
-            let is_mod = is_modified(entry, &full);
-            let dominated = if args.deleted && args.modified {
-                !is_deleted && !is_mod
-            } else if args.deleted {
-                !is_deleted
-            } else {
-                !is_mod
-            };
-            if dominated {
-                continue;
-            }
-        }
-
-        // For -d/-m with -t/-v, compute tags. Git uses "C" for modified (including
-        // unmerged conflict paths under -d/-m), not the unmerged "M" tag from -u/-s.
-        // A deleted file with both -d and -m produces TWO output lines: 'R path' and 'C path'.
-        let (tag, extra_tag) = if args.show_tag || args.show_untracked_cache_tag {
-            if args.deleted || args.modified {
-                let full = work_tree.join(std::str::from_utf8(&entry.path).unwrap_or(""));
-                if !full.exists() {
-                    if args.deleted && args.modified {
-                        (Some('R'), Some('C'))
-                    } else {
-                        (Some('R'), None)
-                    }
-                } else if is_modified(entry, &full) {
-                    (Some('C'), None)
-                } else {
-                    (Some(status_tag(entry)), None)
-                }
-            } else {
-                let base_tag = status_tag(entry);
-                let adjusted_tag = if args.show_untracked_cache_tag {
-                    base_tag.to_ascii_lowercase()
-                } else {
-                    base_tag
-                };
-                (Some(adjusted_tag), None)
-            }
-        } else {
-            (None, None)
+    if args.recurse_submodules {
+        let mut last_dedup: Option<Vec<u8>> = None;
+        let recurse_params = LsFilesRecurseParams {
+            show_cached,
+            show_stage,
+            dedup_paths,
+            show_tag: args.show_tag,
+            show_untracked_cache_tag: args.show_untracked_cache_tag,
+            deleted: args.deleted,
+            modified: args.modified,
+            ignored: args.ignored,
+            others: args.others,
+            unmerged: args.unmerged,
+            eol: args.eol,
+            format: args.format.as_deref(),
+            full_name: args.full_name,
+            precompose_unicode,
+            precompose_walk,
+            quote_fully,
+            term,
+            use_nul,
+            attrs_for_eol: &attrs_for_eol,
         };
+        ls_files_recurse_submodules(
+            &repo,
+            &config,
+            &index,
+            work_tree,
+            work_tree,
+            &config,
+            &cwd,
+            &cwd_prefix,
+            "",
+            &pathspec_filter,
+            &mut matched_index,
+            &mut last_dedup,
+            &recurse_params,
+            &mut out,
+            &mut matcher,
+        )?;
+    } else {
+        let mut last_dedup_path: Option<Vec<u8>> = None;
+        for entry in &index.entries {
+            if entry.overlay_tree_skip_output() {
+                continue;
+            }
+            // Filter by pathspec
+            if !pathspec_filter.is_empty() {
+                let idx = pathspec_filter
+                    .iter()
+                    .position(|spec| spec.matches(&entry.path));
+                match idx {
+                    Some(i) => matched_index[i] = true,
+                    None => continue,
+                }
+            }
 
-        if args.eol {
-            let display =
-                format_ls_display_path(args.full_name, &cwd, work_tree, &entry.path, &cwd_prefix)?;
-            let name = String::from_utf8_lossy(display.as_ref());
-            let path_str = std::str::from_utf8(&entry.path).unwrap_or("");
-
-            // Index / worktree EOL stats: match Git `convert.c` `gather_convert_stats_ascii`.
-            let index_eol = if entry.oid != grit_lib::diff::zero_oid() {
-                if let Ok(obj) = repo.odb.read(&entry.oid) {
-                    grit_lib::crlf::gather_convert_stats_ascii(&obj.data).to_string()
+            // Unmerged: stage != 0
+            if args.unmerged && entry.stage() == 0 {
+                continue;
+            }
+            // --ignored with --cached: only show tracked files that are ignored
+            if args.ignored && show_cached && !args.others {
+                let path_str = String::from_utf8_lossy(&entry.path);
+                // Pass None for index so tracked files aren't auto-skipped
+                let excluded = if let Some(ref mut m) = matcher {
+                    m.check_path(&repo, None, &path_str, false)
+                        .map(|(ig, _)| ig)
+                        .unwrap_or(false)
                 } else {
-                    "binary".to_string()
+                    false
+                };
+                if !excluded {
+                    continue;
                 }
-            } else {
-                String::new()
-            };
+            }
 
-            let wt_path = work_tree.join(path_str);
-            let wt_eol = if let Ok(data) = std::fs::read(&wt_path) {
-                grit_lib::crlf::gather_convert_stats_ascii(&data).to_string()
-            } else {
-                String::new()
-            };
+            // --deleted / --modified: show entries that are deleted or modified on disk.
+            // Applies to every index stage (including unmerged); matches git ls-files.c.
+            // When both -d and -m are set, show if EITHER condition is true.
+            if (args.deleted || args.modified) && !show_cached {
+                if entry.skip_worktree() {
+                    continue;
+                }
+                let full = work_tree.join(std::str::from_utf8(&entry.path).unwrap_or(""));
+                let is_deleted = !full.exists();
+                let is_mod = is_modified(entry, &full);
+                let dominated = if args.deleted && args.modified {
+                    !is_deleted && !is_mod
+                } else if args.deleted {
+                    !is_deleted
+                } else {
+                    !is_mod
+                };
+                if dominated {
+                    continue;
+                }
+            }
 
-            let attr_str =
-                grit_lib::crlf::convert_attr_ascii_for_ls_files(&attrs_for_eol, path_str, &config);
-
-            write!(out, "i/{index_eol} w/{wt_eol} attr/{attr_str}\t{name}")?;
-            out.write_all(&[term])?;
-        } else if let Some(ref fmt) = args.format {
-            // Custom format output
-            let display =
-                format_ls_display_path(args.full_name, &cwd, work_tree, &entry.path, &cwd_prefix)?;
-            let name = String::from_utf8_lossy(display.as_ref());
-            let hex = entry.oid.to_hex();
-            let line = fmt
-                .replace("%(objectmode)", &format!("{:06o}", entry.mode))
-                .replace("%(objectname)", &hex)
-                .replace(
-                    "%(objecttype)",
-                    if entry.mode & 0o170000 == 0o040000 {
-                        "tree"
+            // For -d/-m with -t/-v, compute tags. Git uses "C" for modified (including
+            // unmerged conflict paths under -d/-m), not the unmerged "M" tag from -u/-s.
+            // A deleted file with both -d and -m produces TWO output lines: 'R path' and 'C path'.
+            let (tag, extra_tag) = if args.show_tag || args.show_untracked_cache_tag {
+                if args.deleted || args.modified {
+                    let full = work_tree.join(std::str::from_utf8(&entry.path).unwrap_or(""));
+                    if !full.exists() {
+                        if args.deleted && args.modified {
+                            (Some('R'), Some('C'))
+                        } else {
+                            (Some('R'), None)
+                        }
+                    } else if is_modified(entry, &full) {
+                        (Some('C'), None)
                     } else {
-                        "blob"
-                    },
-                )
-                .replace("%(stage)", &format!("{}", entry.stage()))
-                .replace("%(path)", &name);
-            write!(out, "{}", line)?;
-            out.write_all(&[term])?;
-        } else if show_stage {
-            let display =
-                format_ls_display_path(args.full_name, &cwd, work_tree, &entry.path, &cwd_prefix)?;
-            let name = String::from_utf8_lossy(display.as_ref());
-            let qname = format_ls_path(&name, use_nul, quote_fully);
-            if let Some(t) = tag {
-                write!(out, "{} ", t)?;
-            }
-            write!(
-                out,
-                "{:06o} {} {}\t{}",
-                entry.mode,
-                entry.oid,
-                entry.stage(),
-                qname
-            )?;
-            out.write_all(&[term])?;
-        } else if show_cached || args.deleted || args.modified {
-            // Deduplicate: skip if same path as last printed.
-            // With -t flag, don't deduplicate unmerged entries (stage != 0)
-            // since they have distinct stage info that should be visible.
-            // With -u/--unmerged, each stage must appear on its own line (t6402).
-            // Without -t/-u, deduplicate all entries including unmerged.
-            // `dedup_paths` encodes git ls-files.c: --deduplicate is ignored with -t/-s/-u.
-            if dedup_paths {
-                if let Some(ref last) = last_dedup_path {
-                    if last == &entry.path {
-                        continue;
+                        (Some(status_tag(entry)), None)
                     }
+                } else {
+                    let base_tag = status_tag(entry);
+                    let adjusted_tag = if args.show_untracked_cache_tag {
+                        base_tag.to_ascii_lowercase()
+                    } else {
+                        base_tag
+                    };
+                    (Some(adjusted_tag), None)
                 }
-                last_dedup_path = Some(entry.path.clone());
-            }
-            let display =
-                format_ls_display_path(args.full_name, &cwd, work_tree, &entry.path, &cwd_prefix)?;
-            let name = String::from_utf8_lossy(display.as_ref());
-            let qname = format_ls_path(&name, use_nul, quote_fully);
-            if let Some(t) = tag {
-                write!(out, "{} ", t)?;
-            }
-            write!(out, "{qname}")?;
-            out.write_all(&[term])?;
-            // Output extra line for deleted files with both -d and -m and -t
-            if let Some(et) = extra_tag {
-                write!(out, "{} ", et)?;
+            } else {
+                (None, None)
+            };
+
+            if args.eol {
+                let display = format_ls_display_path(
+                    args.full_name,
+                    &cwd,
+                    work_tree,
+                    &entry.path,
+                    &cwd_prefix,
+                    &config,
+                )?;
+                let name = String::from_utf8_lossy(display.as_ref());
+                let path_str = std::str::from_utf8(&entry.path).unwrap_or("");
+
+                // Index / worktree EOL stats: match Git `convert.c` `gather_convert_stats_ascii`.
+                let index_eol = if entry.oid != grit_lib::diff::zero_oid() {
+                    if let Ok(obj) = repo.odb.read(&entry.oid) {
+                        grit_lib::crlf::gather_convert_stats_ascii(&obj.data).to_string()
+                    } else {
+                        "binary".to_string()
+                    }
+                } else {
+                    String::new()
+                };
+
+                let wt_path = work_tree.join(path_str);
+                let wt_eol = if let Ok(data) = std::fs::read(&wt_path) {
+                    grit_lib::crlf::gather_convert_stats_ascii(&data).to_string()
+                } else {
+                    String::new()
+                };
+
+                let attr_str = grit_lib::crlf::convert_attr_ascii_for_ls_files(
+                    &attrs_for_eol,
+                    path_str,
+                    &config,
+                );
+
+                write!(out, "i/{index_eol} w/{wt_eol} attr/{attr_str}\t{name}")?;
+                out.write_all(&[term])?;
+            } else if let Some(ref fmt) = args.format {
+                // Custom format output
+                let display = format_ls_display_path(
+                    args.full_name,
+                    &cwd,
+                    work_tree,
+                    &entry.path,
+                    &cwd_prefix,
+                    &config,
+                )?;
+                let name = String::from_utf8_lossy(display.as_ref());
+                let hex = entry.oid.to_hex();
+                let line = fmt
+                    .replace("%(objectmode)", &format!("{:06o}", entry.mode))
+                    .replace("%(objectname)", &hex)
+                    .replace(
+                        "%(objecttype)",
+                        if entry.mode & 0o170000 == 0o040000 {
+                            "tree"
+                        } else {
+                            "blob"
+                        },
+                    )
+                    .replace("%(stage)", &format!("{}", entry.stage()))
+                    .replace("%(path)", &name);
+                write!(out, "{}", line)?;
+                out.write_all(&[term])?;
+            } else if show_stage {
+                let display = format_ls_display_path(
+                    args.full_name,
+                    &cwd,
+                    work_tree,
+                    &entry.path,
+                    &cwd_prefix,
+                    &config,
+                )?;
+                let name = String::from_utf8_lossy(display.as_ref());
+                let qname = format_ls_path(&name, use_nul, quote_fully);
+                if let Some(t) = tag {
+                    write!(out, "{} ", t)?;
+                }
+                write!(
+                    out,
+                    "{:06o} {} {}\t{}",
+                    entry.mode,
+                    entry.oid,
+                    entry.stage(),
+                    qname
+                )?;
+                out.write_all(&[term])?;
+            } else if show_cached || args.deleted || args.modified {
+                // Deduplicate: skip if same path as last printed.
+                // With -t flag, don't deduplicate unmerged entries (stage != 0)
+                // since they have distinct stage info that should be visible.
+                // With -u/--unmerged, each stage must appear on its own line (t6402).
+                // Without -t/-u, deduplicate all entries including unmerged.
+                // `dedup_paths` encodes git ls-files.c: --deduplicate is ignored with -t/-s/-u.
+                if dedup_paths {
+                    if let Some(ref last) = last_dedup_path {
+                        if last == &entry.path {
+                            continue;
+                        }
+                    }
+                    last_dedup_path = Some(entry.path.clone());
+                }
+                let display = format_ls_display_path(
+                    args.full_name,
+                    &cwd,
+                    work_tree,
+                    &entry.path,
+                    &cwd_prefix,
+                    &config,
+                )?;
+                let name = String::from_utf8_lossy(display.as_ref());
+                let qname = format_ls_path(&name, use_nul, quote_fully);
+                if let Some(t) = tag {
+                    write!(out, "{} ", t)?;
+                }
                 write!(out, "{qname}")?;
                 out.write_all(&[term])?;
+                // Output extra line for deleted files with both -d and -m and -t
+                if let Some(et) = extra_tag {
+                    write!(out, "{} ", et)?;
+                    write!(out, "{qname}")?;
+                    out.write_all(&[term])?;
+                }
             }
         }
     }
@@ -526,8 +605,14 @@ pub fn run(args: Args) -> Result<()> {
                 }
             }
 
-            let display =
-                format_ls_display_path(args.full_name, &cwd, work_tree, path_bytes, &cwd_prefix)?;
+            let display = format_ls_display_path(
+                args.full_name,
+                &cwd,
+                work_tree,
+                path_bytes,
+                &cwd_prefix,
+                &config,
+            )?;
             filtered_untracked.push(display.into_owned());
         }
 
@@ -635,6 +720,288 @@ pub fn run(args: Args) -> Result<()> {
                 code: 1,
                 message: msg,
             }));
+        }
+    }
+
+    Ok(())
+}
+
+struct LsFilesRecurseParams<'a> {
+    show_cached: bool,
+    show_stage: bool,
+    dedup_paths: bool,
+    show_tag: bool,
+    show_untracked_cache_tag: bool,
+    deleted: bool,
+    modified: bool,
+    ignored: bool,
+    others: bool,
+    unmerged: bool,
+    eol: bool,
+    format: Option<&'a str>,
+    full_name: bool,
+    precompose_unicode: bool,
+    precompose_walk: bool,
+    quote_fully: bool,
+    term: u8,
+    use_nul: bool,
+    attrs_for_eol: &'a [grit_lib::crlf::AttrRule],
+}
+
+fn ls_files_recurse_submodules(
+    repo: &Repository,
+    config: &grit_lib::config::ConfigSet,
+    index: &Index,
+    work_tree: &Path,
+    super_work_tree: &Path,
+    super_config: &grit_lib::config::ConfigSet,
+    cwd: &Path,
+    cwd_prefix: &[u8],
+    prefix: &str,
+    pathspec_filter: &[Pathspec],
+    matched_index: &mut [bool],
+    last_dedup: &mut Option<Vec<u8>>,
+    p: &LsFilesRecurseParams<'_>,
+    out: &mut dyn Write,
+    matcher: &mut Option<IgnoreMatcher>,
+) -> Result<()> {
+    let registrations = load_submodule_registrations(work_tree, Some(index), Some(&repo.odb));
+
+    for entry in &index.entries {
+        if entry.overlay_tree_skip_output() {
+            continue;
+        }
+        let path_str = std::str::from_utf8(&entry.path).unwrap_or("");
+        let super_rel = if prefix.is_empty() {
+            path_str.to_string()
+        } else {
+            format!("{prefix}/{path_str}")
+        };
+        let super_rel_bytes = super_rel.as_bytes();
+
+        let is_gitlink = entry.mode == grit_lib::index::MODE_GITLINK && entry.stage() == 0;
+        if is_gitlink {
+            // `.gitmodules` paths and `submodule.<name>.active` / `submodule.active` are relative to
+            // the **current** repository (Git `is_submodule_active(the_repository, ce->name)`).
+            let rel_path = path_str.to_string();
+            let mod_name = submodule_name_for_path(&registrations, &rel_path);
+            let active = is_submodule_active(config, mod_name, &rel_path);
+            if active {
+                let dot_git = work_tree.join(path_str).join(".git");
+                if let Ok(child_git_dir) = resolve_dot_git(&dot_git) {
+                    let child_wt = work_tree.join(path_str);
+                    if let Ok(child_repo) = Repository::open(&child_git_dir, Some(&child_wt)) {
+                        let sub_cfg =
+                            grit_lib::config::ConfigSet::load(Some(&child_repo.git_dir), true)
+                                .unwrap_or_default();
+                        let sub_idx_path = child_repo.index_path();
+                        let sub_index = child_repo
+                            .load_index_at(&sub_idx_path)
+                            .context("loading submodule index")?;
+                        ls_files_recurse_submodules(
+                            &child_repo,
+                            &sub_cfg,
+                            &sub_index,
+                            &child_wt,
+                            super_work_tree,
+                            super_config,
+                            cwd,
+                            cwd_prefix,
+                            &super_rel,
+                            pathspec_filter,
+                            matched_index,
+                            last_dedup,
+                            p,
+                            out,
+                            matcher,
+                        )?;
+                    }
+                }
+                continue;
+            }
+        }
+
+        if !pathspec_filter.is_empty() {
+            if !recurse_submodules_path_matches(pathspec_filter, &super_rel, super_rel_bytes) {
+                continue;
+            }
+            recurse_submodules_mark_pathspec_hits(
+                pathspec_filter,
+                &super_rel,
+                super_rel_bytes,
+                matched_index,
+            );
+        }
+
+        if p.unmerged && entry.stage() == 0 {
+            continue;
+        }
+        if p.ignored && p.show_cached && !p.others {
+            let excluded = if let Some(ref mut m) = matcher {
+                m.check_path(repo, None, &super_rel, false)
+                    .map(|(ig, _)| ig)
+                    .unwrap_or(false)
+            } else {
+                false
+            };
+            if !excluded {
+                continue;
+            }
+        }
+
+        if (p.deleted || p.modified) && !p.show_cached {
+            if entry.skip_worktree() {
+                continue;
+            }
+            let full = work_tree.join(path_str);
+            let is_deleted = !full.exists();
+            let is_mod = is_modified(entry, &full);
+            let dominated = if p.deleted && p.modified {
+                !is_deleted && !is_mod
+            } else if p.deleted {
+                !is_deleted
+            } else {
+                !is_mod
+            };
+            if dominated {
+                continue;
+            }
+        }
+
+        let (tag, extra_tag) = if p.show_tag || p.show_untracked_cache_tag {
+            if p.deleted || p.modified {
+                let full = work_tree.join(path_str);
+                if !full.exists() {
+                    if p.deleted && p.modified {
+                        (Some('R'), Some('C'))
+                    } else {
+                        (Some('R'), None)
+                    }
+                } else if is_modified(entry, &full) {
+                    (Some('C'), None)
+                } else {
+                    (Some(status_tag(entry)), None)
+                }
+            } else {
+                let base_tag = status_tag(entry);
+                let adjusted_tag = if p.show_untracked_cache_tag {
+                    base_tag.to_ascii_lowercase()
+                } else {
+                    base_tag
+                };
+                (Some(adjusted_tag), None)
+            }
+        } else {
+            (None, None)
+        };
+
+        if p.eol {
+            let display = format_ls_display_path(
+                p.full_name,
+                cwd,
+                super_work_tree,
+                super_rel_bytes,
+                cwd_prefix,
+                super_config,
+            )?;
+            let name = String::from_utf8_lossy(display.as_ref());
+            let index_eol = if entry.oid != grit_lib::diff::zero_oid() {
+                if let Ok(obj) = repo.odb.read(&entry.oid) {
+                    grit_lib::crlf::gather_convert_stats_ascii(&obj.data).to_string()
+                } else {
+                    "binary".to_string()
+                }
+            } else {
+                String::new()
+            };
+            let wt_path = work_tree.join(path_str);
+            let wt_eol = if let Ok(data) = std::fs::read(&wt_path) {
+                grit_lib::crlf::gather_convert_stats_ascii(&data).to_string()
+            } else {
+                String::new()
+            };
+            let attr_str =
+                grit_lib::crlf::convert_attr_ascii_for_ls_files(p.attrs_for_eol, path_str, config);
+            write!(out, "i/{index_eol} w/{wt_eol} attr/{attr_str}\t{name}")?;
+            out.write_all(&[p.term])?;
+        } else if let Some(fmt) = p.format {
+            let display = format_ls_display_path(
+                p.full_name,
+                cwd,
+                super_work_tree,
+                super_rel_bytes,
+                cwd_prefix,
+                super_config,
+            )?;
+            let name = String::from_utf8_lossy(display.as_ref());
+            let hex = entry.oid.to_hex();
+            let line = fmt
+                .replace("%(objectmode)", &format!("{:06o}", entry.mode))
+                .replace("%(objectname)", &hex)
+                .replace(
+                    "%(objecttype)",
+                    if entry.mode & 0o170000 == 0o040000 {
+                        "tree"
+                    } else {
+                        "blob"
+                    },
+                )
+                .replace("%(stage)", &format!("{}", entry.stage()))
+                .replace("%(path)", &name);
+            write!(out, "{}", line)?;
+            out.write_all(&[p.term])?;
+        } else if p.show_stage {
+            let display = format_ls_display_path(
+                p.full_name,
+                cwd,
+                super_work_tree,
+                super_rel_bytes,
+                cwd_prefix,
+                super_config,
+            )?;
+            let name = String::from_utf8_lossy(display.as_ref());
+            let qname = format_ls_path(&name, p.use_nul, p.quote_fully);
+            if let Some(t) = tag {
+                write!(out, "{} ", t)?;
+            }
+            write!(
+                out,
+                "{:06o} {} {}\t{}",
+                entry.mode,
+                entry.oid,
+                entry.stage(),
+                qname
+            )?;
+            out.write_all(&[p.term])?;
+        } else if p.show_cached || p.deleted || p.modified {
+            if p.dedup_paths {
+                if let Some(ref last) = last_dedup {
+                    if last == super_rel_bytes {
+                        continue;
+                    }
+                }
+                *last_dedup = Some(super_rel_bytes.to_vec());
+            }
+            let display = format_ls_display_path(
+                p.full_name,
+                cwd,
+                super_work_tree,
+                super_rel_bytes,
+                cwd_prefix,
+                super_config,
+            )?;
+            let name = String::from_utf8_lossy(display.as_ref());
+            let qname = format_ls_path(&name, p.use_nul, p.quote_fully);
+            if let Some(t) = tag {
+                write!(out, "{} ", t)?;
+            }
+            write!(out, "{qname}")?;
+            out.write_all(&[p.term])?;
+            if let Some(et) = extra_tag {
+                write!(out, "{} ", et)?;
+                write!(out, "{qname}")?;
+                out.write_all(&[p.term])?;
+            }
         }
     }
 
@@ -852,17 +1219,72 @@ impl Pathspec {
                         && (path.len() == dir_prefix.len() || path[dir_prefix.len()] == b'/'))
             }
             Pathspec::Glob(pattern) => {
-                // Try literal match first (for files with glob chars in names)
                 if path == pattern.as_bytes() {
                     return true;
                 }
                 let path_str = String::from_utf8_lossy(path);
-                glob_match(pattern, &path_str)
+                grit_lib::pathspec::pathspec_matches(pattern, path_str.as_ref())
             }
             Pathspec::Magic(spec) => {
                 let path_str = String::from_utf8_lossy(path);
                 crate::pathspec::pathspec_matches(spec, &path_str)
             }
+        }
+    }
+}
+
+/// Pathspec matching for `ls-files --recurse-submodules`: combines magic pathspecs (including
+/// `:(exclude)`) with plain glob/literal specs (Git applies excludes across the full argv list).
+fn recurse_submodules_path_matches(
+    pathspec_filter: &[Pathspec],
+    path: &str,
+    path_bytes: &[u8],
+) -> bool {
+    if pathspec_filter.is_empty() {
+        return true;
+    }
+    let magic_strings: Vec<String> = pathspec_filter
+        .iter()
+        .filter_map(|p| match p {
+            Pathspec::Magic(s) => Some(s.clone()),
+            _ => None,
+        })
+        .collect();
+    let has_non_magic = pathspec_filter
+        .iter()
+        .any(|p| !matches!(p, Pathspec::Magic(_)));
+
+    let magic_ok = if magic_strings.is_empty() {
+        true
+    } else {
+        grit_lib::pathspec::path_allowed_by_pathspec_list(&magic_strings, path)
+    };
+
+    let non_magic_ok = if !has_non_magic {
+        true
+    } else {
+        pathspec_filter.iter().any(|p| match p {
+            Pathspec::Magic(_) => false,
+            other => other.matches(path_bytes),
+        })
+    };
+
+    magic_ok && non_magic_ok
+}
+
+fn recurse_submodules_mark_pathspec_hits(
+    pathspec_filter: &[Pathspec],
+    path: &str,
+    path_bytes: &[u8],
+    matched_index: &mut [bool],
+) {
+    for (i, spec) in pathspec_filter.iter().enumerate() {
+        let hit = match spec {
+            Pathspec::Magic(s) => grit_lib::pathspec::pathspec_contributes_match(s, path),
+            Pathspec::Glob(_) | Pathspec::Literal(_) => spec.matches(path_bytes),
+        };
+        if hit {
+            matched_index[i] = true;
         }
     }
 }
@@ -1110,16 +1532,68 @@ fn format_ls_display_path<'a>(
     work_tree: &Path,
     repo_rel: &'a [u8],
     cwd_prefix: &[u8],
+    config: &grit_lib::config::ConfigSet,
 ) -> Result<Cow<'a, [u8]>> {
     if full_name {
         return Ok(Cow::Borrowed(repo_rel));
     }
     if cwd_inside_work_tree(cwd, work_tree) {
+        if let Some(display) = ls_files_display_through_submodule(cwd, work_tree, repo_rel, config)?
+        {
+            return Ok(Cow::Owned(display));
+        }
         return Ok(Cow::Owned(pathdiff_from_repo_for_display(
             cwd, work_tree, repo_rel,
         )?));
     }
     Ok(Cow::Borrowed(display_path_from_cwd(repo_rel, cwd_prefix)))
+}
+
+/// When the cwd is inside a subdirectory of the superproject, paths that live under an **active**
+/// submodule should be displayed relative to cwd by walking through the submodule work tree
+/// (Git `ls-files --recurse-submodules` from `b/` shows `../submodule/...`, not `submodule/...`).
+fn ls_files_display_through_submodule(
+    cwd: &Path,
+    super_work_tree: &Path,
+    repo_rel: &[u8],
+    super_config: &grit_lib::config::ConfigSet,
+) -> Result<Option<Vec<u8>>> {
+    let rel_str = std::str::from_utf8(repo_rel).unwrap_or("");
+    if rel_str.is_empty() || !rel_str.contains('/') {
+        return Ok(None);
+    }
+    let first_end = rel_str.find('/').unwrap_or(rel_str.len());
+    let first_seg = &rel_str[..first_end];
+    if first_seg.is_empty() || first_seg == ".." {
+        return Ok(None);
+    }
+    let sm_wt = super_work_tree.join(first_seg);
+    if !sm_wt.is_dir() {
+        return Ok(None);
+    }
+    let dot_git = sm_wt.join(".git");
+    let Ok(child_git_dir) = resolve_dot_git(&dot_git) else {
+        return Ok(None);
+    };
+    let Ok(child_repo) = Repository::open(&child_git_dir, Some(&sm_wt)) else {
+        return Ok(None);
+    };
+    let sub_index_path = child_repo.index_path();
+    let Ok(_sub_index) = child_repo.load_index_at(&sub_index_path) else {
+        return Ok(None);
+    };
+    let registrations = load_submodule_registrations(super_work_tree, None, None);
+    let mod_name = submodule_name_for_path(&registrations, first_seg);
+    if !is_submodule_active(super_config, mod_name, first_seg) {
+        return Ok(None);
+    }
+    let rest = rel_str[first_end + 1..].trim_start_matches('/');
+    let target = if rest.is_empty() {
+        sm_wt
+    } else {
+        sm_wt.join(rest)
+    };
+    Ok(Some(pathdiff_relative_lexical(cwd, &target)?.into_bytes()))
 }
 
 fn cwd_prefix_bytes(work_tree: &std::path::Path, cwd: &std::path::Path) -> Result<Vec<u8>> {

--- a/logs/2026-04-09_t3007-ls-files-recurse-submodules.md
+++ b/logs/2026-04-09_t3007-ls-files-recurse-submodules.md
@@ -1,0 +1,25 @@
+# t3007-ls-files-recurse-submodules
+
+## Goal
+
+Make `tests/t3007-ls-files-recurse-submodules.sh` fully pass (24/24).
+
+## Changes
+
+- **`grit-lib`**
+  - `submodule_config`: parse `.gitmodules` → path/name, implement Git-style `is_submodule_active` (`submodule.<name>.active`, `submodule.active`, URL fallback).
+  - `ConfigSet::load_with_options`: merge `config.worktree` only when `extensions.worktreeConfig` is enabled in the common repo `config` (matches Git; fixes t3007 #19).
+  - `Repository::load_index_at`: reject invalid `index.sparse` boolean so submodule config errors surface during recurse (t3007 #17–18).
+  - `pathspec`: `path_allowed_by_pathspec_list`, `pathspec_exclude_matches`, `pathspec_contributes_match` for `:(exclude)` + icase combos (t3007 #12).
+- **`grit ls-files`**
+  - Recursive walk for active gitlinks (open submodule via `.git` gitfile, load its index, recurse).
+  - Superproject-relative paths for matching and output; display paths from super work tree + submodule-through-cwd for `git -C subdir` (t3007 #15).
+  - Skip glob expansion when `--recurse-submodules` (Git does not prune pathspec prefix).
+  - `Pathspec::Glob` uses `pathspec_matches` so `?` matches `/`.
+  - Fatal on `--recurse-submodules --error-unmatch`.
+- **Harness**: `run-tests.sh t3007` → CSV/dashboards; `PLAN.md` marked complete.
+
+## Verification
+
+- `cargo fmt`, `cargo clippy --fix --allow-dirty`, `cargo test -p grit-lib --lib`
+- `./scripts/run-tests.sh t3007-ls-files-recurse-submodules.sh` → 24/24

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   321 |
+| Completed   |   323 |
 | In progress |     5 |
-| Remaining   |   445 |
+| Remaining   |   443 |
 | **Total**   |   771 |
 
-Task lines in `PLAN.md`: 321 completed (`[x]`), 5 in progress (`[~]`), 445 remaining (`[ ]`).
+Task lines in `PLAN.md`: 323 completed (`[x]`), 5 in progress (`[~]`), 443 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t3007-ls-files-recurse-submodules` — 24/24 tests pass (`ls-files --recurse-submodules`: recurse active gitlinks, superproject-relative pathspecs + `:(exclude)`, cwd display through submodule, no glob expansion in recurse mode, `index.sparse` parse errors in nested repos, `config.worktree` gated on `extensions.worktreeConfig`)
 - `t4063-diff-blobs` — 18/18 tests pass (`diff`: blob↔blob and `rev:path` pairs without treating blobs as trees; `HEAD:one..HEAD:two` range split; `rev:path` vs worktree file uses tree path + modes + `write_patch_with_prefix`; raw blob OID vs existing file uses filename as old path; `rev_parse::resolve_treeish_blob_at_path` for tree walks)
 - `t5524-pull-msg` — 3/3 tests pass (`git pull --no-rebase --log` merge message preserves `$` in subject lines; `--log=1` limits shortlog; harness CSV/dashboards refreshed; `PLAN.md` marked complete)
 - `t5605-clone-local` — 23/23 tests pass (streaming pack unpack for 0-byte objects; local clone without `--shared` no longer writes source `alternates`; `--no-hardlinks` / `file://` copy-only objects; `--upload-pack` local-path rejection + env prefix for grit `upload-pack`; corrupt loose ref validation before ref copy; `fetch` no-op when `remote.*.url` is a bundle file; bundle clone HEAD/default-branch parity with Git for `bundle create tip` without `HEAD` line)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements `git ls-files --recurse-submodules` behavior to match Git so `t3007-ls-files-recurse-submodules` passes 24/24.

## Key changes

- **Recursive listing**: For active gitlinks, open the submodule via its `.git` gitfile, load its index, and recurse; paths are matched and printed relative to the **superproject** work tree.
- **Submodule activation**: New `grit_lib::submodule_config` mirrors Git’s `is_submodule_active` (`.gitmodules` mapping, `submodule.<name>.active`, `submodule.active` pathspecs, URL fallback).
- **Pathspecs**: With `--recurse-submodules`, skip glob expansion against the work tree (Git keeps full argv); combine magic pathspecs with `:(exclude)` via `path_allowed_by_pathspec_list`; plain globs use `pathspec_matches` so `?` can match `/`.
- **Display from subdirs**: When cwd is under the superproject, paths inside an active submodule are shown relative to cwd (e.g. `../submodule/...`).
- **Config parity**: `config.worktree` is only merged when `extensions.worktreeConfig` is enabled; `index.sparse` is validated when loading the index so invalid submodule config fails as in Git.

## Verification

- `./scripts/run-tests.sh t3007-ls-files-recurse-submodules.sh` → 24/24
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29ab1df3-a98d-4997-90d0-9815f6d6432c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29ab1df3-a98d-4997-90d0-9815f6d6432c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

