### PR TITLE
fix: make t4069-remerge-diff pass (show -S argv, remerge headers)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -488,7 +488,7 @@ commit → check it off → move on.
 - [ ] `t4108-apply-threeway` ████░░░░░░░░░░░░░░░░ 4/18 (14 left) — git apply --3way
 - [ ] `t4100-apply-stat` ████████░░░░░░░░░░░░ 10/25 (15 left) — git apply --stat --summary test, with --recount
 
-- [ ] `t4069-remerge-diff` █░░░░░░░░░░░░░░░░░░░ 1/16 (15 left) — remerge-diff handling
+- [x] `t4069-remerge-diff` — remerge-diff handling (16/16)
 - [ ] `t4019-diff-wserror` ████░░░░░░░░░░░░░░░░ 5/21 (16 left) — diff whitespace error detection
 - [x] `t4063-diff-blobs` ████████████████████ 18/18 (0 left) — test direct comparison of blobs via git-diff
 - [x] `t4214-log-graph-octopus` ████████████████████ 17/17 (0 left) — git log --graph of skewed left octopus merge.

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -752,7 +752,7 @@ t4067-diff-partial-clone	t4	yes	9	2	7	false	ok	0
 t4068-diff-symmetric	t4	yes	20	20	0	true	ok	0
 t4068-diff-symmetric-merge-base	t4	yes	36	1	35	false	ok	0
 t4069-diff-summary	t4	yes	34	34	0	true	ok	0
-t4069-remerge-diff	t4	yes	16	12	4	false	ok	0
+t4069-remerge-diff	t4	yes	16	16	0	true	ok	0
 t4070-diff-pairs	t4	yes	7	3	4	false	ok	0
 t4070-diff-submodule	t4	yes	31	31	0	true	ok	0
 t4071-diff-empty-tree	t4	yes	32	29	3	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,690 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,690 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T21:21:44+00:00" class="gen-time" title="2026-04-09 21:21 UTC">2026-04-09 21:21 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,690</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -230,22 +230,22 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">73/178 files · 2 skipped · 2,862/4,438 tests</span>
+        <span class="group-meta">74/178 files · 2 skipped · 2,866/4,438 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.5%"></div></div>
-        <span class="group-pct pct-blue">64.5%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.6%"></div></div>
+        <span class="group-pct pct-blue">64.6%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35690 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,690 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T21:21:44+00:00" class="gen-time" title="2026-04-09 21:21 UTC">2026-04-09 21:21 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,690</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -7677,14 +7677,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="16" data-passed="12">
+<tr class="" data-group="t4" data-tests="16" data-passed="16" data-full-pass="1">
   <td class="mono">t4069-remerge-diff</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">16</td>
