### PR TITLE
fix: t3413-rebase-hook — pre-rebase argv and --no-verify

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -601,7 +601,7 @@ t3407-rebase-abort	t3	yes	17	7	10	false	ok	0
 t3408-rebase-multi-line	t3	yes	2	2	0	true	ok	0
 t3409-rebase-environ	t3	yes	3	3	0	true	ok	0
 t3412-rebase-root	t3	yes	25	25	0	true	ok	0
-t3413-rebase-hook	t3	yes	15	9	6	false	ok	0
+t3413-rebase-hook	t3	yes	15	15	0	true	ok	0
 t3415-rebase-autosquash	t3	yes	28	23	5	false	ok	0
 t3416-rebase-onto-threedots	t3	yes	18	12	6	false	ok	0
 t3417-rebase-whitespace-fix	t3	yes	4	4	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,692 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,692 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T20:07:36+00:00" class="gen-time" title="2026-04-09 20:07 UTC">2026-04-09 20:07 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,692</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -219,11 +219,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">56/141 files · 2 skipped · 4,052/5,398 tests</span>
+        <span class="group-meta">57/141 files · 2 skipped · 4,058/5,398 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:75.1%"></div></div>
-        <span class="group-pct pct-blue">75.1%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:75.2%"></div></div>
+        <span class="group-pct pct-blue">75.2%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35692 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,692 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T20:07:36+00:00" class="gen-time" title="2026-04-09 20:07 UTC">2026-04-09 20:07 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,692</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -6167,14 +6167,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="15" data-passed="9">
+<tr class="" data-group="t3" data-tests="15" data-passed="15" data-full-pass="1">
   <td class="mono">t3413-rebase-hook</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">15</td>
-  <td class="right">9</td>
+  <td class="right">15</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:60.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="28" data-passed="23">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit/src/commands/pull.rs
+++ b/grit/src/commands/pull.rs
@@ -590,6 +590,7 @@ fn do_merge_or_rebase_after_fetch(
             autosquash: false,
             no_autosquash: false,
             keep_empty: false,
+            no_verify: false,
         };
         return super::rebase::run(rebase_args);
     }

--- a/grit/src/commands/rebase.rs
+++ b/grit/src/commands/rebase.rs
@@ -231,6 +231,10 @@ pub struct Args {
     /// Keep commits that do not change any file (empty patch).
     #[arg(short = 'k', long = "keep-empty")]
     pub keep_empty: bool,
+
+    /// Do not run the pre-rebase hook.
+    #[arg(long = "no-verify")]
+    pub no_verify: bool,
 }
 
 /// Expand combined short flags (`-ki`, `-ik`) before clap parsing.
@@ -304,6 +308,7 @@ pub fn run(mut args: Args) -> Result<()> {
     }
 
     let pre_rebase_hook_second = args.branch.clone();
+    let mut pre_rebase_upstream_label: Option<String> = None;
 
     // If a branch argument is given, checkout that branch first.
     // Resolve `upstream` before checkout: `git rebase <upstream> <branch>` uses the pre-checkout
@@ -311,6 +316,7 @@ pub fn run(mut args: Args) -> Result<()> {
     if args.branch.is_some() {
         let repo = Repository::discover(None).context("not a git repository")?;
         let uspec = args.upstream.as_deref().unwrap_or("HEAD");
+        pre_rebase_upstream_label = Some(uspec.to_owned());
         let uoid = resolve_revision(&repo, uspec)
             .with_context(|| format!("bad revision '{uspec}'"))?
             .to_hex();
@@ -378,7 +384,7 @@ pub fn run(mut args: Args) -> Result<()> {
         }
     }
 
-    do_rebase(args, pre_rebase_hook_second)
+    do_rebase(args, pre_rebase_hook_second, pre_rebase_upstream_label)
 }
 
 // ── Rebase state directory layout ───────────────────────────────────
