### PR TITLE
fix: make t4011-diff-symlink fully pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -684,7 +684,7 @@ t4007-rename-3	t4	yes	13	6	7	false	ok	0
 t4008-diff-break-rewrite	t4	yes	14	5	9	false	ok	0
 t4009-diff-rename-4	t4	yes	7	4	3	false	ok	0
 t4010-diff-pathspec	t4	yes	17	17	0	true	ok	0
-t4011-diff-symlink	t4	yes	8	7	1	false	ok	0
+t4011-diff-symlink	t4	yes	8	8	0	true	ok	0
 t4011-diff-tree	t4	yes	110	109	1	false	ok	0
 t4012-diff-binary	t4	yes	13	5	8	false	ok	0
 t4013-diff-various	t4	yes	230	92	138	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,687 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,687 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T19:32:39+00:00" class="gen-time" title="2026-04-09 19:32 UTC">2026-04-09 19:32 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,687</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -230,7 +230,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">73/178 files · 2 skipped · 2,862/4,438 tests</span>
+        <span class="group-meta">74/178 files · 2 skipped · 2,863/4,438 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.5%"></div></div>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35687 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,687 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:32:39+00:00" class="gen-time" title="2026-04-09 19:32 UTC">2026-04-09 19:32 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,687</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -6997,14 +6997,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="8" data-passed="7">
+<tr class="" data-group="t4" data-tests="8" data-passed="8" data-full-pass="1">
   <td class="mono">t4011-diff-symlink</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">8</td>
-  <td class="right">7</td>
+  <td class="right">8</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:87.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="110" data-passed="109">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/merge_diff.rs
+++ b/grit-lib/src/merge_diff.rs
@@ -9,7 +9,7 @@ use std::process::{Command, Stdio};
 
 use tempfile::NamedTempFile;
 
-use crate::config::ConfigSet;
+use crate::config::{parse_bool, ConfigSet};
 use crate::crlf::{get_file_attrs, load_gitattributes, DiffAttr, FileAttrs};
 use crate::diff::{diff_trees, DiffStatus};
 use crate::objects::{parse_commit, parse_tree, ObjectId, ObjectKind};
@@ -134,6 +134,40 @@ pub fn is_binary_for_diff(git_dir: &Path, path: &str, blob: &[u8]) -> bool {
         return true;
     }
     crate::crlf::is_binary(blob)
+}
+
+/// True when `diff.<driver>.binary` is set for this path's `diff=<driver>` attribute.
+fn diff_driver_binary_config(config: &ConfigSet, driver: &str) -> bool {
+    let key = format!("diff.{driver}.binary");
+    config
+        .get(&key)
+        .is_some_and(|v| parse_bool(v.as_str()).unwrap_or(false))
+}
+
+/// Force `Binary files ... differ` when the path's diff driver sets `binary`, except for symlinks.
+///
+/// Matches Git's `diff_filespec_is_binary` driver flag: `diff.<name>.binary` applies to paths
+/// using that driver, but symlink modes (`120000`) still emit textual symlink-target patches
+/// (t4011).
+#[must_use]
+pub fn diff_forced_binary_by_driver(
+    git_dir: &Path,
+    config: &ConfigSet,
+    path: &str,
+    old_mode: &str,
+    new_mode: &str,
+) -> bool {
+    let fa = attrs_for_repo_path(git_dir, path);
+    let DiffAttr::Driver(driver) = fa.diff_attr else {
+        return false;
+    };
+    if !diff_driver_binary_config(config, &driver) {
+        return false;
+    }
+    if old_mode == "120000" || new_mode == "120000" {
+        return false;
+    }
+    true
 }
 
 /// True when Git would wrap the textconv command with `sh -c 'cmd "$@"' -- ...`

--- a/grit/src/commands/diff.rs
+++ b/grit/src/commands/diff.rs
@@ -32,8 +32,8 @@ use grit_lib::diffstat::{terminal_columns, write_diffstat_block, DiffstatOptions
 use grit_lib::error::Error;
 use grit_lib::index::Index;
 use grit_lib::merge_diff::{
-    blob_text_for_diff_with_oid, combined_diff_paths, diff_textconv_active,
-    format_worktree_conflict_combined, run_textconv,
+    blob_text_for_diff_with_oid, combined_diff_paths, diff_forced_binary_by_driver,
+    diff_textconv_active, format_worktree_conflict_combined, run_textconv,
 };
 use grit_lib::objects::{parse_commit, ObjectId, ObjectKind};
 use grit_lib::odb::Odb;
@@ -1196,10 +1196,28 @@ pub fn run(mut args: Args) -> Result<()> {
         }
     }
 
