### PR TITLE
fix: make t7412-submodule-absorbgitdirs fully pass

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -834,7 +834,7 @@ commit → check it off → move on.
 
 - [x] `t7517-per-repo-email` — per-repo forced setting of email address (16/16)
 - [ ] `t7525-status-rename` █████████░░░░░░░░░░░ 7/15 (8 left) — git status rename detection options
-- [ ] `t7412-submodule-absorbgitdirs` ██████░░░░░░░░░░░░░░ 4/12 (8 left) — Test submodule absorbgitdirs
+- [x] `t7412-submodule-absorbgitdirs` — Test submodule absorbgitdirs (12/12)
 
 - [ ] `t7413-submodule-is-active` ████░░░░░░░░░░░░░░░░ 2/10 (8 left) — Test with test-tool submodule is-active
 

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1204,7 +1204,7 @@ t7407-submodule-foreach	t7	yes	23	19	4	false	ok	0
 t7408-submodule-reference	t7	yes	16	5	11	false	ok	0
 t7409-submodule-detached-work-tree	t7	yes	3	2	1	false	ok	0
 t7411-submodule-config	t7	yes	20	4	16	false	ok	0
-t7412-submodule-absorbgitdirs	t7	yes	12	5	7	false	ok	0
+t7412-submodule-absorbgitdirs	t7	yes	12	12	0	true	ok	0
 t7413-submodule-is-active	t7	yes	10	2	8	false	ok	0
 t7414-submodule-mistakes	t7	yes	5	5	0	true	ok	0
 t7416-submodule-dash-url	t7	yes	18	9	9	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,693 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,693 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T20:35:13+00:00" class="gen-time" title="2026-04-09 20:35 UTC">2026-04-09 20:35 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,693</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">49/126 files · 11 skipped · 2,501/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.2%"></div></div>
+        <span class="group-pct pct-blue">69.2%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35693 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,693 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T20:35:13+00:00" class="gen-time" title="2026-04-09 20:35 UTC">2026-04-09 20:35 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,693</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">
@@ -12197,14 +12197,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:20.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="12" data-passed="5">
+<tr class="" data-group="t7" data-tests="12" data-passed="12" data-full-pass="1">
   <td class="mono">t7412-submodule-absorbgitdirs</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">12</td>
-  <td class="right">5</td>
+  <td class="right">12</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:41.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="10" data-passed="2">

--- a/grit/src/commands/_submodule_run_update_inner.rs.inc
+++ b/grit/src/commands/_submodule_run_update_inner.rs.inc
@@ -93,7 +93,7 @@ fn run_update_inner(args: &UpdateArgs, discover_base: Option<PathBuf>) -> Result
             continue;
         };
 
-        let modules_dir = submodule_modules_git_dir(&repo.git_dir, &m.path);
+        let modules_dir = submodule_modules_git_dir(&repo.git_dir, &m.name);
 
         // When `--recursive` is set, do not skip submodules that are already at the recorded
         // commit: nested `.gitmodules` paths may still need `submodule update` (t5531 nested clone).
@@ -333,6 +333,28 @@ fn run_update_inner(args: &UpdateArgs, discover_base: Option<PathBuf>) -> Result
 
             let checkout_force = args.force || needs_clone;
 
