### PR TITLE
fix: t3429 rebase todo reread, --root without --onto, --edit-todo

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -616,7 +616,7 @@ t3425-rebase-topology-merges	t3	yes	13	1	12	false	ok	0
 t3426-rebase-submodule	t3	yes	29	10	19	false	ok	0
 t3427-rebase-subtree	t3	yes	3	0	3	false	ok	0
 t3428-rebase-signoff	t3	yes	7	1	6	false	ok	0
-t3429-rebase-edit-todo	t3	yes	7	5	2	false	ok	0
+t3429-rebase-edit-todo	t3	yes	7	7	0	true	ok	0
 t3430-rebase-merges	t3	yes	34	2	32	false	ok	0
 t3431-rebase-fork-point	t3	yes	26	8	18	false	ok	0
 t3432-rebase-fast-forward	t3	yes	219	162	57	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,688 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,688 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T21:10:04+00:00" class="gen-time" title="2026-04-09 21:10 UTC">2026-04-09 21:10 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,688</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -219,7 +219,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">56/141 files · 2 skipped · 4,052/5,398 tests</span>
+        <span class="group-meta">57/141 files · 2 skipped · 4,054/5,398 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:75.1%"></div></div>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35688 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,688 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T21:10:04+00:00" class="gen-time" title="2026-04-09 21:10 UTC">2026-04-09 21:10 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,688</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -6317,14 +6317,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:14.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="7" data-passed="5">
+<tr class="" data-group="t3" data-tests="7" data-passed="7" data-full-pass="1">
   <td class="mono">t3429-rebase-edit-todo</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">7</td>
-  <td class="right">5</td>
+  <td class="right">7</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:71.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="34" data-passed="2">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit/src/commands/pull.rs
+++ b/grit/src/commands/pull.rs
@@ -590,6 +590,7 @@ fn do_merge_or_rebase_after_fetch(
             autosquash: false,
             no_autosquash: false,
             keep_empty: false,
+            edit_todo: false,
         };
         return super::rebase::run(rebase_args);
     }

--- a/grit/src/commands/rebase.rs
+++ b/grit/src/commands/rebase.rs
@@ -231,6 +231,10 @@ pub struct Args {
     /// Keep commits that do not change any file (empty patch).
     #[arg(short = 'k', long = "keep-empty")]
     pub keep_empty: bool,
+
+    /// Edit the todo list of the current interactive rebase.
+    #[arg(long = "edit-todo")]
+    pub edit_todo: bool,
 }
 
 /// Expand combined short flags (`-ki`, `-ik`) before clap parsing.
@@ -279,9 +283,6 @@ pub fn run(mut args: Args) -> Result<()> {
         if args.fork_point {
             bail!("options '--root' and '--fork-point' cannot be used together");
         }
-        if args.onto.is_none() {
-            bail!("a base commit must be provided with --onto when using --root");
-        }
         if args.upstream.is_some() && args.branch.is_some() {
             bail!("git rebase: too many arguments");
         }
@@ -301,6 +302,9 @@ pub fn run(mut args: Args) -> Result<()> {
     }
     if args.quit {
         return do_quit();
+    }
+    if args.edit_todo {
+        return do_edit_todo();
     }
 
     let pre_rebase_hook_second = args.branch.clone();
@@ -592,6 +596,29 @@ fn is_commit_tree_unchanged(repo: &Repository, oid: &ObjectId) -> Result<bool> {
     Ok(commit.tree == parent_tree)
 }
 
+/// Git creates a synthetic empty root commit when `rebase --root` runs without `--onto`
+/// (`commit_tree` with the empty tree and no parents).
+fn synthetic_root_onto_commit_oid(repo: &Repository, config: &ConfigSet) -> Result<ObjectId> {
+    const GIT_EMPTY_TREE_HEX: &str = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+    let tree = ObjectId::from_hex(GIT_EMPTY_TREE_HEX).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let now = time::OffsetDateTime::now_utc();
+    let author = resolve_identity(config, "AUTHOR")?;
+    let committer = resolve_identity(config, "COMMITTER")?;
+    let commit_data = CommitData {
+        tree,
+        parents: Vec::new(),
+        author: format_ident(&author, now),
+        committer: format_ident(&committer, now),
+        author_raw: Vec::new(),
+        committer_raw: Vec::new(),
+        encoding: None,
+        message: String::new(),
+        raw_message: None,
+    };
+    let bytes = serialize_commit(&commit_data);
+    Ok(repo.odb.write(ObjectKind::Commit, &bytes)?)
+}
+
 /// Validates `rebase.instructionFormat` similarly to Git's `get_commit_format` for todo generation.
 fn validate_rebase_instruction_format(config: &ConfigSet) -> Result<()> {
     let Some(fmt) = config.get("rebase.instructionFormat") else {
@@ -849,6 +876,22 @@ fn parse_rebase_replay_step(
             }),
         );
     }
+    if let Ok(Some(prefix)) = parse_interactive_rebase_todo_line(repo, line) {
+        match prefix {
+            ParsedRebaseTodoLine::Exec(s) => return Ok(Some(RebaseReplayStep::Exec(s))),
+            ParsedRebaseTodoLine::Edit(oid) => return Ok(Some(RebaseReplayStep::Edit(oid))),
+            ParsedRebaseTodoLine::MergeReuseMessage {
+                merge_oid,
+                merge_args,
+            } => {
+                return Ok(Some(RebaseReplayStep::MergeReuseMessage {
+                    merge_oid,
+                    merge_args,
+                }));
+            }
+            ParsedRebaseTodoLine::Commit { .. } => {}
+        }
+    }
     Ok(parse_todo_line_with_repo(Some(repo), line)?
         .map(|(oid, cmd)| RebaseReplayStep::PickLike { oid, cmd }))
 }
@@ -1054,31 +1097,41 @@ fn rebase_state_todo_lines(
         .collect()
 }
 