-    // `git diff <path> <path>` — compare a worktree file to another path (e.g. outside the repo).
-    // Triggered when parse_rev_and_paths found two paths and no revisions (first token exists on disk).
+    // `git diff <path> <path>` outside the repo (Git: implicit `--no-index` when either path is
+    // outside the work tree). When both paths are inside the repository, two pathspecs limit the
+    // normal index/worktree diff (t4011: `git diff file.bin link.bin`).
     if revs.is_empty() && paths.len() == 2 && !args.cached {
-        return run_diff_two_paths(&repo, &args, &paths[0], &paths[1], &src_prefix, &dst_prefix);
+        if let Some(wt) = repo.work_tree.as_ref() {
+            let outside =
+                !path_inside_work_tree(wt, &paths[0]) || !path_inside_work_tree(wt, &paths[1]);
+            if outside {
+                let d0 = strip_pathspec_cwd_prefix(&paths[0], pathspec_prefix.as_deref());
+                let d1 = strip_pathspec_cwd_prefix(&paths[1], pathspec_prefix.as_deref());
+                return run_diff_two_paths(
+                    &repo,
+                    &args,
+                    &paths[0],
+                    &paths[1],
+                    &d0,
+                    &d1,
+                    &src_prefix,
+                    &dst_prefix,
+                );
+            }
+        }
     }
 
     // Expand A...B (symmetric diff) → merge-base(A,B)..B
