### PR TITLE
fix: make t5546-receive-limits pass (receive limits on local push)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -588,7 +588,7 @@ commit → check it off → move on.
 - [ ] `t5502-quickfetch` █████░░░░░░░░░░░░░░░ 2/7 (5 left) — test quickfetch from local
 - [x] `t5544-pack-objects-hook` ████████████████████ 7/7 (0 left) — test custom script in place of pack-objects
 - [ ] `t5316-pack-delta-depth` ░░░░░░░░░░░░░░░░░░░░ 0/5 (5 left) — pack-objects breaks long cross-pack delta chains
-- [ ] `t5546-receive-limits` ████████████░░░░░░░░ 11/17 (6 left) — check receive input limits
+- [x] `t5546-receive-limits` — check receive input limits (17/17)
 - [ ] `t5534-push-signed` ██████████░░░░░░░░░░ 7/13 (6 left) — signed push
 - [ ] `t5543-atomic-push` ███████████████░░░░░ 10/13 (3 left) — pushing to a repository using the atomic push option
 - [ ] `t5503-tagfollow` ██████████░░░░░░░░░░ 6/12 (6 left) — test automatic tag following

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -967,7 +967,7 @@ t5542-push-http-shallow	t5	yes	3	1	2	false	ok	0
 t5543-atomic-push	t5	yes	13	7	6	false	ok	0
 t5544-pack-objects-hook	t5	yes	7	3	4	false	ok	0
 t5545-push-options	t5	yes	13	5	8	false	ok	0
-t5546-receive-limits	t5	yes	17	14	3	false	ok	0
+t5546-receive-limits	t5	yes	17	17	0	true	ok	0
 t5547-push-quarantine	t5	yes	6	5	1	false	ok	0
 t5548-push-porcelain	t5	skip	11	0	0	false	ok	0
 t5549-fetch-push-http	t5	yes	3	0	3	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,689 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,689 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T20:00:35+00:00" class="gen-time" title="2026-04-09 20:00 UTC">2026-04-09 20:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,689</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">34/167 files · 17 skipped · 1,569/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.9%"></div></div>
+        <span class="group-pct pct-red">37.9%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35689 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,689 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T20:00:35+00:00" class="gen-time" title="2026-04-09 20:00 UTC">2026-04-09 20:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,689</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -9827,14 +9827,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:38.5%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="17" data-passed="14">
+<tr class="" data-group="t5" data-tests="17" data-passed="17" data-full-pass="1">
   <td class="mono">t5546-receive-limits</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">17</td>
-  <td class="right">14</td>
+  <td class="right">17</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:82.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="6" data-passed="5">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/unpack_objects.rs
+++ b/grit-lib/src/unpack_objects.rs
@@ -30,6 +30,11 @@ pub struct UnpackOptions {
     pub quiet: bool,
     /// Reject packs whose commits/trees/tags reference missing objects.
     pub strict: bool,
+    /// Maximum number of raw pack bytes that may be consumed (including the 20-byte trailer).
+    ///
+    /// Matches Git's `unpack-objects --max-input-size` / `receive.maxInputSize`: counts every
+    /// byte read from the pack stream after crossing the limit. `None` means no limit.
+    pub max_input_bytes: Option<u64>,
 }
 
 /// A delta that could not yet be resolved because its base was not yet known.
@@ -65,7 +70,7 @@ pub fn unpack_objects(reader: &mut dyn Read, odb: &Odb, opts: &UnpackOptions) ->
     /// and `--strict` graph walks without extra ODB reads.
     const MAX_RETAIN_BYTES: usize = 1024 * 1024;
 
-    let mut rd = StreamingPackReader::new(reader);
+    let mut rd = StreamingPackReader::new(reader, opts.max_input_bytes);
 
     // Validate magic and version.
     let sig = rd.read_exact_n(4)?;
@@ -654,23 +659,38 @@ struct StreamingPackReader<'a> {
     inner: &'a mut dyn Read,
     pack_hasher: Sha1,
     stream_pos: usize,
