### PR TITLE
fix: t5812-proto-disable-http — test-httpd redirects and test_grep

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -651,7 +651,7 @@ commit → check it off → move on.
 - [x] `t5323-pack-redundant` ████████████████████ 18/18 (0 left) — Test git pack-redundant
 
 - [ ] `t5528-push-default` ████████░░░░░░░░░░░░ 14/32 (18 left) — check various push.default settings
-- [ ] `t5812-proto-disable-http` ███████░░░░░░░░░░░░░ 11/29 (18 left) — test disabling of git-over-http in clone/fetch
+- [x] `t5812-proto-disable-http` — test disabling of git-over-http in clone/fetch (29/29)
 - [ ] `t5521-pull-options` ███░░░░░░░░░░░░░░░░░ 4/22 (18 left) — pull options
 - [ ] `t5100-mailinfo` ████████████░░░░░░░░ 33/52 (19 left) — git mailinfo and git mailsplit test
 - [ ] `t5541-http-push-smart` █░░░░░░░░░░░░░░░░░░░ 2/21 (19 left) — test smart pushing over http via http-backend

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1032,7 +1032,7 @@ t5801-remote-helpers	t5	skip	35	0	0	false	ok	1
 t5802-connect-helper	t5	yes	8	8	0	true	ok	0
 t5810-proto-disable-local	t5	yes	54	53	1	false	ok	0
 t5811-proto-disable-git	t5	yes	26	18	8	false	ok	0
-t5812-proto-disable-http	t5	yes	29	11	18	false	ok	0
+t5812-proto-disable-http	t5	yes	29	29	0	true	ok	0
 t5813-proto-disable-ssh	t5	yes	81	57	24	false	ok	0
 t5814-proto-disable-ext	t5	yes	0	0	0	false	timeout	0
 t5815-submodule-protos	t5	yes	8	5	3	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,704 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,704 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T20:27:47+00:00" class="gen-time" title="2026-04-09 20:27 UTC">2026-04-09 20:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,704</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">34/167 files · 17 skipped · 1,584/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:38.3%"></div></div>
+        <span class="group-pct pct-red">38.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35704 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,704 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T20:27:47+00:00" class="gen-time" title="2026-04-09 20:27 UTC">2026-04-09 20:27 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,704</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -10477,14 +10477,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:69.2%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="29" data-passed="11">
+<tr class="" data-group="t5" data-tests="29" data-passed="29" data-full-pass="1">
   <td class="mono">t5812-proto-disable-http</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">29</td>
-  <td class="right">11</td>
+  <td class="right">29</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:37.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="81" data-passed="57">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit/src/bin/test_httpd.rs
+++ b/grit/src/bin/test_httpd.rs
@@ -250,6 +250,51 @@ fn read_request(stream: &mut TcpStream) -> Result<Request, String> {
     })
 }
 
+/// Apache `RewriteRule` equivalents for redirect-based HTTP tests (t5812, t5551, …).
+///
+/// Returns `(status, Location)` when this request should be answered with a redirect.
+fn redirect_target(path: &str) -> Option<(u16, String)> {
+    const LOOP_DEEP_PREFIX: &str = "/loop-redir/x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-";
+
+    if let Some(rest) = path.strip_prefix("/ftp-redir/") {
+        return Some((302, format!("ftp://localhost:1000/{rest}")));
+    }
+    if let Some(rest) = path.strip_prefix("/dumb-redir/") {
+        return Some((301, format!("/dumb/{rest}")));
+    }
+    if let Some(rest) = path.strip_prefix("/smart-redir-perm/") {
+        return Some((301, format!("/smart/{rest}")));
+    }
+    if let Some(rest) = path.strip_prefix("/smart-redir-temp/") {
+        return Some((302, format!("/smart/{rest}")));
+    }
+    if let Some(rest) = path.strip_prefix("/smart-redir-auth/") {
+        return Some((301, format!("/auth/smart/{rest}")));
+    }
+    if let Some(rest) = path.strip_prefix("/smart-redir-limited/") {
+        if let Some(repo) = rest.strip_suffix("/info/refs") {
+            return Some((301, format!("/smart/{repo}/info/refs")));
+        }
+    }
+    if path.starts_with(LOOP_DEEP_PREFIX) {
+        let rest = &path[LOOP_DEEP_PREFIX.len()..];
+        return Some((302, format!("/{rest}")));
+    }
+    if let Some(rest) = path.strip_prefix("/loop-redir/") {
+        return Some((302, format!("/loop-redir/x-{rest}")));
+    }
+    None
+}
+
+fn send_redirect(stream: &mut TcpStream, status: u16, location: &str) -> Result<(), String> {
+    let reason = match status {
+        301 => "Moved Permanently",
+        302 => "Found",
+        _ => "Redirect",
+    };
+    send_response(stream, status, reason, &[("Location", location)], b"")
+}
+
 fn log_access(config: &Config, method: &str, path: &str, query: &str, status: u16) {
     use std::fs::OpenOptions;
     let line = if query.is_empty() {
@@ -303,6 +348,12 @@ fn handle_connection(mut stream: TcpStream, config: &Config) -> Result<(), Strin
                 );
             }
         }
+    }
+
+    // Redirect routes (see git/t/lib-httpd/apache.conf — used by t5812-proto-disable-http, t5551, …)
+    if let Some((code, location)) = redirect_target(&req.path) {
+        log_access(config, &req.method, &req.path, &req.query, code);
+        return send_redirect(&mut stream, code, &location);
     }
 
     // Route: /auth/smart/, /auth-push/smart/, /auth-fetch/smart/

