### PR TITLE
fix: t7810 grep pathspec, -f path, -L --cached, log author match

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1271,7 +1271,7 @@ t7702-repack-cyclic-alternate	t7	yes	2	2	0	true	ok	0
 t7703-repack-geometric	t7	yes	18	3	15	false	ok	0
 t7704-repack-cruft	t7	skip	25	5	20	false	ok	0
 t7800-difftool	t7	yes	95	13	82	false	ok	0
-t7810-grep	t7	yes	263	222	41	false	ok	0
+t7810-grep	t7	yes	263	233	30	false	ok	0
 t7811-grep-open	t7	yes	10	7	3	false	ok	0
 t7812-grep-icase-non-ascii	t7	yes	18	18	0	true	ok	0
 t7813-grep-icase-iso	t7	yes	2	2	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,697 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,697 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T20:40:03+00:00" class="gen-time" title="2026-04-09 20:40 UTC">2026-04-09 20:40 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,697</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>758 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,505/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.3%"></div></div>
+        <span class="group-pct pct-blue">69.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35697 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,697 / 45,142 tests · 1,405 files in scope · 758 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T20:40:03+00:00" class="gen-time" title="2026-04-09 20:40 UTC">2026-04-09 20:40 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,697</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">
@@ -12867,14 +12867,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:13.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="263" data-passed="222">
+<tr class="" data-group="t7" data-tests="263" data-passed="233">
   <td class="mono">t7810-grep</td>
   <td>t7</td>
   <td></td>
   <td class="right">263</td>
-  <td class="right">222</td>
+  <td class="right">233</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:84.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:88.6%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="10" data-passed="7">

