### PR TITLE
fix(rebase): autosquash and squash message handling (t3415 25/28)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -348,7 +348,7 @@ commit → check it off → move on.
 - [ ] `t3426-rebase-submodule` ██░░░░░░░░░░░░░░░░░░ 4/29 (25 left) — rebase can handle submodules
 - [ ] `t3452-history-split` ░░░░░░░░░░░░░░░░░░░░ 0/25 (25 left) — tests for git-history split subcommand
 - [ ] `t3203-branch-output` ███████░░░░░░░░░░░░░ 15/41 (26 left) — git branch display tests
-- [ ] `t3415-rebase-autosquash` █░░░░░░░░░░░░░░░░░░░ 2/28 (26 left) — auto squash
+- [~] `t3415-rebase-autosquash` █████████████████░░░ 25/28 (3 left) — auto squash (remaining: abort-last-squash, fixup-chain message order)
 - [ ] `t3321-notes-stripspace` ░░░░░░░░░░░░░░░░░░░░ 1/27 (26 left) — Test commit notes with stripspace behavior
 - [x] `t3406-rebase-message` — messages from rebase operation (32/32)
 - [ ] `t3309-notes-merge-auto-resolve` █░░░░░░░░░░░░░░░░░░░ 2/31 (29 left) — Test notes merging with auto-resolving strategies

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -602,7 +602,7 @@ t3408-rebase-multi-line	t3	yes	2	2	0	true	ok	0
 t3409-rebase-environ	t3	yes	3	3	0	true	ok	0
 t3412-rebase-root	t3	yes	25	25	0	true	ok	0
 t3413-rebase-hook	t3	yes	15	9	6	false	ok	0
-t3415-rebase-autosquash	t3	yes	28	23	5	false	ok	0
+t3415-rebase-autosquash	t3	yes	28	25	3	false	ok	0
 t3416-rebase-onto-threedots	t3	yes	18	12	6	false	ok	0
 t3417-rebase-whitespace-fix	t3	yes	4	4	0	true	ok	0
 t3418-rebase-continue	t3	yes	30	6	24	false	ok	0
@@ -1193,7 +1193,7 @@ t7111-reset-table	t7	yes	42	34	8	false	ok	0
 t7112-reset-submodule	t7	yes	76	24	52	false	ok	0
 t7113-post-index-change-hook	t7	yes	4	1	3	false	ok	0
 t7201-co	t7	yes	46	17	29	false	ok	0
-t7300-clean	t7	yes	53	52	1	false	ok	2
+t7300-clean	t7	yes	53	52	1	false	ok	0
 t7301-clean-interactive	t7	yes	23	8	15	false	ok	0
 t7400-submodule-basic	t7	yes	124	51	73	false	ok	0
 t7401-submodule-summary	t7	yes	25	6	19	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="78.8% of harness tests passing (35,530 / 45,112).">
