### PR TITLE
fix: pre-commit and pre-merge-commit hooks for t7503

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1224,7 +1224,7 @@ t7501-commit-basic	t7	yes	146	142	4	false	ok	0
 t7501-commit-basic-functionality	t7	yes	77	49	28	false	ok	0
 t7502-commit-porcelain	t7	yes	82	31	51	false	ok	0
 t7503-pre-commit-and-diff-whitespace	t7	yes	22	21	1	false	ok	0
-t7503-pre-commit-and-pre-merge-commit-hooks	t7	yes	22	11	11	false	ok	0
+t7503-pre-commit-and-pre-merge-commit-hooks	t7	yes	22	22	0	true	ok	0
 t7504-commit-msg-hook	t7	yes	29	21	8	false	ok	1
 t7505-prepare-commit-msg	t7	yes	30	29	1	false	ok	0
 t7505-prepare-commit-msg-hook	t7	yes	23	7	16	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,697 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,697 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T19:29:04+00:00" class="gen-time" title="2026-04-09 19:29 UTC">2026-04-09 19:29 UTC</time> · <a href="https://github.com/schacon/grit/commit/bb01f16a74dbd56f79d97e4e967199f82147d0ae" style="color:#58a6ff">bb01f16</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,697</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">49/126 files · 11 skipped · 2,505/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.3%"></div></div>
+        <span class="group-pct pct-blue">69.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35697 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,697 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:29:04+00:00" class="gen-time" title="2026-04-09 19:29 UTC">2026-04-09 19:29 UTC</time> · <a href="https://github.com/schacon/grit/commit/bb01f16a74dbd56f79d97e4e967199f82147d0ae" style="color:#58a6ff">bb01f16</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,697</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">
@@ -12397,14 +12397,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:95.5%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="22" data-passed="11">
+<tr class="" data-group="t7" data-tests="22" data-passed="22" data-full-pass="1">
   <td class="mono">t7503-pre-commit-and-pre-merge-commit-hooks</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">22</td>
-  <td class="right">11</td>
+  <td class="right">22</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="29" data-passed="21">

--- a/grit-lib/src/hooks.rs
+++ b/grit-lib/src/hooks.rs
@@ -26,6 +26,92 @@ fn stdio_piped(piped: bool) -> Stdio {
     }
 }
 