+            if !args.remote
+                && !needs_clone
+                && read_submodule_head(&sub_path).as_deref() == Some(recorded_oid)
+            {
+                refresh_gitlink_index_stat(&repo, &m.path)?;
+                if let Ok(sub_repo) = Repository::open(&modules_dir, Some(&sub_path)) {
+                    let _ = reapply_sparse_checkout_if_configured(&sub_repo);
+                } else if let Ok(sub_repo) = Repository::discover(Some(&sub_path)) {
+                    let _ = reapply_sparse_checkout_if_configured(&sub_repo);
+                }
+                if sub_path.join(".git").is_dir() && modules_dir.join("HEAD").exists() {
+                    fs::remove_dir_all(sub_path.join(".git")).with_context(|| {
+                        format!(
+                            "failed to normalize submodule .git after checkout for {}",
+                            sub_path.display()
+                        )
+                    })?;
+                    attach_existing_submodule_worktree(&grit_bin, &modules_dir, &sub_path)?;
+                }
+                continue;
+            }
+
             match effective.as_str() {
                 "rebase" => {
                     let mut pull_cmd = grit_subprocess(&grit_bin);
@@ -414,7 +436,7 @@ fn run_update_inner(args: &UpdateArgs, discover_base: Option<PathBuf>) -> Result
             }
 
             if matches!(effective.as_str(), "" | "checkout") || args.remote {
-                println!(
+                eprintln!(
                     "Submodule path '{}': checked out '{}'",
                     msg_path, checkout_oid
                 );
@@ -442,7 +464,8 @@ fn run_update_inner(args: &UpdateArgs, discover_base: Option<PathBuf>) -> Result
         std::process::exit(1);
     }
 
-    if args.recursive {
+    let recurse_nested = args.recursive || args.implicit_recursive;
+    if recurse_nested {
         for m in &selected {
             let sub_path = work_tree.join(&m.path);
             if !sub_path.join(".git").exists() {
@@ -463,7 +486,8 @@ fn run_update_inner(args: &UpdateArgs, discover_base: Option<PathBuf>) -> Result
                 depth: args.depth,
                 jobs: args.jobs,
                 filter: args.filter.clone(),
-                recursive: args.recursive,
+                recursive: recurse_nested,
+                implicit_recursive: args.implicit_recursive,
                 reference: args.reference.clone(),
                 no_recommend_shallow: args.no_recommend_shallow,
             };

--- a/grit/src/commands/fsck.rs
+++ b/grit/src/commands/fsck.rs
@@ -14,6 +14,7 @@ use grit_lib::diff::zero_oid;
 use grit_lib::error::Error as LibError;
 use grit_lib::fsck_standalone::{fsck_object, fsck_tag_mktag_trailer};
 use grit_lib::ident::fsck_commit_idents;
+use grit_lib::index::MODE_GITLINK;
 use grit_lib::objects::{parse_commit, parse_tree, tag_object_line_oid, ObjectId, ObjectKind};
 use grit_lib::odb::Odb;
 use grit_lib::pack::read_local_pack_indexes;
@@ -577,6 +578,9 @@ fn walk_reachable(
             ObjectKind::Tree => {
                 if let Ok(entries) = parse_tree(&obj.data) {
                     for entry in entries {
+                        if entry.mode == MODE_GITLINK {
+                            continue;
+                        }
                         queue.push_back((entry.oid, Some(oid)));
                     }
                 }
@@ -864,6 +868,9 @@ fn find_referenced_set(odb: &Odb, oids: &BTreeSet<ObjectId>) -> HashSet<ObjectId
             ObjectKind::Tree => {
                 if let Ok(entries) = parse_tree(&obj.data) {
                     for entry in entries {
+                        if entry.mode == MODE_GITLINK {
+                            continue;
+                        }
                         referenced.insert(entry.oid);
                     }
                 }

--- a/grit/src/commands/submodule.rs
+++ b/grit/src/commands/submodule.rs
@@ -496,6 +496,10 @@ pub struct UpdateArgs {
     #[arg(long)]
     pub recursive: bool,
 
+    /// When true, recurse into nested submodules like `git submodule update` (even without `--recursive`).
+    #[arg(skip)]
+    pub implicit_recursive: bool,
+
     /// Borrow objects from this repository (repeatable). Writes `objects/info/alternates` in cloned submodules.
     #[arg(long = "reference", value_name = "REPO", action = clap::ArgAction::Append)]
     pub reference: Vec<String>,
@@ -679,6 +683,7 @@ pub(crate) fn update_after_superproject_merge(init: bool, recursive: bool) -> Re
         jobs: None,
         filter: None,
         recursive,
+        implicit_recursive: false,
         reference: vec![],
         no_recommend_shallow: false,
     })
@@ -807,6 +812,23 @@ pub fn run_submodule_helper(rest: &[String]) -> Result<()> {
             let name = get_default_remote_for_path(path)?;
             println!("{name}");
             Ok(())
+        }
+        "absorbgitdirs" => {
+            let mut super_prefix: Option<String> = None;
+            let mut paths: Vec<String> = Vec::new();
+            let mut quiet_helper = false;
+            for a in rest.iter().skip(1) {
+                if let Some(v) = a.strip_prefix("--super-prefix=") {
+                    super_prefix = Some(v.to_string());
+                } else if a == "-q" || a == "--quiet" {
+                    quiet_helper = true;
+                } else if a.as_str() == "--" {
+                    continue;
+                } else if !a.starts_with('-') {
+                    paths.push(a.clone());
+                }
+            }
+            absorb_git_dirs_impl(super_prefix.as_deref(), &paths, quiet_helper)
         }
         _ => {
             eprintln!("Unknown subcommand: {}", rest[0]);
@@ -1298,17 +1320,20 @@ fn read_gitlink_oid_from_index(repo: &Repository, submodule_path: &str) -> Resul
     Ok(None)
 }
 
-/// Check out `oid` in the submodule at `path` (separate git dir under `.git/modules/` or in-tree `.git`).
+/// Check out `oid` in the submodule at `path` (separate git dir under `.git/modules/<name>/` or in-tree `.git`).
+///
+/// `submodule_name_for_modules` is the `.gitmodules` key (Git's submodule name), which may differ from `path`.
 fn checkout_submodule_worktree(
     grit_bin: &Path,
     repo: &Repository,
     work_tree: &Path,
     submodule_path: &str,
+    submodule_name_for_modules: &str,
     oid: &str,
     quiet: bool,
 ) -> Result<()> {
     let sub_path = work_tree.join(submodule_path);
-    let modules_dir = submodule_modules_git_dir(&repo.git_dir, submodule_path);
+    let modules_dir = submodule_modules_git_dir(&repo.git_dir, submodule_name_for_modules);
 
     // CWD must lie inside `GIT_WORK_TREE`; the superproject root is outside the submodule tree.
     // `--force`: after `clone --no-checkout`, HEAD may already equal `oid` while the index and
@@ -1767,7 +1792,9 @@ fn run_init(args: &InitArgs, quiet: bool) -> Result<()> {
 include!("_submodule_run_update_inner.rs.inc");
 
 fn run_update(args: &UpdateArgs) -> Result<()> {
-    run_update_inner(args, None)
+    let mut a = args.clone();
+    a.implicit_recursive = true;
+    run_update_inner(&a, None)
 }
 
 /// Populate `objects/info/alternates` for a submodule git dir (matches `git clone --reference`).
@@ -1891,6 +1918,7 @@ fn run_add(args: &AddArgs) -> Result<()> {
     };
 
     let sub_path = work_tree.join(&path);
+    let name = args.name.as_deref().unwrap_or(path.as_str());
 
     let grit_bin = grit_exe::grit_executable();
 
@@ -1906,7 +1934,7 @@ fn run_add(args: &AddArgs) -> Result<()> {
         }
     } else {
         // Clone the submodule.
-        let modules_dir = submodule_modules_git_dir(&repo.git_dir, &path);
+        let modules_dir = submodule_modules_git_dir(&repo.git_dir, name);
         // Only create the parent directory; git clone --separate-git-dir
         // will create the modules_dir itself.
         if let Some(parent) = modules_dir.parent() {
@@ -1958,9 +1986,6 @@ fn run_add(args: &AddArgs) -> Result<()> {
         set_separate_gitdir_worktree(&grit_bin, &modules_dir, &sub_path);
     }
 
-    // Derive the submodule name (use --name if provided, otherwise path).
-    let name = args.name.as_deref().unwrap_or(&path);
-
     // Update .gitmodules.
     let gitmodules_path = work_tree.join(".gitmodules");
     let mut config = if gitmodules_path.exists() {
@@ -2005,7 +2030,7 @@ fn run_add(args: &AddArgs) -> Result<()> {
     // `clone --no-checkout` leaves an empty work tree; populate it from the staged gitlink
     // (HEAD’s tree may not include the new submodule until after commit — read the index).
     if let Some(oid) = read_gitlink_oid_from_index(&repo, &path)? {
-        checkout_submodule_worktree(&grit_bin, &repo, work_tree, &path, &oid, args.quiet)?;
+        checkout_submodule_worktree(&grit_bin, &repo, work_tree, &path, name, &oid, args.quiet)?;
     }
 
     if !args.quiet {
@@ -2244,7 +2269,8 @@ fn canonicalize_local_remote_url_base(work_tree: &Path, git_dir: &Path, url: &st
 /// Raw `remote.<default>.url` from config (may be `../sub`); matches Git's
 /// `get_default_remote` + config lookup passed to `relative_url`.
 fn default_remote_url_raw(git_dir: &Path) -> Option<String> {
-    let config_path = git_dir.join("config");
+    let config_dir = grit_lib::repo::common_git_dir_for_config(git_dir);
+    let config_path = config_dir.join("config");
     let content = fs::read_to_string(&config_path).ok()?;
     let config = ConfigFile::parse(&config_path, &content, ConfigScope::Local).ok()?;
     let mut raw_url = None;
@@ -2567,58 +2593,258 @@ fn run_deinit(args: &DeinitArgs, quiet: bool) -> Result<()> {
 }
 
 fn run_absorbgitdirs(args: &AbsorbgitdirsArgs, quiet: bool) -> Result<()> {
+    absorb_git_dirs_impl(None, &args.paths, quiet)
+}
+
+/// True when `path/.git/worktrees` exists and is non-empty (Git `submodule_uses_worktrees`).
+fn submodule_gitdir_has_extra_worktrees(sub_worktree: &Path) -> bool {
+    let wt = sub_worktree.join(".git").join("worktrees");
+    let Ok(entries) = fs::read_dir(&wt) else {
+        return false;
+    };
+    for e in entries.flatten() {
+        let n = e.file_name();
+        if n != "." && n != ".." {
+            return true;
+        }
+    }
+    false
+}
+
+fn resolve_dot_git_to_git_dir(dot_git: &Path) -> Option<PathBuf> {
+    if dot_git.is_dir() {
+        return Some(dot_git.to_path_buf());
+    }
+    if !dot_git.is_file() {
+        return None;
+    }
+    let content = fs::read_to_string(dot_git).ok()?;
+    for line in content.lines() {
+        let line = line.trim();
+        let rest = line.strip_prefix("gitdir:")?.trim();
+        if rest.is_empty() {
+            continue;
+        }
+        let p = Path::new(rest);
+        let resolved = if p.is_absolute() {
+            p.to_path_buf()
+        } else {
+            dot_git.parent()?.join(p)
+        };
+        return fs::canonicalize(&resolved).ok().or(Some(resolved));
+    }
+    None
+}
+
+fn gitlink_path_matches_filter(path: &str, filter: &[String], modules: &[SubmoduleInfo]) -> bool {
+    if filter.is_empty() {
+        return true;
+    }
+    filter.iter().any(|f| {
+        f == path
+            || modules
+                .iter()
+                .any(|m| &m.name == f && m.path.replace('\\', "/") == path)
+    })
+}
+
+fn submodule_name_for_gitlink_path(path: &str, modules: &[SubmoduleInfo]) -> Option<String> {
+    modules
+        .iter()
+        .find(|m| m.path.replace('\\', "/") == path.replace('\\', "/"))
+        .map(|m| m.name.clone())
+}
+
+fn absorb_git_dirs_impl(
+    super_prefix: Option<&str>,
+    path_filter: &[String],
+    quiet: bool,
+) -> Result<()> {
     let repo = Repository::discover(None).context("not a git repository")?;
     let work_tree = repo.work_tree.as_ref().context("bare repository")?;
-    let modules = parse_gitmodules(work_tree)?;
-    let selected = filter_submodules(&modules, &args.paths);
+    let modules_cfg = parse_gitmodules_with_repo(work_tree, Some(&repo))?;
+    let index = repo.load_index().context("failed to read index")?;
 
-    for m in &selected {
-        let sub_path = work_tree.join(&m.path);
-        let dot_git = sub_path.join(".git");
-
-        if !dot_git.is_dir() {
-            // Already a gitfile or doesn't exist — nothing to absorb.
+    let mut gitlink_paths: Vec<String> = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for e in &index.entries {
+        if e.stage() != 0 || e.mode != MODE_GITLINK {
             continue;
         }
-
-        let modules_dir = submodule_modules_git_dir(&repo.git_dir, &m.name);
-
-        // Create the modules directory if needed.
-        fs::create_dir_all(modules_dir.parent().unwrap())?;
-
-        // Move the .git directory to .git/modules/<name>.
-        if modules_dir.exists() {
-            // Already exists, skip.
+        let p = String::from_utf8_lossy(&e.path).replace('\\', "/");
+        if !gitlink_path_matches_filter(&p, path_filter, &modules_cfg) {
             continue;
         }
-
-        fs::rename(&dot_git, &modules_dir).context("failed to move .git directory")?;
-
-        // Update core.worktree in the moved git dir.
-        let moved_config_path = modules_dir.join("config");
-        if moved_config_path.exists() {
-            let content = fs::read_to_string(&moved_config_path)?;
-            let mut cfg = ConfigFile::parse(&moved_config_path, &content, ConfigScope::Local)?;
-            // Set the worktree to point back to the submodule path.
-            let relative_worktree = pathdiff_relative(&modules_dir, &sub_path);
-            cfg.set("core.worktree", &relative_worktree)?;
-            cfg.write()?;
-        }
-
-        // Write a gitfile in place of the .git directory.
-        let relative_gitdir = pathdiff_relative(&sub_path, &modules_dir);
-        fs::write(&dot_git, format!("gitdir: {}\n", relative_gitdir))?;
-
-        if !quiet {
-            eprintln!(
-                "Migrating git directory of '{}' from '{}' to '{}'",
-                m.path,
-                sub_path.join(".git").display(),
-                modules_dir.display()
-            );
+        if seen.insert(p.clone()) {
+            gitlink_paths.push(p);
         }
     }
 
+    for path in gitlink_paths {
+        absorb_git_dir_into_superproject(
+            &repo,
+            work_tree,
+            &path,
+            super_prefix,
+            quiet,
+            &modules_cfg,
+        )?;
+    }
+
+    Ok(())
+}
+
+fn absorb_git_dir_into_superproject(
+    repo: &Repository,
+    work_tree: &Path,
+    path: &str,
+    super_prefix: Option<&str>,
+    quiet: bool,
+    modules_cfg: &[SubmoduleInfo],
+) -> Result<()> {
+    let Some(name) = submodule_name_for_gitlink_path(path, modules_cfg) else {
+        bail!("fatal: could not lookup name for submodule '{path}'");
+    };
+
+    let sub_wt = work_tree.join(path);
+    let dot_git = sub_wt.join(".git");
+
+    if !dot_git.exists() {
+        return Ok(());
+    }
+
+    let common_git = grit_lib::repo::common_git_dir_for_config(&repo.git_dir);
+    let common_git_canon = fs::canonicalize(&common_git).unwrap_or(common_git.clone());
+
+    if let Some(resolved_git) = resolve_dot_git_to_git_dir(&dot_git) {
+        let real_sub = fs::canonicalize(&resolved_git).unwrap_or(resolved_git);
+        if real_sub.starts_with(&common_git_canon) {
+            absorb_git_dir_into_superproject_recurse(repo, work_tree, path, super_prefix, quiet)?;
+            return Ok(());
+        }
+    }
+
+    if dot_git.is_dir() {
+        if submodule_gitdir_has_extra_worktrees(&sub_wt) {
+            bail!(
+                "fatal: relocate_gitdir for submodule '{}' with more than one worktree not supported",
+                path
+            );
+        }
+        relocate_single_git_dir_into_superproject(
+            repo,
+            work_tree,
+            path,
+            &name,
+            super_prefix,
+            quiet,
+        )?;
+    } else if dot_git.is_file() {
+        let modules_dir = submodule_modules_git_dir(&repo.git_dir, &name);
+        fs::create_dir_all(modules_dir.parent().context("modules parent")?)?;
+        connect_work_tree_and_git_dir(&sub_wt, &modules_dir)?;
+    }
+
+    absorb_git_dir_into_superproject_recurse(repo, work_tree, path, super_prefix, quiet)?;
+    Ok(())
+}
+
+fn connect_work_tree_and_git_dir(work_tree: &Path, git_dir: &Path) -> Result<()> {
+    fs::create_dir_all(git_dir.join("objects")).ok();
+    let gitfile = work_tree.join(".git");
+    let rel_gitdir = pathdiff_relative(work_tree, git_dir);
+    fs::write(&gitfile, format!("gitdir: {rel_gitdir}\n")).context("write submodule gitfile")?;
+
+    let cfg_path = git_dir.join("config");
+    let mut cfg = if cfg_path.exists() {
+        let content = fs::read_to_string(&cfg_path)?;
+        ConfigFile::parse(&cfg_path, &content, ConfigScope::Local)?
+    } else {
+        ConfigFile::parse(&cfg_path, "", ConfigScope::Local)?
+    };
+    let rel_wt = pathdiff_relative(git_dir, work_tree);
+    cfg.set("core.worktree", &rel_wt)?;
+    cfg.write()?;
+    Ok(())
+}
+
+fn relocate_single_git_dir_into_superproject(
+    repo: &Repository,
+    work_tree: &Path,
+    path: &str,
+    name: &str,
+    super_prefix: Option<&str>,
+    quiet: bool,
+) -> Result<()> {
+    let sub_wt = work_tree.join(path);
+    let old_git_dir = sub_wt.join(".git");
+    if old_git_dir.is_file() {
+        return Ok(());
+    }
+    if !old_git_dir.is_dir() {
+        return Ok(());
+    }
+
+    let modules_dir = submodule_modules_git_dir(&repo.git_dir, name);
+    if let Some(parent) = modules_dir.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    if modules_dir.exists() {
+        return Ok(());
+    }
+
+    let real_old = fs::canonicalize(&old_git_dir).unwrap_or_else(|_| old_git_dir.clone());
+    fs::rename(&old_git_dir, &modules_dir).context("failed to move .git directory")?;
+    let real_new = fs::canonicalize(&modules_dir).unwrap_or_else(|_| modules_dir.clone());
+
+    if !quiet {
+        let display_prefix = super_prefix.unwrap_or("");
+        eprint!(
+            "Migrating git directory of '{}{}' from\n'{}' to\n'{}'\n",
+            display_prefix,
+            path,
+            real_old.display(),
+            real_new.display()
+        );
+    }
+
+    connect_work_tree_and_git_dir(&sub_wt, &modules_dir)?;
+    Ok(())
+}
+
+fn absorb_git_dir_into_superproject_recurse(
+    _repo: &Repository,
+    work_tree: &Path,
+    path: &str,
+    super_prefix: Option<&str>,
+    quiet: bool,
+) -> Result<()> {
+    let sub_wt = work_tree.join(path);
+    if !sub_wt.is_dir() {
+        return Ok(());
+    }
+
+    let child_prefix = format!(
+        "{}{}/",
+        super_prefix.unwrap_or(""),
+        path.trim_end_matches('/')
+    );
+    let grit_bin = grit_exe::grit_executable();
+    let mut cmd = grit_subprocess(&grit_bin);
+    cmd.current_dir(&sub_wt)
+        .arg("submodule--helper")
+        .arg("absorbgitdirs")
+        .arg(format!("--super-prefix={}", child_prefix));
+    if quiet {
+        cmd.arg("-q");
+    }
+    grit_exe::strip_trace2_env(&mut cmd);
+    let st = cmd
+        .status()
+        .context("submodule--helper absorbgitdirs in submodule")?;
+    if !st.success() {
+        bail!("fatal: could not recurse into submodule '{path}'");
+    }
     Ok(())
 }
 

--- a/logs/2026-04-09_t7412-submodule-absorbgitdirs.md
+++ b/logs/2026-04-09_t7412-submodule-absorbgitdirs.md
@@ -1,0 +1,19 @@
+# t7412-submodule-absorbgitdirs
+
+## Goal
+
+Make `tests/t7412-submodule-absorbgitdirs.sh` pass 12/12 with grit as `git`.
+
+## Changes (summary)
+
+- **`submodule absorbgitdirs`**: Walk index gitlinks (with `.gitmodules` name lookup), match Git’s stderr migration format, recurse into submodules via `submodule--helper absorbgitdirs --super-prefix=…`, handle already-under-common-dir gitdirs, gitfile repair, and multi-worktree rejection.
+- **`submodule--helper`**: Dispatch `absorbgitdirs` with `--super-prefix` / `-q`.
+- **`fsck`**: Do not traverse into gitlink OIDs (submodule commits live in separate object stores); fixes false “missing blob” after submodule workflows.
+- **`submodule update`**: Resolve `.git/modules/<name>/` using submodule **name** (not path); `run_update` enables implicit nested recursion like Git; skip checkout + progress when HEAD already matches recorded gitlink (quiet `submodule update`); `default_remote_url_raw` reads config from **common** git dir (linked worktrees).
+- **`checkout_submodule_worktree`**: Takes submodule name for modules path.
+
+## Validation
+
+- `cargo fmt`, `cargo clippy -p grit-rs -p grit-lib --fix --allow-dirty`
+- `cargo test -p grit-lib --lib` — 160 passed
+- `./scripts/run-tests.sh t7412-submodule-absorbgitdirs.sh` — 12/12

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   325 |
+| Completed   |   326 |
 | In progress |     5 |
-| Remaining   |   441 |
+| Remaining   |   440 |
 | **Total**   |   771 |
 
-Task lines in `PLAN.md`: 325 completed (`[x]`), 5 in progress (`[~]`), 441 remaining (`[ ]`).
+Task lines in `PLAN.md`: 326 completed (`[x]`), 5 in progress (`[~]`), 440 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t7412-submodule-absorbgitdirs` — 12/12 tests pass (`submodule absorbgitdirs`: index gitlinks + `.gitmodules` name lookup, recurse via `submodule--helper`, common-dir / gitfile repair, multi-worktree error; `fsck` skips gitlink OIDs; `submodule update` uses `submodule.<name>` for `.git/modules/` paths, implicit recursive update, quiet no-op when HEAD matches gitlink; `default_remote_url` reads common `config` for linked worktrees)
 - `t3309-notes-merge-auto-resolve` — 31/31 tests pass (`notes merge`: `union` / `cat_sort_uniq` blob combine like Git; successful merge commits use two parents; `notes.mergeStrategy` config errors match upstream expectations)
 - `t4063-diff-blobs` — 18/18 tests pass (`diff`: blob↔blob and `rev:path` pairs without treating blobs as trees; `HEAD:one..HEAD:two` range split; `rev:path` vs worktree file uses tree path + modes + `write_patch_with_prefix`; raw blob OID vs existing file uses filename as old path; `rev_parse::resolve_treeish_blob_at_path` for tree walks)
 - `t5524-pull-msg` — 3/3 tests pass (`git pull --no-rebase --log` merge message preserves `$` in subject lines; `--log=1` limits shortlog; harness CSV/dashboards refreshed; `PLAN.md` marked complete)

--- a/test-results.md
+++ b/test-results.md
@@ -1,5 +1,10 @@
 # Test results
 
+**2026-04-09 (t7412 / submodule absorbgitdirs)**
+
+- `cargo test -p grit-lib --lib`: 160 passed
+- `./scripts/run-tests.sh t7412-submodule-absorbgitdirs.sh`: 12/12 passed
+
 **2026-04-09 (t4063 / diff blobs)**
 
 - `cargo test -p grit-lib --lib`: 155 passed


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible `git submodule absorbgitdirs` and related plumbing so `t7412-submodule-absorbgitdirs` passes 12/12.

## Key changes

- **`submodule absorbgitdirs`**: Operates on index gitlinks with `.gitmodules` name lookup; matches Git stderr migration format; recurses via `submodule--helper absorbgitdirs`; handles common-dir containment, gitfile repair, and multi-worktree rejection.
- **`submodule--helper`**: Adds `absorbgitdirs` with `--super-prefix` and `-q`.
- **`fsck`**: Skips traversing gitlink OIDs (submodule commits are not in the superproject ODB).
- **`submodule update`**: Uses submodule **name** for `.git/modules/<name>/`; top-level `submodule update` implicitly recurses into nested submodules like Git; skips redundant checkout (and progress lines) when HEAD already matches the recorded gitlink; `default_remote_url_raw` reads config from the **common** git directory for linked worktrees.

## Validation

- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t7412-submodule-absorbgitdirs.sh` → 12/12

Also refreshed harness CSV/dashboards and updated `PLAN.md` / `progress.md` / `test-results.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb7c311c-a157-47e0-bc65-533fe0347d05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb7c311c-a157-47e0-bc65-533fe0347d05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

