### PR TITLE
fix: t4129 apply samemode (diff --stat -p + apply modes)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -479,7 +479,7 @@ commit → check it off → move on.
 - [ ] `t4119-apply-config` █░░░░░░░░░░░░░░░░░░░ 1/11 (10 left) — git apply --whitespace=strip and configuration file.
 
 - [ ] `t4215-log-skewed-merges` ░░░░░░░░░░░░░░░░░░░░ 0/10 (10 left) — git log --graph of skewed merges
-- [ ] `t4129-apply-samemode` ██████████░░░░░░░░░░ 12/23 (11 left) — applying patch with mode bits
+- [x] `t4129-apply-samemode` — applying patch with mode bits (23/23)
 - [x] `t4048-diff-combined-binary` ████████████████████ 14/14 (0 left) — combined and merge diff handle binary files and textconv
 - [ ] `t4012-diff-binary` ███░░░░░░░░░░░░░░░░░ 2/13 (11 left) — Binary diff and apply
 

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -799,7 +799,7 @@ t4125-apply-ws-fuzz	t4	yes	4	4	0	true	ok	0
 t4126-apply-empty	t4	yes	8	7	1	false	ok	0
 t4127-apply-same-fn	t4	yes	7	7	0	true	ok	0
 t4128-apply-root	t4	yes	12	12	0	true	ok	0
-t4129-apply-samemode	t4	yes	23	9	14	false	ok	0
+t4129-apply-samemode	t4	yes	23	23	0	true	ok	0
 t4130-apply-criss-cross-rename	t4	yes	7	7	0	true	ok	0
 t4131-apply-fake-ancestor	t4	yes	3	3	0	true	ok	0
 t4132-apply-removal	t4	yes	14	14	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,700 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,700 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T21:06:20+00:00" class="gen-time" title="2026-04-09 21:06 UTC">2026-04-09 21:06 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,700</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -230,22 +230,22 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">73/178 files · 2 skipped · 2,862/4,438 tests</span>
+        <span class="group-meta">74/178 files · 2 skipped · 2,876/4,438 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.5%"></div></div>
-        <span class="group-pct pct-blue">64.5%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.8%"></div></div>
+        <span class="group-pct pct-blue">64.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35700 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,700 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T21:06:20+00:00" class="gen-time" title="2026-04-09 21:06 UTC">2026-04-09 21:06 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,700</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -8147,14 +8147,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="23" data-passed="9">
+<tr class="" data-group="t4" data-tests="23" data-passed="23" data-full-pass="1">
   <td class="mono">t4129-apply-samemode</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">23</td>
-  <td class="right">9</td>
+  <td class="right">23</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:39.1%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="7" data-passed="7" data-full-pass="1">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit/src/commands/apply.rs
+++ b/grit/src/commands/apply.rs
@@ -16,7 +16,9 @@ use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::config::ConfigSet;
 use grit_lib::crlf;
-use grit_lib::index::{Index, IndexEntry};
+use grit_lib::index::{
+    Index, IndexEntry, MODE_EXECUTABLE, MODE_GITLINK, MODE_REGULAR, MODE_SYMLINK,
+};
 use grit_lib::objects::ObjectKind;
 use grit_lib::quote_path::quote_c_style;
 use grit_lib::repo::Repository;
