### PR TITLE
fix: make t1414-reflog-walk fully pass (log -g and rev-list -g)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -415,7 +415,7 @@ t1410-reflog	t1	yes	41	23	18	false	ok	0
 t1411-reflog-show	t1	yes	17	8	9	false	ok	0
 t1412-reflog-loop	t1	yes	3	3	0	true	ok	0
 t1413-reflog-detach	t1	yes	7	7	0	true	ok	0
-t1414-reflog-walk	t1	yes	12	3	9	false	ok	0
+t1414-reflog-walk	t1	yes	12	12	0	true	ok	0
 t1415-worktree-refs	t1	skip	10	4	6	false	ok	0
 t1416-ref-transaction-hooks	t1	yes	10	9	1	false	ok	0
 t1417-reflog-updateref	t1	yes	21	21	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,695 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,695 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T20:57:31+00:00" class="gen-time" title="2026-04-09 20:57 UTC">2026-04-09 20:57 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,695</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -197,11 +197,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">275/368 files · 8 skipped · 11,694/12,747 tests</span>
+        <span class="group-meta">276/368 files · 8 skipped · 11,703/12,747 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:91.7%"></div></div>
-        <span class="group-pct pct-green">91.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:91.8%"></div></div>
+        <span class="group-pct pct-green">91.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t2">
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35695 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,695 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T20:57:31+00:00" class="gen-time" title="2026-04-09 20:57 UTC">2026-04-09 20:57 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,695</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -4307,14 +4307,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="12" data-passed="3">
+<tr class="" data-group="t1" data-tests="12" data-passed="12" data-full-pass="1">
   <td class="mono">t1414-reflog-walk</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">12</td>
-  <td class="right">3</td>
+  <td class="right">12</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:25.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="row-skip" data-group="t1" data-tests="10" data-passed="4">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/reflog.rs
+++ b/grit-lib/src/reflog.rs
@@ -49,6 +49,25 @@ pub fn reflog_exists(git_dir: &Path, refname: &str) -> bool {
     path.is_file()
 }
 
+/// Read a reflog using Git's loose ref DWIM rules when the direct path is missing.
+///
+/// Tries `refname`, then `refs/<refname>`, then `refs/heads/<refname>` (when `refname` is not
+/// already under `refs/`). Matches `read_complete_reflog` in Git's `reflog-walk.c`.
+pub fn read_reflog_dwim(git_dir: &Path, refname: &str) -> Result<Vec<ReflogEntry>> {
+    let mut entries = read_reflog(git_dir, refname)?;
+    if !entries.is_empty() {
+        return Ok(entries);
+    }
+    if !refname.starts_with("refs/") {
+        entries = read_reflog(git_dir, &format!("refs/{refname}"))?;
+        if !entries.is_empty() {
+            return Ok(entries);
+        }
+        entries = read_reflog(git_dir, &format!("refs/heads/{refname}"))?;
+    }
+    Ok(entries)
+}
+
 /// Read all reflog entries for the given ref, in file order (oldest first).
 ///
 /// Returns an empty vec if the reflog file does not exist.

--- a/grit-lib/src/rev_list.rs
+++ b/grit-lib/src/rev_list.rs
@@ -2451,6 +2451,70 @@ fn commit_touches_paths(
     Ok(sparse)
 }
 
+/// Whether `oid` would be included in a dense path-limited history walk for `paths`.
+///
+/// Matches the non-Bloom parts of [`commit_touches_paths`] with `full_history = false` and
+/// `sparse = false`: single-parent commits require a tree change on `paths` vs their parent;
+/// merge commits are omitted when exactly one parent is tree-same on `paths` (Git `TREESAME`
+/// simplification). Used by `log -g -- <path>` to align with Git's reflog path filtering.
+pub fn commit_visible_for_dense_pathspecs(
+    repo: &Repository,
+    oid: ObjectId,
+    paths: &[String],
+) -> Result<bool> {
+    if paths.is_empty() {
+        return Ok(true);
+    }
+    let commit = load_commit(repo, oid)?;
+    let parents = commit.parents.clone();
+    let commit_entries = flatten_tree(repo, commit.tree, "")?;
+    let commit_map: HashMap<String, ObjectId> = commit_entries.into_iter().collect();
+
+    if parents.is_empty() {
+        return Ok(commit_map.keys().any(|path| {
+            paths.iter().any(|spec| {
+                crate::pathspec::matches_pathspec_with_context(
+                    spec,
+                    path,
+                    crate::pathspec::PathspecMatchContext {
+                        is_directory: false,
+                        is_git_submodule: false,
+                    },
+                )
+            })
+        }));
+    }
+
+    if parents.len() == 1 {
+        let parent = load_commit(repo, parents[0])?;
+        let parent_map: HashMap<String, ObjectId> =
+            flatten_tree(repo, parent.tree, "")?.into_iter().collect();
+        return Ok(path_differs_for_specs(&commit_map, &parent_map, paths));
+    }
+
+    let mut treesame_parents = 0usize;
+    let mut differs_any = false;
+    for parent_oid in &parents {
+        let parent = load_commit(repo, *parent_oid)?;
+        let parent_map: HashMap<String, ObjectId> =
+            flatten_tree(repo, parent.tree, "")?.into_iter().collect();
+        let differs = path_differs_for_specs(&commit_map, &parent_map, paths);
+        if differs {
+            differs_any = true;
+        } else {
+            treesame_parents += 1;
+        }
+    }
+
+    if treesame_parents == 1 {
+        return Ok(false);
+    }
+    if differs_any {
+        return Ok(true);
+    }
+    Ok(false)
+}
+
 fn path_differs_for_specs(
     current: &HashMap<String, ObjectId>,
     parent: &HashMap<String, ObjectId>,

--- a/grit-lib/src/rev_parse.rs
+++ b/grit-lib/src/rev_parse.rs
@@ -2056,6 +2056,37 @@ pub fn reflog_walk_refname(repo: &Repository, spec: &str) -> Result<Option<Strin
     Ok(Some(dwim_refname(repo, current_spec.as_str())))
 }
 