+/// Optional environment overrides for commit-style hooks (`GIT_INDEX_FILE`, `GIT_EDITOR`, `GIT_PREFIX`).
+#[derive(Debug, Clone, Default)]
+pub struct HookRunOptions<'a> {
+    /// Absolute or cwd-relative index path passed as `GIT_INDEX_FILE` (matches `run_commit_hook`).
+    pub index_file: Option<&'a Path>,
+    /// When set, overrides `GIT_EDITOR` for the hook subprocess (e.g. `":"` when no editor is used).
+    pub git_editor: Option<&'a str>,
+    /// When set, used as `GIT_PREFIX`; when unset, derived from the repository work tree and hook cwd.
+    pub git_prefix: Option<&'a str>,
+    /// Additional `KEY=value` pairs for the hook subprocess.
+    pub extra_env: &'a [(&'a str, &'a str)],
+}
+
+fn absolute_index_path(index_file: &Path) -> PathBuf {
+    if index_file.is_absolute() {
+        index_file.to_path_buf()
+    } else if let Ok(cwd) = std::env::current_dir() {
+        cwd.join(index_file)
+    } else {
+        index_file.to_path_buf()
+    }
+}
+
+/// `GIT_PREFIX` for the invoking cwd relative to the work tree (Git sets this from the user's
+/// `pwd`, not from the hook subprocess cwd, which is usually the work tree root).
+fn git_prefix_for_invocation(repo: &Repository, invocation_cwd: &Path) -> String {
+    let Some(wt) = repo.work_tree.as_deref() else {
+        return String::new();
+    };
+    if invocation_cwd == repo.git_dir.as_path() {
+        return String::new();
+    }
+    let wt_canon = wt.canonicalize().unwrap_or_else(|_| wt.to_path_buf());
+    let wd_canon = invocation_cwd
+        .canonicalize()
+        .unwrap_or_else(|_| invocation_cwd.to_path_buf());
+    let rel = wd_canon.strip_prefix(&wt_canon).ok();
+    let Some(rel) = rel else {
+        return String::new();
+    };
+    let Some(s) = rel.to_str() else {
+        return String::new();
+    };
+    if s.is_empty() {
+        return String::new();
+    }
+    let mut out = s.replace('\\', "/");
+    if !out.ends_with('/') {
+        out.push('/');
+    }
+    out
+}
+
+fn pairs_from_str_slice(env: &[(&str, &str)]) -> Vec<(String, String)> {
+    env.iter()
+        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+        .collect()
+}
+
+fn build_hook_env(
+    repo: &Repository,
+    work_dir: &Path,
+    opts: &HookRunOptions<'_>,
+) -> Vec<(String, String)> {
+    let mut env: Vec<(String, String)> = Vec::new();
+    if let Some(p) = opts.index_file {
+        env.push((
+            "GIT_INDEX_FILE".to_string(),
+            absolute_index_path(p).to_string_lossy().into_owned(),
+        ));
+    }
+    let invocation_cwd = std::env::current_dir().unwrap_or_else(|_| work_dir.to_path_buf());
+    let prefix = opts
+        .git_prefix
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| git_prefix_for_invocation(repo, &invocation_cwd));
+    env.push(("GIT_PREFIX".to_string(), prefix));
+    if let Some(ed) = opts.git_editor {
+        env.push(("GIT_EDITOR".to_string(), ed.to_string()));
+    }
+    for (k, v) in opts.extra_env {
+        env.push(((*k).to_string(), (*v).to_string()));
+    }
+    env
+}
+
 /// Spawn a hook script. If the kernel rejects direct execution (e.g. no shebang, ENOEXEC), run it
 /// with `/bin/sh` like Git does.
 fn spawn_hook_child(
@@ -33,7 +119,7 @@ fn spawn_hook_child(
     hook_args: &[&str],
     cwd: &Path,
     git_dir: &Path,
-    extra_env: &[(&str, &str)],
+    extra_env: &[(String, String)],
     stdin_piped: bool,
     stdout_piped: bool,
     stderr_piped: bool,
@@ -150,6 +236,17 @@ pub fn run_hook(
     args: &[&str],
     stdin_data: Option<&[u8]>,
 ) -> HookResult {
+    run_hook_opts(repo, hook_name, args, stdin_data, None)
+}
+
+/// Like [`run_hook`] with optional `GIT_INDEX_FILE`, `GIT_EDITOR`, `GIT_PREFIX`, and extra env (Git `run_commit_hook` behavior).
+pub fn run_hook_opts(
+    repo: &Repository,
+    hook_name: &str,
+    args: &[&str],
+    stdin_data: Option<&[u8]>,
+    opts: Option<&HookRunOptions<'_>>,
+) -> HookResult {
     let hooks_dir = resolve_hooks_dir(repo);
     let hook_path = hooks_dir.join(hook_name);
 
@@ -188,12 +285,21 @@ pub fn run_hook(
 
     let stdin_piped = stdin_data.is_some();
 
+    let default_opts = HookRunOptions {
+        index_file: None,
+        git_editor: None,
+        git_prefix: None,
+        extra_env: &[],
+    };
+    let o = opts.unwrap_or(&default_opts);
+    let env_pairs = build_hook_env(repo, work_dir, o);
+
     let mut child = match spawn_hook_child(
         &command_path,
         args,
         work_dir,
         &repo.git_dir,
-        &[],
+        &env_pairs,
         stdin_piped,
         false,
         false,
@@ -251,12 +357,14 @@ pub fn run_hook_in_git_dir(
     let command_path = hook_command_path(repo, &hooks_dir, hook_name, &repo.git_dir);
     let stdin_piped = stdin_data.is_some();
 
+    let env_pairs = pairs_from_str_slice(env_vars);
+
     let mut child = match spawn_hook_child(
         &command_path,
         args,
         &repo.git_dir,
         &repo.git_dir,
-        env_vars,
+        &env_pairs,
         stdin_piped,
         true,
         true,
@@ -317,12 +425,14 @@ pub fn run_hook_with_env(
 
     let stdin_piped = stdin_data.is_some();
 
+    let env_pairs = pairs_from_str_slice(env_vars);
+
     let mut child = match spawn_hook_child(
         &command_path,
         args,
         work_dir,
         &repo.git_dir,
-        env_vars,
+        &env_pairs,
         stdin_piped,
         true,
         true,

--- a/grit/src/commands/commit.rs
+++ b/grit/src/commands/commit.rs
@@ -11,7 +11,7 @@ use grit_lib::diff::{
     DiffStatus,
 };
 use grit_lib::error::Error;
-use grit_lib::hooks::{run_hook, HookResult};
+use grit_lib::hooks::{run_hook, run_hook_opts, HookResult, HookRunOptions};
 use grit_lib::index::Index;
 use grit_lib::objects::{serialize_commit, CommitData, ObjectId, ObjectKind};
 use grit_lib::refs::{append_reflog, list_refs};
@@ -762,11 +762,6 @@ pub fn run(mut args: Args) -> Result<()> {
         }
     }
 
-    // Run pre-commit hook
-    if let HookResult::Failed(code) = run_hook(&repo, "pre-commit", &[], None) {
-        bail!("pre-commit hook exited with status {code}");
-    }
-
     let template_path = resolve_commit_template_path(&args, &config)?;
     let use_editor_for_message = commit_uses_editor(&args, fixup_parsed.as_ref());
 
@@ -842,6 +837,32 @@ pub fn run(mut args: Args) -> Result<()> {
         (resolve_author(&args, &config, &repo, now)?, Vec::new())
     };
     let committer = resolve_committer(&config, now)?;
+
+    let author_hook_env = author_env_for_commit_hooks(&author)?;
+    let author_env_refs: Vec<(&str, &str)> = author_hook_env
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
+
+    let hook_editor = if use_editor_for_message {
+        None
+    } else {
+        Some(":")
+    };
+    let hook_opts = HookRunOptions {
+        index_file: Some(index_path.as_path()),
+        git_editor: hook_editor,
+        git_prefix: None,
+        extra_env: author_env_refs.as_slice(),
+    };
+
+    if !args.no_verify {
+        if let HookResult::Failed(code) =
+            run_hook_opts(&repo, "pre-commit", &[], None, Some(&hook_opts))
+        {
+            bail!("pre-commit hook exited with status {code}");
+        }
+    }
 
     // Append Signed-off-by trailer if --signoff
     if args.signoff {
@@ -944,7 +965,7 @@ pub fn run(mut args: Args) -> Result<()> {
     }
 
     // Run commit-msg hook with temp file containing the message
-    {
+    if !args.no_verify {
         let msg_file = repo.git_dir.join("COMMIT_EDITMSG");
         // Write raw bytes when available so the hook sees the original encoding
         if let Some(ref raw) = raw_message {
@@ -953,7 +974,13 @@ pub fn run(mut args: Args) -> Result<()> {
             fs::write(&msg_file, &message)?;
         }
         let msg_path_str = msg_file.to_string_lossy().to_string();
-        match run_hook(&repo, "commit-msg", &[&msg_path_str], None) {
+        match run_hook_opts(
+            &repo,
+            "commit-msg",
+            &[&msg_path_str],
+            None,
+            Some(&hook_opts),
+        ) {
             HookResult::Failed(code) => {
                 bail!("commit-msg hook exited with status {code}");
             }
@@ -2534,6 +2561,19 @@ fn parse_force_author_parameter(author: &str) -> Result<(String, String)> {
         bail!("malformed --author parameter");
     }
     Ok((name.to_string(), email.to_string()))
+}
+
+/// Build `GIT_AUTHOR_*` values for hook subprocesses (matches Git `determine_author_info` / `export_one`).
+pub(crate) fn author_env_for_commit_hooks(author_line: &str) -> Result<Vec<(String, String)>> {
+    let (name, email, date_tail) = split_stored_author_line(author_line)?;
+    let mut out = vec![
+        ("GIT_AUTHOR_NAME".to_string(), name),
+        ("GIT_AUTHOR_EMAIL".to_string(), email),
+    ];
+    if let Some(dt) = date_tail.filter(|s| !s.is_empty()) {
+        out.push(("GIT_AUTHOR_DATE".to_string(), format!("@{dt}")));
+    }
+    Ok(out)
 }
 
 /// Split a stored author line (`name <email> <epoch> <tz>`) into name, email, and optional date tail.

--- a/grit/src/commands/merge.rs
+++ b/grit/src/commands/merge.rs
@@ -16,7 +16,7 @@ use grit_lib::config::ConfigSet;
 use grit_lib::crlf::MergeAttr;
 use grit_lib::diff::{count_changes, detect_renames, diff_trees, zero_oid, DiffEntry, DiffStatus};
 use grit_lib::diffstat::{terminal_columns, write_diffstat_block, DiffstatOptions, FileStatInput};
-use grit_lib::hooks::run_hook;
+use grit_lib::hooks::{run_hook, run_hook_opts, HookResult, HookRunOptions};
 use grit_lib::index::{Index, IndexEntry, MODE_EXECUTABLE, MODE_GITLINK, MODE_SYMLINK, MODE_TREE};
 use grit_lib::merge_base::is_ancestor;
 use grit_lib::merge_file::{self, ConflictStyle, MergeFavor, MergeInput};
@@ -31,6 +31,7 @@ use grit_lib::state::{resolve_head, HeadState};
 use grit_lib::write_tree::write_tree_from_index;
 use time::OffsetDateTime;
 
+use crate::commands::commit::author_env_for_commit_hooks;
 use crate::commands::diff_index;
 use crate::explicit_exit::{ExplicitExit, SilentNonZeroExit};
 
@@ -202,6 +203,10 @@ pub struct Args {
     /// Do not update the index when a recorded rerere resolution is replayed.
     #[arg(long = "no-rerere-autoupdate")]
     pub no_rerere_autoupdate: bool,
+
+    /// Bypass the pre-merge-commit hook (and commit-msg when implemented for merge).
+    #[arg(long = "no-verify")]
+    pub no_verify: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -526,9 +531,56 @@ fn apply_mergeoptions(args: &mut Args, opts: &str) {
             "--summary" if !cli_no_stat => args.summary = true,
             "--rerere-autoupdate" => args.rerere_autoupdate = true,
             "--no-rerere-autoupdate" => args.no_rerere_autoupdate = true,
+            "--no-verify" => args.no_verify = true,
             _ => {} // ignore unknown options
         }
     }
+}
+
+/// Run `pre-merge-commit`, reload index if the hook ran (Git re-reads index after the hook).
+fn run_pre_merge_commit_hook(
+    repo: &Repository,
+    no_verify: bool,
+    merge_will_launch_editor: bool,
+    index: &mut Index,
+) -> Result<()> {
+    if no_verify {
+        return Ok(());
+    }
+    let index_path = repo.index_path();
+    let config = ConfigSet::load(Some(&repo.git_dir), true)?;
+    let now = OffsetDateTime::now_utc();
+    let author_line = resolve_ident(&config, "author", now)?;
+    let author_env = author_env_for_commit_hooks(&author_line)?;
+    let author_refs: Vec<(&str, &str)> = author_env
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
+    let hook_editor = if merge_will_launch_editor {
+        None
+    } else {
+        Some(":")
+    };
+    let hook_opts = HookRunOptions {
+        index_file: Some(index_path.as_path()),
+        git_editor: hook_editor,
+        git_prefix: None,
+        extra_env: author_refs.as_slice(),
+    };
+    let before = run_hook_opts(repo, "pre-merge-commit", &[], None, Some(&hook_opts));
+    if let HookResult::Failed(code) = before {
+        bail!("pre-merge-commit hook exited with status {code}");
+    }
+    if before.was_executed() {
+        *index = match repo.load_index_at(&index_path) {
+            Ok(idx) => idx,
+            Err(grit_lib::error::Error::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => {
+                Index::new()
+            }
+            Err(e) => return Err(e.into()),
+        };
+    }
+    Ok(())
 }
 
 /// Run the `merge` command.
@@ -1686,6 +1738,13 @@ Aborting"
     }
 
     // Create merge commit
+    run_pre_merge_commit_hook(
+        repo,
+        args.no_verify,
+        args.edit && !args.no_edit,
+        &mut merge_result.index,
+    )?;
+    repo.write_index(&mut merge_result.index)?;
     let tree_oid = write_tree_from_index(&repo.odb, &merge_result.index, "")?;
     let config = ConfigSet::load(Some(&repo.git_dir), true)?;
     let effective_custom_msg = if let Some(ref file_path) = args.file {
@@ -2597,6 +2656,13 @@ fn do_octopus_merge(
         return Ok(());
     }
 
+    run_pre_merge_commit_hook(
+        repo,
+        args.no_verify,
+        args.edit && !args.no_edit,
+        &mut final_index,
+    )?;
+    repo.write_index(&mut final_index)?;
     let tree_oid = write_tree_from_index(&repo.odb, &final_index, "")?;
     let msg = build_octopus_merge_message(head, &merge_names, args.message.as_deref(), repo);
 
@@ -2789,7 +2855,15 @@ fn do_strategy_ours(
         format!("{}\n", head_oid.to_hex()),
     )?;
 
-    let tree_oid = commit_tree(repo, head_oid)?;
+    let mut merge_index = repo.load_index()?;
+    run_pre_merge_commit_hook(
+        repo,
+        args.no_verify,
+        args.edit && !args.no_edit,
+        &mut merge_index,
+    )?;
+    repo.write_index(&mut merge_index)?;
+    let tree_oid = write_tree_from_index(&repo.odb, &merge_index, "")?;
     let msg = build_merge_message(head, &args.commits[0], args.message.as_deref(), repo);
 
     let config = ConfigSet::load(Some(&repo.git_dir), true)?;
@@ -2853,7 +2927,15 @@ fn do_strategy_theirs(
         format!("{}\n", head_oid.to_hex()),
     )?;
 
-    let tree_oid = commit_tree(repo, merge_oid)?;
+    let mut merge_index = repo.load_index()?;
+    run_pre_merge_commit_hook(
+        repo,
+        args.no_verify,
+        args.edit && !args.no_edit,
+        &mut merge_index,
+    )?;
+    repo.write_index(&mut merge_index)?;
+    let tree_oid = write_tree_from_index(&repo.odb, &merge_index, "")?;
     let msg = build_merge_message(head, &args.commits[0], args.message.as_deref(), repo);
 
     let config = ConfigSet::load(Some(&repo.git_dir), true)?;
@@ -3246,6 +3328,10 @@ fn merge_continue(message: Option<String>) -> Result<()> {
         bail!("no merge message found (use -m to provide one)");
     };
 
+    let mut index = index;
+    let no_verify_merge_continue = std::env::args().any(|a| a == "--no-verify");
+    run_pre_merge_commit_hook(&repo, no_verify_merge_continue, false, &mut index)?;
+    repo.write_index(&mut index)?;
     let tree_oid = write_tree_from_index(&repo.odb, &index, "")?;
     let config = ConfigSet::load(Some(git_dir), true)?;
     let now = OffsetDateTime::now_utc();

--- a/grit/src/commands/pull.rs
+++ b/grit/src/commands/pull.rs
@@ -646,6 +646,7 @@ fn build_pull_merge_args(
         file: None,
         rerere_autoupdate: false,
         no_rerere_autoupdate: false,
+        no_verify: false,
     })
 }
 

--- a/logs/2026-04-09_t7503-pre-merge-commit-hooks.md
+++ b/logs/2026-04-09_t7503-pre-merge-commit-hooks.md
@@ -1,0 +1,13 @@
+# t7503 pre-commit / pre-merge-commit hooks
+
+## Summary
+
+- Extended `grit-lib` hook runner with `HookRunOptions` / `run_hook_opts`: `GIT_INDEX_FILE`, `GIT_PREFIX` (from process cwd vs work tree), `GIT_EDITOR`, and extra env.
+- `commit`: resolve author before hooks; export `GIT_AUTHOR_*` to pre-commit and commit-msg; skip pre-commit and commit-msg when `--no-verify`.
+- `merge`: added `--no-verify`; run `pre-merge-commit` before writing the merge tree (reload index if hook ran); same for octopus, ours/theirs strategies, and `merge --continue` when argv contains `--no-verify`.
+- `pull` merge args: `no_verify: false`.
+
+## Validation
+
+- `./scripts/run-tests.sh t7503-pre-commit-and-pre-merge-commit-hooks.sh`
+- `cargo test -p grit-lib --lib`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible hook environment and verification behavior needed for `t7503-pre-commit-and-pre-merge-commit-hooks.sh` (22/22 passing).

### Changes

- **`grit-lib` hooks**: Added `HookRunOptions` and `run_hook_opts` so commit-style hooks receive `GIT_INDEX_FILE`, `GIT_PREFIX` (relative to the work tree from the invoking cwd), optional `GIT_EDITOR`, and arbitrary extra env. `GIT_PREFIX` matches Git: it reflects the user's current directory, not only the hook subprocess cwd.
- **`git commit`**: Resolves author before running hooks and exports `GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, and `GIT_AUTHOR_DATE` for `pre-commit` and `commit-msg`. Honors `--no-verify` for both hooks.
- **`git merge`**: Parses `--no-verify`, runs `pre-merge-commit` before building the merge tree (reloads the index if the hook actually ran), and wires `no_verify: false` into pull's constructed merge args. `merge --continue` respects `--no-verify` when present on the argv.

### Testing

- `./scripts/run-tests.sh t7503-pre-commit-and-pre-merge-commit-hooks.sh`
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c11ccb1e-7a42-475a-a71f-95759ac9d682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c11ccb1e-7a42-475a-a71f-95759ac9d682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