--- a/logs/2026-04-09_t5812-proto-disable-http.md
+++ b/logs/2026-04-09_t5812-proto-disable-http.md
@@ -1,0 +1,17 @@
+# t5812-proto-disable-http
+
+## Outcome
+
+All 29 harness tests pass (`./scripts/run-tests.sh t5812-proto-disable-http.sh`).
+
+## Root cause
+
+1. **test-httpd** did not implement Apache `RewriteRule` redirects used by this file (`/ftp-redir/`, `/loop-redir/`, `/smart-redir-*`, `/dumb-redir/`). Without `/ftp-redir/` → `ftp://…`, Git never followed a redirect and the `GIT_ALLOW_PROTOCOL` + libcurl FTP check did not run.
+
+2. **`test_grep` shadowing**: `tests/test-lib.sh` defined a simplified `test_grep` that stripped unknown flags (e.g. `-E`). The t5812 assertion uses `test_grep -E "(ftp.*disabled|…)"`; with `-E` dropped, `|` was not alternation and the grep failed. Removed the duplicate so `test-lib-functions.sh`’s upstream-style `test_grep` is used.
+
+## Changes
+
+- `grit/src/bin/test_httpd.rs`: `redirect_target` + `send_redirect` for the routes above.
+- `tests/test-lib.sh`: remove duplicate `test_grep`.
+- `PLAN.md` / `progress.md`, harness CSV + dashboards refreshed by `run-tests.sh`.

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   325 |
+| Completed   |   326 |
 | In progress |     5 |
-| Remaining   |   441 |
+| Remaining   |   440 |
 | **Total**   |   771 |
 
-Task lines in `PLAN.md`: 325 completed (`[x]`), 5 in progress (`[~]`), 441 remaining (`[ ]`).
+Task lines in `PLAN.md`: 326 completed (`[x]`), 5 in progress (`[~]`), 440 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t5812-proto-disable-http` — 29/29 tests pass (`test-httpd`: Apache-equivalent redirect routes for ftp/smart/loop redirs; `test-lib.sh`: drop duplicate `test_grep` that shadowed upstream and stripped `-E`; harness CSV/dashboards refreshed)
 - `t3309-notes-merge-auto-resolve` — 31/31 tests pass (`notes merge`: `union` / `cat_sort_uniq` blob combine like Git; successful merge commits use two parents; `notes.mergeStrategy` config errors match upstream expectations)
 - `t4063-diff-blobs` — 18/18 tests pass (`diff`: blob↔blob and `rev:path` pairs without treating blobs as trees; `HEAD:one..HEAD:two` range split; `rev:path` vs worktree file uses tree path + modes + `write_patch_with_prefix`; raw blob OID vs existing file uses filename as old path; `rev_parse::resolve_treeish_blob_at_path` for tree walks)
 - `t5524-pull-msg` — 3/3 tests pass (`git pull --no-rebase --log` merge message preserves `$` in subject lines; `--log=1` limits shortlog; harness CSV/dashboards refreshed; `PLAN.md` marked complete)

--- a/test-results.md
+++ b/test-results.md
@@ -1,5 +1,10 @@
 # Test results
 
+**2026-04-09 (t5812 / proto disable http)**
+
+- `cargo test -p grit-lib --lib`: 160 passed
+- `./scripts/run-tests.sh t5812-proto-disable-http.sh`: 29/29 passed
+
 **2026-04-09 (t4063 / diff blobs)**
 
 - `cargo test -p grit-lib --lib`: 155 passed

--- a/tests/test-lib.sh
+++ b/tests/test-lib.sh
@@ -357,30 +357,6 @@ test_declared_prereq () {
 	return 1
 }
 
-test_grep () {
-	local negate=""
-	local invert=""
-	while test $# -gt 0; do
-		case "$1" in
-		-e) shift; break ;;
-		!) negate=1; shift ;;
-		-v) invert="-v"; shift ;;
-		--) shift; break ;;
-		-*) shift ;;
-		*) break ;;
-		esac
-	done
-	local pattern="$1"
-	shift
-	# Always pass the pattern via -e so values like "--quiet" are not parsed as grep options.
-	if test -n "$negate"
-	then
-		! command grep $invert -e "$pattern" "$@"
-	else
-		command grep $invert -e "$pattern" "$@"
-	fi
-}
-
 # GIT_TRACE2_EVENT helpers (upstream test-lib-functions.sh); use `command grep` so PATH cannot
 # shadow with a directory named `grep` (t6500-gc).
 test_subcommand () {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes `t5812-proto-disable-http` pass all 29 harness tests.

## Changes

1. **`test-httpd`** (`grit/src/bin/test_httpd.rs`): Add redirect handling aligned with upstream Apache rules in `git/t/lib-httpd/apache.conf` — `/ftp-redir/`, `/dumb-redir/`, `/smart-redir-{perm,temp,auth,limited}/`, and `/loop-redir/` (including the deep-prefix unwind rule). This lets system `git` over HTTP hit the FTP redirect and exercise `GIT_ALLOW_PROTOCOL` + libcurl protocol restrictions.

2. **`tests/test-lib.sh`**: Remove a duplicate `test_grep` that was sourced *after* `test-lib-functions.sh` and overwrote the upstream-compatible implementation. The duplicate stripped unknown flags (e.g. `-E`), so `test_grep -E '(a|b)'` failed because `|` was not extended-regex alternation.

3. **Meta**: Refreshed `data/test-files.csv` and dashboards via `run-tests.sh`; updated `PLAN.md`, `progress.md`, `test-results.md`, and added `logs/2026-04-09_t5812-proto-disable-http.md`.

## Verification

- `./scripts/run-tests.sh t5812-proto-disable-http.sh`: 29/29
- `cargo test -p grit-lib --lib`: 160 passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f681e89f-2801-4960-9344-52d444944e5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f681e89f-2801-4960-9344-52d444944e5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