+/// Resolve a user revision string to the reflog file ref name for `log -g` / `rev-list -g`.
+///
+/// Mirrors Git `add_reflog_for_walk` / `read_complete_reflog` ref resolution before reading
+/// `logs/<ref>`.
+pub fn resolve_reflog_walk_log_ref(repo: &Repository, r: &str) -> Result<String> {
+    if let Ok(Some(w)) = reflog_walk_refname(repo, r) {
+        return Ok(w);
+    }
+    if r == "HEAD" || r.starts_with("refs/") {
+        return Ok(r.to_string());
+    }
+    if r.starts_with("@{") {
+        if let Some(n_str) = r.strip_prefix("@{").and_then(|s| s.strip_suffix('}')) {
+            if let Some(stripped) = n_str.strip_prefix('-') {
+                if stripped.parse::<usize>().is_ok() {
+                    if let Ok(branch) = refs::resolve_at_n_branch(&repo.git_dir, r) {
+                        return Ok(format!("refs/heads/{branch}"));
+                    }
+                }
+            }
+        }
+        return Ok(r.to_string());
+    }
+    let candidate = format!("refs/heads/{r}");
+    if refs::resolve_ref(&repo.git_dir, &candidate).is_ok() {
+        Ok(candidate)
+    } else {
+        Ok(r.to_string())
+    }
+}
+
 /// Try to resolve `ref@{...}` with optional chained `@{...}` steps (e.g. `other@{u}@{1}`).
 fn try_resolve_reflog_index(repo: &Repository, spec: &str) -> Result<Option<ObjectId>> {
     let Some((prefix, steps)) = split_reflog_at_chain(spec) else {

--- a/grit/src/commands/commit.rs
+++ b/grit/src/commands/commit.rs
@@ -1067,6 +1067,11 @@ pub fn run(mut args: Args) -> Result<()> {
                 "commit (amend): {}",
                 commit_data.message.lines().next().unwrap_or("")
             )
+        } else if commit_data.parents.len() >= 2 {
+            format!(
+                "commit (merge): {}",
+                commit_data.message.lines().next().unwrap_or("")
+            )
         } else {
             format!(
                 "commit: {}",

--- a/grit/src/commands/log.rs
+++ b/grit/src/commands/log.rs
@@ -29,14 +29,14 @@ use grit_lib::merge_base::is_ancestor;
 use grit_lib::merge_diff::{blob_text_for_diff, is_binary_for_diff};
 use grit_lib::objects::{parse_commit, parse_tag, ObjectId, ObjectKind};
 use grit_lib::odb::Odb;
-use grit_lib::reflog::read_reflog;
+use grit_lib::reflog::{read_reflog_dwim, ReflogEntry};
 use grit_lib::repo::Repository;
 use grit_lib::rev_list::{
-    collect_revision_specs_with_stdin, is_symmetric_diff, merge_bases, rev_list,
-    split_symmetric_diff, OrderingMode, RevListOptions,
+    collect_revision_specs_with_stdin, commit_visible_for_dense_pathspecs, is_symmetric_diff,
+    merge_bases, rev_list, split_symmetric_diff, OrderingMode, RevListOptions,
 };
 use grit_lib::rev_parse::{
-    reflog_walk_refname, resolve_revision_as_commit, try_parse_double_dot_log_range,
+    resolve_reflog_walk_log_ref, resolve_revision_as_commit, try_parse_double_dot_log_range,
 };
 use grit_lib::state::{resolve_head, HeadState};
 use regex::{Regex, RegexBuilder};
@@ -3505,21 +3505,78 @@ fn reflog_grep_matches(patterns: &[Regex], text: &str, all_match: bool, invert: 
     }
 }
 
-/// Whether a reflog transition (`old_oid` → `new_oid`) touches any of `pathspecs`.
+fn reflog_message_is_checkout(message: &str) -> bool {
+    message
+        .trim_start()
+        .to_ascii_lowercase()
+        .starts_with("checkout:")
+}
+
+fn tree_matches_any_pathspec(odb: &Odb, tree_oid: &ObjectId, pathspecs: &[String]) -> Result<bool> {
+    let paths = grit_lib::diff::head_path_states(odb, Some(tree_oid))?;
+    Ok(paths
+        .keys()
+        .any(|path| pathspecs.iter().any(|ps| path_matches(path.as_str(), ps))))
+}
+
+/// Whether a reflog step matches `pathspecs`.
 ///
-/// Used for `git reflog show -- <path>` / `log -g -- <path>`: Git filters reflog lines by whether
-/// the tree diff for that specific reflog step matches the pathspec.
+/// Checkouts match if the pathspec names a path present in either the old or new commit tree
+/// (Git `log -g -- <path>`). Other single-parent steps use the reflog transition diff. Merges use
+/// dense path simplification plus per-parent diffs vs the merge result (t1414).
 fn reflog_transition_touches_paths(
-    odb: &Odb,
+    repo: &Repository,
     old_oid: &ObjectId,
     new_oid: &ObjectId,
+    reflog_message: &str,
     pathspecs: &[String],
 ) -> Result<bool> {
     if pathspecs.is_empty() {
         return Ok(true);
     }
+    let odb = &repo.odb;
     let new_obj = odb.read(new_oid)?;
     let new_commit = parse_commit(&new_obj.data)?;
+
+    let tree_diff_touches = |from_tree: Option<&ObjectId>, to_tree: &ObjectId| -> Result<bool> {
+        let old_t = if let Some(t) = from_tree {
+            Some(*t)
+        } else {
+            None
+        };
+        let entries = diff_trees(odb, old_t.as_ref(), Some(to_tree), "")?;
+        Ok(entries.iter().any(|e| {
+            let path = e.path();
+            pathspecs.iter().any(|ps| path_matches(path, ps))
+        }))
+    };
+
+    if new_commit.parents.len() >= 2 {
+        if !commit_visible_for_dense_pathspecs(repo, *new_oid, pathspecs)? {
+            return Ok(false);
+        }
+        for p in &new_commit.parents {
+            let p_obj = match odb.read(p) {
+                Ok(o) => o,
+                Err(_) => continue,
+            };
+            let p_commit = match parse_commit(&p_obj.data) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            if tree_diff_touches(Some(&p_commit.tree), &new_commit.tree)? {
+                return Ok(true);
+            }
+        }
+        return Ok(false);
+    }
+
+    if new_commit.parents.len() < 2 && reflog_message_is_checkout(reflog_message) {
+        // Match Git: only the checkout *destination* tree counts (t1414 `log -g -- two.t` omits
+        // `main → side` when `two.t` exists only on `main`).
+        return tree_matches_any_pathspec(odb, &new_commit.tree, pathspecs);
+    }
+
     let old_tree = if old_oid.is_zero() {
         None
     } else {
@@ -3533,11 +3590,7 @@ fn reflog_transition_touches_paths(
         };
         Some(old_commit.tree)
     };
-    let entries = diff_trees(odb, old_tree.as_ref(), Some(&new_commit.tree), "")?;
-    Ok(entries.iter().any(|e| {
-        let path = e.path();
-        pathspecs.iter().any(|ps| path_matches(path, ps))
-    }))
+    tree_diff_touches(old_tree.as_ref(), &new_commit.tree)
 }
 
 fn next_reflog_at_open_for_suffix(spec: &str, mut from: usize) -> Option<usize> {
@@ -3572,98 +3625,38 @@ fn reflog_entry_tz(entry: &grit_lib::reflog::ReflogEntry) -> &str {
 fn format_reflog_selector_date(
     display_name: &str,
     entry: &grit_lib::reflog::ReflogEntry,
+    date_mode: Option<&str>,
 ) -> String {
     if let Some(ts) = reflog_entry_unix_ts(entry) {
         let tz = reflog_entry_tz(entry);
-        // `format_date_with_mode` parses Git signature tails via `parse_signature_tail`, which
-        // requires the `Name <email>` prefix before `<unix> <tz>` (see grit-lib `ident.rs`).
         let pseudo = format!("x <x@x> {ts} {tz}");
-        let date = format_date_with_mode(&pseudo, None);
+        let date = format_date_with_mode(&pseudo, date_mode);
         format!("{display_name}@{{{date}}}")
     } else {
         format!("{display_name}@{{0}}")
     }
 }
 
-/// Run the reflog walk mode (`log -g` / `log --walk-reflogs`).
-fn run_reflog_walk(
-    repo: &Repository,
-    args: &Args,
-    _patch_context: usize,
-    author_res: &[Regex],
-    committer_res: &[Regex],
-    grep_res: &[Regex],
-    grep_reflog_res: &[Regex],
-) -> Result<()> {
-    // Determine which ref to walk
-    let refname = if args.revisions.is_empty() {
-        "HEAD".to_string()
-    } else {
-        let r = &args.revisions[0];
-        if let Ok(Some(w)) = reflog_walk_refname(repo, r) {
-            w
-        } else if r == "HEAD" || r.starts_with("refs/") {
-            r.clone()
-        } else if r.starts_with("@{") {
-            // Resolve @{-N} to the previous branch name
-            if let Some(n_str) = r.strip_prefix("@{").and_then(|s| s.strip_suffix('}')) {
-                if let Some(stripped) = n_str.strip_prefix('-') {
-                    if let Ok(_n) = stripped.parse::<usize>() {
-                        if let Ok(branch) = grit_lib::refs::resolve_at_n_branch(&repo.git_dir, r) {
-                            format!("refs/heads/{branch}")
-                        } else {
-                            r.clone()
-                        }
-                    } else {
-                        r.clone()
-                    }
-                } else {
-                    r.clone()
-                }
-            } else {
-                r.clone()
-            }
-        } else {
-            let candidate = format!("refs/heads/{r}");
-            if grit_lib::refs::resolve_ref(&repo.git_dir, &candidate).is_ok() {
-                candidate
-            } else {
-                r.clone()
-            }
-        }
-    };
+/// Reflog file key plus display name for `%gd` / headers (matches Git `complete_reflogs`).
+struct ReflogWalkRef {
+    log_ref: String,
+    display_name: String,
+    user_spec: String,
+    entries: Vec<ReflogEntry>,
+    recno: isize,
+    nr: usize,
+    force_date_selector: bool,
+    tie_order: usize,
+}
 
-    // Use the original user-provided name for display (preserve full ref name if given)
-    let orig_r_owned = args
-        .revisions
-        .first()
-        .cloned()
-        .unwrap_or_else(|| "HEAD".to_string());
-    let orig_r = orig_r_owned.as_str();
-    let display_name = if orig_r.starts_with("refs/") {
-        orig_r
-    } else if refname.starts_with("refs/heads/") {
-        refname.strip_prefix("refs/heads/").unwrap_or(&refname)
-    } else {
-        &refname
-    };
-
-    let entries = read_reflog(&repo.git_dir, &refname).map_err(|e| anyhow::anyhow!("{e}"))?;
-
-    if entries.is_empty() {
-        return Ok(());
-    }
-
-    let effective_pathspecs = if args.pathspecs.is_empty() {
-        Vec::new()
-    } else {
-        validate_pathspec_scope(repo, &args.pathspecs)?;
-        resolve_effective_pathspecs(repo, &args.pathspecs)?
-    };
-
+fn reflog_start_index_and_date_flag(
+    orig_r: &str,
+    entries: &[ReflogEntry],
+) -> (usize, bool, Option<i64>) {
     let nr = entries.len();
     let mut start_j: Option<usize> = None;
     let mut use_date_selector = false;
+    let mut target_ts_for_warn: Option<i64> = None;
 
     let mut pos = 0usize;
     while let Some(at) = next_reflog_at_open_for_suffix(orig_r, pos) {
@@ -3682,15 +3675,17 @@ fn run_reflog_walk(
             start_j = Some(idx.unwrap_or(0));
             use_date_selector = false;
         } else if let Some(target_ts) = grit_lib::rev_parse::reflog_date_selector_timestamp(inner) {
-            let mut picked = 0usize;
-            for (j, e) in entries.iter().enumerate() {
-                if let Some(ts) = reflog_entry_unix_ts(e) {
+            target_ts_for_warn = Some(target_ts);
+            let mut picked = None::<usize>;
+            for i in (0..nr).rev() {
+                if let Some(ts) = reflog_entry_unix_ts(&entries[i]) {
                     if ts <= target_ts {
-                        picked = j;
+                        picked = Some(i);
+                        break;
                     }
                 }
             }
-            start_j = Some(picked);
+            start_j = Some(picked.unwrap_or(0));
             use_date_selector = true;
         } else {
             start_j = Some(nr.saturating_sub(1));
@@ -3700,6 +3695,127 @@ fn run_reflog_walk(
     }
 
     let start_j = start_j.unwrap_or(nr.saturating_sub(1));
+    (start_j, use_date_selector, target_ts_for_warn)
+}
+
+fn reflog_display_name_for(log_ref: &str, user_spec: &str) -> String {
+    if user_spec.starts_with("refs/") {
+        user_spec.to_string()
+    } else if log_ref.starts_with("refs/heads/") {
+        log_ref
+            .strip_prefix("refs/heads/")
+            .unwrap_or(log_ref)
+            .to_string()
+    } else {
+        log_ref.to_string()
+    }
+}
+
+/// Run the reflog walk mode (`log -g` / `log --walk-reflogs`).
+fn run_reflog_walk(
+    repo: &Repository,
+    args: &Args,
+    _patch_context: usize,
+    author_res: &[Regex],
+    committer_res: &[Regex],
+    grep_res: &[Regex],
+    grep_reflog_res: &[Regex],
+) -> Result<()> {
+    let rev_specs: Vec<String> = if args.revisions.is_empty() {
+        vec!["HEAD".to_string()]
+    } else {
+        args.revisions.clone()
+    };
+
+    let date_mode = args.date.as_deref();
+    let force_unix_gd = date_mode == Some("unix");
+
+    let since_ts = args.since.as_ref().and_then(|s| parse_date_to_epoch(s));
+    let until_ts = args.until.as_ref().and_then(|s| parse_date_to_epoch(s));
+
+    let max_parents = if args.no_merges { Some(1usize) } else { None };
+    let min_parents = if args.merges { Some(2usize) } else { None };
+
+    let mut walks: Vec<ReflogWalkRef> = Vec::new();
+    for (tie_order, orig_r) in rev_specs.iter().enumerate() {
+        let log_ref =
+            resolve_reflog_walk_log_ref(repo, orig_r).map_err(|e| anyhow::anyhow!("{e}"))?;
+        let entries =
+            read_reflog_dwim(&repo.git_dir, &log_ref).map_err(|e| anyhow::anyhow!("{e}"))?;
+        if entries.is_empty() {
+            continue;
+        }
+        let display_name = reflog_display_name_for(&log_ref, orig_r);
+        let (start_j, mut use_date, target_ts_for_warn) =
+            reflog_start_index_and_date_flag(orig_r, &entries);
+        if force_unix_gd {
+            use_date = true;
+        }
+        if let Some(target_ts) = target_ts_for_warn {
+            if let Some(oldest_ts) = entries.first().and_then(reflog_entry_unix_ts) {
+                if target_ts < oldest_ts {
+                    let e = &entries[0];
+                    if let Some(ts) = reflog_entry_unix_ts(e) {
+                        let tz = reflog_entry_tz(e);
+                        let pseudo = format!("x <x@x> {ts} {tz}");
+                        let when = format_date_with_mode(&pseudo, Some("rfc"));
+                        eprintln!(
+                            "warning: log for '{}' only goes back to {}",
+                            display_name, when
+                        );
+                    }
+                }
+            }
+        }
+        let nr = entries.len();
+        let recno = start_j as isize;
+        walks.push(ReflogWalkRef {
+            log_ref,
+            display_name,
+            user_spec: orig_r.to_string(),
+            entries,
+            recno,
+            nr,
+            force_date_selector: use_date,
+            tie_order,
+        });
+    }
+
+    // `log -g HEAD@{date} HEAD`: Git walks HEAD from the tip; the date-limited spec does not
+    // narrow the walk when a plain committish for the same ref is also given (t1414).
+    let mut drop_date_when_plain: HashSet<usize> = HashSet::new();
+    let mut by_log: HashMap<String, Vec<usize>> = HashMap::new();
+    for (i, w) in walks.iter().enumerate() {
+        by_log.entry(w.log_ref.clone()).or_default().push(i);
+    }
+    for indices in by_log.values() {
+        let has_plain = indices.iter().any(|&i| !walks[i].user_spec.contains("@{"));
+        if !has_plain {
+            continue;
+        }
+        for &i in indices {
+            if walks[i].force_date_selector {
+                drop_date_when_plain.insert(i);
+            }
+        }
+    }
+    walks = walks
+        .into_iter()
+        .enumerate()
+        .filter(|(i, _)| !drop_date_when_plain.contains(i))
+        .map(|(_, w)| w)
+        .collect();
+
+    if walks.is_empty() {
+        return Ok(());
+    }
+
+    let effective_pathspecs = if args.pathspecs.is_empty() {
+        Vec::new()
+    } else {
+        validate_pathspec_scope(repo, &args.pathspecs)?;
+        resolve_effective_pathspecs(repo, &args.pathspecs)?
+    };
 
     let max = args.max_count.unwrap_or(usize::MAX);
     let skip = args.skip.unwrap_or(0);
@@ -3707,7 +3823,6 @@ fn run_reflog_walk(
     let stdout = io::stdout();
     let mut out = stdout.lock();
 
-    // Detect format
     let is_format_separator = args
         .format
         .as_deref()
@@ -3717,17 +3832,43 @@ fn run_reflog_walk(
     let mut shown = 0usize;
     let mut skipped = 0usize;
 
-    for j in (0..=start_j).rev() {
-        let entry = &entries[j];
+    loop {
         if shown >= max {
             break;
         }
-        if skipped < skip {
-            skipped += 1;
-            continue;
+
+        let mut best_i: Option<usize> = None;
+        let mut best_ts = i64::MIN;
+        let mut best_tie = usize::MAX;
+
+        for (i, w) in walks.iter().enumerate() {
+            if w.recno < 0 {
+                continue;
+            }
+            let e = &w.entries[w.recno as usize];
+            let Some(ts) = reflog_entry_unix_ts(e) else {
+                continue;
+            };
+            if ts > best_ts || (ts == best_ts && w.tie_order < best_tie) {
+                best_ts = ts;
+                best_tie = w.tie_order;
+                best_i = Some(i);
+            }
         }
 
-        // Read the commit object for this entry
+        let Some(wi) = best_i else {
+            break;
+        };
+
+        let w = &mut walks[wi];
+        let entry = w.entries[w.recno as usize].clone();
+        let j = w.recno as usize;
+        let nr = w.nr;
+        let display_name = w.display_name.clone();
+        let use_date_sel = w.force_date_selector;
+
+        w.recno -= 1;
+
         let commit_data = match repo.odb.read(&entry.new_oid) {
             Ok(obj) => match parse_commit(&obj.data) {
                 Ok(c) => c,
@@ -3736,11 +3877,39 @@ fn run_reflog_walk(
             Err(_) => continue,
         };
 
+        let n_parents = commit_data.parents.len();
+        if let Some(mx) = max_parents {
+            if n_parents > mx {
+                continue;
+            }
+        }
+        if let Some(mn) = min_parents {
+            if n_parents < mn {
+                continue;
+            }
+        }
+
+        if let Some(since) = since_ts {
+            if let Some(ets) = reflog_entry_unix_ts(&entry) {
+                if ets < since {
+                    continue;
+                }
+            }
+        }
+        if let Some(until) = until_ts {
+            if let Some(ets) = reflog_entry_unix_ts(&entry) {
+                if ets > until {
+                    continue;
+                }
+            }
+        }
+
         if !effective_pathspecs.is_empty()
             && !reflog_transition_touches_paths(
-                &repo.odb,
+                repo,
                 &entry.old_oid,
                 &entry.new_oid,
+                &entry.message,
                 &effective_pathspecs,
             )?
         {
@@ -3778,14 +3947,18 @@ fn run_reflog_walk(
             continue;
         }
 
-        let selector = if use_date_selector {
-            format_reflog_selector_date(display_name, entry)
+        if skipped < skip {
+            skipped += 1;
+            continue;
+        }
+
+        let selector = if use_date_sel {
+            format_reflog_selector_date(&display_name, &entry, date_mode)
         } else {
             let idx_from_tip = nr - 1 - j;
             format!("{display_name}@{{{idx_from_tip}}}")
         };
 
-        // NUL separator between entries for multi-line formats
         let is_oneline_fmt = args.format.as_deref() == Some("oneline") || args.oneline;
         if args.null_terminator && shown > 0 && !is_oneline_fmt {
             write!(out, "\0")?;
@@ -3896,7 +4069,6 @@ fn run_reflog_walk(
                 }
                 "raw" => {
                     writeln!(out, "commit {}", entry.new_oid.to_hex())?;
-                    // Write raw commit data
                     writeln!(out, "tree {}", commit_data.tree.to_hex())?;
                     for parent in &commit_data.parents {
                         writeln!(out, "parent {}", parent.to_hex())?;
@@ -3943,9 +4115,7 @@ fn run_reflog_walk(
                 writeln!(out, "{} {}: {}", abbrev, selector, entry.message)?;
             }
         } else {
-            // Full format with Reflog headers
             writeln!(out, "commit {}", entry.new_oid.to_hex())?;
-            // Strip timestamp from identity for Reflog: line (git shows only Name <email>)
             let ident_display = if let Some(email_end) = entry.identity.rfind('>') {
                 &entry.identity[..email_end + 1]
             } else {

--- a/grit/src/commands/rev_list.rs
+++ b/grit/src/commands/rev_list.rs
@@ -3,15 +3,19 @@
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::config::ConfigSet;
+use grit_lib::diff::diff_trees;
 use grit_lib::git_date::parse::parse_date_basic;
 use grit_lib::objects::{parse_commit, parse_tree, ObjectId};
 use grit_lib::pack;
+use grit_lib::pathspec::matches_pathspec;
 use grit_lib::promisor::read_promisor_missing_oids;
+use grit_lib::reflog::{read_reflog_dwim, ReflogEntry};
 use grit_lib::repo::Repository;
 use grit_lib::rev_list::{
-    collect_revision_specs_with_stdin, is_symmetric_diff, merge_bases, render_commit,
-    render_commit_with_color, rev_list, split_symmetric_diff, tag_targets, FilterObjectKind,
-    MissingAction, ObjectFilter, OrderingMode, OutputMode, RevListOptions,
+    collect_revision_specs_with_stdin, commit_visible_for_dense_pathspecs, is_symmetric_diff,
+    merge_bases, render_commit, render_commit_with_color, rev_list, split_symmetric_diff,
+    tag_targets, FilterObjectKind, MissingAction, ObjectFilter, OrderingMode, OutputMode,
+    RevListOptions,
 };
 use std::collections::{HashMap, HashSet};
 use std::io::Write;
@@ -100,6 +104,7 @@ pub fn run(args: Args) -> Result<()> {
     let mut use_bitmap_index = false;
     let mut unpacked_only = false;
     let mut test_bitmap = false;
+    let mut walk_reflog = false;
 
     let mut i = 0usize;
     while i < args.args.len() {
@@ -375,25 +380,7 @@ pub fn run(args: Args) -> Result<()> {
                 "--abbrev-commit" | "--no-abbrev-commit" => { /* silently accept */ }
                 "--abbrev" => abbrev_len = 7,
                 "--reflog" | "--walk-reflogs" | "-g" => {
-                    // Walk reflog: output all OIDs in the reflog
-                    let refname = if revision_specs.is_empty() {
-                        "HEAD".to_string()
-                    } else {
-                        let r = &revision_specs[0];
-                        if r == "HEAD" || r.starts_with("refs/") {
-                            r.clone()
-                        } else {
-                            format!("refs/heads/{r}")
-                        }
-                    };
-                    let entries = grit_lib::reflog::read_reflog(&repo.git_dir, &refname)
-                        .map_err(|e| anyhow::anyhow!("{e}"))?;
-                    let stdout = std::io::stdout();
-                    let mut out = stdout.lock();
-                    for entry in entries.iter().rev() {
-                        writeln!(out, "{}", entry.new_oid.to_hex())?;
-                    }
-                    return Ok(());
+                    walk_reflog = true;
                 }
                 _ if arg.starts_with("--filter=") => {
                     let spec = arg.trim_start_matches("--filter=");
@@ -532,6 +519,25 @@ pub fn run(args: Args) -> Result<()> {
         if let Some(def) = default_rev {
             revision_specs.push(def);
         }
+    }
+
+    if walk_reflog {
+        if revision_specs.is_empty() {
+            eprintln!("usage: git rev-list [<options>] <commit>... [--] [<path>...]");
+            std::process::exit(129);
+        }
+        return run_rev_list_reflog_walk(
+            &repo,
+            &revision_specs,
+            options.max_count,
+            options.skip,
+            options.max_parents,
+            options.min_parents,
+            options.since_cutoff,
+            options.until_cutoff,
+            &options.paths,
+            show_parents,
+        );
     }
 
     // Handle symmetric diff (A...B) tokens
@@ -1035,6 +1041,250 @@ fn parse_rev_list_date(s: &str) -> Result<i64> {
     }
     s.parse::<i64>()
         .with_context(|| format!("invalid date: '{s}'"))
+}
+
+struct RevListReflogWalkLog {
+    entries: Vec<ReflogEntry>,
+    recno: isize,
+    nr: usize,
+    tie_order: usize,
+}
+
+fn reflog_entry_unix_ts_rev(entry: &ReflogEntry) -> Option<i64> {
+    let parts: Vec<&str> = entry.identity.rsplitn(3, ' ').collect();
+    if parts.len() >= 2 {
+        parts[1].parse().ok()
+    } else {
+        None
+    }
+}
+
+fn rev_list_reflog_message_is_checkout(message: &str) -> bool {
+    message
+        .trim_start()
+        .to_ascii_lowercase()
+        .starts_with("checkout:")
+}
+
+fn rev_list_tree_matches_any_pathspec(
+    odb: &grit_lib::odb::Odb,
+    tree_oid: &ObjectId,
+    pathspecs: &[String],
+) -> Result<bool> {
+    let paths = grit_lib::diff::head_path_states(odb, Some(tree_oid))?;
+    Ok(paths.keys().any(|path| {
+        pathspecs
+            .iter()
+            .any(|ps| matches_pathspec(ps, path.as_str()))
+    }))
+}
+
+fn rev_list_reflog_transition_touches_paths(
+    repo: &Repository,
+    old_oid: &ObjectId,
+    new_oid: &ObjectId,
+    reflog_message: &str,
+    pathspecs: &[String],
+) -> Result<bool> {
+    if pathspecs.is_empty() {
+        return Ok(true);
+    }
+    let odb = &repo.odb;
+    let new_obj = odb.read(new_oid)?;
+    let new_commit = parse_commit(&new_obj.data)?;
+
+    let tree_diff_touches = |from_tree: Option<ObjectId>, to_tree: &ObjectId| -> Result<bool> {
+        let entries = diff_trees(odb, from_tree.as_ref(), Some(to_tree), "")?;
+        Ok(entries.iter().any(|e| {
+            let path = e.path();
+            pathspecs.iter().any(|ps| matches_pathspec(ps, path))
+        }))
+    };
+
+    if new_commit.parents.len() >= 2 {
+        if !commit_visible_for_dense_pathspecs(repo, *new_oid, pathspecs)? {
+            return Ok(false);
+        }
+        for p in &new_commit.parents {
+            let p_obj = match odb.read(p) {
+                Ok(o) => o,
+                Err(_) => continue,
+            };
+            let p_commit = match parse_commit(&p_obj.data) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            if tree_diff_touches(Some(p_commit.tree), &new_commit.tree)? {
+                return Ok(true);
+            }
+        }
+        return Ok(false);
+    }
+
+    if new_commit.parents.len() < 2 && rev_list_reflog_message_is_checkout(reflog_message) {
+        return rev_list_tree_matches_any_pathspec(odb, &new_commit.tree, pathspecs);
+    }
+
+    let old_tree = if old_oid.is_zero() {
+        None
+    } else {
+        let old_obj = match odb.read(old_oid) {
+            Ok(o) => o,
+            Err(_) => return Ok(false),
+        };
+        let old_commit = match parse_commit(&old_obj.data) {
+            Ok(c) => c,
+            Err(_) => return Ok(false),
+        };
+        Some(old_commit.tree)
+    };
+    tree_diff_touches(old_tree, &new_commit.tree)
+}
+
+fn run_rev_list_reflog_walk(
+    repo: &Repository,
+    revision_specs: &[String],
+    max_count: Option<usize>,
+    skip_n: usize,
+    max_parents: Option<usize>,
+    min_parents: Option<usize>,
+    since_cutoff: Option<i64>,
+    until_cutoff: Option<i64>,
+    paths: &[String],
+    show_parents: bool,
+) -> Result<()> {
+    let mut walks: Vec<RevListReflogWalkLog> = Vec::new();
+    for (tie_order, spec) in revision_specs.iter().enumerate() {
+        let log_ref = grit_lib::rev_parse::resolve_reflog_walk_log_ref(repo, spec)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let entries =
+            read_reflog_dwim(&repo.git_dir, &log_ref).map_err(|e| anyhow::anyhow!("{e}"))?;
+        if entries.is_empty() {
+            continue;
+        }
+        let nr = entries.len();
+        walks.push(RevListReflogWalkLog {
+            entries,
+            recno: (nr - 1) as isize,
+            nr,
+            tie_order,
+        });
+    }
+
+    if walks.is_empty() {
+        return Ok(());
+    }
+
+    let graft_parents = load_graft_parents(&repo.git_dir);
+    let max = max_count.unwrap_or(usize::MAX);
+    let mut shown = 0usize;
+    let mut skipped = 0usize;
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+
+    loop {
+        if shown >= max {
+            break;
+        }
+
+        let mut best_i: Option<usize> = None;
+        let mut best_ts = i64::MIN;
+        let mut best_tie = usize::MAX;
+
+        for (i, w) in walks.iter().enumerate() {
+            if w.recno < 0 {
+                continue;
+            }
+            let e = &w.entries[w.recno as usize];
+            let Some(ts) = reflog_entry_unix_ts_rev(e) else {
+                continue;
+            };
+            if ts > best_ts || (ts == best_ts && w.tie_order < best_tie) {
+                best_ts = ts;
+                best_tie = w.tie_order;
+                best_i = Some(i);
+            }
+        }
+
+        let Some(wi) = best_i else {
+            break;
+        };
+
+        let w = &mut walks[wi];
+        let entry = w.entries[w.recno as usize].clone();
+        w.recno -= 1;
+
+        let commit_data = match repo.odb.read(&entry.new_oid) {
+            Ok(obj) => match parse_commit(&obj.data) {
+                Ok(c) => c,
+                Err(_) => continue,
+            },
+            Err(_) => continue,
+        };
+
+        let n_parents = commit_data.parents.len();
+        if let Some(mx) = max_parents {
+            if n_parents > mx {
+                continue;
+            }
+        }
+        if let Some(mn) = min_parents {
+            if n_parents < mn {
+                continue;
+            }
+        }
+
+        if let Some(since) = since_cutoff {
+            if let Some(ets) = reflog_entry_unix_ts_rev(&entry) {
+                if ets < since {
+                    continue;
+                }
+            }
+        }
+        if let Some(until) = until_cutoff {
+            if let Some(ets) = reflog_entry_unix_ts_rev(&entry) {
+                if ets > until {
+                    continue;
+                }
+            }
+        }
+
+        if !paths.is_empty()
+            && !rev_list_reflog_transition_touches_paths(
+                repo,
+                &entry.old_oid,
+                &entry.new_oid,
+                &entry.message,
+                paths,
+            )?
+        {
+            continue;
+        }
+
+        if skipped < skip_n {
+            skipped += 1;
+            continue;
+        }
+
+        if show_parents {
+            let parents = commit_parents_for_output(&repo, entry.new_oid, &graft_parents)?;
+            if parents.is_empty() {
+                writeln!(out, "{}", entry.new_oid.to_hex())?;
+            } else {
+                let tail = parents
+                    .iter()
+                    .map(ObjectId::to_hex)
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                writeln!(out, "{} {}", entry.new_oid.to_hex(), tail)?;
+            }
+        } else {
+            writeln!(out, "{}", entry.new_oid.to_hex())?;
+        }
+        shown += 1;
+    }
+
+    Ok(())
 }
 
 fn expand_parent_shorthand(repo: &Repository, spec: &str) -> Result<Vec<String>> {

--- a/logs/2026-04-09_t1414-reflog-walk.md
+++ b/logs/2026-04-09_t1414-reflog-walk.md
@@ -1,0 +1,17 @@
+# t1414-reflog-walk
+
+## Goal
+Make `tests/t1414-reflog-walk.sh` pass (12/12).
+
+## Changes
+- **Merge reflog messages**: `commit` uses `commit (merge):` when the new commit has ≥2 parents (`grit/src/commands/commit.rs`).
+- **Reflog read DWIM**: `read_reflog_dwim` in `grit-lib` mirrors Git’s `read_complete_reflog` fallback (`ref` → `refs/<ref>` → `refs/heads/<ref>`).
+- **`log -g`**: Rewrote `run_reflog_walk` to interleave multiple reflogs by entry timestamp (tie-break: argv order), honor `--no-merges`, `--merges`, `--since`/`--until`, `--date=unix` for `%gd`, pathspecs with merge + checkout semantics, and `HEAD@{date} HEAD` (drop date-only stream when plain ref also given). Warning when date selector is before oldest entry.
+- **`rev-list -g`**: Multi-ref interleaved walk, `--parents` on first line, path/date/parent filters; usage exit 129 with no revs.
+- **`rev_parse`**: `resolve_reflog_walk_log_ref` for shared ref resolution.
+- **`rev_list`**: `commit_visible_for_dense_pathspecs` for Git-style merge omission on pathspecs.
+
+## Validation
+- `./scripts/run-tests.sh t1414-reflog-walk.sh` → 12/12
+- `cargo test -p grit-lib --lib`
+- `cargo fmt`, `cargo clippy --fix --allow-dirty`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible `log -g` / `rev-list -g` behavior so `t1414-reflog-walk.sh` passes 12/12.

## Key changes

- **Multi-ref interleaving**: Walk multiple reflogs in timestamp order (argv order breaks ties), matching sorted per-ref output with `--date=unix`.
- **Filters**: `--no-merges` / `--merges`, `--since` / `--until` use reflog entry timestamps; pathspecs use merge simplification + per-parent diffs for merges, and checkout entries match paths present on the **destination** tree only.
- **DWIM reflog paths**: `read_reflog_dwim` + `resolve_reflog_walk_log_ref` align with Git’s reflog file lookup.
- **Merge reflog subject**: `commit (merge):` when the new commit has two or more parents.
- **`rev-list -g`**: Same interleaving and filters; `--parents` prints commit + parents on one line; missing revisions → usage (exit 129).
- **`HEAD@{date} HEAD`**: Drops the date-narrowed duplicate stream when a plain ref for the same log is also given (with warning for old dates).

## Test plan

- `./scripts/run-tests.sh t1414-reflog-walk.sh`
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-788d20f6-3aef-4eb7-a74f-0fca16156f85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-788d20f6-3aef-4eb7-a74f-0fca16156f85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

