### PR TITLE
fix: make t5810-proto-disable-local pass (block dash-prefixed local paths)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -607,7 +607,7 @@ commit → check it off → move on.
 - [x] `t5617-clone-submodules-remote` — Test cloning repos with submodules using remote-tracking branches (9/9 harness)
 - [ ] `t5538-push-shallow` ██░░░░░░░░░░░░░░░░░░ 1/8 (7 left) — push from/to a shallow clone
 - [ ] `t5539-fetch-http-shallow` ██░░░░░░░░░░░░░░░░░░ 1/8 (7 left) — fetch/clone from a shallow clone over http
-- [ ] `t5810-proto-disable-local` █████████████████░░░ 46/54 (8 left) — test disabling of local paths in clone/fetch
+- [x] `t5810-proto-disable-local` — test disabling of local paths in clone/fetch (54/54 harness)
 - [ ] `t5545-push-options` ███████░░░░░░░░░░░░░ 5/13 (8 left) — pushing to a repository using push options
 - [ ] `t5322-pack-objects-sparse` █████░░░░░░░░░░░░░░░ 3/11 (8 left) — pack-objects object selection using sparse algorithm
 - [x] `t5620-backfill` — git backfill on partial clones (10/10 harness)

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1030,7 +1030,7 @@ t5732-protocol-v2-bundle-uri-http	t5	yes	9	3	6	false	ok	0
 t5750-bundle-uri-parse	t5	yes	13	13	0	true	ok	0
 t5801-remote-helpers	t5	skip	35	0	0	false	ok	1
 t5802-connect-helper	t5	yes	8	8	0	true	ok	0
-t5810-proto-disable-local	t5	yes	54	53	1	false	ok	0
+t5810-proto-disable-local	t5	yes	54	54	0	true	ok	0
 t5811-proto-disable-git	t5	yes	26	18	8	false	ok	0
 t5812-proto-disable-http	t5	yes	29	11	18	false	ok	0
 t5813-proto-disable-ssh	t5	yes	81	57	24	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,687 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,687 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T21:10:59+00:00" class="gen-time" title="2026-04-09 21:10 UTC">2026-04-09 21:10 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,687</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">34/167 files · 17 skipped · 1,567/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.9%"></div></div>
+        <span class="group-pct pct-red">37.9%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35687 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,687 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T21:10:59+00:00" class="gen-time" title="2026-04-09 21:10 UTC">2026-04-09 21:10 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,687</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -10457,14 +10457,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="54" data-passed="53">
+<tr class="" data-group="t5" data-tests="54" data-passed="54" data-full-pass="1">
   <td class="mono">t5810-proto-disable-local</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">54</td>
-  <td class="right">53</td>
+  <td class="right">54</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:98.1%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="26" data-passed="18">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit/src/commands/clone.rs
+++ b/grit/src/commands/clone.rs
@@ -539,6 +539,7 @@ pub fn run(mut args: Args) -> Result<()> {
         args.repository.clone()
     };
     let path_only = repo_path_str.split('?').next().unwrap_or("").to_string();
+    crate::transport_path::check_local_url_path_not_option_like(&path_only)?;
     let source_path = PathBuf::from(&path_only);
 
     // Open the source repository, trying .git suffix if direct path fails

--- a/grit/src/commands/fetch.rs
+++ b/grit/src/commands/fetch.rs
@@ -526,6 +526,8 @@ fn fetch_remote(
         bail!("remote '{remote_name}' not found; no such remote");
     };
 