+    max_input_bytes: Option<u64>,
     /// Compressed (or other) bytes already read from `inner` and hashed but not yet consumed by
     /// the current parsing step.
     pending: Vec<u8>,
 }
 
 impl<'a> StreamingPackReader<'a> {
-    fn new(inner: &'a mut dyn Read) -> Self {
+    fn new(inner: &'a mut dyn Read, max_input_bytes: Option<u64>) -> Self {
         Self {
             inner,
             pack_hasher: Sha1::new(),
             stream_pos: 0,
+            max_input_bytes,
             pending: Vec::new(),
         }
     }
 
     fn stream_pos(&self) -> usize {
         self.stream_pos
+    }
+
+    fn enforce_max_input(&self) -> Result<()> {
+        if let Some(limit) = self.max_input_bytes {
+            let pos = u64::try_from(self.stream_pos)
+                .map_err(|_| Error::CorruptObject("pack stream position overflow".to_owned()))?;
+            if pos > limit {
+                return Err(Error::CorruptObject(
+                    "pack exceeds maximum allowed size".to_owned(),
+                ));
+            }
+        }
+        Ok(())
     }
 
     /// Read pack-body bytes (hashed). Used for headers and non-zlib payload reads only.
@@ -686,6 +706,7 @@ impl<'a> StreamingPackReader<'a> {
         if n > 0 {
             self.pack_hasher.update(&buf[..n]);
             self.stream_pos += n;
+            self.enforce_max_input()?;
         }
         Ok(n)
     }
@@ -800,6 +821,7 @@ impl<'a> StreamingPackReader<'a> {
                         self.pack_hasher.update(&self.pending[..consumed]);
                         self.stream_pos += consumed;
                         self.pending.drain(..consumed);
+                        self.enforce_max_input()?;
                         return Ok(Vec::new());
                     }
                     Ok(_) => {
@@ -824,62 +846,6 @@ impl<'a> StreamingPackReader<'a> {
 
         const CHUNK: usize = 64 * 1024;
         let mut scratch = [0u8; CHUNK];
-
-        // `Read::read_exact` with a zero-length buffer returns `Ok` immediately without touching
-        // the zlib stream. Empty trees/tags still have a short zlib wrapper (~8 bytes) that must be
-        // consumed so the next object header aligns (Git pack format).
-        if expected_size == 0 {
-            loop {
-                let mut cursor = std::io::Cursor::new(self.pending.as_slice());
-                let mut z = ZlibDecoder::new(&mut cursor);
-                let mut trial = Vec::new();
-                match z.read_to_end(&mut trial) {
-                    Ok(_) if trial.is_empty() => {
-                        let consumed = z.total_in() as usize;
-                        if consumed == 0 {
-                            let n = self.inner.read(&mut scratch).map_err(Error::Io)?;
-                            if n == 0 {
-                                return Err(Error::CorruptObject(format!(
-                                    "pack stream truncated (zlib) at offset {}",
-                                    self.stream_pos
-                                )));
-                            }
-                            self.pending.extend_from_slice(&scratch[..n]);
-                            continue;
-                        }
-                        if consumed > self.pending.len() {
-                            return Err(Error::CorruptObject(
-                                "zlib total_in exceeds pending buffer".to_owned(),
-                            ));
-                        }
-                        self.pack_hasher.update(&self.pending[..consumed]);
-                        self.stream_pos += consumed;
-                        self.pending.drain(..consumed);
-                        return Ok(Vec::new());
-                    }
-                    Ok(_) => {
-                        return Err(Error::CorruptObject(format!(
-                            "decompressed {} bytes but expected 0",
-                            trial.len()
-                        )));
-                    }
-                    Err(e) => {
-                        let n = self.inner.read(&mut scratch).map_err(Error::Io)?;
-                        if n == 0 {
-                            return Err(if e.kind() == io::ErrorKind::UnexpectedEof {
-                                Error::CorruptObject(format!(
-                                    "pack stream truncated (zlib) at offset {}",
-                                    self.stream_pos
-                                ))
-                            } else {
-                                Error::Zlib(e.to_string())
-                            });
-                        }
-                        self.pending.extend_from_slice(&scratch[..n]);
-                    }
-                }
-            }
-        }
 
         let mut out = vec![0u8; expected_size];
         let mut z = Decompress::new(true);
@@ -915,6 +881,7 @@ impl<'a> StreamingPackReader<'a> {
             self.pack_hasher.update(&self.pending[..consumed]);
             self.stream_pos += consumed;
             self.pending.drain(..consumed);
+            self.enforce_max_input()?;
             out_pos += (z.total_out() - before_out) as usize;
 
             match status {
@@ -959,6 +926,7 @@ impl<'a> StreamingPackReader<'a> {
             b.copy_from_slice(&self.pending[..20]);
             self.pending.drain(..20);
             self.stream_pos += 20;
+            self.enforce_max_input()?;
             return Ok(b);
         }
         let tail = self.pending.len();
@@ -970,6 +938,7 @@ impl<'a> StreamingPackReader<'a> {
             .read_exact(&mut b[tail..])
             .map_err(|e| io_to_corrupt_eof(e, self.stream_pos, "trailer"))?;
         self.stream_pos += 20;
+        self.enforce_max_input()?;
         Ok(b)
     }
 }
@@ -1328,6 +1297,7 @@ mod tests {
             dry_run: true,
             quiet: true,
             strict: false,
+            max_input_bytes: None,
         };
         let count = unpack_objects(&mut pack.as_slice(), &odb, &opts).unwrap();
         assert_eq!(count, 1);

--- a/grit/src/bundle_uri.rs
+++ b/grit/src/bundle_uri.rs
@@ -187,6 +187,7 @@ fn unbundle_pack_into_repo(
         strict: false,
         dry_run: false,
         quiet: true,
+        max_input_bytes: None,
     };
     let mut collected: Vec<ObjectId> = Vec::new();
     let before_ids: std::collections::HashSet<ObjectId> = list_all_loose_oids(&odb);

--- a/grit/src/commands/bundle.rs
+++ b/grit/src/commands/bundle.rs
@@ -345,6 +345,7 @@ fn run_unbundle(args: UnbundleArgs) -> Result<()> {
         strict: false,
         dry_run: false,
         quiet: false,
+        max_input_bytes: None,
     };
     let count = grit_lib::unpack_objects::unpack_objects(&mut &pack_data[..], &repo.odb, &opts)
         .map_err(|e| anyhow::anyhow!("unbundle failed: {e}"))?;

--- a/grit/src/commands/clone.rs
+++ b/grit/src/commands/clone.rs
@@ -4889,6 +4889,7 @@ fn run_bundle_clone(args: Args) -> Result<()> {
             strict: false,
             dry_run: false,
             quiet: true,
+            max_input_bytes: None,
         };
         grit_lib::unpack_objects::unpack_objects(&mut &pack_data[..], &dest.odb, &opts)
             .map_err(|e| anyhow::anyhow!("unbundle failed: {e}"))?;

--- a/grit/src/commands/index_pack.rs
+++ b/grit/src/commands/index_pack.rs
@@ -100,6 +100,10 @@ pub struct Args {
     /// Thread count (accepted; grit is single-threaded).
     #[arg(long = "threads", value_name = "N")]
     pub threads: Option<u32>,
+
+    /// Reject packs whose on-disk size exceeds this limit (supports `k`/`m`/`g` suffixes; `0` = unlimited).
+    #[arg(long = "max-input-size", value_name = "SIZE")]
+    pub max_input_size: Option<String>,
 }
 
 /// A resolved pack object.
@@ -136,6 +140,13 @@ pub fn run(args: Args) -> Result<()> {
     } else {
         bail!("usage: grit index-pack [--stdin | <pack-file>]");
     };
+
+    if let Some(raw) = args.max_input_size.as_deref() {
+        let limit = parse_max_input_size_bytes(raw)?;
+        if limit > 0 && (pack_raw.len() as u64) > limit {
+            bail!("pack exceeds maximum allowed size");
+        }
+    }
 
     if args.verbose {
         trace2_region_scope("Receiving objects", || Ok(()))?;
@@ -334,6 +345,14 @@ fn big_file_threshold_bytes() -> u64 {
         .and_then(|c| c.get("core.bigfilethreshold"))
         .and_then(|s| parse_byte_suffix(&s))
         .unwrap_or(512 * 1024 * 1024)
+}
+
+fn parse_max_input_size_bytes(raw: &str) -> Result<u64> {
+    let v = grit_lib::config::parse_i64(raw.trim()).map_err(|e| anyhow::anyhow!(e))?;
+    if v < 0 {
+        bail!("max-input-size must be non-negative");
+    }
+    Ok(v as u64)
 }
 
 fn parse_byte_suffix(s: &str) -> Option<u64> {

--- a/grit/src/commands/pack_objects.rs
+++ b/grit/src/commands/pack_objects.rs
@@ -673,6 +673,82 @@ fn write_pack_via_stdin_objects(
     Ok(())
 }
 
+/// Build a thin pack of objects reachable from `push_tips` in `local_repo` that the remote does
+/// not already have (loose or packed), matching a network push’s object set for local file pushes.
+///
+/// Returns empty bytes when there is nothing to send (remote already has all reachable objects).
+pub fn build_thin_push_pack(
+    local_repo: &Repository,
+    push_tips: &[ObjectId],
+    remote_git_dir: &Path,
+) -> Result<Vec<u8>> {
+    if push_tips.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let remote_objects = remote_git_dir.join("objects");
+    let remote_odb = Odb::new(&remote_objects);
+
+    let mut have_roots: BTreeSet<ObjectId> = BTreeSet::new();
+    collect_all_loose(&remote_odb, &mut have_roots)?;
+    let remote_pack_dir = remote_objects.join("pack");
+    if remote_pack_dir.is_dir() {
+        let indexes = grit_lib::pack::read_local_pack_indexes(&remote_objects)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        for idx in indexes {
+            for entry in idx.entries {
+                have_roots.insert(entry.oid);
+            }
+        }
+    }
+
+    let mut to_pack: BTreeSet<ObjectId> = BTreeSet::new();
+    for tip in push_tips {
+        walk_reachable(local_repo, tip, &mut to_pack)?;
+    }
+    for oid in &have_roots {
+        to_pack.remove(oid);
+    }
+
+    if to_pack.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let work_dir = local_repo
+        .work_tree
+        .as_deref()
+        .unwrap_or(&local_repo.git_dir);
+    let mut cmd = Command::new(grit_exe::grit_executable());
+    crate::grit_exe::strip_trace2_env(&mut cmd);
+    cmd.current_dir(work_dir)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .arg("pack-objects")
+        .arg("--revs")
+        .arg("--thin")
+        .arg("--stdout")
+        .arg("-q");
+    let mut child = cmd.spawn().context("spawn pack-objects for local push")?;
+    {
+        let mut stdin = child.stdin.take().context("pack-objects stdin")?;
+        for tip in push_tips {
+            writeln!(stdin, "{}", tip.to_hex())?;
+        }
+        writeln!(stdin, "--not")?;
+        for oid in &have_roots {
+            writeln!(stdin, "{}", oid.to_hex())?;
+        }
+    }
+    let out = child
+        .wait_with_output()
+        .context("wait pack-objects for local push")?;
+    if !out.status.success() {
+        bail!("pack-objects failed with status {}", out.status);
+    }
+    Ok(out.stdout)
+}
+
 /// Apply `git pack-objects --filter=<spec>` (subset: `blob:none` for `gc.repackFilter` tests).
 fn apply_list_objects_filter(entries: &mut Vec<PackEntry>, filter: Option<&str>) {
     let Some(spec) = filter.map(str::trim).filter(|s| !s.is_empty()) else {

--- a/grit/src/commands/push.rs
+++ b/grit/src/commands/push.rs
@@ -1,14 +1,15 @@
 //! `grit push` — update remote refs and associated objects.
 //!
-//! Only **local (file://)** transports are supported.  Copies objects from
-//! the local repository to the remote and updates remote refs.
+//! Only **local (file://)** transports are supported.  Sends missing objects
+//! to the remote (thin pack + receive-style ingest) and updates remote refs.
 
+use crate::commands::pack_objects;
 use crate::protocol_wire;
 use crate::wire_trace;
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::config::{parse_bool, parse_color, ConfigFile, ConfigScope, ConfigSet};
-use grit_lib::gitmodules::{oids_from_copied_object_paths, verify_gitmodules_for_commit};
+use grit_lib::gitmodules::verify_gitmodules_for_commit;
 use grit_lib::hooks::{run_hook, run_hook_capture, HookResult};
 use grit_lib::merge_base::is_ancestor;
 use grit_lib::objects::ObjectId;
@@ -23,6 +24,7 @@ use grit_lib::repo::Repository;
 use grit_lib::rev_parse;
 use grit_lib::state::{resolve_head, HeadState};
 
+use std::collections::HashSet;
 use std::fs;
 use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
@@ -1485,22 +1487,49 @@ fn push_to_url(
         fs::write(&push_opts_path, content).context("writing push options")?;
     }
 
-    // Copy objects to remote, tracking what was added for rollback
+    // Send objects to the remote like `receive-pack` (thin pack + unpack/index), tracking new
+    // files for rollback on hook failure.
     let mut copied_objects: Vec<PathBuf> = Vec::new();
     if !args.dry_run {
-        copied_objects = copy_objects_tracked(&repo.git_dir, &remote_repo.git_dir)
-            .context("copying objects to remote")?;
+        let mut push_tips: Vec<ObjectId> = Vec::new();
+        for (i, u) in updates.iter().enumerate() {
+            if pre_reject[i].is_some() {
+                continue;
+            }
+            if let Some(oid) = u.new_oid {
+                push_tips.push(oid);
+            }
+        }
+
+        let thin_pack = pack_objects::build_thin_push_pack(repo, &push_tips, &remote_repo.git_dir)
+            .context("building push pack")?;
+
+        if !thin_pack.is_empty() {
+            let pre_ingest = list_remote_object_files(&remote_repo.git_dir);
+            crate::receive_ingest::ingest_received_pack(
+                &remote_repo.git_dir,
+                &thin_pack,
+                &receive_remote_config,
+            )
+            .context("remote unpack failed")?;
+            let post_ingest = list_remote_object_files(&remote_repo.git_dir);
+            for p in post_ingest {
+                if !pre_ingest.contains(&p) {
+                    copied_objects.push(p);
+                }
+            }
+        }
+
         if push_show_object_progress(args) && !copied_objects.is_empty() {
             maybe_print_push_object_progress(true);
         }
 
-        let remote_config = ConfigSet::load_repo_local_only(&remote_repo.git_dir)?;
-        let fsck_receive = remote_config
+        let fsck_receive = receive_remote_config
             .get_bool("receive.fsckobjects")
-            .or_else(|| remote_config.get_bool("receive.fsckObjects"));
-        let fsck_transfer = remote_config
+            .or_else(|| receive_remote_config.get_bool("receive.fsckObjects"));
+        let fsck_transfer = receive_remote_config
             .get_bool("transfer.fsckobjects")
-            .or_else(|| remote_config.get_bool("transfer.fsckObjects"));
+            .or_else(|| receive_remote_config.get_bool("transfer.fsckObjects"));
         let fsck_enabled = match (fsck_receive, fsck_transfer) {
             (Some(Ok(true)), _) => true,
             (Some(Ok(false)), _) => false,
@@ -1511,15 +1540,13 @@ fn push_to_url(
         if fsck_enabled {
             let remote_objects = remote_repo.git_dir.join("objects");
             let remote_odb = grit_lib::odb::Odb::new(&remote_objects);
-            let copied_oids = oids_from_copied_object_paths(&copied_objects)
-                .context("collecting pushed object ids")?;
-            for update in &updates {
+            for (i, update) in updates.iter().enumerate() {
+                if pre_reject[i].is_some() {
+                    continue;
+                }
                 let Some(new_oid) = update.new_oid else {
                     continue;
                 };
-                if !copied_oids.contains(&new_oid) {
-                    continue;
-                }
                 if let Some(rest) = verify_gitmodules_for_commit(&remote_odb, new_oid)? {
                     for path in &copied_objects {
                         let _ = fs::remove_file(path);
@@ -2728,58 +2755,41 @@ fn maybe_print_push_object_progress(show: bool) {
 
 /// Copy all objects (loose + packs) from src to dst, skipping existing.
 /// Copy objects and return the list of newly created files (for rollback).
-fn copy_objects_tracked(src_git_dir: &Path, dst_git_dir: &Path) -> Result<Vec<PathBuf>> {
-    let src_objects = src_git_dir.join("objects");
+fn list_remote_object_files(dst_git_dir: &Path) -> HashSet<PathBuf> {
+    let mut out = HashSet::new();
     let dst_objects = dst_git_dir.join("objects");
-    let mut copied = Vec::new();
-
-    if src_objects.is_dir() {
-        for entry in fs::read_dir(&src_objects)? {
-            let entry = entry?;
+    if !dst_objects.is_dir() {
+        return out;
+    }
+    if let Ok(entries) = fs::read_dir(&dst_objects) {
+        for entry in entries.flatten() {
             let name = entry.file_name();
             let name_str = name.to_string_lossy();
-            if name_str == "info" || name_str == "pack" {
+            if name_str == "info" {
                 continue;
             }
-            if !entry.file_type()?.is_dir() || name_str.len() != 2 {
-                continue;
-            }
-            let dst_dir = dst_objects.join(&*name);
-            for inner in fs::read_dir(entry.path())? {
-                let inner = inner?;
-                if inner.file_type()?.is_file() {
-                    let dst_file = dst_dir.join(inner.file_name());
-                    if !dst_file.exists() {
-                        fs::create_dir_all(&dst_dir)?;
-                        if fs::hard_link(inner.path(), &dst_file).is_err() {
-                            fs::copy(inner.path(), &dst_file)?;
+            if name_str == "pack" {
+                if let Ok(pack_entries) = fs::read_dir(entry.path()) {
+                    for pe in pack_entries.flatten() {
+                        if pe.file_type().map(|t| t.is_file()).unwrap_or(false) {
+                            out.insert(pe.path());
                         }
-                        copied.push(dst_file);
+                    }
+                }
+                continue;
+            }
+            if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) && name_str.len() == 2 {
+                if let Ok(inner) = fs::read_dir(entry.path()) {
+                    for ie in inner.flatten() {
+                        if ie.file_type().map(|t| t.is_file()).unwrap_or(false) {
+                            out.insert(ie.path());
+                        }
                     }
                 }
             }
         }
     }
-
-    let src_pack = src_objects.join("pack");
-    let dst_pack = dst_objects.join("pack");
-    if src_pack.is_dir() {
-        fs::create_dir_all(&dst_pack)?;
-        for entry in fs::read_dir(&src_pack)? {
-            let entry = entry?;
-            if entry.file_type()?.is_file() {
-                let dst_file = dst_pack.join(entry.file_name());
-                if !dst_file.exists() {
-                    if fs::hard_link(entry.path(), &dst_file).is_err() {
-                        fs::copy(entry.path(), &dst_file)?;
-                    }
-                    copied.push(dst_file);
-                }
-            }
-        }
-    }
-
-    Ok(copied)
+    out
 }
 
 /// Open a repository (bare or non-bare).

--- a/grit/src/commands/receive_pack.rs
+++ b/grit/src/commands/receive_pack.rs
@@ -15,7 +15,7 @@ use grit_lib::pack::read_alternates_recursive;
 use grit_lib::refs;
 use grit_lib::repo::Repository;
 use grit_lib::state::{resolve_head, HeadState};
-use grit_lib::unpack_objects::{pack_bytes_to_object_map, unpack_objects, UnpackOptions};
+use grit_lib::unpack_objects::pack_bytes_to_object_map;
 use std::collections::HashSet;
 use std::io::{self, Cursor, Read, Write};
 use std::path::{Path, PathBuf};
@@ -165,13 +165,12 @@ pub fn run(args: Args) -> Result<()> {
 
     let mut unpack_to_odb_err: Option<String> = None;
     if should_unpack_to_odb {
-        let mut rd = Cursor::new(pack_data.clone());
-        let opts = UnpackOptions {
-            dry_run: false,
-            quiet: true,
-            strict: true,
-        };
-        if let Err(e) = unpack_objects(&mut rd, &repo.odb, &opts) {
+        let remote_for_ingest = ConfigSet::load(Some(&repo.git_dir), false)?;
+        if let Err(e) = crate::receive_ingest::ingest_received_pack(
+            &repo.git_dir,
+            &pack_data,
+            &remote_for_ingest,
+        ) {
             unpack_to_odb_err = Some(format!("{e:#}"));
         }
     }

--- a/grit/src/commands/unpack_objects.rs
+++ b/grit/src/commands/unpack_objects.rs
@@ -4,10 +4,11 @@
 //! writes every object as a loose file in the repository's object database.
 //! Delta objects are resolved automatically.
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use std::io;
 
+use grit_lib::config::parse_i64;
 use grit_lib::repo::Repository;
 use grit_lib::unpack_objects::{unpack_objects, UnpackOptions};
 
@@ -26,16 +27,35 @@ pub struct Args {
     /// is always performed).
     #[arg(long)]
     pub strict: bool,
+
+    /// Maximum pack input size in bytes (`k`/`m`/`g` suffixes; `0` = unlimited).
+    #[arg(long = "max-input-size", value_name = "SIZE")]
+    pub max_input_size: Option<String>,
 }
 
 /// Run `grit unpack-objects`.
 pub fn run(args: Args) -> Result<()> {
     let repo = Repository::discover(None).context("not a git repository")?;
 
+    let max_input_bytes = if let Some(raw) = args.max_input_size.as_deref() {
+        let v = parse_i64(raw.trim()).map_err(|e| anyhow::anyhow!(e))?;
+        if v < 0 {
+            bail!("--max-input-size must be non-negative");
+        }
+        if v == 0 {
+            None
+        } else {
+            Some(v as u64)
+        }
+    } else {
+        None
+    };
+
     let opts = UnpackOptions {
         dry_run: args.dry_run,
         quiet: args.quiet,
         strict: args.strict,
+        max_input_bytes,
     };
 
     let mut stdin = io::stdin().lock();

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -36,6 +36,7 @@ pub mod pkt_line;
 mod precompose;
 pub mod protocol;
 mod protocol_wire;
+mod receive_ingest;
 mod ssh_transport;
 mod trace_packet;
 mod transport_passthrough;

--- a/grit/src/receive_ingest.rs
+++ b/grit/src/receive_ingest.rs
@@ -1,0 +1,122 @@
+//! Receive-side pack ingestion helpers shared by `receive-pack` and local `push`.
+//!
+//! Matches Git `receive-pack` behaviour: choose `unpack-objects` vs `index-pack` from
+//! `receive.unpacklimit` / `transfer.unpacklimit`, and enforce `receive.maxInputSize`.
+
+use anyhow::{bail, Context, Result};
+use grit_lib::config::{parse_git_config_int_strict, ConfigSet};
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use crate::grit_exe;
+
+/// Effective `receive.unpacklimit` / `transfer.unpacklimit` / default (100), matching Git
+/// `receive-pack` (`receive` wins when set non-negative).
+pub fn receive_unpack_limit(cfg: &ConfigSet) -> i32 {
+    let recv = cfg
+        .get("receive.unpacklimit")
+        .and_then(|v| parse_git_config_int_strict(&v).ok());
+    let xfer = cfg
+        .get("transfer.unpacklimit")
+        .and_then(|v| parse_git_config_int_strict(&v).ok());
+    match (recv, xfer) {
+        (Some(r), _) if r >= 0 => r as i32,
+        (_, Some(t)) if t >= 0 => t as i32,
+        _ => 100,
+    }
+}
+
+/// `receive.maxInputSize` as a byte cap (`0` or unset = unlimited).
+pub fn max_input_size_from_config(cfg: &ConfigSet) -> Option<u64> {
+    match cfg.get_i64("receive.maxinputsize") {
+        None => None,
+        Some(Ok(v)) if v <= 0 => None,
+        Some(Ok(v)) => Some(v as u64),
+        Some(Err(_)) => None,
+    }
+}
+
+pub fn pack_object_count(pack: &[u8]) -> Option<u32> {
+    if pack.len() < 12 || &pack[0..4] != b"PACK" {
+        return None;
+    }
+    Some(u32::from_be_bytes(pack[8..12].try_into().ok()?))
+}
+
+/// Ingest a pack into `git_dir` using the same unpack path as Git `receive-pack`.
+pub fn ingest_received_pack(git_dir: &Path, pack: &[u8], remote_cfg: &ConfigSet) -> Result<()> {
+    let unpack_limit = receive_unpack_limit(remote_cfg);
+    let max_input_bytes = max_input_size_from_config(remote_cfg);
+    let nr_objects = pack_object_count(pack).unwrap_or(0);
+    let use_unpack_objects =
+        i64::from(unpack_limit) > 0 && (nr_objects as i64) < i64::from(unpack_limit);
+
+    if use_unpack_objects {
+        ingest_via_unpack_objects_subprocess(git_dir, pack, max_input_bytes)
+    } else {
+        ingest_via_index_pack_subprocess(git_dir, pack, max_input_bytes)
+    }
+}
+
+fn ingest_via_unpack_objects_subprocess(
+    git_dir: &Path,
+    pack: &[u8],
+    max_input: Option<u64>,
+) -> Result<()> {
+    let mut cmd = Command::new(grit_exe::grit_executable());
+    grit_exe::strip_trace2_env(&mut cmd);
+    cmd.arg(format!("--git-dir={}", git_dir.display()))
+        .args(["unpack-objects", "-q", "--strict"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .env("GIT_DIR", git_dir.as_os_str());
+    if let Some(n) = max_input {
+        cmd.arg(format!("--max-input-size={n}"));
+    }
+    let mut child = cmd.spawn().context("spawn grit unpack-objects")?;
+    let mut stdin = child.stdin.take().context("unpack-objects stdin")?;
+    stdin
+        .write_all(pack)
+        .context("write pack to unpack-objects stdin")?;
+    drop(stdin);
+    let out = child
+        .wait_with_output()
+        .context("wait for unpack-objects")?;
+    if out.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    bail!("unpack-objects abnormal exit: {stderr}");
+}
+
+fn ingest_via_index_pack_subprocess(
+    git_dir: &Path,
+    pack: &[u8],
+    max_input: Option<u64>,
+) -> Result<()> {
+    let mut cmd = Command::new(grit_exe::grit_executable());
+    grit_exe::strip_trace2_env(&mut cmd);
+    cmd.arg(format!("--git-dir={}", git_dir.display()))
+        .args(["index-pack", "--stdin", "--fix-thin"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .env("GIT_DIR", git_dir.as_os_str());
+    if let Some(n) = max_input {
+        cmd.arg(format!("--max-input-size={n}"));
+    }
+    let mut child = cmd.spawn().context("spawn grit index-pack")?;
+    let mut stdin = child.stdin.take().context("index-pack stdin")?;
+    stdin
+        .write_all(pack)
+        .context("write pack to index-pack stdin")?;
+    drop(stdin);
+    let out = child.wait_with_output().context("wait for index-pack")?;
+    if out.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    bail!("index-pack abnormal exit: {stderr}");
+}

--- a/logs/2026-04-09_t5546-receive-limits.md
+++ b/logs/2026-04-09_t5546-receive-limits.md
@@ -1,0 +1,21 @@
+# t5546-receive-limits
+
+## Problem
+
+Harness `t5546-receive-limits.sh` failed because:
+
+1. Local path `git push` copied loose objects and never ran receive-side `unpack-objects` / `index-pack`, so `receive.maxInputSize` and unpack-limit routing were ignored.
+2. `receive-pack` unpacked in-process without subprocess flags; `index-pack` had no `--max-input-size`.
+
+## Fix
+
+- Added `grit-lib` `UnpackOptions::max_input_bytes` and enforcement in `StreamingPackReader` (Git-style byte count).
+- `grit unpack-objects --max-input-size`, `grit index-pack --max-input-size`.
+- New `receive_ingest.rs`: shared ingest choosing `unpack-objects` vs `index-pack` from `receive.unpacklimit` / `transfer.unpacklimit` (receive wins) and `receive.maxInputSize`; used by `receive-pack` and local `push`.
+- `push`: build thin pack via new `pack_objects::build_thin_push_pack`, ingest through `receive_ingest`, track new `objects/` files for hook rollback.
+
+## Validation
+
+- `./scripts/run-tests.sh t5546-receive-limits.sh`: 17/17
+- `cargo test -p grit-lib --lib`: pass
+- `cargo clippy -p grit-rs -p grit-lib --fix --allow-dirty`: clean

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   325 |
+| Completed   |   326 |
 | In progress |     5 |
-| Remaining   |   441 |
+| Remaining   |   440 |
 | **Total**   |   771 |
 
-Task lines in `PLAN.md`: 325 completed (`[x]`), 5 in progress (`[~]`), 441 remaining (`[ ]`).
+Task lines in `PLAN.md`: 326 completed (`[x]`), 5 in progress (`[~]`), 440 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t5546-receive-limits` — 17/17 tests pass (local `push`: thin pack + shared receive ingest honoring `receive.maxInputSize`, `receive.unpacklimit` vs `transfer.unpacklimit`; `unpack-objects` `--max-input-size`; `index-pack` `--max-input-size`)
 - `t3309-notes-merge-auto-resolve` — 31/31 tests pass (`notes merge`: `union` / `cat_sort_uniq` blob combine like Git; successful merge commits use two parents; `notes.mergeStrategy` config errors match upstream expectations)
 - `t4063-diff-blobs` — 18/18 tests pass (`diff`: blob↔blob and `rev:path` pairs without treating blobs as trees; `HEAD:one..HEAD:two` range split; `rev:path` vs worktree file uses tree path + modes + `write_patch_with_prefix`; raw blob OID vs existing file uses filename as old path; `rev_parse::resolve_treeish_blob_at_path` for tree walks)
 - `t5524-pull-msg` — 3/3 tests pass (`git pull --no-rebase --log` merge message preserves `$` in subject lines; `--log=1` limits shortlog; harness CSV/dashboards refreshed; `PLAN.md` marked complete)

--- a/test-results.md
+++ b/test-results.md
@@ -1,5 +1,11 @@
 # Test results
 
+**2026-04-09 (t5546 / receive limits)**
+
+- `cargo test -p grit-lib --lib`: 160 passed
+- `cargo clippy -p grit-rs -p grit-lib --fix --allow-dirty`: no warnings
+- `./scripts/run-tests.sh t5546-receive-limits.sh`: 17/17 passed
+
 **2026-04-09 (t4063 / diff blobs)**
 
 - `cargo test -p grit-lib --lib`: 155 passed


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t5546-receive-limits` exercises `receive.maxInputSize`, `receive.unpacklimit` vs `transfer.unpacklimit`, and whether the remote stores objects as loose (`unpack-objects`) vs pack (`index-pack`). Local path `git push` previously hard-linked loose objects and skipped receive-pack semantics entirely.

## Changes

- **`grit push` (local transport):** build a **thin pack** of objects the remote lacks (`pack_objects::build_thin_push_pack`), then ingest it through the same path as `receive-pack`.
- **`receive_ingest`:** shared helper choosing `unpack-objects` vs `index-pack` from config (receive unpacklimit overrides transfer; default 100) and passing `--max-input-size` when `receive.maxInputSize` is set.
- **`unpack-objects` / `index-pack`:** add `--max-input-size`; `grit-lib` `UnpackOptions::max_input_bytes` enforced incrementally in `StreamingPackReader` (Git-style consumed-byte accounting).
- **Harness metadata:** `t5546-receive-limits` 17/17; `PLAN.md` / `progress.md` / `test-results.md` / dashboards updated.

## Validation

- `./scripts/run-tests.sh t5546-receive-limits.sh` — 17/17
- `cargo test -p grit-lib --lib`
- `cargo clippy -p grit-rs -p grit-lib --fix --allow-dirty`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4eb4413-c53d-41c8-9415-2e9870eeb480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4eb4413-c53d-41c8-9415-2e9870eeb480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

