### PR TITLE
fix: make t5517-push-mirror fully pass

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -580,7 +580,7 @@ commit → check it off → move on.
 - [ ] `t5404-tracking-branches` ████████░░░░░░░░░░░░ 3/7 (4 left) — tracking branch update checks for git push
 - [x] `t5618-alternate-refs` ████████████████████ 6/6 (0 left) — test handling of --alternate-refs traversal
 - [ ] `t5410-receive-pack` ████░░░░░░░░░░░░░░░░ 1/5 (4 left) — git receive-pack
-- [ ] `t5517-push-mirror` ████████████░░░░░░░░ 8/13 (5 left) — pushing to a mirror repository
+- [x] `t5517-push-mirror` — pushing to a mirror repository (13/13)
 - [ ] `t5614-clone-submodules-shallow` ████████░░░░░░░░░░░░ 4/9 (5 left) — Test shallow cloning of repos with submodules
 - [ ] `t5200-update-server-info` ███████░░░░░░░░░░░░░ 3/8 (5 left) — Test git update-server-info
 - [ ] `t5564-http-proxy` ███████░░░░░░░░░░░░░ 3/8 (5 left) — test fetching through http proxy

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -933,7 +933,7 @@ t5513-fetch-track	t5	yes	2	1	1	false	ok	0
 t5514-fetch-multiple	t5	yes	25	3	22	false	ok	0
 t5515-fetch-merge-logic	t5	yes	65	1	64	false	ok	0
 t5516-fetch-push	t5	yes	124	40	84	false	ok	0
-t5517-push-mirror	t5	yes	13	7	6	false	ok	0
+t5517-push-mirror	t5	yes	13	13	0	true	ok	0
 t5518-fetch-exit-status	t5	yes	3	2	1	false	ok	0
 t5519-push-alternates	t5	yes	8	7	1	false	ok	0
 t5520-pull	t5	yes	80	19	61	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,692 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,692 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T20:14:32+00:00" class="gen-time" title="2026-04-09 20:14 UTC">2026-04-09 20:14 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,692</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">34/167 files · 17 skipped · 1,572/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:38.0%"></div></div>
+        <span class="group-pct pct-red">38.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35692 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,692 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T20:14:32+00:00" class="gen-time" title="2026-04-09 20:14 UTC">2026-04-09 20:14 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,692</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -9487,14 +9487,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:32.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="13" data-passed="7">
+<tr class="" data-group="t5" data-tests="13" data-passed="13" data-full-pass="1">
   <td class="mono">t5517-push-mirror</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">13</td>