@@ -317,6 +319,10 @@ struct FilePatch {
     old_mode: Option<String>,
     /// New mode from extended header.
     new_mode: Option<String>,
+    /// Source line (1-based) of `old mode` / `deleted file mode` for diagnostics.
+    old_mode_line: Option<usize>,
+    /// Source line (1-based) of `new mode` / `new file mode` for diagnostics.
+    new_mode_line: Option<usize>,
     /// Whether this file is being newly created.
     is_new: bool,
     /// Whether this file is being deleted.
@@ -438,9 +444,15 @@ fn sanitize_patch_header_value(s: &mut String) {
 fn sanitize_file_patch_headers(fp: &mut FilePatch) {
     if let Some(ref mut s) = fp.old_mode {
         sanitize_patch_header_value(s);
+        if s.is_empty() {
+            fp.old_mode = None;
+        }
     }
     if let Some(ref mut s) = fp.new_mode {
         sanitize_patch_header_value(s);
+        if s.is_empty() {
+            fp.new_mode = None;
+        }
     }
     if let Some(ref mut s) = fp.old_oid {
         sanitize_patch_header_value(s);
@@ -919,6 +931,8 @@ fn parse_traditional_patch_pair(
         saw_new_header: true,
         old_mode: None,
         new_mode: None,
+        old_mode_line: None,
+        new_mode_line: None,
         is_new: false,
         is_deleted: false,
         is_rename: false,
@@ -1159,6 +1173,8 @@ fn parse_patch(input: &str, strip: usize) -> Result<Vec<FilePatch>> {
                 saw_new_header: false,
                 old_mode: None,
                 new_mode: None,
+                old_mode_line: None,
+                new_mode_line: None,
                 is_new: false,
                 is_deleted: false,
                 is_rename: false,
@@ -1180,8 +1196,12 @@ fn parse_patch(input: &str, strip: usize) -> Result<Vec<FilePatch>> {
             if let Some((a, b)) = split_diff_git_paths(rest) {
                 fp.diff_old_path = Some(a.clone());
                 fp.diff_new_path = Some(b.clone());
-                fp.old_path = Some(a);
-                fp.new_path = Some(b);
+                fp.old_path = Some(skip_tree_prefix_str(&a, p_strip).ok_or_else(|| {
+                    anyhow::anyhow!("malformed old path in diff --git header: {a}")
+                })?);
+                fp.new_path = Some(skip_tree_prefix_str(&b, p_strip).ok_or_else(|| {
+                    anyhow::anyhow!("malformed new path in diff --git header: {b}")
+                })?);
             }
             i += 1;
 
@@ -1192,16 +1212,37 @@ fn parse_patch(input: &str, strip: usize) -> Result<Vec<FilePatch>> {
                 && !lines[i].starts_with("@@ ")
             {
                 let line = lines[i];
+                let line_no = i + 1;
                 if let Some(val) = line.strip_prefix("old mode ") {
-                    fp.old_mode = Some(val.to_string());
+                    let v = val.trim_end_matches('\r').trim_end();
+                    if v.is_empty() {
+                        bail!("invalid mode on line {line_no}: {line}");
+                    }
+                    fp.old_mode = Some(v.to_string());
+                    fp.old_mode_line = Some(line_no);
                 } else if let Some(val) = line.strip_prefix("new mode ") {
-                    fp.new_mode = Some(val.to_string());
+                    let v = val.trim_end_matches('\r').trim_end();
+                    if v.is_empty() {
+                        bail!("invalid mode on line {line_no}: {line}");
+                    }
+                    fp.new_mode = Some(v.to_string());
+                    fp.new_mode_line = Some(line_no);
                 } else if let Some(val) = line.strip_prefix("new file mode ") {
+                    let v = val.trim_end_matches('\r').trim_end();
+                    if v.is_empty() {
+                        bail!("invalid mode on line {line_no}: {line}");
+                    }
                     fp.is_new = true;
-                    fp.new_mode = Some(val.to_string());
+                    fp.new_mode = Some(v.to_string());
+                    fp.new_mode_line = Some(line_no);
                 } else if let Some(val) = line.strip_prefix("deleted file mode ") {
+                    let v = val.trim_end_matches('\r').trim_end();
+                    if v.is_empty() {
+                        bail!("invalid mode on line {line_no}: {line}");
+                    }
                     fp.is_deleted = true;
-                    fp.old_mode = Some(val.to_string());
+                    fp.old_mode = Some(v.to_string());
+                    fp.old_mode_line = Some(line_no);
                 } else if let Some(val) = line.strip_prefix("rename from ") {
                     fp.is_rename = true;
                     if let Some(p) = find_name_extended_header(val, p_extended) {
@@ -1228,10 +1269,18 @@ fn parse_patch(input: &str, strip: usize) -> Result<Vec<FilePatch>> {
                     fp.dissimilarity_index = val.trim_end_matches('%').parse().ok();
                 } else if let Some(val) = line.strip_prefix("index ") {
                     // Parse "index abc123..def456 100644" or "index abc123..def456"
-                    let hash_part = val.split_whitespace().next().unwrap_or("");
+                    let mut parts = val.split_whitespace();
+                    let hash_part = parts.next().unwrap_or("");
                     if let Some((old, new)) = hash_part.split_once("..") {
                         fp.old_oid = Some(old.to_string());
                         fp.new_oid = Some(new.to_string());
+                    }
+                    if let Some(mode_tok) = parts.next() {
+                        let v = mode_tok.trim_end_matches('\r').trim_end();
+                        if !v.is_empty() {
+                            fp.old_mode = Some(v.to_string());
+                            fp.old_mode_line = Some(line_no);
+                        }
                     }
                 } else if line == "GIT binary patch" {
                     let (binary_patch, next_i) = parse_binary_patch(&lines, i + 1)?;
@@ -1369,6 +1418,7 @@ fn merge_adjacent_blob_to_gitlink_patches(patches: &mut Vec<FilePatch>) {
             merged.new_path = add.new_path.clone();
             merged.saw_new_header = add.saw_new_header;
             merged.new_mode = Some("160000".to_string());
+            merged.new_mode_line = add.new_mode_line;
             merged.is_deleted = false;
             merged.is_new = false;
             merged.new_oid = add.new_oid.clone();
@@ -1897,7 +1947,12 @@ fn verify_patch_paths_not_beyond_symlink(patches: &[FilePatch], args: &Args) -> 
 fn reverse_patches(patches: &mut [FilePatch]) {
     for fp in patches.iter_mut() {
         std::mem::swap(&mut fp.old_path, &mut fp.new_path);
-        std::mem::swap(&mut fp.old_mode, &mut fp.new_mode);
+        // Match Git `reverse_patches`: only swap mode headers when the forward patch had a new
+        // mode or was a deletion (`t4129` reverse apply + mode-only diffs).
+        if fp.new_mode.is_some() || fp.is_deleted {
+            std::mem::swap(&mut fp.old_mode, &mut fp.new_mode);
+            std::mem::swap(&mut fp.old_mode_line, &mut fp.new_mode_line);
+        }
         std::mem::swap(&mut fp.old_oid, &mut fp.new_oid);
         std::mem::swap(&mut fp.is_new, &mut fp.is_deleted);
         if let Some(binary) = fp.binary_patch.as_mut() {
@@ -3816,6 +3871,7 @@ pub fn run(mut args: Args) -> Result<()> {
     } else {
         "<stdin>".to_string()
     };
+    validate_and_canonicalize_patch_modes(&mut patches, &patch_input_display)?;
 
     // Info-only modes unless explicitly overridden by --apply.
     let info_only = (args.stat || args.numstat || args.summary) && !args.apply;
@@ -3843,6 +3899,8 @@ pub fn run(mut args: Args) -> Result<()> {
     }
     verify_patch_paths_not_beyond_symlink(&patches, &args)?;
     let ws_mode = resolve_apply_whitespace_mode(&args);
+
+    prepare_patch_modes_for_apply(&mut patches, &args)?;
 
     // For --cached, we need a repository and index.
     // For working tree apply, we may or may not be in a repo.
@@ -4314,16 +4372,67 @@ fn write_worktree_path(
 
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        if let Some(mode) = mode {
-            let perm = if mode == "100755" { 0o755 } else { 0o644 };
-            fs::set_permissions(path, fs::Permissions::from_mode(perm))?;
+        if let Some(mode_str) = mode {
+            if mode_str != "120000" {
+                chmod_worktree_regular(path, parse_mode(mode_str))?;
+            }
         } else if let Some(executable) = source_exec_bit {
-            let perm = if executable { 0o755 } else { 0o644 };
-            fs::set_permissions(path, fs::Permissions::from_mode(perm))?;
+            chmod_worktree_regular(
+                path,
+                if executable {
+                    MODE_EXECUTABLE
+                } else {
+                    MODE_REGULAR
+                },
+            )?;
         }
     }
 
+    Ok(())
+}
+
+#[cfg(unix)]
+fn process_umask_bits() -> u32 {
+    static UMASK_CACHE: OnceLock<u32> = OnceLock::new();
+    *UMASK_CACHE.get_or_init(|| {
+        #[cfg(target_os = "linux")]
+        {
+            if let Ok(status) = fs::read_to_string("/proc/self/status") {
+                for line in status.lines() {
+                    let line = line.trim_start();
+                    if let Some(rest) = line.strip_prefix("Umask:") {
+                        let tok = rest.trim();
+                        if let Ok(v) = u32::from_str_radix(tok, 8) {
+                            return v;
+                        }
+                    }
+                }
+            }
+        }
+        0o022
+    })
+}
+
+/// Worktree permission bits for a regular file from index mode and current umask (Git checkout).
+#[cfg(unix)]
+fn worktree_mode_from_index_mode(index_mode: u32) -> u32 {
+    let base = if index_mode == MODE_EXECUTABLE {
+        0o777
+    } else {
+        0o666
+    };
+    base & !process_umask_bits()
+}
+
+#[cfg(unix)]
+fn chmod_worktree_regular(path: &Path, index_mode: u32) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let perm_bits = if matches!(index_mode, MODE_REGULAR | MODE_EXECUTABLE) {
+        worktree_mode_from_index_mode(index_mode)
+    } else {
+        index_mode & 0o777
+    };
+    fs::set_permissions(path, fs::Permissions::from_mode(perm_bits))?;
     Ok(())
 }
 
@@ -4633,13 +4742,11 @@ fn apply_to_worktree(
             }
         }
         #[cfg(unix)]
-        let source_exec_bit = if source_adjusted != path_adjusted {
+        let source_exec_bit = {
             use std::os::unix::fs::PermissionsExt;
             fs::metadata(&read_path)
                 .ok()
-                .map(|meta| meta.permissions().mode() & 0o111 != 0)
-        } else {
-            None
+                .map(|meta| meta.permissions().mode() & 0o100 != 0)
         };
 
         if let Some(binary_patch) = fp.binary_patch.as_ref() {
@@ -4660,13 +4767,17 @@ fn apply_to_worktree(
 
             #[cfg(unix)]
             {
-                use std::os::unix::fs::PermissionsExt;
                 if let Some(mode) = fp.new_mode.as_deref() {
-                    let perm = if mode == "100755" { 0o755 } else { 0o644 };
-                    fs::set_permissions(&path, fs::Permissions::from_mode(perm))?;
+                    chmod_worktree_regular(&path, parse_mode(mode))?;
                 } else if let Some(executable) = source_exec_bit {
-                    let perm = if executable { 0o755 } else { 0o644 };
-                    fs::set_permissions(&path, fs::Permissions::from_mode(perm))?;
+                    chmod_worktree_regular(
+                        &path,
+                        if executable {
+                            MODE_EXECUTABLE
+                        } else {
+                            MODE_REGULAR
+                        },
+                    )?;
                 }
             }
 
@@ -4703,9 +4814,7 @@ fn apply_to_worktree(
 
             #[cfg(unix)]
             if let Some(mode) = fp.new_mode.as_deref() {
-                use std::os::unix::fs::PermissionsExt;
-                let perm = if mode == "100755" { 0o755 } else { 0o644 };
-                fs::set_permissions(&path, fs::Permissions::from_mode(perm))?;
+                chmod_worktree_regular(&path, parse_mode(mode))?;
             }
             continue;
         }
@@ -5178,7 +5287,289 @@ fn check_patches(
     Ok(())
 }
 
-/// Parse an octal mode string like "100644" to u32.
+const S_IFMT: u32 = 0o170000;
+const S_IFREG: u32 = 0o100000;
+const S_IFLNK: u32 = 0o120000;
+const S_IFDIR: u32 = 0o040000;
+const S_IFGITLINK: u32 = 0o160000;
+
+/// Git `ce_permissions`: only the owner execute bit matters for regular files.
+fn ce_permissions(mode: u32) -> u32 {
+    if mode & 0o100 != 0 {
+        0o755
+    } else {
+        0o644
+    }
+}
+
+/// Git `create_ce_mode` for stat modes.
+fn create_ce_mode(mode: u32) -> u32 {
+    match mode & S_IFMT {
+        S_IFLNK => MODE_SYMLINK,
+        S_IFDIR => S_IFDIR,
+        S_IFGITLINK => MODE_GITLINK,
+        S_IFREG => S_IFREG | ce_permissions(mode),
+        0 => S_IFREG | ce_permissions(mode),
+        _ => MODE_REGULAR,
+    }
+}
+
+/// Canonicalize a parsed tree mode (Git `canon_mode`).
+fn canon_mode(mode: u32) -> u32 {
+    match mode & S_IFMT {
+        S_IFREG => S_IFREG | ce_permissions(mode),
+        S_IFLNK => MODE_SYMLINK,
+        S_IFDIR => S_IFDIR,
+        S_IFGITLINK => MODE_GITLINK,
+        _ => MODE_REGULAR,
+    }
+}
+
+/// Git `ce_mode_from_stat` (matches `read-cache.h`).
+fn ce_mode_from_stat(ce: Option<u32>, st_mode: u32, trust_file_mode: bool) -> u32 {
+    let is_reg = st_mode & S_IFMT == S_IFREG;
+    if !trust_file_mode && is_reg {
+        if let Some(ce_m) = ce {
+            if ce_m & S_IFMT == S_IFREG {
+                return ce_m;
+            }
+        }
+        return create_ce_mode(0o666);
+    }
+    create_ce_mode(st_mode)
+}
+
+/// Parse a mode token from a patch header (Git `parse_mode_line`); returns canonical index mode.
+fn parse_mode_token(line: &str, patch_input_display: &str, line_no: usize) -> Result<u32> {
+    let line = line.trim_end_matches('\r').trim_end();
+    let mut end = 0usize;
+    for (i, ch) in line.char_indices() {
+        if !matches!(ch, '0'..='7') {
+            end = i;
+            break;
+        }
+    }
+    if end == 0 && !line.is_empty() && matches!(line.as_bytes()[0], b'0'..=b'7') {
+        end = line.len();
+    }
+    if end == 0 {
+        if patch_input_display.is_empty() || patch_input_display == "<stdin>" {
+            bail!("invalid mode on line {line_no}: {line}");
+        }
+        bail!("invalid mode at {patch_input_display}:{line_no}: {line}");
+    }
+    let rest = &line[end..];
+    if !rest.is_empty() && !rest.starts_with(|c: char| c.is_ascii_whitespace()) {
+        if patch_input_display.is_empty() || patch_input_display == "<stdin>" {
+            bail!("invalid mode on line {line_no}: {line}");
+        }
+        bail!("invalid mode at {patch_input_display}:{line_no}: {line}");
+    }
+    let oct_str = &line[..end];
+    let raw = u32::from_str_radix(oct_str, 8).map_err(|_| {
+        if patch_input_display.is_empty() || patch_input_display == "<stdin>" {
+            anyhow::anyhow!("invalid mode on line {line_no}: {line}")
+        } else {
+            anyhow::anyhow!("invalid mode at {patch_input_display}:{line_no}: {line}")
+        }
+    })?;
+    Ok(canon_mode(raw))
+}
+
+fn validate_and_canonicalize_patch_modes(
+    patches: &mut [FilePatch],
+    patch_input_display: &str,
+) -> Result<()> {
+    for fp in patches.iter_mut() {
+        if let Some(ref s) = fp.old_mode {
+            let line = fp.old_mode_line.unwrap_or(0);
+            let canon = parse_mode_token(s, patch_input_display, line.max(1))?;
+            fp.old_mode = Some(format!("{canon:o}"));
+        }
+        if let Some(ref s) = fp.new_mode {
+            let line = fp.new_mode_line.unwrap_or(0);
+            let canon = parse_mode_token(s, patch_input_display, line.max(1))?;
+            fp.new_mode = Some(format!("{canon:o}"));
+        }
+    }
+    Ok(())
+}
+
+/// Parse canonical mode string (already validated) to `u32`.
 fn parse_mode(s: &str) -> u32 {
-    u32::from_str_radix(s, 8).unwrap_or(0o100644)
+    u32::from_str_radix(s.trim(), 8).unwrap_or(MODE_REGULAR)
+}
+
+fn preimage_mode_mismatch_warn(path: &str, st_mode: u32, expected: u32) {
+    eprintln!(
+        "warning: {} has type {:o}, expected {:o}",
+        path, st_mode, expected
+    );
+}
+
+/// Git `check_preimage`: compute `st_mode` for comparing against `patch->old_mode`.
+fn preimage_st_mode_for_apply(
+    trust_file_mode: bool,
+    cached: bool,
+    check_index: bool,
+    ce_mode: Option<u32>,
+    st_stat: Option<u32>,
+    patch_old_declared: Option<u32>,
+    old_path_display: &str,
+) -> Result<u32> {
+    if cached {
+        return ce_mode
+            .ok_or_else(|| anyhow::anyhow!("{old_path_display}: does not exist in index"));
+    }
+    if check_index {
+        let ce = ce_mode
+            .ok_or_else(|| anyhow::anyhow!("{old_path_display}: does not exist in index"))?;
+        let st = st_stat.ok_or_else(|| anyhow::anyhow!("failed to stat {}", old_path_display))?;
+        let is_reg = st & S_IFMT == S_IFREG;
+        if trust_file_mode || !is_reg {
+            return Ok(ce_mode_from_stat(Some(ce), st, trust_file_mode));
+        }
+        return Ok(ce);
+    }
+    let st = st_stat.ok_or_else(|| anyhow::anyhow!("failed to stat {}", old_path_display))?;
+    let is_reg = st & S_IFMT == S_IFREG;
+    if trust_file_mode || !is_reg {
+        return Ok(ce_mode_from_stat(ce_mode, st, trust_file_mode));
+    }
+    if let Some(ce) = ce_mode {
+        return Ok(ce);
+    }
+    Ok(patch_old_declared.unwrap_or(MODE_REGULAR))
+}
+
+/// Reconcile patch extended modes with index/stat like Git `check_preimage`.
+fn reconcile_filepatch_preimage_modes(
+    fp: &mut FilePatch,
+    trust_file_mode: bool,
+    cached: bool,
+    check_index: bool,
+    ce_mode: Option<u32>,
+    st_stat: Option<u32>,
+    old_path_display: &str,
+) -> Result<()> {
+    if fp.is_new {
+        return Ok(());
+    }
+    let old_name = fp
+        .old_path
+        .as_deref()
+        .filter(|p| *p != "/dev/null")
+        .unwrap_or(old_path_display);
+
+    let patch_old = fp.old_mode.as_ref().map(|s| parse_mode(s));
+
+    let st_mode = preimage_st_mode_for_apply(
+        trust_file_mode,
+        cached,
+        check_index,
+        ce_mode,
+        st_stat,
+        patch_old,
+        old_path_display,
+    )?;
+
+    if fp.old_mode.is_none() {
+        fp.old_mode = Some(format!("{st_mode:o}"));
+    }
+    let effective_old = patch_old.unwrap_or(st_mode);
+    if (st_mode ^ effective_old) & S_IFMT != 0 {
+        bail!("{old_name}: wrong type");
+    }
+    if st_mode != effective_old {
+        preimage_mode_mismatch_warn(old_name, st_mode, effective_old);
+    }
+    if fp.new_mode.is_none() && !fp.is_deleted {
+        fp.new_mode = Some(format!("{st_mode:o}"));
+    }
+    Ok(())
+}
+
+/// Fill in missing `old_mode` / `new_mode` and emit mode mismatch warnings (Git `check_preimage`).
+fn prepare_patch_modes_for_apply(patches: &mut [FilePatch], args: &Args) -> Result<()> {
+    let repo_ok = Repository::discover(None).ok();
+    let index = repo_ok.as_ref().and_then(|r| r.load_index().ok());
+    let trust_file_mode = repo_ok
+        .as_ref()
+        .map(|r| {
+            ConfigSet::load(Some(&r.git_dir), true)
+                .unwrap_or_default()
+                .get_bool("core.fileMode")
+                .and_then(|v| v.ok())
+                .unwrap_or(true)
+        })
+        .unwrap_or(true);
+
+    for fp in patches.iter_mut() {
+        if fp.is_new {
+            continue;
+        }
+        let Some(source) = fp.source_path() else {
+            continue;
+        };
+        if source == "/dev/null" {
+            continue;
+        }
+        let adjusted = adjust_path(source, args.directory.as_deref());
+        let ce_mode = index
+            .as_ref()
+            .and_then(|ix| ix.get(adjusted.as_bytes(), 0))
+            .map(|e| e.mode);
+
+        if args.cached {
+            reconcile_filepatch_preimage_modes(
+                fp,
+                trust_file_mode,
+                true,
+                false,
+                ce_mode,
+                None,
+                &adjusted,
+            )?;
+            continue;
+        }
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let path = Path::new(&adjusted);
+            let st_stat = match fs::symlink_metadata(path) {
+                Ok(meta) => Some(meta.permissions().mode()),
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                    if can_apply_with_empty_preimage(fp) {
+                        None
+                    } else {
+                        return Err(err)
+                            .with_context(|| format!("failed to stat {}", path.display()));
+                    }
+                }
+                Err(err) => {
+                    return Err(err).with_context(|| format!("failed to stat {}", path.display()));
+                }
+            };
+            let Some(st) = st_stat else {
+                continue;
+            };
+            reconcile_filepatch_preimage_modes(
+                fp,
+                trust_file_mode,
+                false,
+                args.index,
+                ce_mode,
+                Some(st),
+                &adjusted,
+            )?;
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = (ce_mode, trust_file_mode);
+            bail!("file mode handling is only supported on Unix");
+        }
+    }
+
+    Ok(())
 }

--- a/grit/src/commands/diff.rs
+++ b/grit/src/commands/diff.rs
@@ -2087,6 +2087,61 @@ pub fn run(mut args: Args) -> Result<()> {
             if args.summary {
                 write_diff_summary(&mut out, &entries, args.break_rewrites, quote_path_fully)?;
             }
+            // `git diff --stat -p` prints the stat summary and the unified patch (Git last-flag-wins
+            // for `-p` vs `-s`; combined `-sp` is different).
+            let show_unified_after_stat = emit_unified_patch && !args.no_patch;
+            if show_unified_after_stat {
+                for patch in &conflict_combined_patches {
+                    write!(out, "{patch}")?;
+                }
+                let patch_abbrev = if args.full_index {
+                    40usize
+                } else if let Some(n) = args.abbrev {
+                    n.max(4).min(40)
+                } else {
+                    7
+                };
+                let diff_config = grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true)
+                    .unwrap_or_default();
+                let external_diff_cmd = std::env::var("GIT_EXTERNAL_DIFF")
+                    .ok()
+                    .filter(|s| !s.trim().is_empty())
+                    .or_else(|| {
+                        diff_config
+                            .get("diff.external")
+                            .filter(|s| !s.trim().is_empty())
+                    });
+                write_patch_with_prefix(
+                    &mut out,
+                    &repo,
+                    &entries,
+                    &repo.odb,
+                    &repo.git_dir,
+                    &diff_config,
+                    context_lines,
+                    use_color,
+                    word_diff,
+                    wt_for_content,
+                    suppress_blank_empty,
+                    patch_abbrev,
+                    inter_hunk_context,
+                    args.binary,
+                    args.break_rewrites,
+                    args.irreversible_delete,
+                    !args.no_textconv,
+                    &src_prefix,
+                    &dst_prefix,
+                    args.submodule.as_deref(),
+                    submodule_ignore_flags_from_diff_arg(ignore_sm),
+                    line_ignore,
+                    &diff_algo_ctx,
+                    diff_algo_cli,
+                    args.cached,
+                    args.no_ext_diff,
+                    external_diff_cmd.as_deref(),
+                    relative_prefix_for_paths.as_deref(),
+                )?;
+            }
         } else if args.raw {
             let oid_len = if args.full_index || args.no_abbrev {
                 40

--- a/logs/2026-04-09_t4129-apply-samemode.md
+++ b/logs/2026-04-09_t4129-apply-samemode.md
@@ -1,0 +1,19 @@
+# t4129-apply-samemode
+
+## Summary
+
+Made `tests/t4129-apply-samemode.sh` pass (23/23).
+
+## Root causes
+
+1. **`git diff --stat -p` produced no patch** — `format_besides_unified_patch` treated `--stat` as exclusive; Git emits stat then patch when `-p` wins. Fixed in `grit/src/commands/diff.rs`.
+
+2. **`diff --git` paths kept `b/` prefix** — default strip is 1; paths must become `d/f2` not `b/d/f2`. Fixed when assigning `old_path`/`new_path` from `split_diff_git_paths`.
+
+3. **Mode handling** — Implemented Git-style `canon_mode`, strict `parse_mode_line` errors, optional mode on `index` lines, `prepare_patch_modes_for_apply` mirroring `check_preimage` for `--cached`, `--index`, and worktree, umask-aware checkout permissions, and correct `reverse_patches` mode swap (`new_mode || is_delete`).
+
+## Validation
+
+- `./scripts/run-tests.sh t4129-apply-samemode.sh`
+- `cargo test -p grit-lib --lib`
+- `cargo clippy -p grit-rs --fix --allow-dirty`

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   325 |
+| Completed   |   326 |
 | In progress |     5 |
-| Remaining   |   441 |
+| Remaining   |   440 |
 | **Total**   |   771 |
 
-Task lines in `PLAN.md`: 325 completed (`[x]`), 5 in progress (`[~]`), 441 remaining (`[ ]`).
+Task lines in `PLAN.md`: 326 completed (`[x]`), 5 in progress (`[~]`), 440 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t4129-apply-samemode` — 23/23 tests pass (`diff --stat -p` emits unified hunks after stat; `apply` strips `a/`/`b/` from `diff --git` paths; Git `canon_mode` / invalid mode errors; `core.fileMode` preimage warnings; reverse mode swap matches Git; umask-aware worktree chmod)
 - `t3309-notes-merge-auto-resolve` — 31/31 tests pass (`notes merge`: `union` / `cat_sort_uniq` blob combine like Git; successful merge commits use two parents; `notes.mergeStrategy` config errors match upstream expectations)
 - `t4063-diff-blobs` — 18/18 tests pass (`diff`: blob↔blob and `rev:path` pairs without treating blobs as trees; `HEAD:one..HEAD:two` range split; `rev:path` vs worktree file uses tree path + modes + `write_patch_with_prefix`; raw blob OID vs existing file uses filename as old path; `rev_parse::resolve_treeish_blob_at_path` for tree walks)
 - `t5524-pull-msg` — 3/3 tests pass (`git pull --no-rebase --log` merge message preserves `$` in subject lines; `--log=1` limits shortlog; harness CSV/dashboards refreshed; `PLAN.md` marked complete)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes `t4129-apply-samemode` pass (23/23).

## Changes

- **`git diff --stat -p`**: After writing `--stat` output, also emit the unified patch when `-p` wins (matches Git; fixes empty patches from `git diff --stat -p` used in the test setup).
- **`git apply`**: Strip `a/` / `b/` from `diff --git` paths using `-p` (fixes multi-file staged diffs like `d/f2` vs `b/d/f2`).
- **Modes**: Git-style `canon_mode`, strict invalid mode parsing, optional mode on `index` lines, `core.fileMode` preimage handling aligned with Git `check_preimage`, umask-aware worktree chmod for 100644/100755, and `reverse_patches` mode swap matching Git (`SWAP` only when `new_mode || is_delete`).

## Validation

- `./scripts/run-tests.sh t4129-apply-samemode.sh`
- `cargo test -p grit-lib --lib`
- `cargo clippy -p grit-rs --fix --allow-dirty`

Also updates `data/test-files.csv`, dashboards, `PLAN.md`, `progress.md`, and adds `logs/2026-04-09_t4129-apply-samemode.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32eaeeb7-96a7-4608-b3df-66bbd87fadc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32eaeeb7-96a7-4608-b3df-66bbd87fadc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

