### PR TITLE
fix: make t6017-rev-list-stdin fully pass

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -768,7 +768,7 @@ commit → check it off → move on.
 - [x] `t6200-fmt-merge-msg-extra` — 23/23 tests pass (branches/tags/URLs, --into-name, -m, --log, mixed refs, FETCH_HEAD edge cases)
 - [ ] `t6430-merge-recursive` █████░░░░░░░░░░░░░░░ 10/36 (26 left) — merge-recursive backend test
 - [~] `t6416-recursive-corner-cases` ██████████░░░░░░░░░░ 21/40 (19 left) — recursive merge corner cases involving criss-cross merges
-- [ ] `t6017-rev-list-stdin` ████░░░░░░░░░░░░░░░░ 9/37 (28 left) — log family learns --stdin
+- [x] `t6017-rev-list-stdin` ████████████████████ 37/37 (0 left) — log family learns --stdin
 - [ ] `t6132-pathspec-exclude` ░░░░░░░░░░░░░░░░░░░░ 1/31 (30 left) — test case exclude pathspec
 - [ ] `t6135-pathspec-with-attrs` ██░░░░░░░░░░░░░░░░░░ 5/37 (32 left) — test labels in pathspecs
 - [ ] `t6112-rev-list-filters-objects` ██████░░░░░░░░░░░░░░ 18/54 (36 left) — git rev-list using object filtering

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1056,7 +1056,7 @@ t6013-rev-list-reverse-parents	t6	yes	3	2	1	false	ok	0
 t6014-rev-list-all	t6	yes	4	4	0	true	ok	0
 t6015-rev-list-show-all-parents	t6	yes	38	38	0	true	ok	0
 t6016-rev-list-graph-simplify-history	t6	yes	12	4	8	false	ok	0
-t6017-rev-list-stdin	t6	yes	37	11	26	false	ok	0
+t6017-rev-list-stdin	t6	yes	37	37	0	true	ok	0
 t6018-rev-list-glob	t6	yes	95	30	65	false	ok	0
 t6019-rev-list-ancestry-path	t6	yes	18	5	13	false	ok	0
 t6020-bundle-misc	t6	yes	37	10	27	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,712 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,712 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T20:56:41+00:00" class="gen-time" title="2026-04-09 20:56 UTC">2026-04-09 20:56 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,712</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,33 +241,33 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
       <div class="group-line1">
         <span class="group-id">t6</span>
         <span class="group-desc">Revision tree commands (e.g. merge-base)</span>
-        <span class="group-meta">47/105 files · 3 skipped · 1,830/2,822 tests</span>
+        <span class="group-meta">48/105 files · 3 skipped · 1,856/2,822 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.8%"></div></div>
-        <span class="group-pct pct-blue">64.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:65.8%"></div></div>
+        <span class="group-pct pct-blue">65.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t7">
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35712 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,712 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T20:56:41+00:00" class="gen-time" title="2026-04-09 20:56 UTC">2026-04-09 20:56 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,712</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -10717,14 +10717,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:33.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t6" data-tests="37" data-passed="11">
+<tr class="" data-group="t6" data-tests="37" data-passed="37" data-full-pass="1">
   <td class="mono">t6017-rev-list-stdin</td>
   <td>t6</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">37</td>