-fn next_non_fixup_index(
+/// True when there is another `fixup` / `squash` command after `idx`, skipping only `exec` lines.
+///
+/// Git inserts `exec` after the reword editor; those lines must not prevent the trailing `fixup`
+/// from being treated as the final step in a squash chain (t3429).
+fn has_following_fixup_or_squash_after(
     repo: &Repository,
     todo_lines: &[&str],
-    from: usize,
+    idx: usize,
     interactive: bool,
-) -> Option<usize> {
-    let mut j = from + 1;
+) -> bool {
+    let mut j = idx + 1;
     while j < todo_lines.len() {
-        if let Ok(Some(step)) = parse_rebase_replay_step(repo, todo_lines[j], interactive) {
-            match step {
-                RebaseReplayStep::PickLike { cmd, .. } => {
-                    if matches!(cmd, RebaseTodoCmd::Fixup | RebaseTodoCmd::Squash) {
-                        j += 1;
-                        continue;
-                    }
-                    return Some(j);
-                }
-                RebaseReplayStep::Exec(_)
-                | RebaseReplayStep::Edit(_)
-                | RebaseReplayStep::MergeReuseMessage { .. } => return Some(j),
+        let t = todo_lines[j].trim();
+        if t.is_empty() || t.starts_with('#') {
+            j += 1;
+            continue;
+        }
+        let Ok(Some(step)) = parse_rebase_replay_step(repo, todo_lines[j], interactive) else {
+            j += 1;
+            continue;
+        };
+        match step {
+            RebaseReplayStep::Exec(_) => {
+                j += 1;
+                continue;
+            }
+            RebaseReplayStep::PickLike { cmd, .. } => {
+                return matches!(cmd, RebaseTodoCmd::Fixup | RebaseTodoCmd::Squash);
+            }
+            RebaseReplayStep::Edit(_) | RebaseReplayStep::MergeReuseMessage { .. } => {
+                return false;
             }
         }
-        j += 1;
     }
-    None
+    false
 }
 
 fn is_final_fixup_in_todo(
@@ -1096,7 +1149,7 @@ fn is_final_fixup_in_todo(
     if !matches!(cmd, RebaseTodoCmd::Fixup | RebaseTodoCmd::Squash) {
         return false;
     }
-    next_non_fixup_index(repo, todo_lines, idx, interactive).is_none()
+    !has_following_fixup_or_squash_after(repo, todo_lines, idx, interactive)
 }
 
 #[derive(Clone, Copy, Default)]
@@ -1469,6 +1522,49 @@ fn active_rebase_dir(git_dir: &Path) -> Option<PathBuf> {
     None
 }
 
+/// Canonical on-disk todo path for an in-progress rebase (Git uses
+/// `.git/rebase-merge/git-rebase-todo`). When `GIT_REBASE_TODO` is set, it overrides the default
+/// file; relative paths are resolved against the repository work tree.
+fn rebase_todo_file_path(repo: &Repository, rb_dir: &Path) -> PathBuf {
+    if let Ok(raw) = std::env::var("GIT_REBASE_TODO") {
+        let trimmed = raw.trim();
+        if !trimmed.is_empty() {
+            let p = PathBuf::from(trimmed);
+            if p.is_absolute() {
+                return p;
+            }
+            if let Some(wt) = repo.work_tree.as_deref() {
+                return wt.join(p);
+            }
+            return p;
+        }
+    }
+    rb_dir.join("git-rebase-todo")
+}
+
+fn read_rebase_todo_file(repo: &Repository, rb_dir: &Path) -> Result<String> {
+    let primary = rebase_todo_file_path(repo, rb_dir);
+    if primary.exists() {
+        return fs::read_to_string(&primary)
+            .with_context(|| format!("failed to read rebase todo {}", primary.display()));
+    }
+    let legacy = rb_dir.join("todo");
+    fs::read_to_string(&legacy)
+        .with_context(|| format!("failed to read rebase todo {}", legacy.display()))
+}
+
+fn write_rebase_todo_file(repo: &Repository, rb_dir: &Path, content: &str) -> Result<()> {
+    let primary = rebase_todo_file_path(repo, rb_dir);
+    fs::write(&primary, content)
+        .with_context(|| format!("failed to write rebase todo {}", primary.display()))?;
+    let legacy = rb_dir.join("todo");
+    if primary != legacy {
+        fs::write(&legacy, content)
+            .with_context(|| format!("failed to write rebase todo {}", legacy.display()))?;
+    }
+    Ok(())
+}
+
 fn rebase_state_dir_for_backend(git_dir: &Path, backend: RebaseBackend) -> std::path::PathBuf {
     match backend {
         RebaseBackend::Apply => rebase_apply_dir(git_dir),
@@ -1750,18 +1846,20 @@ fn run_shell_editor(editor: &str, path: &Path) -> Result<std::process::ExitStatu
     Ok(status)
 }
 
-/// Opens `GIT_EDITOR` on `COMMIT_EDITMSG` for an interactive reword during `rebase -i`.
+/// Opens `GIT_EDITOR` on `COMMIT_EDITMSG` during interactive rebase (sequencer path).
 ///
-/// Matches Git's sequencer path: seed the file, run `prepare-commit-msg` with source `reword`,
-/// then invoke the commit editor. Returns the edited message text (before final cleanup).
-fn run_commit_editor_for_reword(
+/// Seeds the file with `template`, runs `prepare-commit-msg` with `prepare_source` (`reword`,
+/// `squash`, …), then invokes the commit editor. Returns the file contents afterward (before
+/// caller-applied cleanup).
+fn run_commit_editor_for_sequencer(
     repo: &Repository,
     git_dir: &Path,
     template: &str,
+    prepare_source: &str,
 ) -> Result<String> {
     let editmsg = git_dir.join("COMMIT_EDITMSG");
     fs::write(&editmsg, template)?;
-    run_prepare_commit_msg_hook(repo, &editmsg, "reword")?;
+    run_prepare_commit_msg_hook(repo, &editmsg, prepare_source)?;
     let config = ConfigSet::load(Some(git_dir), true)?;
     let editor = git_editor_cmd(&config)?;
     let status = run_shell_editor(&editor, &editmsg)?;
@@ -1769,6 +1867,14 @@ fn run_commit_editor_for_reword(
         bail!("there was a problem with the editor");
     }
     fs::read_to_string(&editmsg).context("read COMMIT_EDITMSG after editor")
+}
+
+fn run_commit_editor_for_reword(
+    repo: &Repository,
+    git_dir: &Path,
+    template: &str,
+) -> Result<String> {
+    run_commit_editor_for_sequencer(repo, git_dir, template, "reword")
 }
 
 fn worktree_matches_head(repo: &Repository, git_dir: &Path) -> Result<bool> {
@@ -1879,6 +1985,37 @@ fn apply_autostash_after_ff(repo: &Repository, autostash_oid: &ObjectId) -> Resu
 
 // ── Main rebase flow ────────────────────────────────────────────────
 
+/// Open the interactive rebase todo in the sequence editor (`GIT_SEQUENCE_EDITOR` / `sequence.editor`).
+fn do_edit_todo() -> Result<()> {
+    let repo = Repository::discover(None).context("not a git repository")?;
+    let git_dir = &repo.git_dir;
+
+    if !is_rebase_in_progress(git_dir) {
+        bail!("no rebase in progress");
+    }
+
+    let rb_dir = active_rebase_dir(git_dir)
+        .ok_or_else(|| anyhow::anyhow!("internal: no rebase state directory"))?;
+    if !rb_dir.join("interactive").exists() {
+        bail!("interactive rebase is not in progress; cannot edit todo");
+    }
+
+    let config = ConfigSet::load(Some(git_dir), true).unwrap_or_else(|_| ConfigSet::new());
+    let content = read_rebase_todo_file(&repo, &rb_dir)?;
+    write_rebase_todo_file(&repo, &rb_dir, &content)?;
+
+    let path = rebase_todo_file_path(&repo, &rb_dir);
+    let editor = sequence_editor_cmd(&config)?;
+    let status = run_shell_editor(&editor, &path)?;
+    if !status.success() {
+        bail!("there was a problem with the editor");
+    }
+    let edited = fs::read_to_string(&path)
+        .with_context(|| format!("read rebase todo after edit {}", path.display()))?;
+    write_rebase_todo_file(&repo, &rb_dir, &edited)?;
+    Ok(())
+}
+
 fn do_rebase(args: Args, pre_rebase_hook_second: Option<String>) -> Result<()> {
     let repo = Repository::discover(None).context("not a git repository")?;
     let git_dir = &repo.git_dir;
@@ -1960,30 +2097,33 @@ fn do_rebase(args: Args, pre_rebase_hook_second: Option<String>) -> Result<()> {
         .ok_or_else(|| anyhow::anyhow!("cannot rebase: HEAD is unborn"))?
         .to_owned();
 
-    let (upstream_spec, upstream_oid, onto_oid, onto_name_for_state) = if args.root {
-        let onto_spec = args
-            .onto
-            .as_deref()
-            .ok_or_else(|| anyhow::anyhow!("internal: --root without --onto"))?;
-        let onto = resolve_revision(&repo, onto_spec)
-            .with_context(|| format!("bad revision '{onto_spec}'"))?;
-        ("--root".to_owned(), onto, onto, onto_spec.to_owned())
-    } else {
-        let upstream_spec = args.upstream.as_deref().unwrap_or("HEAD").to_owned();
-        let up_oid = resolve_revision(&repo, &upstream_spec)
-            .with_context(|| format!("bad revision '{upstream_spec}'"))?;
-        let (onto, onto_label) = if let Some(ref onto_spec) = args.onto {
-            let oid = resolve_revision(&repo, onto_spec)
-                .with_context(|| format!("bad revision '{onto_spec}'"))?;
-            (oid, onto_spec.clone())
-        } else if args.keep_base {
-            let oid = find_merge_base(&repo, up_oid, head_oid_early).unwrap_or(up_oid);
-            (oid, upstream_spec.clone())
+    let (upstream_spec, upstream_oid, onto_oid, onto_name_for_state, root_synthetic_onto) =
+        if args.root {
+            if let Some(onto_spec) = args.onto.as_deref() {
+                let onto = resolve_revision(&repo, onto_spec)
+                    .with_context(|| format!("bad revision '{onto_spec}'"))?;
+                ("--root".to_owned(), onto, onto, onto_spec.to_owned(), false)
+            } else {
+                let syn = synthetic_root_onto_commit_oid(&repo, &config)?;
+                let name = syn.to_hex();
+                ("--root".to_owned(), syn, syn, name, true)
+            }
         } else {
-            (up_oid, upstream_spec.clone())
+            let upstream_spec = args.upstream.as_deref().unwrap_or("HEAD").to_owned();
+            let up_oid = resolve_revision(&repo, &upstream_spec)
+                .with_context(|| format!("bad revision '{upstream_spec}'"))?;
+            let (onto, onto_label) = if let Some(ref onto_spec) = args.onto {
+                let oid = resolve_revision(&repo, onto_spec)
+                    .with_context(|| format!("bad revision '{onto_spec}'"))?;
+                (oid, onto_spec.clone())
+            } else if args.keep_base {
+                let oid = find_merge_base(&repo, up_oid, head_oid_early).unwrap_or(up_oid);
+                (oid, upstream_spec.clone())
+            } else {
+                (up_oid, upstream_spec.clone())
+            };
+            (upstream_spec, up_oid, onto, onto_label, false)
         };
-        (upstream_spec, up_oid, onto, onto_label)
-    };
 
     let head = head_state;
     let head_oid = head_oid_early;
@@ -2002,8 +2142,11 @@ fn do_rebase(args: Args, pre_rebase_hook_second: Option<String>) -> Result<()> {
         .whitespace
         .as_deref()
         .is_some_and(|w| w.eq_ignore_ascii_case("fix") || w.eq_ignore_ascii_case("strip"));
-    let allow_preemptive_ff =
-        !args.interactive && args.exec.is_none() && !whitespace_forces_replay && !args.autosquash;
+    let allow_preemptive_ff = !args.interactive
+        && args.exec.is_none()
+        && !whitespace_forces_replay
+        && !args.autosquash
+        && !root_synthetic_onto;
 
     if allow_preemptive_ff && rebase_can_preemptive_ff(&repo, onto_oid, upstream_oid, head_oid)? {
         if !args.no_ff {
@@ -2191,7 +2334,7 @@ fn do_rebase(args: Args, pre_rebase_hook_second: Option<String>) -> Result<()> {
     if rebase_interactive {
         fs::write(rb_dir.join("interactive"), "")?;
     }
-    fs::write(rb_dir.join("todo"), todo.join("\n") + "\n")?;
+    write_rebase_todo_file(&repo, &rb_dir, &(todo.join("\n") + "\n"))?;
     fs::write(rb_dir.join("end"), total.to_string())?;
     fs::write(rb_dir.join("msgnum"), "1")?;
     fs::write(rb_dir.join("last"), total.to_string())?;
@@ -2679,6 +2822,9 @@ fn print_diffstat_from_entries(repo: &Repository, entries: &[DiffEntry]) {
 }
 
 /// Replay all remaining commits from the todo list.
+///
+/// After each successful step, the todo file is re-read so hooks and `exec` lines can append work
+/// (matching Git's `git-rebase-todo` behavior, including `GIT_REBASE_TODO`).
 fn replay_remaining(
     repo: &Repository,
     rb_dir: &Path,
@@ -2694,352 +2840,401 @@ fn replay_remaining(
 
     let rebase_interactive = rb_dir.join("interactive").exists();
 
-    let todo_content = fs::read_to_string(rb_dir.join("todo"))?;
-    let todo: Vec<&str> = todo_content.lines().filter(|l| !l.is_empty()).collect();
-    let _total: usize = fs::read_to_string(rb_dir.join("end"))?.trim().parse()?;
-    let msgnum: usize = fs::read_to_string(rb_dir.join("msgnum"))?.trim().parse()?;
-
     let rewind_marker = rb_dir.join("rewind-notice");
-    if !rewind_marker.exists() && !todo.is_empty() {
-        println!("First, rewinding head to replay your work on top of it...");
-        let _ = fs::write(&rewind_marker, "");
-    }
 
-    for i in (msgnum - 1)..todo.len() {
-        let line = todo[i];
-        let step = parse_rebase_replay_step(repo, line, rebase_interactive)?
-            .ok_or_else(|| anyhow::anyhow!("malformed rebase todo line: {line}"))?;
+    'rebase_loop: loop {
+        let todo_content = read_rebase_todo_file(repo, rb_dir)?;
+        let todo: Vec<&str> = todo_content.lines().filter(|l| !l.is_empty()).collect();
+        let _total: usize = fs::read_to_string(rb_dir.join("end"))?.trim().parse()?;
+        let msgnum: usize = fs::read_to_string(rb_dir.join("msgnum"))?.trim().parse()?;
 
-        fs::write(rb_dir.join("msgnum"), (i + 1).to_string())?;
-        fs::write(rb_dir.join("next"), (i + 1).to_string())?;
+        if !rewind_marker.exists() && !todo.is_empty() {
+            println!("First, rewinding head to replay your work on top of it...");
+            let _ = fs::write(&rewind_marker, "");
+        }
 
-        match step {
-            RebaseReplayStep::Exec(exec_cmd) => {
-                let _ = fs::remove_file(rb_dir.join("current"));
-                let _ = fs::remove_file(rb_dir.join("current-cmd"));
-                let _ = fs::remove_file(rb_dir.join("current-final-fixup"));
-                eprintln!("Executing: {}", exec_cmd);
-                let status = std::process::Command::new("sh")
-                    .arg("-c")
-                    .arg(&exec_cmd)
-                    .current_dir(repo.work_tree.as_deref().unwrap_or_else(|| Path::new(".")))
-                    .status()
-                    .with_context(|| format!("failed to execute: {}", exec_cmd))?;
-                if !status.success() {
-                    let code = status.code().unwrap_or(1);
-                    eprintln!(
-                        "warning: execution failed for: {}\n\
-                         hint: You can fix the problem, and then run\n\
-                         hint:   grit rebase --continue",
-                        exec_cmd
-                    );
-                    let remaining: Vec<&str> = todo[i + 1..].to_vec();
-                    fs::write(rb_dir.join("todo"), remaining.join("\n") + "\n")?;
+        for i in (msgnum - 1)..todo.len() {
+            let line = todo[i];
+            let step = parse_rebase_replay_step(repo, line, rebase_interactive)?
+                .ok_or_else(|| anyhow::anyhow!("malformed rebase todo line: {line}"))?;
+
+            fs::write(rb_dir.join("msgnum"), (i + 1).to_string())?;
+            fs::write(rb_dir.join("next"), (i + 1).to_string())?;
+
+            match step {
+                RebaseReplayStep::Exec(exec_cmd) => {
+                    let _ = fs::remove_file(rb_dir.join("current"));
+                    let _ = fs::remove_file(rb_dir.join("current-cmd"));
+                    let _ = fs::remove_file(rb_dir.join("current-final-fixup"));
+                    let remaining_before: Vec<&str> = todo[i + 1..].to_vec();
+                    write_rebase_todo_file(
+                        repo,
+                        rb_dir,
+                        &(remaining_before.join("\n")
+                            + if remaining_before.is_empty() {
+                                ""
+                            } else {
+                                "\n"
+                            }),
+                    )?;
                     fs::write(rb_dir.join("msgnum"), "1")?;
-                    fs::write(rb_dir.join("end"), remaining.len().to_string())?;
-                    std::process::exit(code);
-                }
-            }
-            RebaseReplayStep::MergeReuseMessage {
-                merge_oid,
-                merge_args,
-            } => {
-                let _ = fs::remove_file(rb_dir.join("current"));
-                let _ = fs::remove_file(rb_dir.join("current-cmd"));
-                let _ = fs::remove_file(rb_dir.join("current-final-fixup"));
-                let old_head = resolve_head(git_dir)?
-                    .oid()
-                    .cloned()
-                    .unwrap_or_else(diff::zero_oid);
-                let next_after =
-                    peek_next_rebase_flush_hint(repo, &todo, i + 1, rebase_interactive);
-                match rebase_merge_reuse_message(
-                    repo,
-                    git_dir,
-                    rb_dir,
-                    &merge_oid,
-                    merge_args.as_str(),
-                    next_after,
-                ) {
-                    Ok(RebaseMergeReuseOutcome::Completed) => {
-                        let head = resolve_head(git_dir)?;
-                        let new_oid = *head
-                            .oid()
-                            .ok_or_else(|| anyhow::anyhow!("HEAD has no OID"))?;
-                        let merge_obj = repo.odb.read(&merge_oid)?;
-                        let mc = parse_commit(&merge_obj.data)?;
-                        let subject = mc.message.lines().next().unwrap_or("");
-                        eprintln!("Applying: {}", subject);
-                        let msg = format!("{ra} (pick): {subject}");
-                        let _ = append_reflog(
-                            git_dir, "HEAD", &old_head, &new_oid, &ident, &msg, false,
-                        );
-                        let rest: Vec<&str> = todo[i + 1..].to_vec();
-                        fs::write(rb_dir.join("todo"), rest.join("\n") + "\n")?;
-                        fs::write(rb_dir.join("msgnum"), "1")?;
-                        fs::write(rb_dir.join("end"), rest.len().to_string())?;
-                        return replay_remaining(
-                            repo,
-                            rb_dir,
-                            autostash_oid,
-                            backend,
-                            had_rebase_autostash,
-                        );
-                    }
-                    Ok(RebaseMergeReuseOutcome::Conflict) => {
-                        let _ = fs::remove_file(rb_dir.join("current"));
-                        let _ = fs::remove_file(rb_dir.join("current-cmd"));
-                        let _ = fs::remove_file(rb_dir.join("current-final-fixup"));
-                        let remaining_merge: Vec<&str> = todo[i..].to_vec();
-                        fs::write(rb_dir.join("todo"), remaining_merge.join("\n") + "\n")?;
-                        fs::write(rb_dir.join("msgnum"), "1")?;
-                        fs::write(rb_dir.join("end"), remaining_merge.len().to_string())?;
-                        let _ = fs::write(
-                            rb_dir.join("stopped-sha"),
-                            format!("{}\n", merge_oid.to_hex()),
-                        );
-                        let merge_obj_cf = repo.odb.read(&merge_oid)?;
-                        let mc_cf = parse_commit(&merge_obj_cf.data)?;
-                        let subj_cf = mc_cf.message.lines().next().unwrap_or("");
+                    fs::write(rb_dir.join("end"), remaining_before.len().to_string())?;
+                    eprintln!("Executing: {}", exec_cmd);
+                    let status = std::process::Command::new("sh")
+                        .arg("-c")
+                        .arg(&exec_cmd)
+                        .current_dir(repo.work_tree.as_deref().unwrap_or_else(|| Path::new(".")))
+                        .status()
+                        .with_context(|| format!("failed to execute: {}", exec_cmd))?;
+                    if !status.success() {
+                        let code = status.code().unwrap_or(1);
                         eprintln!(
-                            "error: could not apply {}... {}\n\
-                             hint: Resolve all conflicts manually, mark them as resolved with\n\
-                             hint: \"grit add <pathspec>\", then run \"grit rebase --continue\".\n\
-                             hint: To skip this commit, run \"grit rebase --skip\".\n\
-                             hint: To abort, run \"grit rebase --abort\".",
-                            &merge_oid.to_hex()[..7],
-                            subj_cf
+                            "warning: execution failed for: {}\n\
+                             hint: You can fix the problem, and then run\n\
+                             hint:   grit rebase --continue",
+                            exec_cmd
                         );
-                        std::process::exit(1);
+                        std::process::exit(code);
                     }
-                    Ok(RebaseMergeReuseOutcome::Blocked) => {
-                        let remaining_blk: Vec<&str> = todo[i..].to_vec();
-                        fs::write(rb_dir.join("todo"), remaining_blk.join("\n") + "\n")?;
-                        fs::write(rb_dir.join("msgnum"), "1")?;
-                        fs::write(rb_dir.join("end"), remaining_blk.len().to_string())?;
-                        std::process::exit(1);
-                    }
-                    Err(e) => {
-                        let _ = fs::remove_file(rb_dir.join("rebase-merge-source"));
-                        let _ = fs::remove_file(rb_dir.join("rebase-merge-args"));
-                        eprintln!("{e:#}");
-                        std::process::exit(1);
-                    }
+                    continue 'rebase_loop;
                 }
-            }
-            RebaseReplayStep::Edit(commit_oid) => {
-                let todo_cmd = RebaseTodoCmd::Pick;
-
-                let commit_hex = commit_oid.to_hex();
-                fs::write(rb_dir.join("current"), format!("{commit_hex}\n"))?;
-                fs::write(
-                    rb_dir.join("current-cmd"),
-                    format!("{}\n", todo_cmd.as_str()),
-                )?;
-                let _ = fs::remove_file(rb_dir.join("current-final-fixup"));
-
-                let old_head = resolve_head(git_dir)?
-                    .oid()
-                    .cloned()
-                    .unwrap_or_else(diff::zero_oid);
-
-                let pick_backend = load_rebase_backend(rb_dir);
-                let final_fixup = is_final_fixup_in_todo(repo, &todo, i, rebase_interactive);
-                let next_after_this =
-                    peek_next_rebase_flush_hint(repo, &todo, i + 1, rebase_interactive);
-                match cherry_pick_for_rebase(
-                    repo,
-                    rb_dir,
-                    &commit_oid,
-                    pick_backend,
-                    todo_cmd,
-                    final_fixup,
-                    next_after_this,
-                    false,
-                ) {
-                    Ok(()) => {
-                        let head = resolve_head(git_dir)?;
-                        let new_oid = *head
-                            .oid()
-                            .ok_or_else(|| anyhow::anyhow!("HEAD has no OID"))?;
-                        let obj = repo.odb.read(&commit_oid)?;
-                        let commit = parse_commit(&obj.data)?;
-                        let root_rebase = rb_dir.join("root").exists();
-                        let msg_for_log =
-                            message_for_root_replayed_commit(repo, &commit, root_rebase);
-                        let subject = msg_for_log.lines().next().unwrap_or("");
-                        eprintln!("Applying: {}", subject);
-                        let msg = format!("{ra} (pick): {subject}");
-                        let _ = append_reflog(
-                            git_dir, "HEAD", &old_head, &new_oid, &ident, &msg, false,
-                        );
-
-                        let remaining: Vec<&str> = todo[i + 1..].to_vec();
-                        fs::write(rb_dir.join("todo"), remaining.join("\n") + "\n")?;
-                        fs::write(rb_dir.join("msgnum"), "1")?;
-                        fs::write(rb_dir.join("end"), remaining.len().to_string())?;
-                        let _ = fs::write(
-                            rb_dir.join("stopped-sha"),
-                            format!("{}\n", commit_oid.to_hex()),
-                        );
-                        let _ = fs::write(rb_dir.join("rebase-amend-continue"), "1\n");
-                        std::process::exit(0);
-                    }
-                    Err(_e) => {
-                        let remaining: Vec<&str> = todo[i + 1..].to_vec();
-                        fs::write(rb_dir.join("todo"), remaining.join("\n") + "\n")?;
-                        fs::write(rb_dir.join("msgnum"), "1")?;
-                        fs::write(rb_dir.join("end"), remaining.len().to_string())?;
-                        let ff = is_final_fixup_in_todo(repo, &todo, i, rebase_interactive);
-                        fs::write(
-                            rb_dir.join("current-final-fixup"),
-                            if ff { "1\n" } else { "0\n" },
-                        )?;
-                        let _ = fs::write(
-                            rb_dir.join("stopped-sha"),
-                            format!("{}\n", commit_oid.to_hex()),
-                        );
-
-                        let obj = repo.odb.read(&commit_oid)?;
-                        let commit = parse_commit(&obj.data)?;
-                        let root_rebase = rb_dir.join("root").exists();
-                        let msg_for_log =
-                            message_for_root_replayed_commit(repo, &commit, root_rebase);
-                        let subject = msg_for_log.lines().next().unwrap_or("");
-
-                        eprintln!(
-                            "error: could not apply {}... {}\n\
-                             hint: Resolve all conflicts manually, mark them as resolved with\n\
-                             hint: \"grit add <pathspec>\", then run \"grit rebase --continue\".\n\
-                             hint: To skip this commit, run \"grit rebase --skip\".\n\
-                             hint: To abort, run \"grit rebase --abort\".",
-                            &commit_oid.to_hex()[..7],
-                            subject
-                        );
-                        std::process::exit(1);
-                    }
-                }
-            }
-            RebaseReplayStep::PickLike {
-                oid: commit_oid,
-                cmd: todo_cmd,
-            } => {
-                let commit_hex = commit_oid.to_hex();
-                fs::write(rb_dir.join("current"), format!("{commit_hex}\n"))?;
-                fs::write(
-                    rb_dir.join("current-cmd"),
-                    format!("{}\n", todo_cmd.as_str()),
-                )?;
-                let _ = fs::remove_file(rb_dir.join("current-final-fixup"));
-
-                let old_head = resolve_head(git_dir)?
-                    .oid()
-                    .cloned()
-                    .unwrap_or_else(diff::zero_oid);
-
-                let pick_backend = load_rebase_backend(rb_dir);
-                let final_fixup = is_final_fixup_in_todo(repo, &todo, i, rebase_interactive);
-                let next_after_this =
-                    peek_next_rebase_flush_hint(repo, &todo, i + 1, rebase_interactive);
-                match cherry_pick_for_rebase(
-                    repo,
-                    rb_dir,
-                    &commit_oid,
-                    pick_backend,
-                    todo_cmd,
-                    final_fixup,
-                    next_after_this,
-                    true,
-                ) {
-                    Ok(()) => {
-                        let head = resolve_head(git_dir)?;
-                        let new_oid = *head
-                            .oid()
-                            .ok_or_else(|| anyhow::anyhow!("HEAD has no OID"))?;
-                        let obj = repo.odb.read(&commit_oid)?;
-                        let commit = parse_commit(&obj.data)?;
-                        let root_rebase = rb_dir.join("root").exists();
-                        let msg_for_log =
-                            message_for_root_replayed_commit(repo, &commit, root_rebase);
-                        let subject = msg_for_log.lines().next().unwrap_or("");
-                        eprintln!("Applying: {}", subject);
-                        let msg = format!("{ra} (pick): {subject}");
-                        let _ = append_reflog(
-                            git_dir, "HEAD", &old_head, &new_oid, &ident, &msg, false,
-                        );
-
-                        if let Ok(global_exec) = fs::read_to_string(rb_dir.join("exec")) {
-                            let global_exec = global_exec.trim();
-                            if !global_exec.is_empty() {
-                                eprintln!("Executing: {}", global_exec);
-                                let status = std::process::Command::new("sh")
-                                    .arg("-c")
-                                    .arg(global_exec)
-                                    .current_dir(
-                                        repo.work_tree.as_deref().unwrap_or_else(|| Path::new(".")),
-                                    )
-                                    .status()
-                                    .with_context(|| {
-                                        format!("failed to execute: {}", global_exec)
-                                    })?;
-                                if !status.success() {
-                                    let code = status.code().unwrap_or(1);
-                                    eprintln!(
-                                        "warning: execution failed for: {}\n\
-                                         hint: You can fix the problem, and then run\n\
-                                         hint:   grit rebase --continue",
-                                        global_exec
-                                    );
-                                    let remaining: Vec<&str> = todo[i + 1..].to_vec();
-                                    fs::write(rb_dir.join("todo"), remaining.join("\n") + "\n")?;
-                                    fs::write(rb_dir.join("msgnum"), "1")?;
-                                    fs::write(rb_dir.join("end"), remaining.len().to_string())?;
-                                    std::process::exit(code);
-                                }
-                            }
+                RebaseReplayStep::MergeReuseMessage {
+                    merge_oid,
+                    merge_args,
+                } => {
+                    let _ = fs::remove_file(rb_dir.join("current"));
+                    let _ = fs::remove_file(rb_dir.join("current-cmd"));
+                    let _ = fs::remove_file(rb_dir.join("current-final-fixup"));
+                    let old_head = resolve_head(git_dir)?
+                        .oid()
+                        .cloned()
+                        .unwrap_or_else(diff::zero_oid);
+                    let next_after =
+                        peek_next_rebase_flush_hint(repo, &todo, i + 1, rebase_interactive);
+                    match rebase_merge_reuse_message(
+                        repo,
+                        git_dir,
+                        rb_dir,
+                        &merge_oid,
+                        merge_args.as_str(),
+                        next_after,
+                    ) {
+                        Ok(RebaseMergeReuseOutcome::Completed) => {
+                            let head = resolve_head(git_dir)?;
+                            let new_oid = *head
+                                .oid()
+                                .ok_or_else(|| anyhow::anyhow!("HEAD has no OID"))?;
+                            let merge_obj = repo.odb.read(&merge_oid)?;
+                            let mc = parse_commit(&merge_obj.data)?;
+                            let subject = mc.message.lines().next().unwrap_or("");
+                            eprintln!("Applying: {}", subject);
+                            let msg = format!("{ra} (pick): {subject}");
+                            let _ = append_reflog(
+                                git_dir, "HEAD", &old_head, &new_oid, &ident, &msg, false,
+                            );
+                            let rest: Vec<&str> = todo[i + 1..].to_vec();
+                            write_rebase_todo_file(
+                                repo,
+                                rb_dir,
+                                &(rest.join("\n") + if rest.is_empty() { "" } else { "\n" }),
+                            )?;
+                            fs::write(rb_dir.join("msgnum"), "1")?;
+                            fs::write(rb_dir.join("end"), rest.len().to_string())?;
+                            continue 'rebase_loop;
+                        }
+                        Ok(RebaseMergeReuseOutcome::Conflict) => {
+                            let _ = fs::remove_file(rb_dir.join("current"));
+                            let _ = fs::remove_file(rb_dir.join("current-cmd"));
+                            let _ = fs::remove_file(rb_dir.join("current-final-fixup"));
+                            let remaining_merge: Vec<&str> = todo[i..].to_vec();
+                            write_rebase_todo_file(
+                                repo,
+                                rb_dir,
+                                &(remaining_merge.join("\n")
+                                    + if remaining_merge.is_empty() { "" } else { "\n" }),
+                            )?;
+                            fs::write(rb_dir.join("msgnum"), "1")?;
+                            fs::write(rb_dir.join("end"), remaining_merge.len().to_string())?;
+                            let _ = fs::write(
+                                rb_dir.join("stopped-sha"),
+                                format!("{}\n", merge_oid.to_hex()),
+                            );
+                            let merge_obj_cf = repo.odb.read(&merge_oid)?;
+                            let mc_cf = parse_commit(&merge_obj_cf.data)?;
+                            let subj_cf = mc_cf.message.lines().next().unwrap_or("");
+                            eprintln!(
+                                "error: could not apply {}... {}\n\
+                                 hint: Resolve all conflicts manually, mark them as resolved with\n\
+                                 hint: \"grit add <pathspec>\", then run \"grit rebase --continue\".\n\
+                                 hint: To skip this commit, run \"grit rebase --skip\".\n\
+                                 hint: To abort, run \"grit rebase --abort\".",
+                                &merge_oid.to_hex()[..7],
+                                subj_cf
+                            );
+                            std::process::exit(1);
+                        }
+                        Ok(RebaseMergeReuseOutcome::Blocked) => {
+                            let remaining_blk: Vec<&str> = todo[i..].to_vec();
+                            write_rebase_todo_file(
+                                repo,
+                                rb_dir,
+                                &(remaining_blk.join("\n")
+                                    + if remaining_blk.is_empty() { "" } else { "\n" }),
+                            )?;
+                            fs::write(rb_dir.join("msgnum"), "1")?;
+                            fs::write(rb_dir.join("end"), remaining_blk.len().to_string())?;
+                            std::process::exit(1);
+                        }
+                        Err(e) => {
+                            let _ = fs::remove_file(rb_dir.join("rebase-merge-source"));
+                            let _ = fs::remove_file(rb_dir.join("rebase-merge-args"));
+                            eprintln!("{e:#}");
+                            std::process::exit(1);
                         }
                     }
-                    Err(_e) => {
-                        let remaining: Vec<&str> = todo[i + 1..].to_vec();
-                        fs::write(rb_dir.join("todo"), remaining.join("\n") + "\n")?;
-                        fs::write(rb_dir.join("msgnum"), "1")?;
-                        fs::write(rb_dir.join("end"), remaining.len().to_string())?;
-                        let ff = is_final_fixup_in_todo(repo, &todo, i, rebase_interactive);
-                        fs::write(
-                            rb_dir.join("current-final-fixup"),
-                            if ff { "1\n" } else { "0\n" },
-                        )?;
-                        let _ = fs::write(
-                            rb_dir.join("stopped-sha"),
-                            format!("{}\n", commit_oid.to_hex()),
-                        );
+                }
+                RebaseReplayStep::Edit(commit_oid) => {
+                    let todo_cmd = RebaseTodoCmd::Pick;
 
-                        let obj = repo.odb.read(&commit_oid)?;
-                        let commit = parse_commit(&obj.data)?;
-                        let root_rebase = rb_dir.join("root").exists();
-                        let msg_for_log =
-                            message_for_root_replayed_commit(repo, &commit, root_rebase);
-                        let subject = msg_for_log.lines().next().unwrap_or("");
+                    let commit_hex = commit_oid.to_hex();
+                    fs::write(rb_dir.join("current"), format!("{commit_hex}\n"))?;
+                    fs::write(
+                        rb_dir.join("current-cmd"),
+                        format!("{}\n", todo_cmd.as_str()),
+                    )?;
+                    let _ = fs::remove_file(rb_dir.join("current-final-fixup"));
 
-                        eprintln!(
-                            "error: could not apply {}... {}\n\
-                             hint: Resolve all conflicts manually, mark them as resolved with\n\
-                             hint: \"grit add <pathspec>\", then run \"grit rebase --continue\".\n\
-                             hint: To skip this commit, run \"grit rebase --skip\".\n\
-                             hint: To abort, run \"grit rebase --abort\".",
-                            &commit_oid.to_hex()[..7],
-                            subject
-                        );
-                        std::process::exit(1);
+                    let old_head = resolve_head(git_dir)?
+                        .oid()
+                        .cloned()
+                        .unwrap_or_else(diff::zero_oid);
+
+                    let pick_backend = load_rebase_backend(rb_dir);
+                    let final_fixup = is_final_fixup_in_todo(repo, &todo, i, rebase_interactive);
+                    let next_after_this =
+                        peek_next_rebase_flush_hint(repo, &todo, i + 1, rebase_interactive);
+                    match cherry_pick_for_rebase(
+                        repo,
+                        rb_dir,
+                        &commit_oid,
+                        pick_backend,
+                        todo_cmd,
+                        final_fixup,
+                        next_after_this,
+                        false,
+                    ) {
+                        Ok(()) => {
+                            let head = resolve_head(git_dir)?;
+                            let new_oid = *head
+                                .oid()
+                                .ok_or_else(|| anyhow::anyhow!("HEAD has no OID"))?;
+                            let obj = repo.odb.read(&commit_oid)?;
+                            let commit = parse_commit(&obj.data)?;
+                            let root_rebase = rb_dir.join("root").exists();
+                            let msg_for_log =
+                                message_for_root_replayed_commit(repo, &commit, root_rebase);
+                            let subject = msg_for_log.lines().next().unwrap_or("");
+                            eprintln!("Applying: {}", subject);
+                            let msg = format!("{ra} (pick): {subject}");
+                            let _ = append_reflog(
+                                git_dir, "HEAD", &old_head, &new_oid, &ident, &msg, false,
+                            );
+
+                            let remaining: Vec<&str> = todo[i + 1..].to_vec();
+                            write_rebase_todo_file(
+                                repo,
+                                rb_dir,
+                                &(remaining.join("\n")
+                                    + if remaining.is_empty() { "" } else { "\n" }),
+                            )?;
+                            fs::write(rb_dir.join("msgnum"), "1")?;
+                            fs::write(rb_dir.join("end"), remaining.len().to_string())?;
+                            let _ = fs::write(
+                                rb_dir.join("stopped-sha"),
+                                format!("{}\n", commit_oid.to_hex()),
+                            );
+                            let _ = fs::write(rb_dir.join("rebase-amend-continue"), "1\n");
+                            std::process::exit(0);
+                        }
+                        Err(_e) => {
+                            let remaining: Vec<&str> = todo[i + 1..].to_vec();
+                            write_rebase_todo_file(
+                                repo,
+                                rb_dir,
+                                &(remaining.join("\n")
+                                    + if remaining.is_empty() { "" } else { "\n" }),
+                            )?;
+                            fs::write(rb_dir.join("msgnum"), "1")?;
+                            fs::write(rb_dir.join("end"), remaining.len().to_string())?;
+                            let ff = is_final_fixup_in_todo(repo, &todo, i, rebase_interactive);
+                            fs::write(
+                                rb_dir.join("current-final-fixup"),
+                                if ff { "1\n" } else { "0\n" },
+                            )?;
+                            let _ = fs::write(
+                                rb_dir.join("stopped-sha"),
+                                format!("{}\n", commit_oid.to_hex()),
+                            );
+
+                            let obj = repo.odb.read(&commit_oid)?;
+                            let commit = parse_commit(&obj.data)?;
+                            let root_rebase = rb_dir.join("root").exists();
+                            let msg_for_log =
+                                message_for_root_replayed_commit(repo, &commit, root_rebase);
+                            let subject = msg_for_log.lines().next().unwrap_or("");
+
+                            eprintln!(
+                                "error: could not apply {}... {}\n\
+                                 hint: Resolve all conflicts manually, mark them as resolved with\n\
+                                 hint: \"grit add <pathspec>\", then run \"grit rebase --continue\".\n\
+                                 hint: To skip this commit, run \"grit rebase --skip\".\n\
+                                 hint: To abort, run \"grit rebase --abort\".",
+                                &commit_oid.to_hex()[..7],
+                                subject
+                            );
+                            std::process::exit(1);
+                        }
+                    }
+                }
+                RebaseReplayStep::PickLike {
+                    oid: commit_oid,
+                    cmd: todo_cmd,
+                } => {
+                    let commit_hex = commit_oid.to_hex();
+                    fs::write(rb_dir.join("current"), format!("{commit_hex}\n"))?;
+                    fs::write(
+                        rb_dir.join("current-cmd"),
+                        format!("{}\n", todo_cmd.as_str()),
+                    )?;
+                    let _ = fs::remove_file(rb_dir.join("current-final-fixup"));
+
+                    let old_head = resolve_head(git_dir)?
+                        .oid()
+                        .cloned()
+                        .unwrap_or_else(diff::zero_oid);
+
+                    let pick_backend = load_rebase_backend(rb_dir);
+                    let final_fixup = is_final_fixup_in_todo(repo, &todo, i, rebase_interactive);
+                    let next_after_this =
+                        peek_next_rebase_flush_hint(repo, &todo, i + 1, rebase_interactive);
+                    match cherry_pick_for_rebase(
+                        repo,
+                        rb_dir,
+                        &commit_oid,
+                        pick_backend,
+                        todo_cmd,
+                        final_fixup,
+                        next_after_this,
+                        true,
+                    ) {
+                        Ok(()) => {
+                            let head = resolve_head(git_dir)?;
+                            let new_oid = *head
+                                .oid()
+                                .ok_or_else(|| anyhow::anyhow!("HEAD has no OID"))?;
+                            let obj = repo.odb.read(&commit_oid)?;
+                            let commit = parse_commit(&obj.data)?;
+                            let root_rebase = rb_dir.join("root").exists();
+                            let msg_for_log =
+                                message_for_root_replayed_commit(repo, &commit, root_rebase);
+                            let subject = msg_for_log.lines().next().unwrap_or("");
+                            eprintln!("Applying: {}", subject);
+                            let msg = format!("{ra} (pick): {subject}");
+                            let _ = append_reflog(
+                                git_dir, "HEAD", &old_head, &new_oid, &ident, &msg, false,
+                            );
+
+                            if rebase_interactive {
+                                pop_first_nonempty_todo_line(repo, rb_dir)?;
+                            } else {
+                                let remaining: Vec<&str> = todo[i + 1..].to_vec();
+                                write_rebase_todo_file(
+                                    repo,
+                                    rb_dir,
+                                    &(remaining.join("\n")
+                                        + if remaining.is_empty() { "" } else { "\n" }),
+                                )?;
+                                fs::write(rb_dir.join("msgnum"), "1")?;
+                                fs::write(rb_dir.join("end"), remaining.len().to_string())?;
+                            }
+
+                            if let Ok(global_exec) = fs::read_to_string(rb_dir.join("exec")) {
+                                let global_exec = global_exec.trim();
+                                if !global_exec.is_empty() {
+                                    eprintln!("Executing: {}", global_exec);
+                                    let status = std::process::Command::new("sh")
+                                        .arg("-c")
+                                        .arg(global_exec)
+                                        .current_dir(
+                                            repo.work_tree
+                                                .as_deref()
+                                                .unwrap_or_else(|| Path::new(".")),
+                                        )
+                                        .status()
+                                        .with_context(|| {
+                                            format!("failed to execute: {}", global_exec)
+                                        })?;
+                                    if !status.success() {
+                                        let code = status.code().unwrap_or(1);
+                                        eprintln!(
+                                            "warning: execution failed for: {}\n\
+                                             hint: You can fix the problem, and then run\n\
+                                             hint:   grit rebase --continue",
+                                            global_exec
+                                        );
+                                        std::process::exit(code);
+                                    }
+                                }
+                            }
+
+                            continue 'rebase_loop;
+                        }
+                        Err(_e) => {
+                            let remaining: Vec<&str> = todo[i + 1..].to_vec();
+                            write_rebase_todo_file(
+                                repo,
+                                rb_dir,
+                                &(remaining.join("\n")
+                                    + if remaining.is_empty() { "" } else { "\n" }),
+                            )?;
+                            fs::write(rb_dir.join("msgnum"), "1")?;
+                            fs::write(rb_dir.join("end"), remaining.len().to_string())?;
+                            let ff = is_final_fixup_in_todo(repo, &todo, i, rebase_interactive);
+                            fs::write(
+                                rb_dir.join("current-final-fixup"),
+                                if ff { "1\n" } else { "0\n" },
+                            )?;
+                            let _ = fs::write(
+                                rb_dir.join("stopped-sha"),
+                                format!("{}\n", commit_oid.to_hex()),
+                            );
+
+                            let obj = repo.odb.read(&commit_oid)?;
+                            let commit = parse_commit(&obj.data)?;
+                            let root_rebase = rb_dir.join("root").exists();
+                            let msg_for_log =
+                                message_for_root_replayed_commit(repo, &commit, root_rebase);
+                            let subject = msg_for_log.lines().next().unwrap_or("");
+
+                            eprintln!(
+                                "error: could not apply {}... {}\n\
+                                 hint: Resolve all conflicts manually, mark them as resolved with\n\
+                                 hint: \"grit add <pathspec>\", then run \"grit rebase --continue\".\n\
+                                 hint: To skip this commit, run \"grit rebase --skip\".\n\
+                                 hint: To abort, run \"grit rebase --abort\".",
+                                &commit_oid.to_hex()[..7],
+                                subject
+                            );
+                            std::process::exit(1);
+                        }
                     }
                 }
             }
         }
-    }
 
-    // Rebase complete — restore branch ref
-    finish_rebase(repo, rb_dir, autostash_oid, backend, had_rebase_autostash)?;
-    Ok(())
+        finish_rebase(repo, rb_dir, autostash_oid, backend, had_rebase_autostash)?;
+        return Ok(());
+    }
 }
 
 fn rebase_keep_empty(rb_dir: &Path) -> bool {
@@ -3333,8 +3528,14 @@ fn cherry_pick_for_rebase(
                 let body = message_body_after_subject(&hc.message);
                 format!("{subj}\n{body}")
             };
-            let raw = commit_message_after_prepare_hook(repo, git_dir, &template, "squash")?;
-            let cleaned = apply_commit_msg_cleanup(&raw, rebase_commit_msg_cleanup(&config));
+            let squash_chain = read_squash_ctx(rb_dir);
+            let after_editor = if final_fixup && squash_chain.seen_squash {
+                run_commit_editor_for_sequencer(repo, git_dir, &template, "squash")?
+            } else {
+                commit_message_after_prepare_hook(repo, git_dir, &template, "squash")?
+            };
+            let cleaned =
+                apply_commit_msg_cleanup(&after_editor, rebase_commit_msg_cleanup(&config));
             let new_oid = commit_from_merged_index(
                 repo,
                 git_dir,
@@ -3360,8 +3561,8 @@ fn cherry_pick_for_rebase(
             fs::read_to_string(&squash_path)?
         };
         let _ = fs::remove_file(git_dir.join("MERGE_MSG"));
-        let raw = commit_message_after_prepare_hook(repo, git_dir, &tmpl, "squash")?;
-        let cleaned = apply_commit_msg_cleanup(&raw, rebase_commit_msg_cleanup(&config));
+        let after_editor = run_commit_editor_for_sequencer(repo, git_dir, &tmpl, "squash")?;
+        let cleaned = apply_commit_msg_cleanup(&after_editor, rebase_commit_msg_cleanup(&config));
         let new_oid = commit_from_merged_index(
             repo,
             git_dir,
@@ -3549,9 +3750,8 @@ fn read_current_final_fixup(rb_dir: &Path) -> bool {
         .unwrap_or(false)
 }
 
-fn pop_first_nonempty_todo_line(rb_dir: &Path) -> Result<()> {
-    let path = rb_dir.join("todo");
-    let s = fs::read_to_string(&path)?;
+fn pop_first_nonempty_todo_line(repo: &Repository, rb_dir: &Path) -> Result<()> {
+    let s = read_rebase_todo_file(repo, rb_dir)?;
     let mut lines: Vec<String> = s.lines().map(|l| l.to_owned()).collect();
     while let Some(idx) = lines.iter().position(|l| {
         let t = l.trim();
@@ -3565,15 +3765,14 @@ fn pop_first_nonempty_todo_line(rb_dir: &Path) -> Result<()> {
         out.push('\n');
     }
     let remaining: usize = out.lines().filter(|l| !l.trim().is_empty()).count();
-    fs::write(&path, out)?;
+    write_rebase_todo_file(repo, rb_dir, &out)?;
     fs::write(rb_dir.join("msgnum"), "1")?;
     fs::write(rb_dir.join("end"), remaining.to_string())?;
     Ok(())
 }
 
-fn trim_completed_merge_line_from_rebase_todo(rb_dir: &Path) -> Result<()> {
-    let path = rb_dir.join("todo");
-    let s = fs::read_to_string(&path)?;
+fn trim_completed_merge_line_from_rebase_todo(repo: &Repository, rb_dir: &Path) -> Result<()> {
+    let s = read_rebase_todo_file(repo, rb_dir)?;
     let mut lines: Vec<String> = s.lines().map(|l| l.to_owned()).collect();
     let mut i = 0usize;
     while i < lines.len() {
@@ -3596,7 +3795,7 @@ fn trim_completed_merge_line_from_rebase_todo(rb_dir: &Path) -> Result<()> {
         out.push('\n');
     }
     let remaining: usize = out.lines().filter(|l| !l.trim().is_empty()).count();
-    fs::write(&path, out)?;
+    write_rebase_todo_file(repo, rb_dir, &out)?;
     fs::write(rb_dir.join("msgnum"), "1")?;
     fs::write(rb_dir.join("end"), remaining.to_string())?;
     Ok(())
@@ -3626,7 +3825,7 @@ fn do_continue() -> Result<()> {
         let merge_src_oid = ObjectId::from_hex(src_hex.trim())?;
         let merge_args = fs::read_to_string(rb_dir.join("rebase-merge-args"))?;
         let merge_args = merge_args.trim();
-        let todo_retry = fs::read_to_string(rb_dir.join("todo"))?;
+        let todo_retry = read_rebase_todo_file(&repo, &rb_dir)?;
         let todo_lines_retry: Vec<&str> = todo_retry.lines().filter(|l| !l.is_empty()).collect();
         let next_after_retry =
             peek_next_rebase_flush_hint(&repo, &todo_lines_retry, 1, interactive_continue);
@@ -3635,8 +3834,8 @@ fn do_continue() -> Result<()> {
             let _ = fs::remove_file(rb_dir.join("rebase-merge-source"));
             let _ = fs::remove_file(rb_dir.join("rebase-merge-args"));
             record_rebase_in_rewritten_pending(git_dir, &rb_dir, &merge_src_oid, next_after_retry)?;
-            pop_first_nonempty_todo_line(&rb_dir)?;
-            trim_completed_merge_line_from_rebase_todo(&rb_dir)?;
+            pop_first_nonempty_todo_line(&repo, &rb_dir)?;
+            trim_completed_merge_line_from_rebase_todo(&repo, &rb_dir)?;
             return replay_remaining(
                 &repo,
                 &rb_dir,
@@ -3672,9 +3871,9 @@ fn do_continue() -> Result<()> {
         }
         let _ = fs::remove_file(rb_dir.join("rebase-merge-source"));
         let _ = fs::remove_file(rb_dir.join("rebase-merge-args"));
-        pop_first_nonempty_todo_line(&rb_dir)?;
-        trim_completed_merge_line_from_rebase_todo(&rb_dir)?;
-        let todo_after = fs::read_to_string(rb_dir.join("todo"))?;
+        pop_first_nonempty_todo_line(&repo, &rb_dir)?;
+        trim_completed_merge_line_from_rebase_todo(&repo, &rb_dir)?;
+        let todo_after = read_rebase_todo_file(&repo, &rb_dir)?;
         let todo_lines_after: Vec<&str> = todo_after.lines().filter(|l| !l.is_empty()).collect();
         let next_peek =
             peek_next_rebase_flush_hint(&repo, &todo_lines_after, 0, interactive_continue);
@@ -3688,7 +3887,7 @@ fn do_continue() -> Result<()> {
         );
     }
 
-    let todo_content_continue = fs::read_to_string(rb_dir.join("todo"))?;
+    let todo_content_continue = read_rebase_todo_file(&repo, &rb_dir)?;
     let todo_lines_continue: Vec<&str> = todo_content_continue
         .lines()
         .filter(|l| !l.is_empty())
@@ -3871,8 +4070,14 @@ fn do_continue() -> Result<()> {
                 let body = message_body_after_subject(&hc.message);
                 format!("{subj}\n{body}")
             };
-            let raw = commit_message_after_prepare_hook(&repo, git_dir, &template, "squash")?;
-            let cleaned = apply_commit_msg_cleanup(&raw, rebase_commit_msg_cleanup(&config));
+            let squash_chain = read_squash_ctx(&rb_dir);
+            let after_editor = if final_fixup && squash_chain.seen_squash {
+                run_commit_editor_for_sequencer(&repo, git_dir, &template, "squash")?
+            } else {
+                commit_message_after_prepare_hook(&repo, git_dir, &template, "squash")?
+            };
+            let cleaned =
+                apply_commit_msg_cleanup(&after_editor, rebase_commit_msg_cleanup(&config));
             let oid = commit_from_merged_index(
                 &repo,
                 git_dir,
@@ -3892,8 +4097,9 @@ fn do_continue() -> Result<()> {
             } else {
                 fs::read_to_string(&squash_path)?
             };
-            let raw = commit_message_after_prepare_hook(&repo, git_dir, &tmpl, "squash")?;
-            let cleaned = apply_commit_msg_cleanup(&raw, rebase_commit_msg_cleanup(&config));
+            let after_editor = run_commit_editor_for_sequencer(&repo, git_dir, &tmpl, "squash")?;
+            let cleaned =
+                apply_commit_msg_cleanup(&after_editor, rebase_commit_msg_cleanup(&config));
             let oid = commit_from_merged_index(
                 &repo,
                 git_dir,
@@ -4019,7 +4225,7 @@ fn do_skip() -> Result<()> {
     let had_autostash_skip = autostash_skip.is_some();
     let backend_skip = load_rebase_backend(&rb_dir);
 
-    let todo_content_skip = fs::read_to_string(rb_dir.join("todo"))?;
+    let todo_content_skip = read_rebase_todo_file(&repo, &rb_dir)?;
     let todo_lines_skip: Vec<&str> = todo_content_skip
         .lines()
         .filter(|l| !l.is_empty())

--- a/logs/2026-04-09_t3429-rebase-edit-todo-agent.md
+++ b/logs/2026-04-09_t3429-rebase-edit-todo-agent.md
@@ -1,0 +1,21 @@
+# t3429-rebase-edit-todo (agent)
+
+## Summary
+
+Made `tests/t3429-rebase-edit-todo.sh` pass 7/7.
+
+## Changes (grit)
+
+- **Canonical todo file:** read/write `.git/rebase-merge/git-rebase-todo` (and legacy `todo`), honor `GIT_REBASE_TODO` with work-tree-relative resolution.
+- **Re-read todo after steps:** outer loop in `replay_remaining`; trim todo on disk *before* global `-x` exec so appended lines survive.
+- **Non-interactive `-x` + appended `exec` lines:** `parse_rebase_replay_step` parses interactive `exec`/`edit`/`merge` even when `interactive` marker is absent.
+- **`rebase --root` without `--onto`:** synthetic empty-root commit (Git parity); disable preemptive fast-forward for that case.
+- **`rebase --edit-todo`:** new flag for in-progress interactive rebase.
+- **Final fixup in squash chain:** `is_final_fixup_in_todo` ignores trailing `exec` when looking for a following `fixup`/`squash`; final fixup with prior `squash` runs commit editor (`GIT_EDITOR`) and uses `prepare-commit-msg` source `squash`.
+- **`pull.rs`:** `rebase::Args` initializer includes `edit_todo: false`.
+
+## Validation
+
+- `./scripts/run-tests.sh t3429-rebase-edit-todo.sh` — 7/7
+- `cargo test -p grit-lib --lib` — pass
+- `cargo check -p grit-rs` — pass


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes `t3429-rebase-edit-todo` pass 7/7 by aligning rebase todo handling with Git: canonical `git-rebase-todo`, re-reading after steps (including after `-x` exec appends), `rebase --root` without `--onto`, and `rebase --edit-todo`.

## Key changes

- Read/write `.git/rebase-merge/git-rebase-todo` (plus legacy `todo`); honor `GIT_REBASE_TODO` with work-tree-relative paths.
- `replay_remaining` reloads the todo after each completed step; trim the on-disk todo **before** running the global `-x` hook so appended lines are not overwritten.
- Parse `exec` / `edit` / `merge` todo lines even when the rebase is not marked interactive (non-interactive `-x` still uses `rebase-merge/` without the `interactive` file).
- `rebase --root` without `--onto`: create Git’s synthetic empty-root onto commit; skip preemptive fast-forward in that case.
- New `grit rebase --edit-todo` for in-progress interactive rebases.
- Fix final fixup detection when `exec` lines are inserted after reword (ignore `exec` when scanning for a following `fixup`/`squash`); run the commit editor for the final fixup when the chain included `squash`.
- `pull.rs`: extend manual `rebase::Args { ... }` with `edit_todo: false`.

## Testing

- `./scripts/run-tests.sh t3429-rebase-edit-todo.sh` — 7/7
- `cargo test -p grit-lib --lib`
- `cargo check -p grit-rs`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2898d632-af5e-42e4-8ed4-473e11eeb964"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2898d632-af5e-42e4-8ed4-473e11eeb964"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