+    crate::transport_path::check_local_url_path_not_option_like(&url)?;
+
     let is_ext_url = url.starts_with("ext::");
     if is_ext_url {
         crate::protocol::check_protocol_allowed("ext", Some(git_dir))?;

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -39,6 +39,7 @@ mod protocol_wire;
 mod ssh_transport;
 mod trace_packet;
 mod transport_passthrough;
+mod transport_path;
 mod wire_trace;
 
 mod upstream_help_builtin_synopsis {

--- a/grit/src/transport_path.rs
+++ b/grit/src/transport_path.rs
@@ -1,0 +1,27 @@
+//! Safety checks for local transport URLs (matches Git `connect.c` / `path.c`).
+
+use anyhow::{bail, Result};
+
+/// Returns true when `str` is non-empty and begins with `-`, matching Git's
+/// `looks_like_command_line_option` (used before quoting a path for shell-backed transport).
+#[must_use]
+pub(crate) fn looks_like_command_line_option(s: &str) -> bool {
+    !s.is_empty() && s.starts_with('-')
+}
+
+/// Rejects repository path strings that could be mistaken for options when passed to a shell.
+///
+/// Git dies with `strange pathname '%s' blocked` when the parsed local path starts with `-`.
+/// Absolute paths like `/tmp/-repo.git` are allowed because the path string begins with `/`.
+pub(crate) fn check_local_url_path_not_option_like(url: &str) -> Result<()> {
+    let path = url
+        .strip_prefix("file://")
+        .unwrap_or(url)
+        .split('?')
+        .next()
+        .unwrap_or("");
+    if looks_like_command_line_option(path) {
+        bail!("fatal: strange pathname '{path}' blocked");
+    }
+    Ok(())
+}

--- a/logs/2026-04-09_t5810-proto-disable-local.md
+++ b/logs/2026-04-09_t5810-proto-disable-local.md
@@ -1,0 +1,20 @@
+# t5810-proto-disable-local
+
+## Goal
+
+Make harness `t5810-proto-disable-local.sh` fully pass (local protocol allow/deny + dash-prefixed repo paths).
+
+## Failure
+
+Test 53: `git fetch -- -repo.git` must fail **before** `upload-pack` runs so `GIT_TRACE` contains no `upload-pack` line. Grit was resolving `-repo.git` to a valid path and negotiating.
+
+## Fix
+
+- Added `grit/src/transport_path.rs`: `check_local_url_path_not_option_like` — if the path part (after optional `file://`, before `?`) starts with `-`, bail with Git’s message `fatal: strange pathname '…' blocked`.
+- Call sites: `fetch_remote` after URL resolution (`fetch.rs`); local `clone` path before `open_source_repo` (`clone.rs`).
+- Registered module in `main.rs`.
+
+## Verification
+
+- `./scripts/run-tests.sh t5810-proto-disable-local.sh` → 54/54
+- `cargo fmt`, `cargo clippy -p grit-rs --fix --allow-dirty`, `cargo test -p grit-lib --lib`

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   325 |
+| Completed   |   326 |
 | In progress |     5 |
-| Remaining   |   441 |
+| Remaining   |   440 |
 | **Total**   |   771 |
 
-Task lines in `PLAN.md`: 325 completed (`[x]`), 5 in progress (`[~]`), 441 remaining (`[ ]`).
+Task lines in `PLAN.md`: 326 completed (`[x]`), 5 in progress (`[~]`), 440 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t5810-proto-disable-local` — 54/54 tests pass (reject local `fetch`/`clone` URLs whose path component starts with `-` before upload-pack, matching Git `looks_like_command_line_option` / `strange pathname` blocked; `transport_path` helper wired from `fetch` + `clone`)
 - `t3309-notes-merge-auto-resolve` — 31/31 tests pass (`notes merge`: `union` / `cat_sort_uniq` blob combine like Git; successful merge commits use two parents; `notes.mergeStrategy` config errors match upstream expectations)
 - `t4063-diff-blobs` — 18/18 tests pass (`diff`: blob↔blob and `rev:path` pairs without treating blobs as trees; `HEAD:one..HEAD:two` range split; `rev:path` vs worktree file uses tree path + modes + `write_patch_with_prefix`; raw blob OID vs existing file uses filename as old path; `rev_parse::resolve_treeish_blob_at_path` for tree walks)
 - `t5524-pull-msg` — 3/3 tests pass (`git pull --no-rebase --log` merge message preserves `$` in subject lines; `--log=1` limits shortlog; harness CSV/dashboards refreshed; `PLAN.md` marked complete)

--- a/test-results.md
+++ b/test-results.md
@@ -1,5 +1,10 @@
 # Test results
 
+**2026-04-09 (t5810 / proto-disable-local)**
+
+- `cargo test -p grit-lib --lib`: 160 passed
+- `./scripts/run-tests.sh t5810-proto-disable-local.sh`: 54/54 passed
+
 **2026-04-09 (t4063 / diff blobs)**
 
 - `cargo test -p grit-lib --lib`: 155 passed


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t5810-proto-disable-local` failed on **repo names starting with dash**: `git fetch -- -repo.git` must fail **before** `upload-pack` runs so `GIT_TRACE` does not contain `upload-pack`.

## Changes

- Add `grit/src/transport_path.rs` with Git-aligned `looks_like_command_line_option` / `check_local_url_path_not_option_like` (same rule as upstream `connect.c`: path starting with `-` → `fatal: strange pathname '…' blocked`).
- Wire the check into `fetch` (after URL resolution) and local `clone` (before opening the source repo).
- Harness: **54/54** for `t5810-proto-disable-local.sh`; refreshed `data/test-files.csv` and dashboards; updated `PLAN.md` / `progress.md` / `test-results.md` and added `logs/2026-04-09_t5810-proto-disable-local.md`.

## Validation

- `cargo fmt`, `cargo clippy -p grit-rs --fix --allow-dirty`
- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t5810-proto-disable-local.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1b988e7-ac76-4a4c-b776-481e8cce8b83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1b988e7-ac76-4a4c-b776-481e8cce8b83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