+<meta property="og:description" content="78.8% of harness tests passing (35,535 / 45,112).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="78.8% of harness tests passing (35,530 / 45,112).">
+<meta name="twitter:description" content="78.8% of harness tests passing (35,535 / 45,112).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T16:30:42+00:00" class="gen-time" title="2026-04-09 16:30 UTC">2026-04-09 16:30 UTC</time> · <a href="https://github.com/schacon/grit/commit/7cfe71677eb58eb382a548e40cc0ad9e587d560d" style="color:#58a6ff">7cfe716</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T19:56:32+00:00" class="gen-time" title="2026-04-09 19:56 UTC">2026-04-09 19:56 UTC</time> · <a href="https://github.com/schacon/grit/commit/cbee7d7f221f5433fc3bf9357584a1381a064ebb" style="color:#58a6ff">cbee7d7</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,7 +157,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,530</div>
+      <div class="summary-big-val">35,535</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>746 files fully passing</span>
+    <span>748 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -219,11 +219,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">54/141 files · 2 skipped · 3,954/5,369 tests</span>
+        <span class="group-meta">54/141 files · 2 skipped · 3,956/5,369 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:73.6%"></div></div>
-        <span class="group-pct pct-blue">73.6%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:73.7%"></div></div>
+        <span class="group-pct pct-blue">73.7%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">46/126 files · 11 skipped · 2,475/3,614 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,478/3,614 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.5%"></div></div>
-        <span class="group-pct pct-blue">68.5%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.6%"></div></div>
+        <span class="group-pct pct-blue">68.6%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35530 of 45112 tests passing across 1405 harness files (78.8% pass rate).</desc>
+  <desc id="svg-desc">35535 of 45112 tests passing across 1405 harness files (78.8% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.8% pass rate · 35,530 / 45,112 tests · 1,405 files in scope · 746 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">78.8% pass rate · 35,535 / 45,112 tests · 1,405 files in scope · 748 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="552" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T16:30:42+00:00" class="gen-time" title="2026-04-09 16:30 UTC">2026-04-09 16:30 UTC</time> · <a href="https://github.com/schacon/grit/commit/7cfe71677eb58eb382a548e40cc0ad9e587d560d" style="color:#58a6ff">7cfe716</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:56:32+00:00" class="gen-time" title="2026-04-09 19:56 UTC">2026-04-09 19:56 UTC</time> · <a href="https://github.com/schacon/grit/commit/cbee7d7f221f5433fc3bf9357584a1381a064ebb" style="color:#58a6ff">cbee7d7</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,112</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,530</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,535</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">78.8%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -6177,14 +6177,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:60.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="28" data-passed="23">
+<tr class="" data-group="t3" data-tests="28" data-passed="25">
   <td class="mono">t3415-rebase-autosquash</td>
   <td>t3</td>
   <td></td>
   <td class="right">28</td>
-  <td class="right">23</td>
+  <td class="right">25</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:82.1%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:89.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="18" data-passed="12">
@@ -11717,14 +11717,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:80.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="11" data-passed="10">
+<tr class="" data-group="t7" data-tests="11" data-passed="11" data-full-pass="1">
   <td class="mono">t7012-skip-worktree-writing</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">11</td>
-  <td class="right">10</td>
+  <td class="right">11</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">6</td>
 </tr>
 <tr class="" data-group="t7" data-tests="26" data-passed="26" data-full-pass="1">
@@ -12095,7 +12095,7 @@ tr.row-skip td { opacity: 0.65; }
   <td class="right">52</td>
   <td class="right">ok</td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.1%"></div></div></td>
-  <td class="right small">2</td>
+  <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="23" data-passed="8">
   <td class="mono">t7301-clean-interactive</td>
@@ -12917,14 +12917,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.4%"></div></div></td>
   <td class="right small">7</td>
 </tr>
-<tr class="" data-group="t7" data-tests="22" data-passed="20">
+<tr class="" data-group="t7" data-tests="22" data-passed="22" data-full-pass="1">
   <td class="mono">t7815-grep-binary</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">22</td>
-  <td class="right">20</td>
+  <td class="right">22</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="145" data-passed="145" data-full-pass="1">

--- a/grit/src/commands/rebase.rs
+++ b/grit/src/commands/rebase.rs
@@ -552,16 +552,18 @@ fn commit_subject_single_line(message: &str) -> String {
     out
 }
 
+/// Strips one `fixup! ` / `amend! ` / `squash! ` prefix (bang + space), matching Git's
+/// `skip_fixupish` in `sequencer.c` (`todo_list_rearrange_squash`).
 fn skip_fixupish_prefix(subject: &str) -> Option<&str> {
     let s = subject.trim_start();
-    if let Some(rest) = s.strip_prefix("fixup!") {
-        return Some(rest.trim_start());
+    if let Some(rest) = s.strip_prefix("fixup! ") {
+        return Some(rest);
     }
-    if let Some(rest) = s.strip_prefix("amend!") {
-        return Some(rest.trim_start());
+    if let Some(rest) = s.strip_prefix("amend! ") {
+        return Some(rest);
     }
-    if let Some(rest) = s.strip_prefix("squash!") {
-        return Some(rest.trim_start());
+    if let Some(rest) = s.strip_prefix("squash! ") {
+        return Some(rest);
     }
     None
 }
@@ -732,6 +734,8 @@ fn rearrange_autosquash(
         }
         if let Some(i2) = target_idx {
             rearranged = true;
+            // Git uses `starts_with(subject, "fixup!")` / `"amend!"` vs else → squash, so
+            // `squash! squash! …` becomes squash commands (not fixup).
             let t = subj.trim_start();
             cmds[i] = if t.starts_with("fixup!") || t.starts_with("amend!") {
                 RebaseTodoCmd::Fixup
@@ -1081,8 +1085,27 @@ fn next_non_fixup_index(
     None
 }
 
+fn rebase_todo_first_word(line: &str) -> Option<&str> {
+    let t = line.trim();
+    if t.is_empty() || t.starts_with('#') {
+        return None;
+    }
+    t.split_whitespace().next()
+}
+
+fn rebase_todo_word_is_fixup_or_squash(word: &str) -> bool {
+    matches!(
+        word.to_ascii_lowercase().as_str(),
+        "fixup" | "f" | "squash" | "s"
+    )
+}
+
+/// `is_final_fixup`: Git `sequencer.c` when `rebase -k` / `keep-empty` is in effect (`-ki` cases in
+/// t3415). Otherwise a hybrid: Git's trailing fixup/squash scan plus grit's rule that a later
+/// non-fixup pick blocks finalization (non-`-k` `--autosquash` / `-i` autosquash).
 fn is_final_fixup_in_todo(
     repo: &Repository,
+    rb_dir: &Path,
     todo_lines: &[&str],
     idx: usize,
     interactive: bool,
@@ -1096,6 +1119,32 @@ fn is_final_fixup_in_todo(
     if !matches!(cmd, RebaseTodoCmd::Fixup | RebaseTodoCmd::Squash) {
         return false;
     }
+
+    let mut j = idx + 1;
+    while j < todo_lines.len() {
+        let t = todo_lines[j].trim();
+        if t.is_empty() || t.starts_with('#') {
+            j += 1;
+            continue;
+        }
+        let Some(w) = rebase_todo_first_word(todo_lines[j]) else {
+            j += 1;
+            continue;
+        };
+        if w.eq_ignore_ascii_case("noop") {
+            j += 1;
+            continue;
+        }
+        if rebase_todo_word_is_fixup_or_squash(w) {
+            return false;
+        }
+        break;
+    }
+
+    if rebase_keep_empty(rb_dir) {
+        return true;
+    }
+
     next_non_fixup_index(repo, todo_lines, idx, interactive).is_none()
 }
 
@@ -1744,24 +1793,28 @@ fn run_shell_editor(editor: &str, path: &Path) -> Result<std::process::ExitStatu
             .arg(format!("{} \"$@\"", editor))
             .arg(editor)
             .arg(path)
+            .stdin(std::process::Stdio::inherit())
+            .stdout(std::process::Stdio::inherit())
+            .stderr(std::process::Stdio::inherit())
             .status()
     }
     .context("failed to run editor")?;
     Ok(status)
 }
 
-/// Opens `GIT_EDITOR` on `COMMIT_EDITMSG` for an interactive reword during `rebase -i`.
+/// Opens `GIT_EDITOR` on `COMMIT_EDITMSG` after seeding it and running `prepare-commit-msg`.
 ///
-/// Matches Git's sequencer path: seed the file, run `prepare-commit-msg` with source `reword`,
-/// then invoke the commit editor. Returns the edited message text (before final cleanup).
-fn run_commit_editor_for_reword(
+/// `prepare_source` is the hook's second argument (`reword`, `squash`, `message`, …), matching
+/// Git's `git commit -e` path during interactive rebase.
+fn run_commit_editor_for_template(
     repo: &Repository,
     git_dir: &Path,
     template: &str,
+    prepare_source: &str,
 ) -> Result<String> {
     let editmsg = git_dir.join("COMMIT_EDITMSG");
     fs::write(&editmsg, template)?;
-    run_prepare_commit_msg_hook(repo, &editmsg, "reword")?;
+    run_prepare_commit_msg_hook(repo, &editmsg, prepare_source)?;
     let config = ConfigSet::load(Some(git_dir), true)?;
     let editor = git_editor_cmd(&config)?;
     let status = run_shell_editor(&editor, &editmsg)?;
@@ -1769,6 +1822,15 @@ fn run_commit_editor_for_reword(
         bail!("there was a problem with the editor");
     }
     fs::read_to_string(&editmsg).context("read COMMIT_EDITMSG after editor")
+}
+
+/// Opens `GIT_EDITOR` on `COMMIT_EDITMSG` for an interactive reword during `rebase -i`.
+fn run_commit_editor_for_reword(
+    repo: &Repository,
+    git_dir: &Path,
+    template: &str,
+) -> Result<String> {
+    run_commit_editor_for_template(repo, git_dir, template, "reword")
 }
 
 fn worktree_matches_head(repo: &Repository, git_dir: &Path) -> Result<bool> {
@@ -1903,6 +1965,10 @@ fn do_rebase(args: Args, pre_rebase_hook_second: Option<String>) -> Result<()> {
         .unwrap_or(false);
     let want_autosquash =
         (args.autosquash || (config_autosquash && args.interactive)) && !args.no_autosquash;
+
+    if want_autosquash {
+        validate_rebase_instruction_format(&config)?;
+    }
 
     validate_apply_merge_backend_combo(&args, &config, want_autosquash)?;
 
@@ -2100,7 +2166,6 @@ fn do_rebase(args: Args, pre_rebase_hook_second: Option<String>) -> Result<()> {
         }
         (edited_lines, true)
     } else if want_autosquash {
-        validate_rebase_instruction_format(&config)?;
         let entries = rearrange_autosquash(&repo, commits)?;
         (rebase_state_todo_lines(&repo, &config, &entries)?, false)
     } else {
@@ -2734,9 +2799,10 @@ fn replay_remaining(
                         exec_cmd
                     );
                     let remaining: Vec<&str> = todo[i + 1..].to_vec();
+                    let n = remaining.iter().filter(|l| !l.trim().is_empty()).count();
                     fs::write(rb_dir.join("todo"), remaining.join("\n") + "\n")?;
                     fs::write(rb_dir.join("msgnum"), "1")?;
-                    fs::write(rb_dir.join("end"), remaining.len().to_string())?;
+                    fs::write(rb_dir.join("end"), n.to_string())?;
                     std::process::exit(code);
                 }
             }
@@ -2844,7 +2910,8 @@ fn replay_remaining(
                     .unwrap_or_else(diff::zero_oid);
 
                 let pick_backend = load_rebase_backend(rb_dir);
-                let final_fixup = is_final_fixup_in_todo(repo, &todo, i, rebase_interactive);
+                let final_fixup =
+                    is_final_fixup_in_todo(repo, rb_dir, &todo, i, rebase_interactive);
                 let next_after_this =
                     peek_next_rebase_flush_hint(repo, &todo, i + 1, rebase_interactive);
                 match cherry_pick_for_rebase(
@@ -2875,9 +2942,10 @@ fn replay_remaining(
                         );
 
                         let remaining: Vec<&str> = todo[i + 1..].to_vec();
+                        let n = remaining.iter().filter(|l| !l.trim().is_empty()).count();
                         fs::write(rb_dir.join("todo"), remaining.join("\n") + "\n")?;
                         fs::write(rb_dir.join("msgnum"), "1")?;
-                        fs::write(rb_dir.join("end"), remaining.len().to_string())?;
+                        fs::write(rb_dir.join("end"), n.to_string())?;
                         let _ = fs::write(
                             rb_dir.join("stopped-sha"),
                             format!("{}\n", commit_oid.to_hex()),
@@ -2886,11 +2954,12 @@ fn replay_remaining(
                         std::process::exit(0);
                     }
                     Err(_e) => {
-                        let remaining: Vec<&str> = todo[i + 1..].to_vec();
+                        let remaining: Vec<&str> = todo[i..].to_vec();
+                        let n = remaining.iter().filter(|l| !l.trim().is_empty()).count();
                         fs::write(rb_dir.join("todo"), remaining.join("\n") + "\n")?;
                         fs::write(rb_dir.join("msgnum"), "1")?;
-                        fs::write(rb_dir.join("end"), remaining.len().to_string())?;
-                        let ff = is_final_fixup_in_todo(repo, &todo, i, rebase_interactive);
+                        fs::write(rb_dir.join("end"), n.to_string())?;
+                        let ff = is_final_fixup_in_todo(repo, rb_dir, &todo, i, rebase_interactive);
                         fs::write(
                             rb_dir.join("current-final-fixup"),
                             if ff { "1\n" } else { "0\n" },
@@ -2938,7 +3007,8 @@ fn replay_remaining(
                     .unwrap_or_else(diff::zero_oid);
 
                 let pick_backend = load_rebase_backend(rb_dir);
-                let final_fixup = is_final_fixup_in_todo(repo, &todo, i, rebase_interactive);
+                let final_fixup =
+                    is_final_fixup_in_todo(repo, rb_dir, &todo, i, rebase_interactive);
                 let next_after_this =
                     peek_next_rebase_flush_hint(repo, &todo, i + 1, rebase_interactive);
                 match cherry_pick_for_rebase(
@@ -2991,20 +3061,23 @@ fn replay_remaining(
                                         global_exec
                                     );
                                     let remaining: Vec<&str> = todo[i + 1..].to_vec();
+                                    let n =
+                                        remaining.iter().filter(|l| !l.trim().is_empty()).count();
                                     fs::write(rb_dir.join("todo"), remaining.join("\n") + "\n")?;
                                     fs::write(rb_dir.join("msgnum"), "1")?;
-                                    fs::write(rb_dir.join("end"), remaining.len().to_string())?;
+                                    fs::write(rb_dir.join("end"), n.to_string())?;
                                     std::process::exit(code);
                                 }
                             }
                         }
                     }
                     Err(_e) => {
-                        let remaining: Vec<&str> = todo[i + 1..].to_vec();
+                        let remaining: Vec<&str> = todo[i..].to_vec();
+                        let n = remaining.iter().filter(|l| !l.trim().is_empty()).count();
                         fs::write(rb_dir.join("todo"), remaining.join("\n") + "\n")?;
                         fs::write(rb_dir.join("msgnum"), "1")?;
-                        fs::write(rb_dir.join("end"), remaining.len().to_string())?;
-                        let ff = is_final_fixup_in_todo(repo, &todo, i, rebase_interactive);
+                        fs::write(rb_dir.join("end"), n.to_string())?;
+                        let ff = is_final_fixup_in_todo(repo, rb_dir, &todo, i, rebase_interactive);
                         fs::write(
                             rb_dir.join("current-final-fixup"),
                             if ff { "1\n" } else { "0\n" },
@@ -3285,12 +3358,17 @@ fn cherry_pick_for_rebase(
         let amend_parent = hc.parents.first().copied().unwrap_or(head_oid);
 
         if todo_cmd == RebaseTodoCmd::Fixup && !final_fixup {
+            // `message-fixup` holds the non-comment message Git would pass for intermediate
+            // fixups; run the hook and use `rebase_commit_msg_cleanup` so `prepare-commit-msg`
+            // can append lines that must survive when `commit.cleanup` is unset (t3415).
             let fixup_path = rb_dir.join("message-fixup");
-            let msg = if fixup_path.exists() {
+            let tmpl = if fixup_path.exists() {
                 fs::read_to_string(&fixup_path)?
             } else {
                 hc.message.clone()
             };
+            let raw = commit_message_after_prepare_hook(repo, git_dir, &tmpl, "message")?;
+            let cleaned = apply_commit_msg_cleanup(&raw, rebase_commit_msg_cleanup(&config));
             let new_oid = commit_from_merged_index(
                 repo,
                 git_dir,
@@ -3298,7 +3376,7 @@ fn cherry_pick_for_rebase(
                 &config,
                 vec![amend_parent],
                 &hc.author,
-                msg,
+                cleaned,
             )?;
             fs::write(git_dir.join("HEAD"), format!("{}\n", new_oid.to_hex()))?;
             record_rebase_in_rewritten_pending(git_dir, rb_dir, commit_oid, next_after_line)?;
@@ -3326,15 +3404,15 @@ fn cherry_pick_for_rebase(
 
         if todo_cmd == RebaseTodoCmd::Fixup {
             let fixup_path = rb_dir.join("message-fixup");
-            let template = if fixup_path.exists() {
-                fs::read_to_string(&fixup_path)?
+            let cleaned = if fixup_path.exists() {
+                let tmpl = fs::read_to_string(&fixup_path)?;
+                let after_editor = run_commit_editor_for_template(repo, git_dir, &tmpl, "squash")?;
+                apply_commit_msg_cleanup(&after_editor, rebase_commit_msg_cleanup(&config))
             } else {
-                let subj = hc.message.lines().next().unwrap_or("");
-                let body = message_body_after_subject(&hc.message);
-                format!("{subj}\n{body}")
+                let tmpl = fs::read_to_string(rb_dir.join("message-squash"))?;
+                let after_editor = run_commit_editor_for_template(repo, git_dir, &tmpl, "squash")?;
+                apply_commit_msg_cleanup(&after_editor, rebase_commit_msg_cleanup(&config))
             };
-            let raw = commit_message_after_prepare_hook(repo, git_dir, &template, "squash")?;
-            let cleaned = apply_commit_msg_cleanup(&raw, rebase_commit_msg_cleanup(&config));
             let new_oid = commit_from_merged_index(
                 repo,
                 git_dir,
@@ -3354,14 +3432,16 @@ fn cherry_pick_for_rebase(
 
         let squash_path = rb_dir.join("message-squash");
         let fixup_path = rb_dir.join("message-fixup");
-        let tmpl = if fixup_path.exists() {
-            fs::read_to_string(&fixup_path)?
+        let cleaned = if fixup_path.exists() {
+            let tmpl = fs::read_to_string(&fixup_path)?;
+            let after_editor = run_commit_editor_for_template(repo, git_dir, &tmpl, "squash")?;
+            apply_commit_msg_cleanup(&after_editor, rebase_commit_msg_cleanup(&config))
         } else {
-            fs::read_to_string(&squash_path)?
+            let tmpl = fs::read_to_string(&squash_path)?;
+            let after_editor = run_commit_editor_for_template(repo, git_dir, &tmpl, "squash")?;
+            apply_commit_msg_cleanup(&after_editor, rebase_commit_msg_cleanup(&config))
         };
         let _ = fs::remove_file(git_dir.join("MERGE_MSG"));
-        let raw = commit_message_after_prepare_hook(repo, git_dir, &tmpl, "squash")?;
-        let cleaned = apply_commit_msg_cleanup(&raw, rebase_commit_msg_cleanup(&config));
         let new_oid = commit_from_merged_index(
             repo,
             git_dir,
@@ -3833,13 +3913,13 @@ fn do_continue() -> Result<()> {
 
         if todo_cmd == RebaseTodoCmd::Fixup && !final_fixup {
             let fixup_path = rb_dir.join("message-fixup");
-            let msg = if git_dir.join("MERGE_MSG").exists() {
-                fs::read_to_string(git_dir.join("MERGE_MSG"))?
-            } else if fixup_path.exists() {
+            let tmpl = if fixup_path.exists() {
                 fs::read_to_string(&fixup_path)?
             } else {
                 hc.message.clone()
             };
+            let raw = commit_message_after_prepare_hook(&repo, git_dir, &tmpl, "message")?;
+            let cleaned = apply_commit_msg_cleanup(&raw, rebase_commit_msg_cleanup(&config));
             commit_from_merged_index(
                 &repo,
                 git_dir,
@@ -3847,7 +3927,7 @@ fn do_continue() -> Result<()> {
                 &config,
                 vec![amend_parent],
                 &hc.author,
-                msg,
+                cleaned,
             )?
         } else if todo_cmd == RebaseTodoCmd::Squash && !final_fixup {
             let tmpl = fs::read_to_string(rb_dir.join("message-squash"))?;
@@ -3864,15 +3944,15 @@ fn do_continue() -> Result<()> {
             )?
         } else if todo_cmd == RebaseTodoCmd::Fixup {
             let fixup_path = rb_dir.join("message-fixup");
-            let template = if fixup_path.exists() {
-                fs::read_to_string(&fixup_path)?
+            let cleaned = if fixup_path.exists() {
+                let tmpl = fs::read_to_string(&fixup_path)?;
+                let after_editor = run_commit_editor_for_template(&repo, git_dir, &tmpl, "squash")?;
+                apply_commit_msg_cleanup(&after_editor, rebase_commit_msg_cleanup(&config))
             } else {
-                let subj = hc.message.lines().next().unwrap_or("");
-                let body = message_body_after_subject(&hc.message);
-                format!("{subj}\n{body}")
+                let tmpl = fs::read_to_string(rb_dir.join("message-squash"))?;
+                let after_editor = run_commit_editor_for_template(&repo, git_dir, &tmpl, "squash")?;
+                apply_commit_msg_cleanup(&after_editor, rebase_commit_msg_cleanup(&config))
             };
-            let raw = commit_message_after_prepare_hook(&repo, git_dir, &template, "squash")?;
-            let cleaned = apply_commit_msg_cleanup(&raw, rebase_commit_msg_cleanup(&config));
             let oid = commit_from_merged_index(
                 &repo,
                 git_dir,
@@ -3887,13 +3967,15 @@ fn do_continue() -> Result<()> {
         } else {
             let squash_path = rb_dir.join("message-squash");
             let fixup_path = rb_dir.join("message-fixup");
-            let tmpl = if fixup_path.exists() {
-                fs::read_to_string(&fixup_path)?
+            let cleaned = if fixup_path.exists() {
+                let tmpl = fs::read_to_string(&fixup_path)?;
+                let after_editor = run_commit_editor_for_template(&repo, git_dir, &tmpl, "squash")?;
+                apply_commit_msg_cleanup(&after_editor, rebase_commit_msg_cleanup(&config))
             } else {
-                fs::read_to_string(&squash_path)?
+                let tmpl = fs::read_to_string(&squash_path)?;
+                let after_editor = run_commit_editor_for_template(&repo, git_dir, &tmpl, "squash")?;
+                apply_commit_msg_cleanup(&after_editor, rebase_commit_msg_cleanup(&config))
             };
-            let raw = commit_message_after_prepare_hook(&repo, git_dir, &tmpl, "squash")?;
-            let cleaned = apply_commit_msg_cleanup(&raw, rebase_commit_msg_cleanup(&config));
             let oid = commit_from_merged_index(
                 &repo,
                 git_dir,
@@ -4055,9 +4137,26 @@ fn do_skip() -> Result<()> {
         }
     }
 
-    // Advance past the current commit in the todo list
-    // (replay_remaining reads todo and msgnum, so just advance msgnum or trim todo)
-    // The todo was already trimmed when conflicts happened, so just continue
+    if interactive_skip {
+        let todo_raw = fs::read_to_string(rb_dir.join("todo"))?;
+        let mut lines: Vec<&str> = todo_raw.lines().collect();
+        if let Some(pos) = lines.iter().position(|l| {
+            let t = l.trim();
+            !t.is_empty() && !t.starts_with('#')
+        }) {
+            lines.remove(pos);
+            let new_todo = if lines.is_empty() {
+                String::new()
+            } else {
+                lines.join("\n") + "\n"
+            };
+            let n = lines.iter().filter(|l| !l.trim().is_empty()).count();
+            fs::write(rb_dir.join("todo"), new_todo)?;
+            fs::write(rb_dir.join("end"), n.to_string())?;
+        }
+        fs::write(rb_dir.join("msgnum"), "1")?;
+    }
+
     replay_remaining(
         &repo,
         &rb_dir,

--- a/logs/2026-04-09_t3415-rebase-autosquash.md
+++ b/logs/2026-04-09_t3415-rebase-autosquash.md
@@ -1,0 +1,22 @@
+# t3415-rebase-autosquash (2026-04-09)
+
+## Result
+
+- Harness: **25/28** passing (`./scripts/run-tests.sh t3415-rebase-autosquash.sh`).
+- Remaining failures: **abort last squash** (26), **fixup a fixup** (27).
+
+## Rust changes (`grit/src/commands/rebase.rs`)
+
+- Autosquash: `skip_fixupish_prefix` matches Git (`fixup! ` / `squash! ` / `amend! ` with space); command type uses `starts_with("fixup!")` / `amend!` vs squash (fixes `squash! squash!`).
+- `is_final_fixup_in_todo`: hybrid — Git-style scan for trailing fixup/squash after skipping `noop`; when `rebase-merge/keep-empty` exists (`-k`), final after that scan; else also require `next_non_fixup_index` absent (preserves non-`-k` autosquash message folding).
+- Squash/final fixup: run commit editor for `message-fixup` path too (Git `commit -e`); `run_commit_editor_for_template` + `run_commit_editor_for_reword` wrapper.
+- Intermediate fixup: `message-fixup` + `prepare-commit-msg` + `rebase_commit_msg_cleanup` (t3415 `commit.cleanup` / hook appends).
+- `replay_remaining`: on cherry-pick failure, keep current line in `todo` (`todo[i..]`); fix `end` to count non-empty lines when trimming todo after exec/global-exec failure.
+- `do_skip`: when `interactive` marker present, drop first non-comment todo line before `replay_remaining`.
+- `run_shell_editor`: inherit stdin/stdout/stderr for nested `sh -c` editor.
+- `do_rebase`: validate `rebase.instructionFormat` when autosquash requested; `run_interactive_rebase` validates when autosquash rearranges inside `-i`.
+
+## Follow-up (26–27)
+
+- **26**: Final squash with failing `core.editor` must leave rebase stopped, allow amend + `rebase --skip` without completing the squash chain incorrectly.
+- **27**: Folded message for chained squashes onto same empty tree should include **XZWY** (likely final-fixup / empty-merge / message accumulation ordering).

--- a/progress.md
+++ b/progress.md
@@ -7,14 +7,15 @@
 | Status      | Count |
 |-------------|-------|
 | Completed   |   315 |
-| In progress |     5 |
-| Remaining   |   450 |
+| In progress |     6 |
+| Remaining   |   449 |
 | **Total**   |   770 |
 
-Task lines in `PLAN.md`: 315 completed (`[x]`), 5 in progress (`[~]`), 450 remaining (`[ ]`).
+Task lines in `PLAN.md`: 315 completed (`[x]`), 6 in progress (`[~]`), 449 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t3415-rebase-autosquash` — 25/28 (in progress): autosquash `fixup! ` / `squash! ` prefix parity with Git, hybrid `is_final_fixup` for `-k` vs default autosquash, squash editor + `prepare-commit-msg` paths, replay failure todo/`end` accounting, `rebase.instructionFormat` validation for autosquash; still failing: abort-last-squash (`-ki` editor failure + `--skip`), fixup-chain folded message (`XZWY`)
 - `t5609-clone-branch` — 7/7 tests pass (`clone --branch`: `read_raw_ref` for ref existence so `refs/remotes/origin/HEAD` is set when default branch is packed; reject `--branch` when `refs/heads/<name>` missing on source, including empty repos)
 - `t5802-connect-helper` — 8/8 tests pass (`ext::` sh -c upload-pack argv extraction; `git daemon --inetd` minimal path; streaming unpack zero-byte trees + duplicate `want` dedup; fetch NAK round + tag-following for ext/HTTP; rev-parse `tag^1` peels tags; harness CSV/dashboards refreshed)
 - `t7421-submodule-summary-add` — 5/5 tests pass (`submodule summary`: index↔commit gitlink diff, pathspecs + renamed paths, `rev-parse` first line for abbrev; `submodule update --remote`: local URL fast path updates `refs/remotes/origin/*` + copies objects, stages gitlink in super index)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves `grit rebase` autosquash and interactive squash/fixup handling to align with Git’s `sequencer` behavior for most of `t3415-rebase-autosquash`.

## Changes

- Autosquash subject parsing: require `fixup! ` / `squash! ` / `amend! ` (space after `!`), matching Git’s `skip_fixupish`.
- Fixup vs squash todo command: use `starts_with("fixup!")` / `amend!` vs else squash (fixes `squash! squash!`).
- `is_final_fixup`: hybrid — Git-style scan after skipping `noop`; when `rebase-merge/keep-empty` exists (`-k`), treat as Git final; otherwise require no later non-fixup line (preserves non-`-k` autosquash folding).
- Final squash/fixup: always run the commit editor when using `message-fixup` (Git `commit -e` path); shared `run_commit_editor_for_template`.
- Intermediate fixup: `message-fixup` + `prepare-commit-msg` + `rebase_commit_msg_cleanup` so hook-appended lines survive when `commit.cleanup` is unset.
- `replay_remaining`: on failure, keep the current todo line in `todo`; `end` counts non-empty lines when rewriting todo after exec failures.
- `rebase --skip`: for interactive rebase, drop the first non-comment todo line before continuing.
- `run_shell_editor`: inherit stdio for nested `sh -c` editors.
- Validate `rebase.instructionFormat` when autosquash is active (including inside `run_interactive_rebase` when autosquash rearranges).

## Test status

- `t3415-rebase-autosquash`: **25/28** passing.
- Still failing: **abort last squash** (26), **fixup a fixup** (27).

## Housekeeping

- Refreshed `data/test-files.csv` and dashboards via `./scripts/run-tests.sh t3415-rebase-autosquash.sh`.
- Updated `PLAN.md` / `progress.md` and added `logs/2026-04-09_t3415-rebase-autosquash.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9aee05bc-7a70-4223-bbdc-a9aba3374dfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9aee05bc-7a70-4223-bbdc-a9aba3374dfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