@@ -1879,7 +1885,11 @@ fn apply_autostash_after_ff(repo: &Repository, autostash_oid: &ObjectId) -> Resu
 
 // ── Main rebase flow ────────────────────────────────────────────────
 
-fn do_rebase(args: Args, pre_rebase_hook_second: Option<String>) -> Result<()> {
+fn do_rebase(
+    args: Args,
+    pre_rebase_hook_second: Option<String>,
+    pre_rebase_upstream_label: Option<String>,
+) -> Result<()> {
     let repo = Repository::discover(None).context("not a git repository")?;
     let git_dir = &repo.git_dir;
 
@@ -2052,18 +2062,19 @@ fn do_rebase(args: Args, pre_rebase_hook_second: Option<String>) -> Result<()> {
         commits.retain(|oid| !is_commit_tree_unchanged(&repo, oid).unwrap_or(false));
     }
 
-    let hook_arg1: &str = if args.root {
-        "--root"
-    } else {
-        upstream_spec.as_str()
-    };
+    let hook_upstream = pre_rebase_upstream_label
+        .as_deref()
+        .unwrap_or_else(|| upstream_spec.as_str());
+    let hook_arg1: &str = if args.root { "--root" } else { hook_upstream };
     let hook_arg2: Option<&str> = pre_rebase_hook_second.as_deref();
     let hook_args: Vec<&str> = match hook_arg2 {
         Some(s) => vec![hook_arg1, s],
         None => vec![hook_arg1],
     };
-    if let HookResult::Failed(_) = run_hook(&repo, "pre-rebase", &hook_args, None) {
-        bail!("The pre-rebase hook refused to rebase.");
+    if !args.no_verify {
+        if let HookResult::Failed(_) = run_hook(&repo, "pre-rebase", &hook_args, None) {
+            bail!("The pre-rebase hook refused to rebase.");
+        }
     }
 
     let (rebase_todo_lines, rebase_interactive) = if args.interactive {

--- a/logs/2026-04-09_t3413-rebase-hook.md
+++ b/logs/2026-04-09_t3413-rebase-hook.md
@@ -1,0 +1,18 @@
+# t3413-rebase-hook
+
+## Issue
+
+Harness showed 6/15 failures:
+
+- Pre-rebase hook second argument correct, but first was the resolved upstream OID when using `git rebase <upstream> <branch>` (should stay the user-given ref name, e.g. `main`).
+- `rebase --no-verify` was not implemented (hook still ran / behavior differed).
+
+## Fix
+
+- `grit/src/commands/rebase.rs`: When `<branch>` is present, save the pre-checkout upstream spec and pass it to `do_rebase` for hook argv only; internal resolution still uses hex OID. Added `--no-verify` flag and skip `pre-rebase` when set.
+- `grit/src/commands/pull.rs`: Initialize `no_verify: false` in manual `rebase::Args` struct.
+
+## Verification
+
+- `bash tests/t3413-rebase-hook.sh` — 15/15 pass.
+- `cargo test -p grit-lib --lib` — pass.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes `tests/t3413-rebase-hook.sh` pass (15/15).

## Changes

- **Pre-rebase hook first argument:** For `git rebase <upstream> <branch>`, we resolve `<upstream>` to an OID before checkout for correct semantics, but the `pre-rebase` hook must still receive the user-given ref name (e.g. `main`), not the hex OID.
- **`rebase --no-verify`:** Skip the `pre-rebase` hook when this flag is set, matching Git.
- **`git pull`:** Initialize `no_verify: false` on the manual `rebase::Args` construction.

## Testing

- `./scripts/run-tests.sh t3413-rebase-hook.sh`
- `cargo test -p grit-lib --lib`

## Note

`cargo clippy -p grit-rs -- -D warnings` currently fails on pre-existing issues in `grit-lib` (unrelated to this change).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2b87b17-1593-441e-8992-08ec4e246d1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2b87b17-1593-441e-8992-08ec4e246d1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

