### PR TITLE
fix: t3907 stash show config (stash.showStat/showPatch)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -668,7 +668,7 @@ t3903-stash	t3	yes	142	86	56	false	ok	0
 t3904-stash-patch	t3	yes	10	10	0	true	ok	0
 t3905-stash-include-untracked	t3	yes	34	13	21	false	ok	0
 t3906-stash-submodule	t3	yes	8	5	3	false	ok	0
-t3907-stash-show-config	t3	yes	10	1	9	false	ok	0
+t3907-stash-show-config	t3	yes	10	10	0	true	ok	0
 t3908-stash-in-worktree	t3	yes	2	1	1	false	ok	0
 t3909-stash-pathspec-file	t3	yes	5	5	0	true	ok	0
 t3910-mac-os-precompose	t3	yes	29	24	5	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79% of harness tests passing (35,681 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79% of harness tests passing (35,681 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T19:28:19+00:00" class="gen-time" title="2026-04-09 19:28 UTC">2026-04-09 19:28 UTC</time> · <a href="https://github.com/schacon/grit/commit/5bf62c619e11069427ad31d399f307f351a03ad7" style="color:#58a6ff">5bf62c6</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,681</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>758 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -219,11 +219,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">56/141 files · 2 skipped · 4,052/5,398 tests</span>
+        <span class="group-meta">57/141 files · 2 skipped · 4,061/5,398 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:75.1%"></div></div>
-        <span class="group-pct pct-blue">75.1%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:75.2%"></div></div>
+        <span class="group-pct pct-blue">75.2%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35681 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,681 / 45,142 tests · 1,405 files in scope · 758 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:28:19+00:00" class="gen-time" title="2026-04-09 19:28 UTC">2026-04-09 19:28 UTC</time> · <a href="https://github.com/schacon/grit/commit/5bf62c619e11069427ad31d399f307f351a03ad7" style="color:#58a6ff">5bf62c6</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,681</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -6837,14 +6837,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:62.5%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="10" data-passed="1">
+<tr class="" data-group="t3" data-tests="10" data-passed="10" data-full-pass="1">
   <td class="mono">t3907-stash-show-config</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">10</td>
-  <td class="right">1</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:10.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="2" data-passed="1">

--- a/grit/src/bundle_uri_test_tool.rs
+++ b/grit/src/bundle_uri_test_tool.rs
@@ -6,7 +6,7 @@ use std::fs;
 use std::io::{BufRead, Write};
 use std::path::Path;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 
 use crate::git_path;
 

--- a/grit/src/commands/diff.rs
+++ b/grit/src/commands/diff.rs
@@ -2087,6 +2087,68 @@ pub fn run(mut args: Args) -> Result<()> {
             if args.summary {
                 write_diff_summary(&mut out, &entries, args.break_rewrites, quote_path_fully)?;
             }
+            if diff_cli_requests_unified_patch_alongside_stat(&raw_args) && !args.no_patch {
+                let patch_abbrev = if args.full_index {
+                    40
+                } else if let Some(n) = args.abbrev {
+                    n.max(4).min(40)
+                } else {
+                    7
+                };
+                for patch in &conflict_combined_patches {
+                    write!(out, "{patch}")?;
+                }
+                if let Some(ref ds) = dirstat_opts {
+                    write_dirstat(
+                        &mut out,
+                        ds,
+                        &entries,
+                        &repo.odb,
+                        wt_for_content,
+                        args.break_rewrites,
+                    )?;
+                }
+                let diff_config = grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true)
+                    .unwrap_or_default();
+                let external_diff_cmd = std::env::var("GIT_EXTERNAL_DIFF")
+                    .ok()
+                    .filter(|s| !s.trim().is_empty())
+                    .or_else(|| {
+                        diff_config
+                            .get("diff.external")
+                            .filter(|s| !s.trim().is_empty())
+                    });
+                write_patch_with_prefix(
+                    &mut out,
+                    &repo,
+                    &entries,
+                    &repo.odb,
+                    &repo.git_dir,
+                    &diff_config,
+                    context_lines,
+                    use_color,
+                    word_diff,
+                    wt_for_content,
+                    suppress_blank_empty,
+                    patch_abbrev,
+                    inter_hunk_context,
+                    args.binary,
+                    args.break_rewrites,
+                    args.irreversible_delete,
+                    !args.no_textconv,
+                    &src_prefix,
+                    &dst_prefix,
+                    args.submodule.as_deref(),
+                    submodule_ignore_flags_from_diff_arg(ignore_sm),
+                    line_ignore,
+                    &diff_algo_ctx,
+                    diff_algo_cli,
+                    args.cached,
+                    args.no_ext_diff,
+                    external_diff_cmd.as_deref(),
+                    relative_prefix_for_paths.as_deref(),
+                )?;
+            }
         } else if args.raw {
             let oid_len = if args.full_index || args.no_abbrev {
                 40
@@ -3325,6 +3387,54 @@ fn apply_diff_filter(entries: Vec<DiffEntry>, filter: &str) -> Vec<DiffEntry> {
             true
         })
         .collect()
+}
+
+/// Whether the user asked for a unified patch in addition to another format (e.g. `--stat`).
+///
+/// Unlike [`diff_emit_unified_patch_from_argv`], this starts from **no** patch: plain
+/// `git diff --stat` must not append hunks, while `git diff --stat -p` must (matches Git).
+fn diff_cli_requests_unified_patch_alongside_stat(argv: &[String]) -> bool {
+    let Some(diff_pos) = argv.iter().position(|a| a == "diff") else {
+        return false;
+    };
+    let mut emit = false;
+    for arg in argv.iter().skip(diff_pos + 1) {
+        if arg == "--" {
+            break;
+        }
+        if arg == "-s" || arg == "--no-patch" {
+            emit = false;
+            continue;
+        }
+        if arg == "-p" || arg == "--patch" || arg == "-u" {
+            emit = true;
+            continue;
+        }
+        if arg == "--submodule" || arg.starts_with("--submodule=") {
+            emit = true;
+            continue;
+        }
+        if arg.starts_with("-U") || arg.starts_with("--unified") {
+            emit = true;
+            continue;
+        }
+        if arg.starts_with('-') && !arg.starts_with("--") && arg.len() > 2 {
+            const COMBINABLE: &[u8] = b"spuwqRb";
+            let bytes = arg.as_bytes();
+            let tail = &bytes[1..];
+            if !tail.is_empty() && tail.iter().all(|b| COMBINABLE.contains(b)) {
+                for &b in tail {
+                    match b {
+                        b's' => emit = false,
+                        b'p' | b'u' => emit = true,
+                        b'w' | b'b' | b'q' | b'R' => {}
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+    emit
 }
 
 /// Whether to emit unified patch hunks for this `git diff` invocation.

--- a/grit/src/commands/stash.rs
+++ b/grit/src/commands/stash.rs
@@ -18,7 +18,11 @@ use std::io::{self, BufRead, Write as IoWrite};
 use std::path::Path;
 
 use grit_lib::config::ConfigSet;
-use grit_lib::diff::{diff_index_to_tree, diff_index_to_worktree, unified_diff};
+use grit_lib::diff::{
+    count_changes, diff_index_to_tree, diff_index_to_worktree, diff_trees, empty_blob_oid,
+    unified_diff, zero_oid, DiffEntry, DiffStatus,
+};
+use grit_lib::diffstat::{terminal_columns, write_diffstat_block, DiffstatOptions, FileStatInput};
 use grit_lib::error::Error;
 use grit_lib::index::{
     entry_from_stat, Index, IndexEntry, MODE_EXECUTABLE, MODE_GITLINK, MODE_REGULAR, MODE_SYMLINK,
@@ -351,7 +355,7 @@ pub fn run(args: Args) -> Result<()> {
         Some(StashCommand::List { args: list_args }) => do_list(list_args),
         Some(StashCommand::Show { args: show_args }) => {
             let parsed = parse_stash_show_args(&show_args)?;
-            do_show(parsed.stash_ref, parsed.mode, parsed.patience)
+            do_show(parsed)
         }
         Some(StashCommand::Pop {
             index,
@@ -551,14 +555,27 @@ fn do_branch_from_rest(rest: &[String]) -> Result<()> {
     do_branch(branch_name, stash_ref)
 }
 
+/// Parsed `git stash show` argv after dispatch.
+///
+/// When `cli_specified_format` is false, Git applies `stash.showStat` / `stash.showPatch` only
+/// (untracked-related flags alone do not disable that). Otherwise Git defaults to patch if no
+/// output format was requested and honors combined `--stat` + `-p`.
 struct ParsedStashShow {
     stash_ref: Option<String>,
-    mode: ShowMode,
+    /// True if any argument could change diff output (anything Git would pass as a revision flag),
+    /// except `-u` / `--include-untracked` / `--only-untracked` alone.
+    cli_specified_format: bool,
+    explicit_stat: bool,
+    explicit_patch: bool,
+    other_mode: Option<ShowMode>,
     patience: bool,
 }
 
 fn parse_stash_show_args(raw: &[String]) -> Result<ParsedStashShow> {
-    let mut mode = ShowMode::Stat;
+    let mut cli_specified_format = false;
+    let mut explicit_stat = false;
+    let mut explicit_patch = false;
+    let mut other_mode: Option<ShowMode> = None;
     let mut patience = false;
     let mut pos: Vec<String> = Vec::new();
     let mut i = 0usize;
@@ -570,17 +587,35 @@ fn parse_stash_show_args(raw: &[String]) -> Result<ParsedStashShow> {
         }
         if a.starts_with('-') && a.len() > 1 {
             match a.as_str() {
-                "-p" | "--patch" => mode = ShowMode::Patch,
-                "--stat" => mode = ShowMode::Stat,
-                "--name-status" => mode = ShowMode::NameStatus,
-                "--name-only" => mode = ShowMode::NameOnly,
-                "--numstat" => mode = ShowMode::Numstat,
-                "--patience" => patience = true,
+                "-p" | "--patch" => {
+                    cli_specified_format = true;
+                    explicit_patch = true;
+                }
+                "--stat" => {
+                    cli_specified_format = true;
+                    explicit_stat = true;
+                }
+                "--name-status" => {
+                    cli_specified_format = true;
+                    other_mode = Some(ShowMode::NameStatus);
+                }
+                "--name-only" => {
+                    cli_specified_format = true;
+                    other_mode = Some(ShowMode::NameOnly);
+                }
+                "--numstat" => {
+                    cli_specified_format = true;
+                    other_mode = Some(ShowMode::Numstat);
+                }
+                "--patience" => {
+                    cli_specified_format = true;
+                    patience = true;
+                }
                 "-u" | "--include-untracked" | "--only-untracked" => {
                     // Accepted for compatibility; untracked content is not shown yet.
                 }
                 _ if a.starts_with("--no-") => {
-                    // ignore for forward-compat
+                    cli_specified_format = true;
                 }
                 _ => {
                     eprintln!("usage: git stash show [-u | --include-untracked | --only-untracked] [<diff-options>] [<stash>]");
@@ -598,7 +633,10 @@ fn parse_stash_show_args(raw: &[String]) -> Result<ParsedStashShow> {
     }
     Ok(ParsedStashShow {
         stash_ref: pos.into_iter().next(),
-        mode,
+        cli_specified_format,
+        explicit_stat,
+        explicit_patch,
+        other_mode,
         patience,
     })
 }
@@ -1875,21 +1913,57 @@ enum ShowMode {
     Numstat,
 }
 
-fn do_show(stash_ref: Option<String>, mode: ShowMode, patience: bool) -> Result<()> {
-    let repo = Repository::discover(None).context("not a git repository")?;
-    let stash_oid = resolve_stash_ref(&repo, stash_ref.as_deref())?;
+fn stash_show_config_bool(config: &ConfigSet, key: &str, default: bool) -> Result<bool> {
+    match config.get_bool(key) {
+        None => Ok(default),
+        Some(Ok(b)) => Ok(b),
+        Some(Err(msg)) => bail!("bad boolean config value for '{key}': {msg}"),
+    }
+}
 
-    match mode {
-        ShowMode::Patch => {
-            if patience {
-                // Patience is accepted; diff algorithm not wired — same output as default.
-            }
-            show_stash_diff(&repo, &stash_oid, true)?;
+fn do_show(parsed: ParsedStashShow) -> Result<()> {
+    let repo = Repository::discover(None).context("not a git repository")?;
+    let stash_oid = resolve_stash_ref(&repo, parsed.stash_ref.as_deref())?;
+
+    let config = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_else(|_| ConfigSet::new());
+    let cfg_show_stat = stash_show_config_bool(&config, "stash.showStat", true)?;
+    let cfg_show_patch = stash_show_config_bool(&config, "stash.showPatch", false)?;
+
+    if let Some(mode) = parsed.other_mode {
+        if parsed.patience {
+            // Patience is accepted; diff algorithm not wired — same output as default.
         }
-        ShowMode::NameStatus => show_stash_name_status(&repo, &stash_oid, true)?,
-        ShowMode::NameOnly => show_stash_name_status(&repo, &stash_oid, false)?,
-        ShowMode::Stat => show_stash_stat(&repo, &stash_oid)?,
-        ShowMode::Numstat => show_stash_numstat(&repo, &stash_oid)?,
+        match mode {
+            ShowMode::NameStatus => show_stash_name_status(&repo, &stash_oid, true)?,
+            ShowMode::NameOnly => show_stash_name_status(&repo, &stash_oid, false)?,
+            ShowMode::Numstat => show_stash_numstat(&repo, &stash_oid)?,
+            ShowMode::Stat | ShowMode::Patch => {}
+        }
+        return Ok(());
+    }
+
+    let (show_stat, show_patch) = if parsed.cli_specified_format {
+        let stat = parsed.explicit_stat;
+        let mut patch = parsed.explicit_patch;
+        if !stat && !patch {
+            patch = true;
+        }
+        (stat, patch)
+    } else {
+        if !cfg_show_stat && !cfg_show_patch {
+            return Ok(());
+        }
+        (cfg_show_stat, cfg_show_patch)
+    };
+
+    if show_stat {
+        show_stash_stat(&repo, &stash_oid, &config)?;
+    }
+    if show_patch {
+        if parsed.patience {
+            // Patience is accepted; diff algorithm not wired — same output as default.
+        }
+        show_stash_diff(&repo, &stash_oid, true)?;
     }
 
     Ok(())
@@ -1967,140 +2041,98 @@ fn show_stash_diff(repo: &Repository, stash_oid: &ObjectId, _with_hunks: bool) -
     Ok(())
 }
 
-fn show_stash_stat(repo: &Repository, stash_oid: &ObjectId) -> Result<()> {
+fn stash_stat_path_display(entry: &DiffEntry) -> String {
+    let old_path = entry.old_path.as_deref().unwrap_or("");
+    let new_path = entry.new_path.as_deref().unwrap_or("");
+    match entry.status {
+        DiffStatus::Renamed | DiffStatus::Copied => {
+            grit_lib::diff::format_rename_path(old_path, new_path)
+        }
+        _ => new_path.to_string(),
+    }
+}
+
+fn show_stash_stat(repo: &Repository, stash_oid: &ObjectId, config: &ConfigSet) -> Result<()> {
     let obj = repo.odb.read(stash_oid)?;
     let stash_commit = parse_commit(&obj.data)?;
-
     let old_tree = stash_index_tree_oid(repo, &stash_commit)?;
-    let old_entries = flatten_tree_full(&repo.odb, &old_tree, "")?;
-    let new_entries = flatten_tree_full(&repo.odb, &stash_commit.tree, "")?;
-
-    // Build maps
-    use std::collections::BTreeMap;
-    let mut old_map: BTreeMap<&str, &FlatTreeEntry> = BTreeMap::new();
-    for e in &old_entries {
-        old_map.insert(&e.path, e);
-    }
-    let mut new_map: BTreeMap<&str, &FlatTreeEntry> = BTreeMap::new();
-    for e in &new_entries {
-        new_map.insert(&e.path, e);
-    }
-
-    let mut all_paths: BTreeSet<&str> = BTreeSet::new();
-    for e in &old_entries {
-        all_paths.insert(&e.path);
-    }
-    for e in &new_entries {
-        all_paths.insert(&e.path);
-    }
-
-    struct StatEntry {
-        path: String,
-        insertions: usize,
-        deletions: usize,
-    }
-
-    let mut stats: Vec<StatEntry> = Vec::new();
-    let mut total_insertions = 0usize;
-    let mut total_deletions = 0usize;
-    let mut total_files = 0usize;
-
-    for path in &all_paths {
-        match (old_map.get(path), new_map.get(path)) {
-            (Some(o), Some(n)) if o.oid != n.oid || o.mode != n.mode => {
-                let (ins, del) = count_line_changes(&repo.odb, &o.oid, &n.oid)?;
-                total_insertions += ins;
-                total_deletions += del;
-                total_files += 1;
-                stats.push(StatEntry {
-                    path: path.to_string(),
-                    insertions: ins,
-                    deletions: del,
-                });
-            }
-            (None, Some(n)) => {
-                let blob = repo.odb.read(&n.oid)?;
-                let ins = String::from_utf8_lossy(&blob.data).lines().count();
-                total_insertions += ins;
-                total_files += 1;
-                stats.push(StatEntry {
-                    path: path.to_string(),
-                    insertions: ins,
-                    deletions: 0,
-                });
-            }
-            (Some(o), None) => {
-                let blob = repo.odb.read(&o.oid)?;
-                let del = String::from_utf8_lossy(&blob.data).lines().count();
-                total_deletions += del;
-                total_files += 1;
-                stats.push(StatEntry {
-                    path: path.to_string(),
-                    insertions: 0,
-                    deletions: del,
-                });
-            }
-            _ => {}
-        }
-    }
-
-    if stats.is_empty() {
+    let entries = diff_trees(&repo.odb, Some(&old_tree), Some(&stash_commit.tree), "")?;
+    if entries.is_empty() {
         return Ok(());
     }
 
-    // Find max path width and max changes for scaling
-    let max_path_len = stats.iter().map(|s| s.path.len()).max().unwrap_or(0);
-    let max_changes = stats
-        .iter()
-        .map(|s| s.insertions + s.deletions)
-        .max()
-        .unwrap_or(0);
+    let eff_name_width = config
+        .get("diff.statNameWidth")
+        .and_then(|v| v.parse::<usize>().ok());
+    let eff_graph_width = config
+        .get("diff.statGraphWidth")
+        .and_then(|v| v.parse::<usize>().ok());
 
-    // Scale bar to fit in terminal (max bar width ~50)
-    let max_bar_width = 50usize;
-    let scale = if max_changes > max_bar_width {
-        max_bar_width as f64 / max_changes as f64
-    } else {
-        1.0
+    let mut files: Vec<FileStatInput> = Vec::with_capacity(entries.len());
+    for entry in &entries {
+        let path_display = stash_stat_path_display(entry);
+        let old_raw = if entry.old_oid == zero_oid() {
+            Vec::new()
+        } else {
+            repo.odb
+                .read(&entry.old_oid)
+                .map(|o| o.data)
+                .unwrap_or_default()
+        };
+        let new_raw = if entry.new_oid == zero_oid() {
+            Vec::new()
+        } else {
+            repo.odb
+                .read(&entry.new_oid)
+                .map(|o| o.data)
+                .unwrap_or_default()
+        };
+        let binary = blob_is_binary(&old_raw) || blob_is_binary(&new_raw);
+        if binary {
+            let deleted = if entry.old_oid == zero_oid() {
+                0
+            } else {
+                old_raw.len()
+            };
+            let added = if entry.new_oid == zero_oid() {
+                0
+            } else {
+                new_raw.len()
+            };
+            files.push(FileStatInput {
+                path_display,
+                insertions: added,
+                deletions: deleted,
+                is_binary: true,
+            });
+        } else {
+            let old_content = String::from_utf8_lossy(&old_raw).into_owned();
+            let new_content = String::from_utf8_lossy(&new_raw).into_owned();
+            let (ins, del) = count_changes(&old_content, &new_content);
+            files.push(FileStatInput {
+                path_display,
+                insertions: ins,
+                deletions: del,
+                is_binary: false,
+            });
+        }
+    }
+
+    let opts = DiffstatOptions {
+        total_width: terminal_columns(),
+        line_prefix: "",
+        subtract_prefix_from_terminal: false,
+        stat_name_width: eff_name_width,
+        stat_graph_width: eff_graph_width,
+        stat_count: None,
+        color_add: "",
+        color_del: "",
+        color_reset: "",
+        graph_bar_slack: 0,
+        graph_prefix_budget_slack: 0,
     };
-
-    for s in &stats {
-        let changes = s.insertions + s.deletions;
-        let bar_ins = (s.insertions as f64 * scale).ceil() as usize;
-        let bar_del = (s.deletions as f64 * scale).ceil() as usize;
-        let bar = format!("{}{}", "+".repeat(bar_ins), "-".repeat(bar_del));
-        println!(
-            " {:<width$} | {:>3} {}",
-            s.path,
-            changes,
-            bar,
-            width = max_path_len,
-        );
-    }
-
-    // Summary line
-    let mut summary_parts = Vec::new();
-    summary_parts.push(format!(
-        " {} file{} changed",
-        total_files,
-        if total_files == 1 { "" } else { "s" }
-    ));
-    if total_insertions > 0 {
-        summary_parts.push(format!(
-            " {} insertion{}(+)",
-            total_insertions,
-            if total_insertions == 1 { "" } else { "s" }
-        ));
-    }
-    if total_deletions > 0 {
-        summary_parts.push(format!(
-            " {} deletion{}(-)",
-            total_deletions,
-            if total_deletions == 1 { "" } else { "s" }
-        ));
-    }
-    println!("{}", summary_parts.join(","));
-
+    let mut out = std::io::stdout().lock();
+    write_diffstat_block(&mut out, &files, &opts)?;
     Ok(())
 }
 
@@ -3317,33 +3349,42 @@ fn show_tree_diff(odb: &Odb, old: &[FlatTreeEntry], new: &[FlatTreeEntry]) -> Re
                         println!("old mode {}", format_mode(o.mode));
                         println!("new mode {}", format_mode(n.mode));
                     }
-                    println!("index {}..{}", &o.oid.to_hex()[..7], &n.oid.to_hex()[..7]);
-                    println!("--- a/{path}");
-                    println!("+++ b/{path}");
-                    show_blob_diff(odb, &o.oid, &n.oid)?;
+                    println!(
+                        "index {}..{} {}",
+                        &o.oid.to_hex()[..7],
+                        &n.oid.to_hex()[..7],
+                        format_mode(n.mode)
+                    );
+                    print!("{}", stash_unified_diff_body(odb, path, &o.oid, &n.oid)?);
                 }
             }
             (None, Some(n)) => {
                 println!("diff --git a/{path} b/{path}");
                 println!("new file mode {}", format_mode(n.mode));
-                println!("--- /dev/null");
-                println!("+++ b/{path}");
-                let blob = odb.read(&n.oid)?;
-                let text = String::from_utf8_lossy(&blob.data);
-                for line in text.lines() {
-                    println!("+{line}");
-                }
+                println!(
+                    "index {}..{} {}",
+                    &empty_blob_oid().to_hex()[..7],
+                    &n.oid.to_hex()[..7],
+                    format_mode(n.mode)
+                );
+                print!(
+                    "{}",
+                    stash_unified_diff_body(odb, path, &empty_blob_oid(), &n.oid)?
+                );
             }
             (Some(o), None) => {
                 println!("diff --git a/{path} b/{path}");
                 println!("deleted file mode {}", format_mode(o.mode));
-                println!("--- a/{path}");
-                println!("+++ /dev/null");
-                let blob = odb.read(&o.oid)?;
-                let text = String::from_utf8_lossy(&blob.data);
-                for line in text.lines() {
-                    println!("-{line}");
-                }
+                println!(
+                    "index {}..{} {}",
+                    &o.oid.to_hex()[..7],
+                    &empty_blob_oid().to_hex()[..7],
+                    format_mode(o.mode)
+                );
+                print!(
+                    "{}",
+                    stash_unified_diff_body(odb, path, &o.oid, &empty_blob_oid())?
+                );
             }
             (None, None) => unreachable!(),
         }
@@ -3352,25 +3393,21 @@ fn show_tree_diff(odb: &Odb, old: &[FlatTreeEntry], new: &[FlatTreeEntry]) -> Re
     Ok(())
 }
 
-/// Show a simple line diff between two blobs.
-fn show_blob_diff(odb: &Odb, old_oid: &ObjectId, new_oid: &ObjectId) -> Result<()> {
+/// Unified diff body (`---` / `+++` / `@@` hunks) for two blobs, matching `grit diff` formatting.
+fn stash_unified_diff_body(
+    odb: &Odb,
+    path: &str,
+    old_oid: &ObjectId,
+    new_oid: &ObjectId,
+) -> Result<String> {
     let old_blob = odb.read(old_oid)?;
     let new_blob = odb.read(new_oid)?;
+    if blob_is_binary(&old_blob.data) || blob_is_binary(&new_blob.data) {
+        return Ok(format!("Binary files a/{path} and b/{path} differ\n"));
+    }
     let old_text = String::from_utf8_lossy(&old_blob.data);
     let new_text = String::from_utf8_lossy(&new_blob.data);
-
-    use similar::TextDiff;
-    let diff = TextDiff::from_lines(&old_text as &str, &new_text as &str);
-    for change in diff.iter_all_changes() {
-        let sign = match change.tag() {
-            similar::ChangeTag::Delete => "-",
-            similar::ChangeTag::Insert => "+",
-            similar::ChangeTag::Equal => " ",
-        };
-        print!("{sign}{change}");
-    }
-
-    Ok(())
+    Ok(unified_diff(&old_text, &new_text, path, path, 3))
 }
 
 fn format_mode(mode: u32) -> String {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes `tests/t3907-stash-show-config.sh` pass (10/10).

### Changes

- **`grit stash show`** reads `stash.showStat` (default true) and `stash.showPatch` (default false) when no diff-format flags are on the command line, matching Git. If both are false, output is empty.
- When the user passes diff-related flags, behavior matches Git: default to patch if no format was chosen; `--stat` and `-p` can be combined (stat then patch).
- **`--stat` output** for stash uses the same diffstat path as `grit diff` (`diff_trees` + `write_diffstat_block`) so `git diff --stat` and `git stash show` byte-match in the harness.
- **Stash patch** uses `unified_diff` with proper `index` lines so combined stat+patch matches `git diff --stat -p`.
- **`grit diff --stat -p`** now appends the unified patch only when `-p`/`-u`/etc. appear on argv (plain `--stat` no longer incorrectly emitted a patch).

### Testing

- `./scripts/run-tests.sh t3907-stash-show-config.sh`
- `cargo test -p grit-lib --lib`

Also removed an unused `bail` import in `bundle_uri_test_tool.rs`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ffee23c2-ef22-4f36-918f-8eb19841b655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ffee23c2-ef22-4f36-918f-8eb19841b655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