-  <td class="right">11</td>
+  <td class="right">37</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:29.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t6" data-tests="95" data-passed="30">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/refs.rs
+++ b/grit-lib/src/refs.rs
@@ -745,17 +745,24 @@ pub fn list_refs(git_dir: &Path, prefix: &str) -> Result<Vec<(String, ObjectId)>
 /// List refs matching a glob pattern (e.g. `refs/heads/topic/*`).
 pub fn list_refs_glob(git_dir: &Path, pattern: &str) -> Result<Vec<(String, ObjectId)>> {
     let glob_pos = pattern.find(['*', '?', '[']);
-    let prefix = match glob_pos {
+    let prefix_owned: String = match glob_pos {
         Some(pos) => match pattern[..pos].rfind('/') {
-            Some(slash) => &pattern[..=slash],
-            None => "",
+            Some(slash) => pattern[..=slash].to_owned(),
+            None => String::new(),
         },
-        None => pattern,
+        None => {
+            let mut p = pattern.trim_end_matches('/').to_owned();
+            if !p.is_empty() {
+                p.push('/');
+            }
+            p
+        }
     };
+    let prefix = prefix_owned.as_str();
     let all = list_refs(git_dir, prefix)?;
     let mut results = Vec::new();
     for (refname, oid) in all {
-        if glob_match(pattern, &refname) {
+        if ref_matches_glob(&refname, pattern) {
             results.push((refname, oid));
         }
     }

--- a/grit-lib/src/rev_list.rs
+++ b/grit-lib/src/rev_list.rs
@@ -2038,6 +2038,18 @@ fn resolve_specs(repo: &Repository, specs: &[String]) -> Result<Vec<ObjectId>> {
     Ok(out)
 }
 
+/// Resolve revision argument strings to commit OIDs for history walks (`log`, `rev-list`).
+///
+/// Each spec is interpreted like Git's `handle_revision_arg` for a plain commit tip: ranges
+/// (`A..B`), exclusions (`^rev`), and revision expressions are supported via
+/// [`split_revision_token`] and [`resolve_revision_for_range_end`].
+pub fn resolve_revision_specs_to_commits(
+    repo: &Repository,
+    specs: &[String],
+) -> Result<Vec<ObjectId>> {
+    resolve_specs(repo, specs)
+}
+
 fn resolve_specs_for_objects(
     repo: &Repository,
     specs: &[String],
@@ -2484,80 +2496,312 @@ fn load_commit(repo: &Repository, oid: ObjectId) -> Result<crate::objects::Commi
     parse_commit(&object.data)
 }
 
-/// Merge command-line arguments and `--stdin` input lines for this subset.
+fn extend_split_token(
+    token: &str,
+    not_mode: bool,
+    positive: &mut Vec<String>,
+    negative: &mut Vec<String>,
+) {
+    let (pos, neg) = split_revision_token(token);
+    if not_mode {
+        positive.extend(neg);
+        negative.extend(pos);
+    } else {
+        positive.extend(pos);
+        negative.extend(neg);
+    }
+}
+
+/// Git `parse_long_opt`-style parsing for a single argv vector (used for `--stdin` lines).
 ///
-/// Returns `(positive_specs, negative_specs)`.
+/// Returns `Some((consumed_arg_count, value))` when `line` is `--<opt>` or `--<opt>=...`.
+/// Consumed count is 1 for stuck form, 2 for detached form (caller must supply next line as value).
+fn parse_long_opt_value(opt: &str, argv0: &str, argv1: Option<&str>) -> Option<(usize, String)> {
+    let rest = argv0.strip_prefix("--")?;
+    let rest = rest.strip_prefix(opt)?;
+    if let Some(stripped) = rest.strip_prefix('=') {
+        return Some((1, stripped.to_owned()));
+    }
+    if !rest.is_empty() {
+        return None;
+    }
+    let Some(next) = argv1 else {
+        return None;
+    };
+    Some((2, next.to_owned()))
+}
+
+fn stdin_die_requires_value(opt: &str) -> Error {
+    Error::Message(format!("fatal: Option '{opt}' requires a value"))
+}
+
+fn apply_stdin_pseudo_opt(
+    git_dir: &Path,
+    line: &str,
+    next_line: Option<&str>,
+    not_mode: bool,
+    positive: &mut Vec<String>,
+    negative: &mut Vec<String>,
+    stdin_all_refs: &mut bool,
+) -> Result<Option<usize>> {
+    if line == "--end-of-options" {
+        return Ok(Some(1));
+    }
+    if line == "--all" {
+        if not_mode {
+            for (_, oid) in refs::list_refs(git_dir, "refs/")? {
+                let s = oid.to_hex();
+                negative.push(s);
+            }
+            if let Ok(head_oid) = refs::resolve_ref(git_dir, "HEAD") {
+                negative.push(head_oid.to_hex());
+            }
+        } else {
+            *stdin_all_refs = true;
+        }
+        return Ok(Some(1));
+    }
+    if line == "--not" {
+        return Ok(Some(1));
+    }
+    if line == "--branches" {
+        for (_, oid) in refs::list_refs(git_dir, "refs/heads/")? {
+            let s = oid.to_hex();
+            if not_mode {
+                negative.push(s);
+            } else {
+                positive.push(s);
+            }
+        }
+        return Ok(Some(1));
+    }
+    if line == "--tags" {
+        for (_, oid) in refs::list_refs(git_dir, "refs/tags/")? {
+            let s = oid.to_hex();
+            if not_mode {
+                negative.push(s);
+            } else {
+                positive.push(s);
+            }
+        }
+        return Ok(Some(1));
+    }
+    if line == "--remotes" {
+        for (_, oid) in refs::list_refs(git_dir, "refs/remotes/")? {
+            let s = oid.to_hex();
+            if not_mode {
+                negative.push(s);
+            } else {
+                positive.push(s);
+            }
+        }
+        return Ok(Some(1));
+    }
+    if let Some((consumed, pattern)) = parse_long_opt_value("branches", line, next_line) {
+        let full_pattern = format!("refs/heads/{pattern}");
+        for (_, oid) in refs::list_refs_glob(git_dir, &full_pattern)? {
+            let s = oid.to_hex();
+            if not_mode {
+                negative.push(s);
+            } else {
+                positive.push(s);
+            }
+        }
+        return Ok(Some(consumed));
+    }
+    if let Some((1, pattern)) = parse_long_opt_value("tags", line, None) {
+        let full_pattern = format!("refs/tags/{pattern}");
+        for (_, oid) in refs::list_refs_glob(git_dir, &full_pattern)? {
+            let s = oid.to_hex();
+            if not_mode {
+                negative.push(s);
+            } else {
+                positive.push(s);
+            }
+        }
+        return Ok(Some(1));
+    }
+    if let Some((consumed, pattern)) = parse_long_opt_value("tags", line, next_line) {
+        let full_pattern = format!("refs/tags/{pattern}");
+        for (_, oid) in refs::list_refs_glob(git_dir, &full_pattern)? {
+            let s = oid.to_hex();
+            if not_mode {
+                negative.push(s);
+            } else {
+                positive.push(s);
+            }
+        }
+        return Ok(Some(consumed));
+    }
+    if let Some((1, pattern)) = parse_long_opt_value("remotes", line, None) {
+        let full_pattern = format!("refs/remotes/{pattern}");
+        for (_, oid) in refs::list_refs_glob(git_dir, &full_pattern)? {
+            let s = oid.to_hex();
+            if not_mode {
+                negative.push(s);
+            } else {
+                positive.push(s);
+            }
+        }
+        return Ok(Some(1));
+    }
+    if let Some((consumed, pattern)) = parse_long_opt_value("remotes", line, next_line) {
+        let full_pattern = format!("refs/remotes/{pattern}");
+        for (_, oid) in refs::list_refs_glob(git_dir, &full_pattern)? {
+            let s = oid.to_hex();
+            if not_mode {
+                negative.push(s);
+            } else {
+                positive.push(s);
+            }
+        }
+        return Ok(Some(consumed));
+    }
+    if line == "--glob" {
+        return Err(stdin_die_requires_value("--glob"));
+    }
+    if let Some((1, pattern)) = parse_long_opt_value("glob", line, None) {
+        for (_, oid) in refs::list_refs_glob(git_dir, &pattern)? {
+            let s = oid.to_hex();
+            if not_mode {
+                negative.push(s);
+            } else {
+                positive.push(s);
+            }
+        }
+        return Ok(Some(1));
+    }
+    if let Some((consumed, pattern)) = parse_long_opt_value("glob", line, next_line) {
+        for (_, oid) in refs::list_refs_glob(git_dir, &pattern)? {
+            let s = oid.to_hex();
+            if not_mode {
+                negative.push(s);
+            } else {
+                positive.push(s);
+            }
+        }
+        return Ok(Some(consumed));
+    }
+    if line == "--no-walk" || line.starts_with("--no-walk=") {
+        if let Some(rest) = line.strip_prefix("--no-walk=") {
+            if rest == "sorted" || rest == "unsorted" {
+                return Ok(Some(1));
+            }
+            eprintln!("error: invalid argument to --no-walk");
+            return Err(Error::Message(format!(
+                "fatal: invalid option '{line}' in --stdin mode"
+            )));
+        }
+        return Ok(Some(1));
+    }
+    if line.starts_with("--") {
+        return Err(Error::Message(format!(
+            "fatal: invalid option '{line}' in --stdin mode"
+        )));
+    }
+    if line.starts_with('-') {
+        return Err(Error::Message(format!(
+            "fatal: invalid option '{line}' in --stdin mode"
+        )));
+    }
+    Ok(None)
+}
+
+/// Read `--stdin` revision lines and pathspec tail (after `--`), matching Git `read_revisions_from_stdin`.
+fn read_revisions_from_stdin_lines(
+    git_dir: &Path,
+) -> Result<(Vec<String>, Vec<String>, bool, Vec<String>)> {
+    let stdin = std::io::read_to_string(std::io::stdin()).map_err(Error::Io)?;
+    let lines: Vec<String> = stdin.lines().map(std::borrow::ToOwned::to_owned).collect();
+
+    let mut positive = Vec::new();
+    let mut negative = Vec::new();
+    let mut stdin_all_refs = false;
+    let mut stdin_not_mode = false;
+    let mut seen_end_of_options = false;
+    let mut i = 0usize;
+
+    while i < lines.len() {
+        let line = lines[i].as_str();
+        if line.is_empty() {
+            break;
+        }
+        if line == "--" {
+            i += 1;
+            let paths: Vec<String> = lines[i..].to_vec();
+            return Ok((positive, negative, stdin_all_refs, paths));
+        }
+
+        if !seen_end_of_options && line.starts_with('-') {
+            if line == "--end-of-options" {
+                seen_end_of_options = true;
+                i += 1;
+                continue;
+            }
+            let next = lines.get(i + 1).map(|s| s.as_str());
+            match apply_stdin_pseudo_opt(
+                git_dir,
+                line,
+                next,
+                stdin_not_mode,
+                &mut positive,
+                &mut negative,
+                &mut stdin_all_refs,
+            )? {
+                Some(consumed) => {
+                    if line == "--not" && consumed == 1 {
+                        stdin_not_mode = !stdin_not_mode;
+                    }
+                    i += consumed;
+                }
+                None => {
+                    extend_split_token(line, stdin_not_mode, &mut positive, &mut negative);
+                    i += 1;
+                }
+            }
+            continue;
+        }
+
+        extend_split_token(line, stdin_not_mode, &mut positive, &mut negative);
+        i += 1;
+    }
+
+    Ok((positive, negative, stdin_all_refs, Vec::new()))
+}
+
+/// Merge command-line revision strings with `--stdin` lines (and optional stdin pathspecs).
+///
+/// Returns `(positive_specs, negative_specs, stdin_saw_all, stdin_pathspecs)`.
+///
+/// Command-line `--not` is applied while building `args_specs` (see `rev-list`); stdin uses an
+/// independent `--not` toggle, matching Git.
 ///
 /// # Errors
 ///
-/// Returns [`Error::InvalidRef`] when stdin provides invalid pseudo-options.
+/// Returns [`Error::Message`] for Git-compatible `fatal:` stderr lines from stdin mode.
 pub fn collect_revision_specs_with_stdin(
+    git_dir: &Path,
     args_specs: &[String],
     read_stdin: bool,
-) -> Result<(Vec<String>, Vec<String>, bool)> {
+) -> Result<(Vec<String>, Vec<String>, bool, Vec<String>)> {
     let mut positive = Vec::new();
     let mut negative = Vec::new();
-    let mut not_mode = false;
 
     for spec in args_specs {
         let (pos, neg) = split_revision_token(spec);
-        if not_mode {
-            positive.extend(neg);
-            negative.extend(pos);
-        } else {
-            positive.extend(pos);
-            negative.extend(neg);
-        }
+        positive.extend(pos);
+        negative.extend(neg);
     }
 
     if !read_stdin {
-        return Ok((positive, negative, false));
+        return Ok((positive, negative, false, Vec::new()));
     }
 
-    let mut in_paths = false;
-    let mut stdin_all_refs = false;
-    let stdin = std::io::read_to_string(std::io::stdin()).map_err(Error::Io)?;
-    for raw_line in stdin.lines() {
-        let line = raw_line.trim();
-        if line.is_empty() {
-            continue;
-        }
-        if in_paths {
-            continue;
-        }
-        if line == "--" {
-            in_paths = true;
-            continue;
-        }
-        if line == "--not" {
-            not_mode = !not_mode;
-            continue;
-        }
-        if line == "--all" {
-            stdin_all_refs = true;
-            continue;
-        }
-        if line.starts_with("--") {
-            return Err(Error::InvalidRef(format!(
-                "invalid option '{line}' in --stdin mode"
-            )));
-        }
-        if line.starts_with('-') {
-            return Err(Error::InvalidRef(format!(
-                "invalid option '{line}' in --stdin mode"
-            )));
-        }
-        let (pos, neg) = split_revision_token(line);
-        if not_mode {
-            positive.extend(neg);
-            negative.extend(pos);
-        } else {
-            positive.extend(pos);
-            negative.extend(neg);
-        }
-    }
+    let (s_pos, s_neg, stdin_all_refs, stdin_paths) = read_revisions_from_stdin_lines(git_dir)?;
+    positive.extend(s_pos);
+    negative.extend(s_neg);
 
-    Ok((positive, negative, stdin_all_refs))
+    Ok((positive, negative, stdin_all_refs, stdin_paths))
 }
 
 /// Resolve every local tag object ID.

--- a/grit/src/commands/log.rs
+++ b/grit/src/commands/log.rs
@@ -51,7 +51,12 @@ use std::sync::{Arc, Mutex};
 #[command(about = "Show commit logs")]
 pub struct Args {
     /// Revisions and pathspecs (separated by --).
+    #[arg(allow_hyphen_values = true)]
     pub revisions: Vec<String>,
+
+    /// Raw argv after the `log` subcommand (includes revision pseudo-options that clap strips before parsing).
+    #[arg(skip)]
+    pub raw_argv_tail: Vec<String>,
 
     /// Limit the number of commits to show.
     #[arg(short = 'n', long = "max-count")]
@@ -416,6 +421,10 @@ pub struct Args {
     /// End of options marker (everything after is a revision/path).
     #[arg(long = "end-of-options")]
     pub end_of_options: bool,
+
+    /// Read extra revisions and optional pathspecs (after a stdin `--`) from stdin.
+    #[arg(long = "stdin")]
+    pub read_stdin: bool,
 
     /// Date ordering.
     #[arg(long = "date-order")]
@@ -1221,14 +1230,200 @@ fn resolve_decoration_display(args: &Args, format_requires_decorations: bool) ->
     (show, full)
 }
 
-fn run_graph_log(repo: &Repository, args: &Args, patch_context: usize) -> Result<()> {
+/// Strip `git log`-only flags from the revision list and expand revision pseudo-options
+/// (`--all`, `--glob`, `--branches`, …) into concrete revision strings, matching `git log` /
+/// `setup_revisions` behavior.
+fn merge_log_revision_argv(repo: &Repository, args: &Args) -> Result<Vec<String>> {
+    let src: &[String] = if args.raw_argv_tail.is_empty() {
+        &args.revisions
+    } else {
+        &args.raw_argv_tail
+    };
+    let mut out = Vec::new();
+    let mut not_mode = false;
+    let mut end_opts = false;
+    let mut i = 0usize;
+    while i < src.len() {
+        let arg = &src[i];
+        if !end_opts && arg == "--" {
+            out.push(arg.clone());
+            out.extend(src[i + 1..].iter().cloned());
+            break;
+        }
+        if !end_opts && arg == "--end-of-options" {
+            end_opts = true;
+            out.push("--end-of-options".to_owned());
+            i += 1;
+            continue;
+        }
+        if !end_opts && arg.starts_with('-') && arg != "--" {
+            match arg.as_str() {
+                "--not" => {
+                    not_mode = !not_mode;
+                }
+                "--all" => {
+                    if not_mode {
+                        for (_, oid) in grit_lib::refs::list_refs(&repo.git_dir, "refs/")? {
+                            let s = oid.to_hex();
+                            out.push(format!("^{s}"));
+                        }
+                        if let Ok(head_oid) = grit_lib::refs::resolve_ref(&repo.git_dir, "HEAD") {
+                            out.push(format!("^{}", head_oid.to_hex()));
+                        }
+                    } else {
+                        out.push("--all".to_owned());
+                    }
+                }
+                "--branches" => {
+                    let matching = grit_lib::refs::list_refs(&repo.git_dir, "refs/heads/")?;
+                    for (_, oid) in matching {
+                        let s = oid.to_hex();
+                        if not_mode {
+                            out.push(format!("^{s}"));
+                        } else {
+                            out.push(s);
+                        }
+                    }
+                }
+                "--tags" => {
+                    let matching = grit_lib::refs::list_refs(&repo.git_dir, "refs/tags/")?;
+                    for (_, oid) in matching {
+                        let s = oid.to_hex();
+                        if not_mode {
+                            out.push(format!("^{s}"));
+                        } else {
+                            out.push(s);
+                        }
+                    }
+                }
+                "--remotes" => {
+                    let matching = grit_lib::refs::list_refs(&repo.git_dir, "refs/remotes/")?;
+                    for (_, oid) in matching {
+                        let s = oid.to_hex();
+                        if not_mode {
+                            out.push(format!("^{s}"));
+                        } else {
+                            out.push(s);
+                        }
+                    }
+                }
+                _ if arg.starts_with("--branches=") => {
+                    let pattern = arg.trim_start_matches("--branches=");
+                    let full_pattern = format!("refs/heads/{pattern}");
+                    let matching = grit_lib::refs::list_refs_glob(&repo.git_dir, &full_pattern)?;
+                    for (_, oid) in matching {
+                        let s = oid.to_hex();
+                        if not_mode {
+                            out.push(format!("^{s}"));
+                        } else {
+                            out.push(s);
+                        }
+                    }
+                }
+                _ if arg.starts_with("--tags=") => {
+                    let pattern = arg.trim_start_matches("--tags=");
+                    let full_pattern = format!("refs/tags/{pattern}");
+                    let matching = grit_lib::refs::list_refs_glob(&repo.git_dir, &full_pattern)?;
+                    for (_, oid) in matching {
+                        let s = oid.to_hex();
+                        if not_mode {
+                            out.push(format!("^{s}"));
+                        } else {
+                            out.push(s);
+                        }
+                    }
+                }
+                _ if arg.starts_with("--remotes=") => {
+                    let pattern = arg.trim_start_matches("--remotes=");
+                    let full_pattern = format!("refs/remotes/{pattern}");
+                    let matching = grit_lib::refs::list_refs_glob(&repo.git_dir, &full_pattern)?;
+                    for (_, oid) in matching {
+                        let s = oid.to_hex();
+                        if not_mode {
+                            out.push(format!("^{s}"));
+                        } else {
+                            out.push(s);
+                        }
+                    }
+                }
+                _ if arg.starts_with("--glob=") => {
+                    let pattern = arg.trim_start_matches("--glob=");
+                    let matching = grit_lib::refs::list_refs_glob(&repo.git_dir, pattern)?;
+                    for (_, oid) in matching {
+                        let s = oid.to_hex();
+                        if not_mode {
+                            out.push(format!("^{s}"));
+                        } else {
+                            out.push(s);
+                        }
+                    }
+                }
+                "--glob" => {
+                    i += 1;
+                    let Some(next) = src.get(i) else {
+                        anyhow::bail!("--glob requires a value");
+                    };
+                    let matching = grit_lib::refs::list_refs_glob(&repo.git_dir, next)?;
+                    for (_, oid) in matching {
+                        let s = oid.to_hex();
+                        if not_mode {
+                            out.push(format!("^{s}"));
+                        } else {
+                            out.push(s);
+                        }
+                    }
+                }
+                _ => {
+                    // Log-only or already-handled flags: skip.
+                }
+            }
+            i += 1;
+            continue;
+        }
+        if not_mode {
+            if let Some(stripped) = arg.strip_prefix('^') {
+                out.push(stripped.to_owned());
+            } else {
+                out.push(format!("^{arg}"));
+            }
+        } else {
+            out.push(arg.clone());
+        }
+        i += 1;
+    }
+    Ok(out)
+}
+
+fn pathspecs_after_dashdash(merged_argv: &[String], clap_pathspecs: &[String]) -> Vec<String> {
+    if let Some(pos) = merged_argv.iter().position(|s| s == "--") {
+        merged_argv[pos + 1..].to_vec()
+    } else {
+        clap_pathspecs.to_vec()
+    }
+}
+
+/// Collect revision argument strings from `git log` argv (before `--stdin`), matching the
+/// revision vs pathspec disambiguation used for graph output.
+fn extract_log_cli_revision_specs(
+    repo: &Repository,
+    _args: &Args,
+    merged_revisions: &[String],
+) -> Result<(Vec<String>, Vec<String>)> {
     let mut implied_pathspecs: Vec<String> = Vec::new();
     let mut revision_specs = Vec::new();
-    for rev in &args.revisions {
+    let mut after_end_of_options = false;
+    for rev in merged_revisions {
+        if rev == "--end-of-options" {
+            after_end_of_options = true;
+            continue;
+        }
         if rev == "--" {
             break;
         }
-        if rev.starts_with('-') && !rev.starts_with('^') {
+        if rev == "--all" {
+            continue;
+        }
+        if !after_end_of_options && rev.starts_with('-') && !rev.starts_with('^') {
             continue;
         }
         if let Some(stripped) = rev.strip_prefix('^') {
@@ -1270,26 +1465,29 @@ fn run_graph_log(repo: &Repository, args: &Args, patch_context: usize) -> Result
         }
     }
 
-    if args.branches {
-        let mut seen: std::collections::HashSet<String> = revision_specs.iter().cloned().collect();
-        for (_, oid) in grit_lib::refs::list_refs(&repo.git_dir, "refs/heads/")? {
-            let s = oid.to_hex();
-            if seen.insert(s.clone()) {
-                revision_specs.push(s);
-            }
-        }
-    }
-
     if !implied_pathspecs.is_empty() {
         validate_pathspec_scope(repo, &implied_pathspecs)?;
     }
 
-    let mut combined_pathspecs = args.pathspecs.clone();
+    Ok((revision_specs, implied_pathspecs))
+}
+
+fn run_graph_log(repo: &Repository, args: &Args, patch_context: usize) -> Result<()> {
+    let merged_argv = merge_log_revision_argv(repo, args)?;
+    let (revision_specs, implied_pathspecs) =
+        extract_log_cli_revision_specs(repo, args, &merged_argv)?;
+
+    let (mut positive_specs, negative_specs, stdin_all_refs, stdin_paths) =
+        collect_revision_specs_with_stdin(&repo.git_dir, &revision_specs, args.read_stdin)
+            .map_err(|e| anyhow::anyhow!("failed to parse revision arguments: {e}"))?;
+
+    let mut combined_pathspecs = pathspecs_after_dashdash(&merged_argv, &args.pathspecs);
     combined_pathspecs.extend(implied_pathspecs);
+    combined_pathspecs.extend(stdin_paths);
     combined_pathspecs = resolve_effective_pathspecs(repo, &combined_pathspecs)?;
 
     let mut options = RevListOptions {
-        all_refs: args.all,
+        all_refs: args.all || stdin_all_refs,
         first_parent: args.first_parent,
         simplify_by_decoration: false,
         skip: args.skip.unwrap_or(0),
@@ -1315,13 +1513,6 @@ fn run_graph_log(repo: &Repository, args: &Args, patch_context: usize) -> Result
     }
     if args.merges {
         options.min_parents = Some(2);
-    }
-
-    let (mut positive_specs, negative_specs, stdin_all_refs) =
-        collect_revision_specs_with_stdin(&revision_specs, false)
-            .map_err(|e| anyhow::anyhow!("failed to parse revision arguments: {e}"))?;
-    if stdin_all_refs {
-        options.all_refs = true;
     }
 
     if positive_specs.is_empty() && !options.all_refs {
@@ -2605,6 +2796,9 @@ pub fn run(mut args: Args) -> Result<()> {
             .unwrap_or(3)
     };
     if !args.line_range.is_empty() {
+        if args.read_stdin {
+            anyhow::bail!("--stdin cannot be used with -L");
+        }
         return run_line_log(&repo, args, patch_context);
     }
     if args
@@ -2616,6 +2810,12 @@ pub fn run(mut args: Args) -> Result<()> {
     }
     validate_pathspec_scope(&repo, &args.pathspecs)?;
     let mut implied_pathspecs: Vec<String> = Vec::new();
+    let mut stdin_merged_all_refs = false;
+
+    fn dedupe_oid_order(v: Vec<ObjectId>) -> Vec<ObjectId> {
+        let mut seen = HashSet::new();
+        v.into_iter().filter(|o| seen.insert(*o)).collect()
+    }
 
     let use_color = log_resolve_stdout_color(&args, &repo.git_dir);
 
@@ -2732,81 +2932,37 @@ pub fn run(mut args: Args) -> Result<()> {
         return run_graph_log(&repo, &args, patch_context);
     }
 
-    // Determine starting points and excluded commits.
-    // Revisions prefixed with `^` (e.g. `^HEAD`) mean "exclude this and its
-    // ancestors" — standard git revision range syntax.
-    let (start_oids, exclude_oids) = if args.all {
-        (collect_all_ref_oids(&repo.git_dir)?, Vec::new())
-    } else if args.revisions.is_empty() {
-        if args.branches {
-            let mut pairs: Vec<(ObjectId, i64)> = Vec::new();
-            let mut seen: std::collections::HashSet<ObjectId> = std::collections::HashSet::new();
-            for (_, oid) in grit_lib::refs::list_refs(&repo.git_dir, "refs/heads/")? {
-                if seen.insert(oid) {
-                    let obj = repo.odb.read(&oid)?;
-                    let c = parse_commit(&obj.data)?;
-                    let e = extract_epoch_from_ident(&c.committer);
-                    pairs.push((oid, e));
-                }
-            }
-            pairs.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
-            let oids: Vec<ObjectId> = pairs.into_iter().map(|(o, _)| o).collect();
-            if oids.is_empty() {
-                let head = resolve_head(&repo.git_dir)?;
-                match head.oid() {
-                    Some(oid) => (vec![*oid], Vec::new()),
-                    // No commits yet: succeed with empty output (t8290; friendlier than Git's fatal).
-                    None => (Vec::new(), Vec::new()),
-                }
-            } else {
-                (oids, Vec::new())
-            }
-        } else {
-            let head = resolve_head(&repo.git_dir)?;
-            match head.oid() {
-                Some(oid) => (vec![*oid], Vec::new()),
-                None => (Vec::new(), Vec::new()),
-            }
+    // Determine starting points and excluded commits from merged argv + stdin (matches Git
+    // `setup_revisions` ordering for pseudo-options stripped before clap).
+    let merged_argv = merge_log_revision_argv(&repo, &args)?;
+    let (argv_specs, implied_cli) = extract_log_cli_revision_specs(&repo, &args, &merged_argv)?;
+    implied_pathspecs.extend(implied_cli);
+    let (pos_s, neg_s, stdin_all_refs, stdin_paths) =
+        collect_revision_specs_with_stdin(&repo.git_dir, &argv_specs, args.read_stdin)
+            .map_err(|e| anyhow::anyhow!("failed to parse revision arguments: {e}"))?;
+    implied_pathspecs.extend(stdin_paths);
+
+    let mut start_oids = grit_lib::rev_list::resolve_revision_specs_to_commits(&repo, &pos_s)?;
+    let mut exclude_oids = grit_lib::rev_list::resolve_revision_specs_to_commits(&repo, &neg_s)?;
+
+    if args.all {
+        start_oids.extend(collect_all_ref_oids(&repo.git_dir)?);
+    }
+    if stdin_all_refs {
+        stdin_merged_all_refs = true;
+        start_oids.extend(collect_all_ref_oids(&repo.git_dir)?);
+    }
+
+    start_oids = dedupe_oid_order(start_oids);
+    exclude_oids = dedupe_oid_order(exclude_oids);
+
+    if start_oids.is_empty() && !args.all {
+        let head = resolve_head(&repo.git_dir)?;
+        if let Some(oid) = head.oid() {
+            start_oids.push(*oid);
         }
-    } else {
-        let mut oids = Vec::new();
-        let mut excludes = Vec::new();
-        for rev in &args.revisions {
-            if let Some(stripped) = rev.strip_prefix('^') {
-                let oid = resolve_revision_as_commit(&repo, stripped)?;
-                excludes.push(oid);
-            } else if let Some((excl, tip)) = try_parse_double_dot_log_range(&repo, rev)? {
-                excludes.push(excl);
-                oids.push(tip);
-            } else {
-                match resolve_revision_as_commit(&repo, rev) {
-                    Ok(oid) => oids.push(oid),
-                    Err(_err) if is_likely_pathspec_during_rev_parse(rev) => {
-                        implied_pathspecs.push(rev.clone());
-                    }
-                    Err(_err) => match resolve_revision_as_commit_after_precompose(&repo, rev) {
-                        Ok(oid) => oids.push(oid),
-                        Err(_err)
-                            if grit_lib::precompose_config::effective_core_precomposeunicode(
-                                Some(&repo.git_dir),
-                            ) && grit_lib::unicode_normalization::has_non_ascii_utf8(rev) =>
-                        {
-                            implied_pathspecs.push(rev.clone());
-                        }
-                        Err(err) => return Err(err.into()),
-                    },
-                }
-            }
-        }
-        // If only excludes are given with no positive refs, use HEAD
-        if oids.is_empty() {
-            let head = resolve_head(&repo.git_dir)?;
-            if let Some(oid) = head.oid() {
-                oids.push(*oid);
-            }
-        }
-        (oids, excludes)
-    };
+    }
+    start_oids = dedupe_oid_order(start_oids);
 
     if !implied_pathspecs.is_empty() {
         validate_pathspec_scope(&repo, &implied_pathspecs)?;
@@ -2820,11 +2976,12 @@ pub fn run(mut args: Args) -> Result<()> {
     };
 
     // Build source map for --source
-    let source_map: std::collections::HashMap<ObjectId, String> = if args.source && args.all {
-        build_source_map(&repo.odb, &repo.git_dir, args.first_parent)?
-    } else {
-        std::collections::HashMap::new()
-    };
+    let source_map: std::collections::HashMap<ObjectId, String> =
+        if args.source && (args.all || stdin_merged_all_refs) {
+            build_source_map(&repo.odb, &repo.git_dir, args.first_parent)?
+        } else {
+            std::collections::HashMap::new()
+        };
 
     let format_requires_decorations = args
         .format
@@ -2858,7 +3015,7 @@ pub fn run(mut args: Args) -> Result<()> {
         .or(decoration_map_for_display.as_ref());
 
     // Walk commits
-    let mut combined_pathspecs = args.pathspecs.clone();
+    let mut combined_pathspecs = pathspecs_after_dashdash(&merged_argv, &args.pathspecs);
     combined_pathspecs.extend(implied_pathspecs.iter().cloned());
     combined_pathspecs = resolve_effective_pathspecs(&repo, &combined_pathspecs)?;
 
@@ -6716,6 +6873,7 @@ fn write_commit_diff(
                 &entries,
                 &entries,
                 args,
+                pathspecs,
                 graph_stat_prefix,
                 show_patch,
                 false,
@@ -6767,6 +6925,7 @@ fn write_commit_diff(
         &entries,
         &combined_entries,
         args,
+        pathspecs,
         graph_stat_prefix,
         show_patch,
         is_merge,
@@ -6776,6 +6935,35 @@ fn write_commit_diff(
     Ok(())
 }
 
+fn diff_entry_matches_any_pathspec(entry: &DiffEntry, specs: &[String]) -> bool {
+    if specs.is_empty() {
+        return true;
+    }
+    let paths = [
+        entry.path(),
+        entry.old_path.as_deref().unwrap_or(""),
+        entry.new_path.as_deref().unwrap_or(""),
+    ];
+    for spec in specs {
+        for p in paths {
+            if !p.is_empty() && grit_lib::pathspec::matches_pathspec(spec, p) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn filter_diff_entries_by_pathspecs(entries: Vec<DiffEntry>, specs: &[String]) -> Vec<DiffEntry> {
+    if specs.is_empty() {
+        return entries;
+    }
+    entries
+        .into_iter()
+        .filter(|e| diff_entry_matches_any_pathspec(e, specs))
+        .collect()
+}
+
 fn write_commit_diff_body(
     out: &mut impl Write,
     odb: &Odb,
@@ -6783,22 +6971,30 @@ fn write_commit_diff_body(
     entries: &[DiffEntry],
     combined_entries: &[DiffEntry],
     args: &Args,
+    pathspecs: &[String],
     graph_stat_prefix: Option<&str>,
     show_patch: bool,
     treat_as_merge_for_format: bool,
     patch_context: usize,
 ) -> Result<()> {
     let combined_style = merge_diff_is_combined_style(args, treat_as_merge_for_format, git_dir)?;
-    let list_raw_name = if combined_style {
-        combined_entries
+    let entries_owned: Vec<DiffEntry> = entries.to_vec();
+    let combined_owned: Vec<DiffEntry> = combined_entries.to_vec();
+    let entries_f = filter_diff_entries_by_pathspecs(entries_owned, pathspecs);
+    let combined_f = filter_diff_entries_by_pathspecs(combined_owned, pathspecs);
+    let list_raw_name: &[DiffEntry] = if combined_style {
+        &combined_f
     } else {
-        entries
+        &entries_f
     };
-    let list_patch = if combined_style {
-        combined_entries
+    let list_patch: &[DiffEntry] = if combined_style {
+        &combined_f
     } else {
-        entries
+        &entries_f
     };
+    if list_raw_name.is_empty() && list_patch.is_empty() {
+        return Ok(());
+    }
     let has_patch = show_patch && !list_patch.is_empty();
 
     if args.raw {
@@ -6826,10 +7022,12 @@ fn write_commit_diff_body(
     }
 
     if args.name_only {
+        if !list_raw_name.is_empty() {
+            writeln!(out)?;
+        }
         for entry in list_raw_name {
             writeln!(out, "{}", entry.path())?;
         }
-        writeln!(out)?;
     }
 
     if args.name_status {

--- a/grit/src/commands/reflog.rs
+++ b/grit/src/commands/reflog.rs
@@ -253,6 +253,7 @@ fn run_show(args: ShowArgs) -> Result<()> {
 
     crate::commands::log::run(crate::commands::log::Args {
         revisions: vec![args.refname],
+        raw_argv_tail: Vec::new(),
         max_count: args.max_count,
         oneline,
         format,
@@ -338,6 +339,7 @@ fn run_show(args: ShowArgs) -> Result<()> {
         fixed_strings: false,
         perl_regexp: false,
         end_of_options: false,
+        read_stdin: false,
         date_order: false,
         author_date_order: false,
         topo_order: false,

--- a/grit/src/commands/rev_list.rs
+++ b/grit/src/commands/rev_list.rs
@@ -78,6 +78,21 @@ enum DiskUsageFormat {
     Human,
 }
 
+fn push_ref_oids_as_specs(
+    specs: &mut Vec<String>,
+    not_mode: bool,
+    oids: impl Iterator<Item = ObjectId>,
+) {
+    for oid in oids {
+        let s = oid.to_hex();
+        if not_mode {
+            specs.push(format!("^{s}"));
+        } else {
+            specs.push(s);
+        }
+    }
+}
+
 /// Run `grit rev-list`.
 pub fn run(args: Args) -> Result<()> {
     let repo = Repository::discover(None).context("failed to discover repository")?;
@@ -117,7 +132,26 @@ pub fn run(args: Args) -> Result<()> {
         }
         if !end_of_options && arg.starts_with('-') {
             match arg.as_str() {
-                "--all" => options.all_refs = true,
+                "--all" => {
+                    if not_mode {
+                        let matching = grit_lib::refs::list_refs(&repo.git_dir, "refs/")
+                            .context("failed to list refs")?;
+                        push_ref_oids_as_specs(
+                            &mut revision_specs,
+                            true,
+                            matching.into_iter().map(|(_, oid)| oid),
+                        );
+                        if let Ok(head_oid) = grit_lib::refs::resolve_ref(&repo.git_dir, "HEAD") {
+                            push_ref_oids_as_specs(
+                                &mut revision_specs,
+                                true,
+                                std::iter::once(head_oid),
+                            );
+                        }
+                    } else {
+                        options.all_refs = true;
+                    }
+                }
                 "--first-parent" => options.first_parent = true,
                 "--ancestry-path" => options.ancestry_path = true,
                 "--simplify-by-decoration" => options.simplify_by_decoration = true,
@@ -247,9 +281,11 @@ pub fn run(args: Args) -> Result<()> {
                     let pattern = arg.trim_start_matches("--glob=");
                     let matching = grit_lib::refs::list_refs_glob(&repo.git_dir, pattern)
                         .context("failed to list glob refs")?;
-                    for (_, oid) in matching {
-                        revision_specs.push(oid.to_hex());
-                    }
+                    push_ref_oids_as_specs(
+                        &mut revision_specs,
+                        not_mode,
+                        matching.into_iter().map(|(_, oid)| oid),
+                    );
                 }
                 "--glob" => {
                     // Detached option: next arg is the pattern.
@@ -257,58 +293,72 @@ pub fn run(args: Args) -> Result<()> {
                     if let Some(next) = args.args.get(i) {
                         let matching = grit_lib::refs::list_refs_glob(&repo.git_dir, next)
                             .context("failed to list glob refs")?;
-                        for (_, oid) in matching {
-                            revision_specs.push(oid.to_hex());
-                        }
+                        push_ref_oids_as_specs(
+                            &mut revision_specs,
+                            not_mode,
+                            matching.into_iter().map(|(_, oid)| oid),
+                        );
                     }
                 }
                 "--branches" => {
                     let matching = grit_lib::refs::list_refs(&repo.git_dir, "refs/heads/")
                         .context("failed to list branch refs")?;
-                    for (_, oid) in matching {
-                        revision_specs.push(oid.to_hex());
-                    }
+                    push_ref_oids_as_specs(
+                        &mut revision_specs,
+                        not_mode,
+                        matching.into_iter().map(|(_, oid)| oid),
+                    );
                 }
                 _ if arg.starts_with("--branches=") => {
                     let pattern = arg.trim_start_matches("--branches=");
                     let full_pattern = format!("refs/heads/{pattern}");
                     let matching = grit_lib::refs::list_refs_glob(&repo.git_dir, &full_pattern)
                         .context("failed to list branch refs")?;
-                    for (_, oid) in matching {
-                        revision_specs.push(oid.to_hex());
-                    }
+                    push_ref_oids_as_specs(
+                        &mut revision_specs,
+                        not_mode,
+                        matching.into_iter().map(|(_, oid)| oid),
+                    );
                 }
                 "--tags" => {
                     let matching = grit_lib::refs::list_refs(&repo.git_dir, "refs/tags/")
                         .context("failed to list tag refs")?;
-                    for (_, oid) in matching {
-                        revision_specs.push(oid.to_hex());
-                    }
+                    push_ref_oids_as_specs(
+                        &mut revision_specs,
+                        not_mode,
+                        matching.into_iter().map(|(_, oid)| oid),
+                    );
                 }
                 _ if arg.starts_with("--tags=") => {
                     let pattern = arg.trim_start_matches("--tags=");
                     let full_pattern = format!("refs/tags/{pattern}");
                     let matching = grit_lib::refs::list_refs_glob(&repo.git_dir, &full_pattern)
                         .context("failed to list tag refs")?;
-                    for (_, oid) in matching {
-                        revision_specs.push(oid.to_hex());
-                    }
+                    push_ref_oids_as_specs(
+                        &mut revision_specs,
+                        not_mode,
+                        matching.into_iter().map(|(_, oid)| oid),
+                    );
                 }
                 "--remotes" => {
                     let matching = grit_lib::refs::list_refs(&repo.git_dir, "refs/remotes/")
                         .context("failed to list remote refs")?;
-                    for (_, oid) in matching {
-                        revision_specs.push(oid.to_hex());
-                    }
+                    push_ref_oids_as_specs(
+                        &mut revision_specs,
+                        not_mode,
+                        matching.into_iter().map(|(_, oid)| oid),
+                    );
                 }
                 _ if arg.starts_with("--remotes=") => {
                     let pattern = arg.trim_start_matches("--remotes=");
                     let full_pattern = format!("refs/remotes/{pattern}");
                     let matching = grit_lib::refs::list_refs_glob(&repo.git_dir, &full_pattern)
                         .context("failed to list remote refs")?;
-                    for (_, oid) in matching {
-                        revision_specs.push(oid.to_hex());
-                    }
+                    push_ref_oids_as_specs(
+                        &mut revision_specs,
+                        not_mode,
+                        matching.into_iter().map(|(_, oid)| oid),
+                    );
                 }
                 "--alternate-refs" => {
                     // List refs from alternate object directories
@@ -317,10 +367,14 @@ pub fn run(args: Args) -> Result<()> {
                         for alt_dir in alts {
                             // alt_dir is an objects dir; the git_dir is its parent
                             if let Some(alt_git_dir) = alt_dir.parent() {
-                                if let Ok(refs) = grit_lib::refs::list_refs(alt_git_dir, "refs/") {
-                                    for (_, oid) in refs {
-                                        revision_specs.push(oid.to_hex());
-                                    }
+                                if let Ok(alt_refs) =
+                                    grit_lib::refs::list_refs(alt_git_dir, "refs/")
+                                {
+                                    push_ref_oids_as_specs(
+                                        &mut revision_specs,
+                                        not_mode,
+                                        alt_refs.into_iter().map(|(_, oid)| oid),
+                                    );
                                 }
                                 // Also include HEAD
                                 let head_path = alt_git_dir.join("HEAD");
@@ -329,10 +383,19 @@ pub fn run(args: Args) -> Result<()> {
                                     if let Some(ref_target) = content.strip_prefix("ref: ") {
                                         let ref_path = alt_git_dir.join(ref_target);
                                         if let Ok(oid_hex) = std::fs::read_to_string(&ref_path) {
-                                            revision_specs.push(oid_hex.trim().to_string());
+                                            let hex = oid_hex.trim().to_string();
+                                            if not_mode {
+                                                revision_specs.push(format!("^{hex}"));
+                                            } else {
+                                                revision_specs.push(hex);
+                                            }
                                         }
                                     } else if content.len() == 40 {
-                                        revision_specs.push(content.to_string());
+                                        if not_mode {
+                                            revision_specs.push(format!("^{content}"));
+                                        } else {
+                                            revision_specs.push(content.to_string());
+                                        }
                                     }
                                 }
                             }
@@ -551,11 +614,14 @@ pub fn run(args: Args) -> Result<()> {
         }
     }
 
-    let (mut positive_specs, mut negative_specs, stdin_all_refs) =
-        collect_revision_specs_with_stdin(&processed_specs, read_stdin)
+    let (mut positive_specs, mut negative_specs, stdin_all_refs, stdin_paths) =
+        collect_revision_specs_with_stdin(&repo.git_dir, &processed_specs, read_stdin)
             .context("failed to parse revision arguments")?;
     if stdin_all_refs {
         options.all_refs = true;
+    }
+    if !stdin_paths.is_empty() {
+        options.paths.extend(stdin_paths);
     }
 
     // If symmetric diff, resolve merge bases and set up positive/negative

--- a/grit/src/commands/show.rs
+++ b/grit/src/commands/show.rs
@@ -430,8 +430,8 @@ pub fn run(mut args: Args) -> Result<()> {
         });
 
     if wants_walk {
-        let (positive_specs, negative_specs, _) =
-            collect_revision_specs_with_stdin(&rev_strings_owned, false)
+        let (positive_specs, negative_specs, _, _) =
+            collect_revision_specs_with_stdin(&repo.git_dir, &rev_strings_owned, false)
                 .map_err(|e| anyhow::anyhow!("failed to parse revision arguments: {e}"))?;
 
         let mut negative_specs = negative_specs;

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -3550,6 +3550,38 @@ fn preprocess_log_pickaxe_args(rest: Vec<String>) -> Vec<String> {
     out
 }
 
+/// Remove revision pseudo-options that must not reach clap (unknown flags) but are still needed
+/// for `merge_log_revision_argv` via [`commands::log::Args::raw_argv_tail`].
+fn strip_log_revision_pseudo_for_clap(rest: &[String]) -> Vec<String> {
+    let mut out = Vec::with_capacity(rest.len());
+    let mut i = 0usize;
+    while i < rest.len() {
+        let a = rest[i].as_str();
+        if a == "--not" {
+            i += 1;
+            continue;
+        }
+        if a == "--glob" {
+            i += 1;
+            if i < rest.len() {
+                i += 1;
+            }
+            continue;
+        }
+        if let Some(pat) = a.strip_prefix("--glob=") {
+            if pat.is_empty() {
+                // Keep bare `--glob=` so clap can report missing value if needed; do not strip.
+                out.push(rest[i].clone());
+            }
+            i += 1;
+            continue;
+        }
+        out.push(rest[i].clone());
+        i += 1;
+    }
+    out
+}
+
 fn preprocess_log_args(rest: &[String]) -> Vec<String> {
     let mut result = Vec::new();
     let mut saw_graph = false;
@@ -4230,8 +4262,12 @@ pub(crate) fn dispatch(subcmd: &str, rest: &[String], opts: &GlobalOpts) -> Resu
         "interpret-trailers" => commands::interpret_trailers::run_from_argv(rest),
         "last-modified" => commands::last_modified::run(parse_cmd_args(subcmd, rest)),
         "log" => {
-            let rest = preprocess_log_pickaxe_args(preprocess_log_args(rest));
-            commands::log::run(parse_cmd_args(subcmd, &rest))
+            let raw_tail = rest.to_vec();
+            let for_clap = strip_log_revision_pseudo_for_clap(rest);
+            let rest = preprocess_log_pickaxe_args(preprocess_log_args(&for_clap));
+            let mut parsed: commands::log::Args = parse_cmd_args(subcmd, &rest);
+            parsed.raw_argv_tail = raw_tail;
+            commands::log::run(parsed)
         }
         "ls-files" => commands::ls_files::run(parse_cmd_args(subcmd, rest)),
         "ls-remote" => commands::ls_remote::run(parse_cmd_args(subcmd, rest)),

--- a/logs/2026-04-09_t6017-rev-list-stdin.md
+++ b/logs/2026-04-09_t6017-rev-list-stdin.md
@@ -1,0 +1,19 @@
+# t6017-rev-list-stdin
+
+## Goal
+
+Make `tests/t6017-rev-list-stdin.sh` fully pass (37/37).
+
+## Changes (summary)
+
+- **grit-lib `rev_list`**: Rewrote `collect_revision_specs_with_stdin` to mirror Git `read_revisions_from_stdin`: line-based parsing, stdin-only `--not` toggle, `handle_revision_pseudo_opt`-style options (`--glob`, `--all` under `--not` includes HEAD), `--end-of-options`, pathspec tail after stdin `--`, Git-compatible fatal messages via `Error::Message`. Added `resolve_revision_specs_to_commits` for callers.
+- **grit-lib `refs`**: Fixed `list_refs_glob` for patterns without wildcards (prefix `refs/heads` + `ref_matches_glob`).
+- **grit `rev-list`**: Pseudo-options (`--glob`, `--branches`, …) and `--all` under `--not` now emit `^<oid>` specs; stdin pathspecs appended to options.
+- **grit `log`**: `--stdin` flag; preserve raw argv tail in `main` (strip `--not`/`--glob` for clap only); `merge_log_revision_argv` + unified walk setup; `allow_hyphen_values` on revisions; pathspecs from merged argv after `--`; filter `--name-only`/`--name-status`/`--raw` entries by effective pathspecs; blank line before name list when needed.
+- **Harness**: `run-tests.sh t6017-rev-list-stdin.sh` → CSV + dashboards.
+
+## Validation
+
+- `cargo fmt`, `cargo clippy -p grit-rs -p grit-lib --fix --allow-dirty`
+- `cargo test -p grit-lib --lib`
+- `./scripts/run-tests.sh t6017-rev-list-stdin.sh` → 37/37

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   325 |
+| Completed   |   326 |
 | In progress |     5 |
-| Remaining   |   441 |
+| Remaining   |   440 |
 | **Total**   |   771 |
 
-Task lines in `PLAN.md`: 325 completed (`[x]`), 5 in progress (`[~]`), 441 remaining (`[ ]`).
+Task lines in `PLAN.md`: 326 completed (`[x]`), 5 in progress (`[~]`), 440 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t6017-rev-list-stdin` — 37/37 tests pass (`rev-list` / `log --stdin`: Git-style stdin revision parsing with independent `--not`, pseudo-options `--glob`/`--all`/`--branches`, `--end-of-options`, stdin pathspecs after `--`; `list_refs_glob` exact patterns; `rev-list` `--not` with ref expansion; `log` raw argv merge + pathspec union + `--name-only` path filtering)
 - `t3309-notes-merge-auto-resolve` — 31/31 tests pass (`notes merge`: `union` / `cat_sort_uniq` blob combine like Git; successful merge commits use two parents; `notes.mergeStrategy` config errors match upstream expectations)
 - `t4063-diff-blobs` — 18/18 tests pass (`diff`: blob↔blob and `rev:path` pairs without treating blobs as trees; `HEAD:one..HEAD:two` range split; `rev:path` vs worktree file uses tree path + modes + `write_patch_with_prefix`; raw blob OID vs existing file uses filename as old path; `rev_parse::resolve_treeish_blob_at_path` for tree walks)
 - `t5524-pull-msg` — 3/3 tests pass (`git pull --no-rebase --log` merge message preserves `$` in subject lines; `--log=1` limits shortlog; harness CSV/dashboards refreshed; `PLAN.md` marked complete)

--- a/test-results.md
+++ b/test-results.md
@@ -1,5 +1,10 @@
 # Test results
 
+**2026-04-09 (t6017 / rev-list --stdin)**
+
+- `cargo test -p grit-lib --lib`: 160 passed
+- `./scripts/run-tests.sh t6017-rev-list-stdin.sh`: 37/37 passed
+
 **2026-04-09 (t4063 / diff blobs)**
 
 - `cargo test -p grit-lib --lib`: 155 passed


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible `--stdin` revision ingestion for `rev-list` and `log`, fixes ref glob listing for exact patterns, and aligns `rev-list` pseudo-option expansion with `--not`. Updates harness results for `t6017-rev-list-stdin` (37/37).

## Key changes

- **`grit-lib`**: `collect_revision_specs_with_stdin` now mirrors Git `read_revisions_from_stdin` (stdin `--not`, pseudo-options, `--end-of-options`, pathspec tail, error messages). `list_refs_glob` uses correct prefix + `ref_matches_glob` for patterns without metacharacters. Added `resolve_revision_specs_to_commits`.
- **`grit rev-list`**: Ref-expanding options respect command-line `--not`; stdin pathspecs merge into `RevListOptions.paths`.
- **`grit log`**: `--stdin`, raw argv preservation in `main` (strip `--not`/`--glob` only for clap), merged argv walk, `allow_hyphen_values` for revisions, pathspecs after `--` from merged argv, and pathspec filtering for `--name-only` output when CLI + stdin pathspecs combine.

## Validation

- `cargo fmt`, `cargo clippy -p grit-rs -p grit-lib --fix --allow-dirty`
- `cargo test -p grit-lib --lib` (160 passed)
- `./scripts/run-tests.sh t6017-rev-list-stdin.sh` (37/37)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ab40311-e8d2-4d0a-9bff-235a426d46fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ab40311-e8d2-4d0a-9bff-235a426d46fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