--- a/grit/src/commands/grep.rs
+++ b/grit/src/commands/grep.rs
@@ -19,22 +19,15 @@ use grit_lib::merge_diff::{blob_text_for_diff, blob_text_for_diff_with_oid, diff
 use grit_lib::objects::{parse_commit, parse_tree, ObjectId, ObjectKind};
 use grit_lib::refs::resolve_ref;
 use grit_lib::repo::Repository;
-use grit_lib::rev_parse::{discover_optional, resolve_revision, show_prefix, split_treeish_colon};
+use grit_lib::rev_parse::{discover_optional, resolve_revision, split_treeish_colon};
 use grit_lib::wildmatch::wildmatch;
 
 use crate::pathspec::resolve_pathspec;
 
-/// Strip [`show_prefix`] from a work-tree-relative path for user-facing output (t1501 `git grep`
-/// from `work/sub`).
-fn grep_output_path(repo: &Repository, full_worktree_relative: &str) -> String {
-    let Ok(cwd) = std::env::current_dir() else {
-        return full_worktree_relative.to_owned();
-    };
-    let pfx = show_prefix(repo, &cwd);
-    if !pfx.is_empty() && full_worktree_relative.starts_with(&pfx) {
-        return full_worktree_relative[pfx.len()..].to_owned();
-    }
-    full_worktree_relative.to_owned()
+/// Quoted path for stderr / binary messages: cwd-relative like match lines (t7810 subdir paths).
+fn grep_output_path(repo: &Repository, path_prefix: &str, path_str: &str, args: &Args) -> String {
+    let rel = worktree_display_rel(repo, path_prefix, path_str, args);
+    path_for_output(&rel, args)
 }
 
 /// Arguments for `grit grep`.
@@ -440,20 +433,12 @@ fn run_inner(pattern_tokens: Vec<PatternToken>, mut args: Args) -> Result<()> {
     let (first_pos_pattern, tree_ish, mut pathspecs) =
         parse_positional(&args, &repo, has_peeled_patterns)?;
     pathspecs = pathspecs_relative_to_cwd(&repo, &pathspecs);
-    let cwd = std::env::current_dir().context("cannot get current directory")?;
-    let pathspec_prefix = repo
-        .work_tree
-        .as_ref()
-        .map(|_| show_prefix(&repo, &cwd))
-        .filter(|p| !p.is_empty())
-        .map(|mut p| {
-            p.pop();
-            p
-        });
+    // `pathspecs_relative_to_cwd` already rebased user pathspecs to repo-relative paths; do not
+    // apply `show_prefix` again in `resolve_pathspec` (would double-prefix under subdirs, t7810 -f).
     pathspecs = if let Some(wt) = repo.work_tree.as_ref() {
         pathspecs
             .into_iter()
-            .map(|p| resolve_pathspec(&p, wt, pathspec_prefix.as_deref()))
+            .map(|p| resolve_pathspec(&p, wt, None))
             .collect()
     } else {
         pathspecs
@@ -876,11 +861,16 @@ fn grep_cached(
         } else {
             format!("{path_prefix}{path_str}")
         };
-        let output_path = grep_output_path(repo, &full_path);
+        let output_path = grep_output_path(repo, path_prefix, &path_str, args);
 
         // Pathspec filtering is relative to the superproject
         let is_submodule = entry.mode == MODE_GITLINK;
         if !pathspecs.is_empty() && !any_pathspec_matches(&full_path, pathspecs, is_submodule) {
+            continue;
+        }
+
+        // `git grep -L --cached` lists tracked paths without matches; skip intent-to-add (t7810).
+        if args.cached && args.files_without_match && entry.intent_to_add() {
             continue;
         }
 
@@ -1083,7 +1073,7 @@ fn grep_worktree(
         } else {
             format!("{path_prefix}{path_str}")
         };
-        let output_path = grep_output_path(repo, &full_rel);
+        let output_path = grep_output_path(repo, path_prefix, &path_str, args);
         let display_path = worktree_display_rel(repo, path_prefix, &path_str, args);
 
         // Pathspec filtering is relative to the superproject

--- a/grit/src/commands/grep_pattern.rs
+++ b/grit/src/commands/grep_pattern.rs
@@ -6,6 +6,7 @@
 
 use anyhow::{Context, Result};
 use std::io::Read;
+use std::path::Path;
 
 /// A shell token that participates in Git's boolean pattern expression.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -90,7 +91,15 @@ pub(crate) fn extract_pattern_tokens(rest: &[String]) -> Result<(Vec<PatternToke
                             .context("cannot read patterns from stdin")?;
                         s
                     } else {
-                        std::fs::read_to_string(path)
+                        let p = Path::new(path);
+                        let resolved = if p.is_absolute() {
+                            p.to_path_buf()
+                        } else {
+                            std::env::current_dir()
+                                .unwrap_or_else(|_| Path::new(".").to_path_buf())
+                                .join(p)
+                        };
+                        std::fs::read_to_string(&resolved)
                             .with_context(|| format!("cannot read pattern file: '{path}'"))?
                     };
                     for line in content.lines() {

--- a/grit/src/commands/log.rs
+++ b/grit/src/commands/log.rs
@@ -1116,6 +1116,19 @@ fn extract_epoch_from_ident(ident: &str) -> i64 {
     committer_timestamp_for_until_filter(ident)
 }
 
+/// Strip the timestamp trailer from a Git ident line (Git `strip_timestamp` in `grep.c`).
+///
+/// The author/committer payload is `Name <email> <epoch> <tz>`; pattern matching uses only
+/// the `Name <email>` prefix (through the closing `>`), so `--author=-0700` does not match
+/// the timezone field (t7810).
+fn ident_for_author_pattern_match(ident: &str) -> String {
+    if let Some(gt) = ident.rfind('>') {
+        ident[..=gt].to_string()
+    } else {
+        ident.to_string()
+    }
+}
+
 /// When `git log --graph <tip> --branches` is used, Git prefers `<tip>` as the leftmost
 /// branch tip when it is incomparable with the current first commit (t3451-history-reword).
 fn prefer_explicit_tip_first_in_graph_walk(
@@ -3747,15 +3760,17 @@ fn run_reflog_walk(
             continue;
         }
 
+        let author_key = ident_for_author_pattern_match(&commit_data.author);
         let author_ok =
-            author_res.is_empty() || author_res.iter().any(|re| re.is_match(&commit_data.author));
+            author_res.is_empty() || author_res.iter().any(|re| re.is_match(author_key.as_str()));
         if !author_ok {
             continue;
         }
+        let committer_key = ident_for_author_pattern_match(&commit_data.committer);
         let committer_ok = committer_res.is_empty()
             || committer_res
                 .iter()
-                .any(|re| re.is_match(&commit_data.committer));
+                .any(|re| re.is_match(committer_key.as_str()));
         if !committer_ok {
             continue;
         }
@@ -4298,16 +4313,21 @@ impl<'a> WalkCommitsIter<'a> {
             if self.merges_only && !is_merge {
                 continue;
             }
+            let author_key = ident_for_author_pattern_match(&info.author);
             let author_ok = self.author_res.is_empty()
-                || self.author_res.iter().any(|re| re.is_match(&info.author));
+                || self
+                    .author_res
+                    .iter()
+                    .any(|re| re.is_match(author_key.as_str()));
             if !author_ok {
                 continue;
             }
+            let committer_key = ident_for_author_pattern_match(&info.committer);
             let committer_ok = self.committer_res.is_empty()
                 || self
                     .committer_res
                     .iter()
-                    .any(|re| re.is_match(&info.committer));
+                    .any(|re| re.is_match(committer_key.as_str()));
             if !committer_ok {
                 continue;
             }

--- a/grit/src/pathspec.rs
+++ b/grit/src/pathspec.rs
@@ -337,8 +337,13 @@ pub fn pathdiff(cwd: &Path, work_tree: &Path) -> Option<String> {
 /// or `None` when cwd is the work tree root.
 #[must_use]
 pub fn resolve_pathspec(pathspec: &str, work_tree: &Path, prefix: Option<&str>) -> String {
+    // Git: `.` at repo root means "match the whole tree" (not an empty pathspec).
+    // An empty resolved pathspec would match nothing and breaks `grep -- . t` max-depth.
     if pathspec == "." {
-        return prefix.unwrap_or("").to_owned();
+        return match prefix {
+            Some(p) if !p.is_empty() => p.to_owned(),
+            _ => ".".to_owned(),
+        };
     }
     if pathspec.contains("../") || pathspec.starts_with("../") {
         let cwd = std::env::current_dir().unwrap_or_default();

--- a/logs/2026-04-09_t7810-grep-progress.md
+++ b/logs/2026-04-09_t7810-grep-progress.md
@@ -1,0 +1,15 @@
+# t7810-grep progress (2026-04-09)
+
+## Changes
+
+- `pathspec.rs`: resolve `.` at repo root to `.` (not empty) so `--max-depth 0 -- . t` matches Git.
+- `grep.rs`: avoid double-prefixing pathspecs after `pathspecs_relative_to_cwd` (fixes `grep -f` from subdir).
+- `grep.rs`: binary-match messages use `path_for_output` on cwd-relative path (quoted names in subdir).
+- `grep.rs`: `grep -L --cached` skips intent-to-add entries.
+- `log.rs`: `--author` / `--committer` match ident with timestamp stripped after `>` (t7810 log grep, timestamp tests).
+
+## Harness
+
+After release build: **233/263** passing, **30** failing.
+
+Remaining failures cluster around: `grep -p` / `-W` / `--max-count` with show-function, `--no-index` + discovery/fallback, parent-dir `git grep ..`, and full `color.grep.*` slot support.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Incremental fixes toward `t7810-grep.sh` parity with Git.

### Code

- **`grit/src/pathspec.rs`**: Treat `.` at repo root as `.` (not empty) so pathspec + `--max-depth` behaves like Git (`-- . t`).
- **`grit/src/commands/grep.rs`**: After `pathspecs_relative_to_cwd`, resolve pathspecs without applying `show_prefix` again (fixes double `sub/dir/` prefix and `grep -f` from a subdirectory). Binary “matches” lines use the same quoting as normal output. `grep -L --cached` skips intent-to-add index entries.
- **`grit/src/commands/grep_pattern.rs`**: Read `-f` pattern files relative to cwd (resolved absolute read).
- **`grit/src/commands/log.rs`**: `--author` / `--committer` regexes match the ident with timestamp stripped after `>` (Git `strip_timestamp` behavior).

### Test status

`./scripts/run-tests.sh t7810-grep.sh`: **233 / 263** passing (was 222 / 263).

### Remaining t7810 gaps (not in this PR)

Roughly: `grep -p` / `-W` / `--max-count` with show-function, `--no-index` discovery and fallback, `git grep ..` from subdir, full `color.grep.*` slots, and related dashdash / rev disambiguation for `--no-index`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1cd0596f-098f-4485-a14c-912e01fce4fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1cd0596f-098f-4485-a14c-912e01fce4fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