-  <td class="right">12</td>
+  <td class="right">16</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:75.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="7" data-passed="3">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit/src/commands/remerge_diff.rs
+++ b/grit/src/commands/remerge_diff.rs
@@ -298,9 +298,21 @@ pub(crate) fn write_remerge_diff(
         .filter_map(|d| d.rename_rr_ours_dest.clone())
         .collect();
 
+    // `merge` records both `file/directory` and a synthetic `modify/delete` for the relocated
+    // `path~HEAD` blob. Git's `show --remerge-diff` omits the redundant modify/delete block
+    // (t4069 non-content conflicts).
+    let file_directory_relocated: std::collections::HashSet<String> = conflict_descs
+        .iter()
+        .filter(|d| d.kind == "file/directory")
+        .map(|d| d.subject_path.clone())
+        .collect();
+
     let mut ordered_descs: Vec<&ConflictDescription> = conflict_descs
         .iter()
         .filter(|d| {
+            if d.kind == "modify/delete" && file_directory_relocated.contains(&d.subject_path) {
+                return false;
+            }
             if d.kind == "rename/delete" {
                 if let Some(a) = d.remerge_anchor_path.as_deref() {
                     return !has_rename_rename.contains(a);

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -3503,6 +3503,33 @@ fn preprocess_diff_args(rest: &[String]) -> Vec<String> {
 /// Preprocess log arguments: convert `-<N>` shorthand to `-n <N>`, and make bare `-L` visible to clap.
 /// Map `git log` pickaxe `-G` / `-S` (including glued forms) to hidden long options so `-G` stays
 /// free for `--basic-regexp` on `--grep`.
+/// Split glued pickaxe argv like `-Sneedle` into `-S` + `needle`.
+///
+/// POSIX `/bin/sh` parses `-S"not present"` as a single token `-Snot present`, which clap would
+/// reject as an unknown short flag. Git accepts the glued form (t4069-remerge-diff).
+fn preprocess_show_argv(rest: &[String]) -> Vec<String> {
+    let mut out = Vec::with_capacity(rest.len() + 2);
+    let mut i = 0usize;
+    while i < rest.len() {
+        let arg = rest[i].as_str();
+        if arg == "--" {
+            out.extend_from_slice(&rest[i..]);
+            break;
+        }
+        if let Some(needle) = arg.strip_prefix("-S") {
+            if !needle.is_empty() {
+                out.push("-S".to_owned());
+                out.push(needle.to_owned());
+                i += 1;
+                continue;
+            }
+        }
+        out.push(rest[i].clone());
+        i += 1;
+    }
+    out
+}
+
 fn preprocess_log_pickaxe_args(rest: Vec<String>) -> Vec<String> {
     let mut out = Vec::with_capacity(rest.len() + 4);
     let mut i = 0usize;
@@ -4323,7 +4350,7 @@ pub(crate) fn dispatch(subcmd: &str, rest: &[String], opts: &GlobalOpts) -> Resu
         "sh-setup" => commands::sh_setup::run(parse_cmd_args(subcmd, rest)),
         "shell" => commands::shell::run(parse_cmd_args(subcmd, rest)),
         "shortlog" => commands::shortlog::run(parse_cmd_args(subcmd, rest)),
-        "show" => commands::show::run(parse_cmd_args(subcmd, rest)),
+        "show" => commands::show::run(parse_cmd_args(subcmd, &preprocess_show_argv(rest))),
         "show-branch" => commands::show_branch::run(parse_cmd_args(subcmd, rest)),
         "show-index" => commands::show_index::run(parse_cmd_args(subcmd, rest)),
         "show-ref" => commands::show_ref::run(parse_cmd_args(subcmd, rest)),

--- a/logs/2026-04-09_t4069-remerge-diff.md
+++ b/logs/2026-04-09_t4069-remerge-diff.md
@@ -1,0 +1,19 @@
+# t4069-remerge-diff (2026-04-09)
+
+## Failures fixed
+
+1. **Test 6 (`-S"not present"` under POSIX `/bin/sh`)**  
+   The shell passes a single argv token `-Snot present`. Clap rejected it as an unknown short flag. Added `preprocess_show_argv` in `grit/src/main.rs` to split glued `-S<needle>` into `-S` + `<needle>` before parsing `git show`.
+
+2. **Tests 9–11 (non-content conflicts)**  
+   Merge records both `file/directory` and a synthetic `modify/delete` for the relocated `path~HEAD` blob. Upstream Git’s `show --remerge-diff` does **not** emit the extra modify/delete block (fixture in t4069). Filtered those descriptions in `write_remerge_diff` when `subject_path` matches a `file/directory` relocation path.
+
+## Validation
+
+- `./scripts/run-tests.sh t4069-remerge-diff.sh` → 16/16
+- `cargo test -p grit-lib --lib`
+- `cargo clippy -p grit-rs --fix --allow-dirty`
+
+## Branch
+
+`cursor/t4069-remerge-diff-test-passing-faea`

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   325 |
+| Completed   |   326 |
 | In progress |     5 |
-| Remaining   |   441 |
+| Remaining   |   440 |
 | **Total**   |   771 |
 
-Task lines in `PLAN.md`: 325 completed (`[x]`), 5 in progress (`[~]`), 441 remaining (`[ ]`).
+Task lines in `PLAN.md`: 326 completed (`[x]`), 5 in progress (`[~]`), 440 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t4069-remerge-diff` — 16/16 tests pass (`show`: POSIX `-S"not present"` glued argv split for clap; `--remerge-diff` omits redundant `modify/delete` for `file/directory` relocated paths like Git)
 - `t3309-notes-merge-auto-resolve` — 31/31 tests pass (`notes merge`: `union` / `cat_sort_uniq` blob combine like Git; successful merge commits use two parents; `notes.mergeStrategy` config errors match upstream expectations)
 - `t4063-diff-blobs` — 18/18 tests pass (`diff`: blob↔blob and `rev:path` pairs without treating blobs as trees; `HEAD:one..HEAD:two` range split; `rev:path` vs worktree file uses tree path + modes + `write_patch_with_prefix`; raw blob OID vs existing file uses filename as old path; `rev_parse::resolve_treeish_blob_at_path` for tree walks)
 - `t5524-pull-msg` — 3/3 tests pass (`git pull --no-rebase --log` merge message preserves `$` in subject lines; `--log=1` limits shortlog; harness CSV/dashboards refreshed; `PLAN.md` marked complete)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **`git show` argv:** POSIX `/bin/sh` passes `-S"not present"` as a single token (`-Snot present`), which clap rejected. Added `preprocess_show_argv` to split glued `-S<needle>` into `-S` + `<needle>` before parsing (same idea as log pickaxe preprocessing).

- **`--remerge-diff` output:** Merge records both `file/directory` and a synthetic `modify/delete` for the relocated `path~HEAD` blob. Upstream Git’s `show --remerge-diff` omits the redundant modify/delete block for that case (t4069 non-content conflicts). Filter those descriptions when building remerge-diff output.

## Test plan

- `./scripts/run-tests.sh t4069-remerge-diff.sh` (16/16)
- `cargo test -p grit-lib --lib`
- `cargo clippy -p grit-rs --fix --allow-dirty`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc6e3d4e-3517-455b-b685-4c3cb3e3a146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc6e3d4e-3517-455b-b685-4c3cb3e3a146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

