### PR TITLE
fix: pass t1512 rev-parse disambiguation tests

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -447,7 +447,7 @@ t1508-at-combinations	t1	yes	35	22	13	false	ok	0
 t1509-root-work-tree	t1	yes	0	0	0	false	ok	0
 t1510-repo-setup	t1	yes	109	105	4	false	ok	0
 t1511-rev-parse-caret	t1	yes	17	11	6	false	ok	0
-t1512-rev-parse-disambiguation	t1	yes	38	34	4	false	ok	0
+t1512-rev-parse-disambiguation	t1	yes	38	38	0	true	ok	0
 t1513-rev-parse-prefix	t1	yes	11	9	2	false	ok	0
 t1514-rev-parse-push	t1	yes	9	8	1	false	ok	0
 t1515-rev-parse-outside-repo	t1	yes	4	4	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79% of harness tests passing (35,676 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79% of harness tests passing (35,676 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T19:50:07+00:00" class="gen-time" title="2026-04-09 19:50 UTC">2026-04-09 19:50 UTC</time> · <a href="https://github.com/schacon/grit/commit/5bf62c619e11069427ad31d399f307f351a03ad7" style="color:#58a6ff">5bf62c6</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,676</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>758 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -197,11 +197,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">275/368 files · 8 skipped · 11,694/12,747 tests</span>
+        <span class="group-meta">276/368 files · 8 skipped · 11,698/12,747 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:91.7%"></div></div>
-        <span class="group-pct pct-green">91.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:91.8%"></div></div>
+        <span class="group-pct pct-green">91.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t2">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35676 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,676 / 45,142 tests · 1,405 files in scope · 758 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:50:07+00:00" class="gen-time" title="2026-04-09 19:50 UTC">2026-04-09 19:50 UTC</time> · <a href="https://github.com/schacon/grit/commit/5bf62c619e11069427ad31d399f307f351a03ad7" style="color:#58a6ff">5bf62c6</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,676</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -4627,14 +4627,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:64.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="38" data-passed="34">
+<tr class="" data-group="t1" data-tests="38" data-passed="38" data-full-pass="1">
   <td class="mono">t1512-rev-parse-disambiguation</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">38</td>
-  <td class="right">34</td>
+  <td class="right">38</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:89.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="11" data-passed="9">

--- a/grit-lib/src/rev_parse.rs
+++ b/grit-lib/src/rev_parse.rs
@@ -12,7 +12,7 @@ use std::path::{Component, Path, PathBuf};
 
 use regex::Regex;
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use crate::config::ConfigSet;
 use crate::error::{Error, Result};
@@ -1327,6 +1327,42 @@ fn read_core_disambiguate(repo: &Repository) -> Option<&'static str> {
     }
 }
 