-  <td class="right">7</td>
+  <td class="right">13</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:53.8%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="3" data-passed="2">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit/src/commands/push.rs
+++ b/grit/src/commands/push.rs
@@ -384,7 +384,7 @@ fn sort_collateral_indices(
 
 /// Delegate `git push` to the system binary when `--receive-pack` is set (matches Git's
 /// `git-receive-pack` / `send-pack` protocol for wrapper tests).
-fn run_push_via_system_git(repo: &Repository, args: &Args) -> Result<()> {
+fn run_push_via_system_git(repo: &Repository, args: &Args, mirror_for_push: bool) -> Result<()> {
     let system_git = std::env::var("GIT_REAL_GIT")
         .ok()
         .filter(|p| Path::new(p).is_file())
@@ -438,7 +438,7 @@ fn run_push_via_system_git(repo: &Repository, args: &Args) -> Result<()> {
     if args.branches {
         cmd.arg("--branches");
     }
-    if args.mirror {
+    if mirror_for_push {
         cmd.arg("--mirror");
     }
     if args.quiet {
@@ -502,18 +502,11 @@ pub fn run(args: Args) -> Result<()> {
     let repo = Repository::discover(None).context("not a git repository")?;
     let config = ConfigSet::load(Some(&repo.git_dir), true)?;
 
-    if args.receive_pack.is_some() {
-        return run_push_via_system_git(&repo, &args);
-    }
-
     let push_all = args.all || args.branches;
 
     // Validate flag combinations
     if push_all && !args.refspecs.is_empty() {
         bail!("--all/--branches can not be combined with refspecs");
-    }
-    if push_all && args.mirror {
-        bail!("--all and --mirror cannot be used together");
     }
     if push_all && args.tags {
         bail!("--all and --tags cannot be used together");
@@ -584,19 +577,40 @@ pub fn run(args: Args) -> Result<()> {
     };
     let remote_name = remote_name_owned.as_str();
 
-    // Collect push refspecs from config if no CLI refspecs
-    let push_refspecs_from_config: Vec<String> =
-        if args.refspecs.is_empty() && !args.mirror && !push_all && !args.delete {
-            config.get_all(&format!("remote.{remote_name}.push"))
-        } else {
-            Vec::new()
-        };
-
-    // Push to each URL
     let path_style_remote = args
         .remote
         .as_ref()
         .is_some_and(|r| r.contains('/') || r.starts_with('.') || std::path::Path::new(r).exists());
+
+    let push_mirror_remote = if !path_style_remote && !_is_path_remote {
+        config
+            .get(&format!("remote.{remote_name}.mirror"))
+            .map(|s| parse_bool(s.trim()).unwrap_or(false))
+            .unwrap_or(false)
+    } else {
+        false
+    };
+    let mirror_for_push = args.mirror || push_mirror_remote;
+
+    if push_all && mirror_for_push {
+        bail!("--all and --mirror cannot be used together");
+    }
+
+    if mirror_for_push && !args.refspecs.is_empty() && !args.delete {
+        bail!("fatal: --mirror can't be combined with refspecs");
+    }
+
+    if args.receive_pack.is_some() {
+        return run_push_via_system_git(&repo, &args, mirror_for_push);
+    }
+
+    // Collect push refspecs from config if no CLI refspecs
+    let push_refspecs_from_config: Vec<String> =
+        if args.refspecs.is_empty() && !mirror_for_push && !push_all && !args.delete {
+            config.get_all(&format!("remote.{remote_name}.push"))
+        } else {
+            Vec::new()
+        };
 
     for url in &urls {
         push_to_url(
@@ -609,6 +623,7 @@ pub fn run(args: Args) -> Result<()> {
             push_all,
             &push_refspecs_from_config,
             path_style_remote,
+            mirror_for_push,
         )?;
     }
 
@@ -646,6 +661,7 @@ fn push_to_url(
     push_all: bool,
     push_refspecs_from_config: &[String],
     path_style_remote: bool,
+    mirror_for_push: bool,
 ) -> Result<()> {
     if protocol_wire::effective_client_protocol_version() == 1 {
         wire_trace::trace_packet_push('<', "version 1");
@@ -696,7 +712,7 @@ fn push_to_url(
             Vec::new()
         } else if !args.refspecs.is_empty() {
             args.refspecs.clone()
-        } else if args.mirror || args.delete || args.tags {
+        } else if mirror_for_push || args.delete || args.tags {
             bail!(
                 "--receive-pack is not supported with --mirror, --delete, or --tags in this mode"
             );
@@ -735,7 +751,7 @@ fn push_to_url(
     // on the remote). Submodule recursion runs on this set, matching Git transport behavior.
     let mut submodule_tips: Vec<ObjectId> = Vec::new();
 
-    if args.mirror {
+    if mirror_for_push {
         // Mirror: push all local refs to remote, and delete remote refs
         // that don't exist locally.
         let local_all = refs::list_refs(&repo.git_dir, "refs/")?;
@@ -1170,7 +1186,7 @@ fn push_to_url(
         }
     }
 
-    let mirror_atomic_order = if args.mirror && args.atomic {
+    let mirror_atomic_order = if mirror_for_push && args.atomic {
         Some(mirror_atomic_ref_order(&updates))
     } else {
         None
@@ -1198,7 +1214,7 @@ fn push_to_url(
 
     if !repo.is_bare()
         && !matches!(recurse_mode, PushRecurseSubmodules::Off)
-        && !(args.mirror || push_all || args.delete)
+        && !(mirror_for_push || push_all || args.delete)
         && !combined_tips.is_empty()
     {
         let tips = combined_tips;
@@ -1360,7 +1376,8 @@ fn push_to_url(
             if old == new {
                 continue;
             }
-            if !args.force
+            if !mirror_for_push
+                && !args.force
                 && !update.refspec_force
                 && args.force_with_lease.is_none()
                 && !update.remote_ref.starts_with("refs/tags/")
@@ -1373,7 +1390,8 @@ fn push_to_url(
                     update.remote_ref
                 ));
             }
-            if !args.force
+            if !mirror_for_push
+                && !args.force
                 && !update.refspec_force
                 && args.force_with_lease.is_none()
                 && update.remote_ref.starts_with("refs/tags/")

--- a/logs/2026-04-09_t5517-push-mirror.md
+++ b/logs/2026-04-09_t5517-push-mirror.md
@@ -1,0 +1,21 @@
+# t5517-push-mirror
+
+## Failures (before)
+
+- Mirror push rejected non-fast-forward branch updates and tag moves (mirror must force-sync).
+- `remote.<name>.mirror=true` was ignored for `git remote add --mirror` (fetch uses `+refs/*:refs/*`); plain `git push` did not mirror.
+- `git push <remote> <refspec>` with mirrored remote did not fail.
+- Early `--receive-pack` delegation skipped mirror+refspec validation.
+
+## Changes (`grit/src/commands/push.rs`)
+
+- `mirror_for_push = args.mirror || parse_bool(remote.<name>.mirror)` for named remotes (not path URLs).
+- Mirror path: same ref listing/deletes as `--mirror`; skip non-FF pre-reject for branches and tags.
+- Error `fatal: --mirror can't be combined with refspecs` when mirroring and refspecs present (not `--delete`).
+- `--all` with effective mirror: same error as `--all` + `--mirror`.
+- `run_push_via_system_git` takes `mirror_for_push` and runs after the checks above.
+
+## Verification
+
+- `./scripts/run-tests.sh t5517-push-mirror.sh` → 13/13
+- `cargo test -p grit-lib --lib`

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   325 |
+| Completed   |   326 |
 | In progress |     5 |
-| Remaining   |   441 |
+| Remaining   |   440 |
 | **Total**   |   771 |
 
-Task lines in `PLAN.md`: 325 completed (`[x]`), 5 in progress (`[~]`), 441 remaining (`[ ]`).
+Task lines in `PLAN.md`: 326 completed (`[x]`), 5 in progress (`[~]`), 440 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t5517-push-mirror` — 13/13 tests pass (`push`: `remote.<name>.mirror` enables full mirror push including ref deletion; mirror skips non-FF branch/tag rejection; refspecs with mirror remote fail like Git; `--receive-pack` delegates after mirror validation)
 - `t3309-notes-merge-auto-resolve` — 31/31 tests pass (`notes merge`: `union` / `cat_sort_uniq` blob combine like Git; successful merge commits use two parents; `notes.mergeStrategy` config errors match upstream expectations)
 - `t4063-diff-blobs` — 18/18 tests pass (`diff`: blob↔blob and `rev:path` pairs without treating blobs as trees; `HEAD:one..HEAD:two` range split; `rev:path` vs worktree file uses tree path + modes + `write_patch_with_prefix`; raw blob OID vs existing file uses filename as old path; `rev_parse::resolve_treeish_blob_at_path` for tree walks)
 - `t5524-pull-msg` — 3/3 tests pass (`git pull --no-rebase --log` merge message preserves `$` in subject lines; `--log=1` limits shortlog; harness CSV/dashboards refreshed; `PLAN.md` marked complete)

--- a/test-results.md
+++ b/test-results.md
@@ -1,5 +1,10 @@
 # Test results
 
+**2026-04-09 (t5517 / push mirror)**
+
+- `cargo test -p grit-lib --lib`: 160 passed
+- `./scripts/run-tests.sh t5517-push-mirror.sh`: 13/13 passed
+
 **2026-04-09 (t4063 / diff blobs)**
 
 - `cargo test -p grit-lib --lib`: 155 passed


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible mirror push behavior so `tests/t5517-push-mirror.sh` passes 13/13.

## Changes

- **`remote.<name>.mirror`**: When the push target is a configured remote (not a path/URL) and `remote.<name>.mirror` parses as true (`parse_bool`), treat the push like `--mirror`: full ref sync including deletes of remote-only refs.
- **Non-fast-forward**: Skip branch and tag “already exists / behind” pre-rejection when mirroring (mirror is a force-sync).
- **Refspecs**: Fail with `fatal: --mirror can't be combined with refspecs` when mirroring and explicit refspecs are given (matches Git); still allows `--delete` flows.
- **`--all`**: Reject when a mirror push is in effect (same as `--all` + `--mirror`).
- **`--receive-pack`**: Run mirror/refspec validation before delegating to system `git push`; pass `--mirror` to the delegate when appropriate.

## Verification

- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t5517-push-mirror.sh` → 13/13

## Metadata

- `PLAN.md` / `progress.md` / harness CSV + dashboards updated.
- Log: `logs/2026-04-09_t5517-push-mirror.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25ec5384-f2c1-4af4-a8f0-fb67eb5e14e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25ec5384-f2c1-4af4-a8f0-fb67eb5e14e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