@@ -2412,11 +2430,16 @@ fn run_diff_blob_vs_file(
 ///
 /// This matches `git diff <in-repo-path> <other-path>` when both arguments exist on disk and are
 /// not revision specs.
+///
+/// `path_in_repo` / `path_other` are used for reading the work tree (after pathspec resolution).
+/// `display_in_repo` / `display_other` are used in `---` / `+++` labels (repo-root-relative).
 fn run_diff_two_paths(
     repo: &Repository,
     args: &Args,
     path_in_repo: &str,
     path_other: &str,
+    display_in_repo: &str,
+    display_other: &str,
     src_prefix: &str,
     dst_prefix: &str,
 ) -> Result<()> {
@@ -2483,8 +2506,8 @@ fn run_diff_two_paths(
             .unwrap_or(3)
     };
 
-    let old_label = format!("{src_prefix}{path_in_repo}");
-    let new_label = format!("{dst_prefix}{path_other}");
+    let old_label = format!("{src_prefix}{display_in_repo}");
+    let new_label = format!("{dst_prefix}{display_other}");
     let patch = unified_diff(
         text_a.as_ref(),
         text_b.as_ref(),
@@ -3675,6 +3698,37 @@ fn resolve_diff_relative_prefix(
     }
 }
 
+/// True when `rel_under_wt` resolves to a path under `wt` (matches Git `path_inside_repo` for diff).
+fn path_inside_work_tree(wt: &Path, rel_under_wt: &str) -> bool {
+    let candidate = wt.join(rel_under_wt);
+    let wt_canon = wt.canonicalize().unwrap_or_else(|_| wt.to_path_buf());
+    if let Ok(c_canon) = candidate.canonicalize() {
+        return c_canon.starts_with(&wt_canon);
+    }
+    let Some(parent) = candidate.parent() else {
+        return false;
+    };
+    if parent == Path::new("") {
+        return true;
+    }
+    parent
+        .canonicalize()
+        .map(|p| p.starts_with(&wt_canon))
+        .unwrap_or(true)
+}
+
+/// Strip the cwd-relative prefix that [`resolve_pathspec`] prepends (from [`show_prefix`]).
+///
+/// Diff headers use repo-root-relative paths plus `a/` / `b/`; labels must not duplicate the cwd
+/// segment (matches Git when running `git diff f1 f2` from a subdirectory).
+fn strip_pathspec_cwd_prefix(path: &str, cwd_prefix: Option<&str>) -> String {
+    let Some(pfx) = cwd_prefix.filter(|s| !s.is_empty()) else {
+        return path.to_owned();
+    };
+    let with_slash = format!("{pfx}/");
+    path.strip_prefix(&with_slash).unwrap_or(path).to_owned()
+}
+
 /// Map a `--relative`-stripped display path back to the repository-relative path for index I/O.
 fn repo_relative_path_for_relative_display(display: &str, prefix: Option<&str>) -> String {
     let Some(pfx) = prefix.filter(|s| !s.is_empty()) else {
@@ -4027,6 +4081,22 @@ fn read_content_raw(odb: &Odb, oid: &ObjectId) -> Vec<u8> {
     }
 }
 
+/// Read bytes from the work tree at `path` relative to `wt`.
+///
+/// For symlinks, returns the link target as UTF-8 bytes (same as blob hashing), not the
+/// dereferenced file contents (t4011: `git diff` for intent-to-add symlinks vs `*.bin` rules).
+fn read_worktree_file_raw(wt: &Path, path: &str) -> Option<Vec<u8>> {
+    let full = wt.join(path);
+    let meta = std::fs::symlink_metadata(&full).ok()?;
+    if meta.file_type().is_symlink() {
+        std::fs::read_link(&full)
+            .ok()
+            .map(|t| t.to_string_lossy().into_owned().into_bytes())
+    } else {
+        std::fs::read(&full).ok()
+    }
+}
+
 /// Read raw bytes, falling back to the working tree if the OID isn't in the ODB.
 fn read_content_raw_or_worktree(
     odb: &Odb,
@@ -4038,7 +4108,7 @@ fn read_content_raw_or_worktree(
         // Empty tree / new file side: read from the work tree when available (t1501 tree diffs).
         if let Some(wt) = work_tree {
             if path != "/dev/null" {
-                if let Ok(data) = std::fs::read(wt.join(path)) {
+                if let Some(data) = read_worktree_file_raw(wt, path) {
                     return data;
                 }
             }
@@ -4052,7 +4122,7 @@ fn read_content_raw_or_worktree(
     // Fall back to reading from working tree
     if let Some(wt) = work_tree {
         if path != "/dev/null" {
-            if let Ok(data) = std::fs::read(wt.join(path)) {
+            if let Some(data) = read_worktree_file_raw(wt, path) {
                 return data;
             }
         }
@@ -4592,7 +4662,16 @@ fn write_patch_with_prefix(
 
         let textconv_patch =
             use_textconv && diff_textconv_active(git_dir, config, path_for_attrs.as_str());
-        if !textconv_patch && (is_binary(&old_content_raw) || is_binary(&new_content_raw)) {
+        let forced_binary = diff_forced_binary_by_driver(
+            git_dir,
+            config,
+            path_for_attrs.as_str(),
+            entry.old_mode.as_str(),
+            entry.new_mode.as_str(),
+        );
+        if !textconv_patch
+            && (forced_binary || is_binary(&old_content_raw) || is_binary(&new_content_raw))
+        {
             if show_binary {
                 // --binary: output a "GIT binary patch" block
                 write_git_binary_patch(
@@ -4603,11 +4682,17 @@ fn write_patch_with_prefix(
                     new_path,
                 )?;
             } else {
-                writeln!(
-                    out,
-                    "Binary files {}{} and {}{} differ",
-                    src_prefix, old_path, dst_prefix, new_path
-                )?;
+                let bin_old = if old_path == "/dev/null" {
+                    "/dev/null".to_owned()
+                } else {
+                    format!("{src_prefix}{old_path}")
+                };
+                let bin_new = if new_path == "/dev/null" {
+                    "/dev/null".to_owned()
+                } else {
+                    format!("{dst_prefix}{new_path}")
+                };
+                writeln!(out, "Binary files {bin_old} and {bin_new} differ")?;
             }
             continue;
         }

--- a/logs/2026-04-09_t4011-diff-symlink.md
+++ b/logs/2026-04-09_t4011-diff-symlink.md
@@ -1,0 +1,9 @@
+## t4011-diff-symlink
+
+- Failure was test 8: `git diff file.bin link.bin` with `*.bin diff=bin` and `diff.bin.binary true`, intent-to-add entries.
+- Root causes fixed:
+  1. Two in-repo paths were routed through `run_diff_two_paths` (file-vs-file); Git uses pathspec mode unless implicit `--no-index` (path outside repo). Gated that branch on `path_inside_work_tree`.
+  2. `read_content_raw_or_worktree` used `fs::read`, following symlinks; symlink diffs showed target file bytes. Added `read_worktree_file_raw` using `read_link` for symlinks.
+  3. `diff.<driver>.binary` was ignored; added `diff_forced_binary_by_driver` in `merge_diff` (skipped for mode `120000` so symlink patches stay textual).
+  4. Binary summary line used `a//dev/null`; Git prints `/dev/null` without prefix — fixed label construction.
+- Harness: `./scripts/run-tests.sh t4011-diff-symlink.sh` → 8/8.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes `t4011-diff-symlink` (8/8) by aligning `grit diff` with Git for pathspec vs two-file comparison, symlink worktree reads, `diff.<driver>.binary`, and binary summary line formatting.

## Changes

- **Two-path routing:** Only use the file-vs-file path when at least one argument is outside the work tree (implicit `--no-index`). Two in-repo paths are normal pathspec-limited index/worktree diffs.
- **Symlink content:** When reading the work tree for diff bodies, use `read_link` for symlinks instead of `read` (which followed the link and showed the target file bytes).
- **`diff.<driver>.binary`:** New `diff_forced_binary_by_driver` in `grit-lib` mirrors Git’s driver `binary` flag; skipped when either side is mode `120000` so symlink patches stay textual.
- **Binary line:** `Binary files /dev/null and b/path differ` — `/dev/null` is not prefixed with `a/`.

## Validation

- `./scripts/run-tests.sh t4011-diff-symlink.sh` → 8/8
- `cargo test -p grit-lib --lib`
- `cargo check -p grit-rs -p grit-lib`

Note: `cargo clippy -p grit-lib` currently reports many pre-existing deny-level issues in the crate; not introduced by this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62e9f695-2b86-4adb-b5c3-3d14511297dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62e9f695-2b86-4adb-b5c3-3d14511297dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