+/// When `spec` resolved as an abbreviated object id, warn if `refs/heads/<spec>` exists and
+/// points at a different object (Git: `rev-parse` warns "refname ... is ambiguous").
+fn warn_if_branch_refname_collides_with_abbrev_hex(
+    repo: &Repository,
+    spec: &str,
+    object_oid: ObjectId,
+) {
+    if spec.len() >= 40 {
+        return;
+    }
+    let branch_ref = format!("refs/heads/{spec}");
+    let Ok(ref_oid) = refs::resolve_ref(&repo.git_dir, &branch_ref) else {
+        return;
+    };
+    if ref_oid != object_oid {
+        eprintln!("warning: refname '{spec}' is ambiguous.");
+    }
+}
+
+/// When a hex-like `spec` resolved as a ref under `refs/heads/` or `refs/tags/`, warn if that name
+/// also matches object(s) in the ODB (Git: `warning: refname 'abc' is ambiguous.`).
+fn warn_if_hex_ref_collides_with_objects(repo: &Repository, spec: &str, ref_oid: ObjectId) {
+    if spec.len() >= 40 || !is_hex_prefix(spec) {
+        return;
+    }
+    let Ok(matches) = find_abbrev_matches(repo, spec) else {
+        return;
+    };
+    if matches.is_empty() {
+        return;
+    }
+    if matches.len() > 1 || matches[0] != ref_oid {
+        eprintln!("warning: refname '{spec}' is ambiguous.");
+    }
+}
+
 fn disambiguate_hex_by_peel(
     repo: &Repository,
     spec: &str,
@@ -1359,6 +1395,23 @@ fn disambiguate_hex_by_peel(
         let mut sorted = filtered;
         sorted.sort_by_key(|o| o.to_hex());
         return Ok(sorted[0]);
+    }
+    // `^{commit}`: multiple objects may peel to the same commit (e.g. HEAD, tag, peeled tree-ish).
+    // If exactly one distinct commit is produced, pick a deterministic representative (t1512).
+    if peel == "commit" {
+        let mut by_peeled: HashMap<ObjectId, Vec<ObjectId>> = HashMap::new();
+        for oid in &filtered {
+            if let Ok(c) = apply_peel(repo, *oid, Some("commit")) {
+                by_peeled.entry(c).or_default().push(*oid);
+            }
+        }
+        if by_peeled.len() == 1 {
+            let mut reps: Vec<ObjectId> = by_peeled.into_values().next().unwrap_or_default();
+            reps.sort_by_key(|o| o.to_hex());
+            if let Some(oid) = reps.first().copied() {
+                return Ok(oid);
+            }
+        }
     }
     Err(Error::InvalidRef(format!(
         "short object ID {spec} is ambiguous"
@@ -1632,29 +1685,44 @@ fn resolve_base(
     if is_hex_prefix(spec) && spec.len() < 40 {
         let tag_ref = format!("refs/tags/{spec}");
         if let Ok(oid) = refs::resolve_ref(&repo.git_dir, &tag_ref) {
+            warn_if_hex_ref_collides_with_objects(repo, spec, oid);
             return Ok(oid);
         }
         let branch_ref = format!("refs/heads/{spec}");
         if let Ok(oid) = refs::resolve_ref(&repo.git_dir, &branch_ref) {
+            warn_if_hex_ref_collides_with_objects(repo, spec, oid);
             return Ok(oid);
         }
     }
 
     if is_hex_prefix(spec) {
         let matches = find_abbrev_matches(repo, spec)?;
-        if matches.len() == 1 {
-            return Ok(matches[0]);
-        }
-        if matches.len() > 1 {
+        if matches.is_empty() {
+            // Git treats 4+ hex digits as an abbreviated object id lookup first. When nothing
+            // matches, fail as unknown revision — do not fall through to index DWIM (which would
+            // incorrectly report "ambiguous argument" for paths like `000000000`).
+            if (4..40).contains(&spec.len()) {
+                return Err(Error::ObjectNotFound(spec.to_owned()));
+            }
+        } else if matches.len() == 1 {
+            let oid = matches[0];
+            warn_if_branch_refname_collides_with_abbrev_hex(repo, spec, oid);
+            return Ok(oid);
+        } else if matches.len() > 1 {
             if commit_only_hex {
-                return disambiguate_hex_by_peel(repo, spec, &matches, "commit");
+                let oid = disambiguate_hex_by_peel(repo, spec, &matches, "commit")?;
+                warn_if_branch_refname_collides_with_abbrev_hex(repo, spec, oid);
+                return Ok(oid);
             }
             if let Some(p) = peel_for_disambig {
-                return disambiguate_hex_by_peel(repo, spec, &matches, p);
+                let oid = disambiguate_hex_by_peel(repo, spec, &matches, p)?;
+                warn_if_branch_refname_collides_with_abbrev_hex(repo, spec, oid);
+                return Ok(oid);
             }
             if use_disambiguate_config {
                 if let Some(pref) = read_core_disambiguate(repo) {
                     if let Ok(oid) = disambiguate_hex_by_peel(repo, spec, &matches, pref) {
+                        warn_if_branch_refname_collides_with_abbrev_hex(repo, spec, oid);
                         return Ok(oid);
                     }
                 }

--- a/grit/src/bundle_uri_test_tool.rs
+++ b/grit/src/bundle_uri_test_tool.rs
@@ -6,7 +6,7 @@ use std::fs;
 use std::io::{BufRead, Write};
 use std::path::Path;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 
 use crate::git_path;
 

--- a/grit/src/commands/apply.rs
+++ b/grit/src/commands/apply.rs
@@ -20,7 +20,7 @@ use grit_lib::index::{Index, IndexEntry};
 use grit_lib::objects::ObjectKind;
 use grit_lib::quote_path::quote_c_style;
 use grit_lib::repo::Repository;
-use grit_lib::rev_parse::resolve_revision;
+use grit_lib::rev_parse::resolve_revision_for_patch_old_blob;
 use grit_lib::ws::{self, WhitespaceGitAttr, WS_BLANK_AT_EOF, WS_DEFAULT_RULE, WS_INCOMPLETE_LINE};
 use regex::Regex;
 use std::borrow::Cow;
@@ -3845,7 +3845,7 @@ fn build_fake_ancestor_file(patches: &[FilePatch], args: &Args, out_path: &Path)
         }
 
         let resolved = if let Some(old_oid) = fp.old_oid.as_deref() {
-            let oid = resolve_revision(&repo, old_oid)
+            let oid = resolve_revision_for_patch_old_blob(&repo, old_oid)
                 .with_context(|| format!("resolving old blob id `{old_oid}` for `{adjusted}`"))?;
             let mode = fp.old_mode.as_deref().map(parse_mode).unwrap_or(0o100644);
             Some((mode, oid))

--- a/grit/src/commands/log.rs
+++ b/grit/src/commands/log.rs
@@ -36,7 +36,8 @@ use grit_lib::rev_list::{
     split_symmetric_diff, OrderingMode, RevListOptions,
 };
 use grit_lib::rev_parse::{
-    reflog_walk_refname, resolve_revision_as_commit, try_parse_double_dot_log_range,
+    peel_to_commit_for_merge_base, reflog_walk_refname, resolve_revision_as_commit,
+    resolve_revision_for_range_end, try_parse_double_dot_log_range,
 };
 use grit_lib::state::{resolve_head, HeadState};
 use regex::{Regex, RegexBuilder};
@@ -5208,15 +5209,22 @@ fn run_symmetric_log(repo: &Repository, args: &Args, _patch_context: usize) -> R
         _ => anyhow::bail!("symmetric revision required"),
     };
 
-    let lhs_oid = grit_lib::rev_parse::resolve_revision(repo, &lhs)
-        .with_context(|| format!("bad revision '{lhs}'"))?;
-    let rhs_oid = grit_lib::rev_parse::resolve_revision(repo, &rhs)
-        .with_context(|| format!("bad revision '{rhs}'"))?;
+    // Symmetric ranges use the same commit-ish disambiguation as two-dot ranges
+    // (`resolve_revision_for_range_end`), not plain `rev-parse` object resolution.
+    let lhs_spec = if lhs.is_empty() { "HEAD" } else { lhs.as_str() };
+    let rhs_spec = if rhs.is_empty() { "HEAD" } else { rhs.as_str() };
+    let lhs_tip = resolve_revision_for_range_end(repo, lhs_spec)
+        .with_context(|| format!("bad revision '{lhs_spec}'"))?;
+    let rhs_tip = resolve_revision_for_range_end(repo, rhs_spec)
+        .with_context(|| format!("bad revision '{rhs_spec}'"))?;
+    let lhs_oid = peel_to_commit_for_merge_base(repo, lhs_tip)?;
+    let rhs_oid = peel_to_commit_for_merge_base(repo, rhs_tip)?;
     let bases = merge_bases(repo, lhs_oid, rhs_oid, args.first_parent)
         .context("failed to compute merge bases for symmetric range")?;
     let negative: Vec<String> = bases.iter().map(|b| b.to_hex()).collect();
 
-    let positive = vec![lhs, rhs];
+    // `rev-list` resolves each positive spec; empty sides mean HEAD (same as parsing above).
+    let positive = vec![lhs_spec.to_owned(), rhs_spec.to_owned()];
     let options = RevListOptions {
         left_right: true,
         left_only: args.left_only,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes `tests/t1512-rev-parse-disambiguation.sh` fully pass (38/38).

## Changes

- **`grit apply --build-fake-ancestor`**: Resolve `index <old>..<new>` old blob IDs with [`resolve_revision_for_patch_old_blob`](grit/src/commands/apply.rs) so ambiguous short hex uses blob disambiguation (matches Git for patch lines).
- **`rev_parse`**: Treat 4–39 hex with zero ODB matches as [`ObjectNotFound`](grit-lib/src/rev_parse.rs) instead of falling through to index DWIM (`fatal: ambiguous argument` for names like `000000000`). Warn when a hex-like ref under `refs/heads/` or `refs/tags/` also matches object abbreviations, and when an abbreviated object id disagrees with `refs/heads/<spec>` (short SHA refname ambiguity). Extend `^{commit}` disambiguation so multiple candidates that all peel to the same commit resolve deterministically.
- **`grit log` symmetric ranges** ([`run_symmetric_log`](grit/src/commands/log.rs)): Resolve endpoints with [`resolve_revision_for_range_end`](grit-lib/src/rev_parse.rs) + peel to commit (same commit-ish rules as two-dot ranges), and pass `HEAD` for empty sides into `rev-list` so `...0000000000` works.
- **Harness**: Refreshed `data/test-files.csv` and dashboard HTML/SVG after the green run.
- **Clippy**: Dropped unused `bail` import in [`bundle_uri_test_tool.rs`](grit/src/bundle_uri_test_tool.rs).

## Validation

- `./scripts/run-tests.sh t1512-rev-parse-disambiguation.sh` → 38/38
- `cargo test -p grit-lib --lib`
- `cargo clippy -p grit-lib -p grit-rs --fix --allow-dirty`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2deba64a-e628-40ec-9b28-b607eba36b9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2deba64a-e628-40ec-9b28-b607eba36b9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

