### PR TITLE
fix: make t4000-diff-format pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -673,7 +673,7 @@ t3908-stash-in-worktree	t3	yes	2	1	1	false	ok	0
 t3909-stash-pathspec-file	t3	yes	5	5	0	true	ok	0
 t3910-mac-os-precompose	t3	yes	29	24	5	false	ok	0
 t3920-crlf-messages	t3	yes	18	6	12	false	ok	0
-t4000-diff-format	t4	yes	41	23	18	false	ok	0
+t4000-diff-format	t4	yes	41	41	0	true	ok	0
 t4001-diff-rename	t4	yes	23	19	4	false	ok	0
 t4002-diff-basic	t4	yes	63	57	6	false	ok	0
 t4003-diff-rename-1	t4	yes	7	4	3	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,704 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,704 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T21:42:42+00:00" class="gen-time" title="2026-04-09 21:42 UTC">2026-04-09 21:42 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,704</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -230,22 +230,22 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">73/178 files · 2 skipped · 2,862/4,438 tests</span>
+        <span class="group-meta">74/178 files · 2 skipped · 2,880/4,438 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.5%"></div></div>
-        <span class="group-pct pct-blue">64.5%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.9%"></div></div>
+        <span class="group-pct pct-blue">64.9%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35704 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,704 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T21:42:42+00:00" class="gen-time" title="2026-04-09 21:42 UTC">2026-04-09 21:42 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,704</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -6887,14 +6887,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:33.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="41" data-passed="23">
+<tr class="" data-group="t4" data-tests="41" data-passed="41" data-full-pass="1">
   <td class="mono">t4000-diff-format</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">41</td>
-  <td class="right">23</td>
+  <td class="right">41</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.1%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="23" data-passed="19">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit/src/commands/diff.rs
+++ b/grit/src/commands/diff.rs
@@ -581,6 +581,10 @@ pub struct Args {
     #[arg(long = "shortstat")]
     pub shortstat: bool,
 
+    /// Compact per-file summary with mode/new/gone annotations (like `git diff --compact-summary`).
+    #[arg(long = "compact-summary")]
+    pub compact_summary: bool,
+
     /// Show machine-readable stat (additions/deletions per file).
     #[arg(long = "numstat")]
     pub numstat: bool,
@@ -737,6 +741,14 @@ pub struct Args {
     #[arg(short = 's', long = "no-patch")]
     pub no_patch: bool,
 
+    /// Emit raw diff lines before the unified patch (same as Git `diff --patch-with-raw`).
+    #[arg(long = "patch-with-raw")]
+    pub patch_with_raw: bool,
+
+    /// Emit `--stat` before the unified patch (same as Git `diff --patch-with-stat`).
+    #[arg(long = "patch-with-stat")]
+    pub patch_with_stat: bool,
+
     /// Directory-level diffstat (`--dirstat=lines`, etc.). Empty value means default `changes`.
     /// Later `--dirstat` / `-X` options override earlier ones (Git semantics).
     #[arg(
@@ -863,7 +875,7 @@ pub struct Args {
 
 /// Parsed `--dirstat` / `diff.dirstat` options (Git-compatible).
 #[derive(Clone, Debug)]
-struct DirstatOptions {
+pub(crate) struct DirstatOptions {
     /// `changes` (byte damage), `lines` (insertion+deletion lines), or `files` (1 per file).
     mode: DirstatMode,
     cumulative: bool,
@@ -1112,8 +1124,6 @@ pub fn run(mut args: Args) -> Result<()> {
     };
     let diff_algo_cli = parse_cli_diff_algorithm_from_argv();
 
-    let emit_unified_patch = diff_emit_unified_patch_from_argv(&raw_args);
-
     let cwd = env::current_dir().context("failed to read current directory")?;
     let pathspec_prefix = repo
         .work_tree
@@ -1221,6 +1231,9 @@ pub fn run(mut args: Args) -> Result<()> {
                 "--name-status" => args.name_status = true,
                 "--numstat" => args.numstat = true,
                 "--shortstat" => args.shortstat = true,
+                "--compact-summary" => args.compact_summary = true,
+                "--patch-with-raw" => args.patch_with_raw = true,
+                "--patch-with-stat" => args.patch_with_stat = true,
                 "--summary" => args.summary = true,
                 "--quiet" | "-q" => args.quiet = true,
                 s if s.starts_with("--stat-width=") => {
@@ -1863,18 +1876,26 @@ pub fn run(mut args: Args) -> Result<()> {
     let (dirstat_opts, dirstat_config_warnings) =
         resolve_dirstat_options(&args, &repo.git_dir, dirstat_cli_active)?;
     let relative_prefix_for_paths = resolve_diff_relative_prefix(work_tree, &repo.git_dir, &args);
-    let format_besides_unified_patch = args.shortstat
-        || stat_enabled
+    if args.compact_summary {
+        stat_enabled = true;
+    }
+    let stat_block_active = stat_enabled
         || args.stat_count.is_some()
         || args.stat_width.is_some()
         || args.stat_graph_width.is_some()
-        || args.stat_name_width.is_some()
+        || args.stat_name_width.is_some();
+    let show_unified_patch = diff_show_unified_patch_last_wins(&raw_args);
+    let format_besides_unified_patch = args.shortstat
+        || stat_block_active
         || args.raw
         || args.numstat
         || args.name_only
         || args.name_status
-        || (args.summary && !stat_enabled)
-        || dirstat_opts.is_some();
+        || (args.summary && !stat_block_active)
+        || dirstat_opts.is_some()
+        || args.compact_summary
+        || args.patch_with_raw
+        || args.patch_with_stat;
 
     let merge_in_progress = std::fs::metadata(repo.git_dir.join("MERGE_HEAD")).is_ok();
     let mut conflict_combined_patches: Vec<String> = Vec::new();
@@ -1929,8 +1950,7 @@ pub fn run(mut args: Args) -> Result<()> {
             }
             // Git keeps index↔worktree `U`/`M` lines for `--raw` / `--name-only` during conflicts;
             // combined `diff --cc` replaces them only when unified patch is the sole format.
-            let strip_conflict_index_lines =
-                emit_unified_patch && !args.no_patch && !format_besides_unified_patch;
+            let strip_conflict_index_lines = show_unified_patch && !format_besides_unified_patch;
             if strip_conflict_index_lines {
                 entries.retain(|e| {
                     if conflict_paths.iter().any(|p| p == e.path()) {
@@ -2038,6 +2058,43 @@ pub fn run(mut args: Args) -> Result<()> {
                     .and_then(|s| s.parse().ok())
             })
             .unwrap_or(0);
+        let patch_abbrev = if args.full_index {
+            40
+        } else if let Some(n) = args.abbrev {
+            n.max(4).min(40)
+        } else {
+            7
+        };
+        let oid_len = if args.full_index || args.no_abbrev {
+            40
+        } else if let Some(n) = args.abbrev {
+            n.max(4).min(40)
+        } else {
+            7
+        };
+        let mut wrote_output = false;
+        let mut need_blank_before_patch = false;
+
+        if args.raw {
+            write_raw(&mut out, &entries, oid_len)?;
+            wrote_output = true;
+            need_blank_before_patch = true;
+        }
+        if args.numstat {
+            write_numstat(
+                &mut out,
+                &entries,
+                &repo.odb,
+                wt_for_content,
+                args.break_rewrites,
+                line_ignore,
+                &ws_mode,
+                &diff_algo_ctx,
+                diff_algo_cli,
+            )?;
+            wrote_output = true;
+            need_blank_before_patch = true;
+        }
         if args.shortstat {
             write_shortstat(
                 &mut out,
@@ -2050,22 +2107,82 @@ pub fn run(mut args: Args) -> Result<()> {
                 &diff_algo_ctx,
                 diff_algo_cli,
             )?;
-            if let Some(ref ds) = dirstat_opts {
-                write_dirstat(
+            wrote_output = true;
+            need_blank_before_patch = true;
+        }
+        if stat_block_active {
+            if args.compact_summary {
+                write_compact_summary(
                     &mut out,
-                    ds,
                     &entries,
                     &repo.odb,
                     wt_for_content,
                     args.break_rewrites,
+                    line_ignore,
+                    &ws_mode,
+                    &diff_algo_ctx,
+                    diff_algo_cli,
+                    &repo.git_dir,
+                    quote_path_fully,
+                )?;
+            } else {
+                write_stat(
+                    &mut out,
+                    &entries,
+                    &repo.odb,
+                    wt_for_content,
+                    args.stat_count,
+                    args.stat_width,
+                    args.stat_name_width,
+                    args.break_rewrites,
+                    args.stat_graph_width,
+                    args.line_prefix.as_deref().unwrap_or(""),
+                    &repo.git_dir,
+                    line_ignore,
+                    &ws_mode,
+                    quote_path_fully,
+                    &diff_algo_ctx,
+                    diff_algo_cli,
                 )?;
             }
-        } else if stat_enabled
-            || args.stat_count.is_some()
-            || args.stat_width.is_some()
-            || args.stat_graph_width.is_some()
-            || args.stat_name_width.is_some()
-        {
+            if args.summary {
+                write_diff_summary(&mut out, &entries, args.break_rewrites, quote_path_fully)?;
+            }
+            wrote_output = true;
+            need_blank_before_patch = true;
+        } else if args.summary {
+            write_diff_summary(&mut out, &entries, args.break_rewrites, quote_path_fully)?;
+            wrote_output = true;
+            need_blank_before_patch = true;
+        }
+        if args.name_only {
+            write_name_only(&mut out, &entries, quote_path_fully)?;
+            wrote_output = true;
+            need_blank_before_patch = true;
+        }
+        if args.name_status {
+            write_name_status(&mut out, &entries, quote_path_fully)?;
+            wrote_output = true;
+            need_blank_before_patch = true;
+        }
+        if let Some(ref ds) = dirstat_opts {
+            write_dirstat(
+                &mut out,
+                ds,
+                &entries,
+                &repo.odb,
+                wt_for_content,
+                args.break_rewrites,
+            )?;
+            wrote_output = true;
+            need_blank_before_patch = true;
+        }
+
+        if args.patch_with_raw && show_unified_patch && !args.raw {
+            write_raw(&mut out, &entries, oid_len)?;
+            need_blank_before_patch = true;
+        }
+        if args.patch_with_stat && show_unified_patch && !stat_block_active {
             write_stat(
                 &mut out,
                 &entries,
@@ -2084,102 +2201,55 @@ pub fn run(mut args: Args) -> Result<()> {
                 &diff_algo_ctx,
                 diff_algo_cli,
             )?;
-            if args.summary {
-                write_diff_summary(&mut out, &entries, args.break_rewrites, quote_path_fully)?;
+            need_blank_before_patch = true;
+        }
+        if show_unified_patch {
+            if need_blank_before_patch && wrote_output {
+                writeln!(out)?;
             }
-        } else if args.raw {
-            let oid_len = if args.full_index || args.no_abbrev {
-                40
-            } else if let Some(n) = args.abbrev {
-                n.max(4).min(40)
-            } else {
-                7
-            };
-            write_raw(&mut out, &entries, oid_len)?;
-        } else if args.numstat {
-            write_numstat(
+            for patch in &conflict_combined_patches {
+                write!(out, "{patch}")?;
+            }
+            let diff_config =
+                grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+            let external_diff_cmd = std::env::var("GIT_EXTERNAL_DIFF")
+                .ok()
+                .filter(|s| !s.trim().is_empty())
+                .or_else(|| {
+                    diff_config
+                        .get("diff.external")
+                        .filter(|s| !s.trim().is_empty())
+                });
+            write_patch_with_prefix(
                 &mut out,
+                &repo,
                 &entries,
                 &repo.odb,
+                &repo.git_dir,
+                &diff_config,
+                context_lines,
+                use_color,
+                word_diff,
                 wt_for_content,
+                suppress_blank_empty,
+                patch_abbrev,
+                inter_hunk_context,
+                args.binary,
                 args.break_rewrites,
+                args.irreversible_delete,
+                !args.no_textconv,
+                &src_prefix,
+                &dst_prefix,
+                args.submodule.as_deref(),
+                submodule_ignore_flags_from_diff_arg(ignore_sm),
                 line_ignore,
-                &ws_mode,
                 &diff_algo_ctx,
                 diff_algo_cli,
+                args.cached,
+                args.no_ext_diff,
+                external_diff_cmd.as_deref(),
+                relative_prefix_for_paths.as_deref(),
             )?;
-        } else if args.name_only {
-            write_name_only(&mut out, &entries, quote_path_fully)?;
-        } else if args.name_status {
-            write_name_status(&mut out, &entries, quote_path_fully)?;
-        } else if args.summary && !stat_enabled {
-            write_diff_summary(&mut out, &entries, args.break_rewrites, quote_path_fully)?;
-        } else {
-            let patch_abbrev = if args.full_index {
-                40
-            } else if let Some(n) = args.abbrev {
-                n.max(4).min(40)
-            } else {
-                7
-            };
-            let show_unified = emit_unified_patch && !args.no_patch;
-            if show_unified {
-                for patch in &conflict_combined_patches {
-                    write!(out, "{patch}")?;
-                }
-            }
-            if let Some(ref ds) = dirstat_opts {
-                write_dirstat(
-                    &mut out,
-                    ds,
-                    &entries,
-                    &repo.odb,
-                    wt_for_content,
-                    args.break_rewrites,
-                )?;
-            }
-            if show_unified {
-                let diff_config = grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true)
-                    .unwrap_or_default();
-                let external_diff_cmd = std::env::var("GIT_EXTERNAL_DIFF")
-                    .ok()
-                    .filter(|s| !s.trim().is_empty())
-                    .or_else(|| {
-                        diff_config
-                            .get("diff.external")
-                            .filter(|s| !s.trim().is_empty())
-                    });
-                write_patch_with_prefix(
-                    &mut out,
-                    &repo,
-                    &entries,
-                    &repo.odb,
-                    &repo.git_dir,
-                    &diff_config,
-                    context_lines,
-                    use_color,
-                    word_diff,
-                    wt_for_content,
-                    suppress_blank_empty,
-                    patch_abbrev,
-                    inter_hunk_context,
-                    args.binary,
-                    args.break_rewrites,
-                    args.irreversible_delete,
-                    !args.no_textconv,
-                    &src_prefix,
-                    &dst_prefix,
-                    args.submodule.as_deref(),
-                    submodule_ignore_flags_from_diff_arg(ignore_sm),
-                    line_ignore,
-                    &diff_algo_ctx,
-                    diff_algo_cli,
-                    args.cached,
-                    args.no_ext_diff,
-                    external_diff_cmd.as_deref(),
-                    relative_prefix_for_paths.as_deref(),
-                )?;
-            }
         }
     }
 
@@ -3327,16 +3397,17 @@ fn apply_diff_filter(entries: Vec<DiffEntry>, filter: &str) -> Vec<DiffEntry> {
         .collect()
 }
 
-/// Whether to emit unified patch hunks for this `git diff` invocation.
+/// Last-flag-wins patch emission after a plumbing subcommand (`diff-files`, `diff-index`, …).
 ///
 /// Git uses last-flag-wins among `-s` / `--no-patch` (suppress) and `-p` / `--patch` / `-u` /
 /// `-U` / `--unified` (show patch). Combined short flags (e.g. `-sp`) are expanded per character.
-fn diff_emit_unified_patch_from_argv(argv: &[String]) -> bool {
-    let Some(diff_pos) = argv.iter().position(|a| a == "diff") else {
-        return true;
+pub(crate) fn diff_emit_unified_patch_from_plumbing_argv(subcmd: &str, argv: &[String]) -> bool {
+    let default_emit = subcmd != "diff-files";
+    let Some(pos) = argv.iter().position(|a| a == subcmd) else {
+        return default_emit;
     };
-    let mut emit = true;
-    for arg in argv.iter().skip(diff_pos + 1) {
+    let mut emit = default_emit;
+    for arg in argv.iter().skip(pos + 1) {
         if arg == "--" {
             break;
         }
@@ -3345,6 +3416,10 @@ fn diff_emit_unified_patch_from_argv(argv: &[String]) -> bool {
             continue;
         }
         if arg == "-p" || arg == "--patch" || arg == "-u" {
+            emit = true;
+            continue;
+        }
+        if arg == "--patch-with-raw" || arg == "--patch-with-stat" {
             emit = true;
             continue;
         }
@@ -3375,8 +3450,289 @@ fn diff_emit_unified_patch_from_argv(argv: &[String]) -> bool {
     emit
 }
 
+/// Whether to emit unified patch hunks for this `git diff` invocation.
+pub(crate) fn diff_emit_unified_patch_from_argv(argv: &[String]) -> bool {
+    diff_emit_unified_patch_from_plumbing_argv("diff", argv)
+}
+
+/// Whether `git diff` should emit the unified patch (last wins among `-s` / format flags / `-p`).
+fn diff_show_unified_patch_last_wins(argv: &[String]) -> bool {
+    let Some(pos) = argv.iter().position(|a| a == "diff") else {
+        return true;
+    };
+    let mut show = true;
+    for arg in argv.iter().skip(pos + 1) {
+        if arg == "--" {
+            break;
+        }
+        match arg.as_str() {
+            "-s" | "--no-patch" => show = false,
+            "-p" | "--patch" | "-u" => show = true,
+            "--patch-with-raw" | "--patch-with-stat" => show = true,
+            "--submodule" | "--histogram" | "--patience" | "--minimal" => show = true,
+            s if s.starts_with("--submodule=") => show = true,
+            s if s.starts_with("-U") || s.starts_with("--unified") => show = true,
+            "--stat" | "--shortstat" | "--numstat" | "--raw" | "--name-only" | "--name-status"
+            | "--summary" | "--compact-summary" | "--dirstat" | "--dirstat-by-file"
+            | "--cumulative" => show = false,
+            s if s.starts_with("--stat=") => show = false,
+            s if s.starts_with("--dirstat=") => show = false,
+            s if s.starts_with("--dirstat-by-file=") => show = false,
+            _ if arg.starts_with('-')
+                && !arg.starts_with("--")
+                && arg.len() > 2
+                && arg.as_bytes().get(1).is_some_and(|b| *b != b'-') =>
+            {
+                const COMBINABLE: &[u8] = b"spuwqRb";
+                let bytes = arg.as_bytes();
+                let tail = &bytes[1..];
+                if !tail.is_empty() && tail.iter().all(|b| COMBINABLE.contains(b)) {
+                    for &b in tail {
+                        match b {
+                            b's' => show = false,
+                            b'p' | b'u' => show = true,
+                            _ => {}
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    show
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DiffFilesEmitKind {
+    Raw,
+    Stat,
+    NumStat,
+    Shortstat,
+    Dirstat,
+    Summary,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum DiffFilesStatVariant {
+    #[default]
+    None,
+    Stat,
+    CompactSummary,
+}
+
+#[derive(Debug, Default, Clone)]
+pub(crate) struct DiffFilesFormatParse {
+    pub emit_queue: Vec<DiffFilesEmitKind>,
+    pub stat_variant: DiffFilesStatVariant,
+    pub patch_with_raw: bool,
+    pub patch_with_stat: bool,
+    pub dirstat_cli: DirstatCliState,
+    pub explicit_raw: bool,
+    pub suppress_diff: bool,
+    pub format: DiffFilesDefaultFormat,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DiffFilesDefaultFormat {
+    Raw,
+    Patch,
+    Stat,
+    NumStat,
+    NameOnly,
+    NameStatus,
+}
+
+impl Default for DiffFilesDefaultFormat {
+    fn default() -> Self {
+        Self::Raw
+    }
+}
+
+/// Parse `diff-files`-specific output flags in argv order (matches Git: `-s` suppresses following format output until `-p`).
+pub(crate) fn parse_diff_files_format_argv(argv: &[String]) -> DiffFilesFormatParse {
+    let mut out = DiffFilesFormatParse::default();
+    let Some(pos) = argv.iter().position(|a| a == "diff-files") else {
+        return out;
+    };
+    let mut idx = pos + 1;
+    let mut end_of_options = false;
+    while idx < argv.len() {
+        let arg = &argv[idx];
+        if !end_of_options && arg == "--" {
+            end_of_options = true;
+            idx += 1;
+            continue;
+        }
+        if !end_of_options && arg.starts_with('-') {
+            match arg.as_str() {
+                "-s" | "--no-patch" => {
+                    out.suppress_diff = true;
+                    out.emit_queue.clear();
+                    out.patch_with_raw = false;
+                    out.patch_with_stat = false;
+                    out.stat_variant = DiffFilesStatVariant::None;
+                    out.dirstat_cli = DirstatCliState::default();
+                    out.explicit_raw = false;
+                    out.format = DiffFilesDefaultFormat::Raw;
+                }
+                "-p" | "--patch" | "-u" => {
+                    out.suppress_diff = false;
+                    out.format = DiffFilesDefaultFormat::Patch;
+                }
+                "--raw" => {
+                    out.explicit_raw = true;
+                    out.format = DiffFilesDefaultFormat::Raw;
+                    out.emit_queue.push(DiffFilesEmitKind::Raw);
+                    out.suppress_diff = false;
+                }
+                "--stat" => {
+                    out.format = DiffFilesDefaultFormat::Stat;
+                    out.stat_variant = DiffFilesStatVariant::Stat;
+                    out.emit_queue.push(DiffFilesEmitKind::Stat);
+                    out.suppress_diff = false;
+                }
+                "--compact-summary" => {
+                    out.format = DiffFilesDefaultFormat::Stat;
+                    out.stat_variant = DiffFilesStatVariant::CompactSummary;
+                    out.emit_queue.push(DiffFilesEmitKind::Stat);
+                    out.suppress_diff = false;
+                }
+                "--numstat" => {
+                    out.format = DiffFilesDefaultFormat::NumStat;
+                    out.emit_queue.push(DiffFilesEmitKind::NumStat);
+                    out.suppress_diff = false;
+                }
+                "--shortstat" => {
+                    out.emit_queue.push(DiffFilesEmitKind::Shortstat);
+                    out.suppress_diff = false;
+                }
+                "--name-only" => {
+                    out.format = DiffFilesDefaultFormat::NameOnly;
+                    out.suppress_diff = false;
+                }
+                "--name-status" => {
+                    out.format = DiffFilesDefaultFormat::NameStatus;
+                    out.suppress_diff = false;
+                }
+                "--summary" => {
+                    out.emit_queue.push(DiffFilesEmitKind::Summary);
+                }
+                "--patch-with-raw" => {
+                    out.patch_with_raw = true;
+                    out.format = DiffFilesDefaultFormat::Patch;
+                    out.suppress_diff = false;
+                }
+                "--patch-with-stat" => {
+                    out.patch_with_stat = true;
+                    out.format = DiffFilesDefaultFormat::Patch;
+                    out.suppress_diff = false;
+                }
+                "--dirstat" => {
+                    out.format = DiffFilesDefaultFormat::Patch;
+                    out.dirstat_cli.dirstat.push(String::new());
+                    out.emit_queue.push(DiffFilesEmitKind::Dirstat);
+                    out.suppress_diff = false;
+                }
+                s if s.starts_with("--dirstat=") => {
+                    out.format = DiffFilesDefaultFormat::Patch;
+                    out.dirstat_cli
+                        .dirstat
+                        .push(s.strip_prefix("--dirstat=").unwrap_or("").to_owned());
+                    out.emit_queue.push(DiffFilesEmitKind::Dirstat);
+                    out.suppress_diff = false;
+                }
+                "--dirstat-by-file" => {
+                    out.format = DiffFilesDefaultFormat::Patch;
+                    if out.dirstat_cli.dirstat_by_file.is_none() {
+                        out.dirstat_cli.dirstat_by_file = Some(String::new());
+                    }
+                    out.emit_queue.push(DiffFilesEmitKind::Dirstat);
+                    out.suppress_diff = false;
+                }
+                s if s.starts_with("--dirstat-by-file=") => {
+                    out.format = DiffFilesDefaultFormat::Patch;
+                    out.dirstat_cli.dirstat_by_file = Some(
+                        s.strip_prefix("--dirstat-by-file=")
+                            .unwrap_or("")
+                            .to_owned(),
+                    );
+                    out.emit_queue.push(DiffFilesEmitKind::Dirstat);
+                    out.suppress_diff = false;
+                }
+                "--cumulative" => {
+                    out.format = DiffFilesDefaultFormat::Patch;
+                    out.dirstat_cli.dirstat_cumulative_flag = true;
+                    out.emit_queue.push(DiffFilesEmitKind::Dirstat);
+                    out.suppress_diff = false;
+                }
+                _ if arg.starts_with('-')
+                    && !arg.starts_with("--")
+                    && arg.len() > 2
+                    && arg.as_bytes().get(1).is_some_and(|b| *b != b'-') =>
+                {
+                    const COMBINABLE: &[u8] = b"spuwqRb";
+                    let bytes = arg.as_bytes();
+                    let tail = &bytes[1..];
+                    if !tail.is_empty() && tail.iter().all(|b| COMBINABLE.contains(b)) {
+                        for &b in tail {
+                            match b {
+                                b's' => {
+                                    out.suppress_diff = true;
+                                    out.emit_queue.clear();
+                                    out.patch_with_raw = false;
+                                    out.patch_with_stat = false;
+                                    out.stat_variant = DiffFilesStatVariant::None;
+                                    out.dirstat_cli = DirstatCliState::default();
+                                    out.explicit_raw = false;
+                                    out.format = DiffFilesDefaultFormat::Raw;
+                                }
+                                b'p' | b'u' => {
+                                    out.suppress_diff = false;
+                                    out.format = DiffFilesDefaultFormat::Patch;
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+            idx += 1;
+            continue;
+        }
+        idx += 1;
+    }
+    out
+}
+
+/// CLI state for `--dirstat` / `--dirstat-by-file` / `--cumulative` (shared by `diff` and `diff-files`).
+#[derive(Debug, Default, Clone)]
+pub(crate) struct DirstatCliState {
+    pub dirstat: Vec<String>,
+    pub dirstat_by_file: Option<String>,
+    pub dirstat_cumulative_flag: bool,
+}
+
+impl From<&Args> for DirstatCliState {
+    fn from(args: &Args) -> Self {
+        Self {
+            dirstat: args.dirstat.clone(),
+            dirstat_by_file: args.dirstat_by_file.clone(),
+            dirstat_cumulative_flag: args.dirstat_cumulative_flag,
+        }
+    }
+}
+
 fn resolve_dirstat_options(
     args: &Args,
+    git_dir: &std::path::Path,
+    cli_active: bool,
+) -> Result<(Option<DirstatOptions>, Vec<String>)> {
+    resolve_dirstat_options_from_cli(&DirstatCliState::from(args), git_dir, cli_active)
+}
+
+pub(crate) fn resolve_dirstat_options_from_cli(
+    cli: &DirstatCliState,
     git_dir: &std::path::Path,
     cli_active: bool,
 ) -> Result<(Option<DirstatOptions>, Vec<String>)> {
@@ -3392,18 +3748,18 @@ fn resolve_dirstat_options(
         opts = o;
     }
 
-    if args.dirstat_cumulative_flag {
+    if cli.dirstat_cumulative_flag {
         parse_dirstat_apply_tokens("cumulative", &mut opts, true, &mut warnings)?;
     }
 
-    if let Some(ref p) = args.dirstat_by_file {
+    if let Some(ref p) = cli.dirstat_by_file {
         parse_dirstat_apply_tokens("files", &mut opts, true, &mut warnings)?;
         if !p.is_empty() {
             parse_dirstat_apply_tokens(p, &mut opts, true, &mut warnings)?;
         }
     }
 
-    for param in &args.dirstat {
+    for param in &cli.dirstat {
         if param.is_empty() {
             opts = DirstatOptions::default();
         } else {
@@ -3553,7 +3909,7 @@ fn gather_dirstat_recursive(
     Ok(if cumulative { 0 } else { sum })
 }
 
-fn write_dirstat(
+pub(crate) fn write_dirstat(
     out: &mut impl Write,
     opts: &DirstatOptions,
     entries: &[DiffEntry],
@@ -4955,6 +5311,132 @@ fn word_diff_output(
     }
 
     output
+}
+
+fn mode_str_has_executable_bit(mode_str: &str) -> bool {
+    u32::from_str_radix(mode_str, 8)
+        .map(|m| m & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+fn compact_summary_display_path(entry: &DiffEntry, quote_path_fully: bool) -> String {
+    let path = grit_lib::quote_path::quote_c_style(entry.path(), quote_path_fully);
+    match entry.status {
+        DiffStatus::Added => format!("{path} (new)"),
+        DiffStatus::Deleted => format!("{path} (gone)"),
+        _ => {
+            let old_x = mode_str_has_executable_bit(&entry.old_mode);
+            let new_x = mode_str_has_executable_bit(&entry.new_mode);
+            if new_x != old_x {
+                if new_x {
+                    format!("{path} (mode +x)")
+                } else {
+                    format!("{path} (mode -x)")
+                }
+            } else {
+                path
+            }
+        }
+    }
+}
+
+/// Per-file compact summary plus totals line (matches `git diff --compact-summary`).
+fn write_compact_summary(
+    out: &mut impl Write,
+    entries: &[DiffEntry],
+    odb: &Odb,
+    work_tree: Option<&Path>,
+    break_rewrites: bool,
+    line_ignore: Option<&[Regex]>,
+    ws_mode: &WhitespaceMode,
+    algo_ctx: &DiffAlgoContext,
+    algo_cli: Option<similar::Algorithm>,
+    git_dir: &Path,
+    quote_path_fully: bool,
+) -> Result<()> {
+    if entries.is_empty() {
+        return Ok(());
+    }
+
+    let mut files: Vec<FileStatInput> = Vec::with_capacity(entries.len());
+    let mut total_ins = 0usize;
+    let mut total_del = 0usize;
+    for entry in entries {
+        if entry.status == DiffStatus::Unmerged {
+            continue;
+        }
+        let old_raw = read_content_raw(odb, &entry.old_oid);
+        let new_raw = read_content_raw_or_worktree(odb, &entry.new_oid, work_tree, entry.path());
+        let binary = is_binary(&old_raw) || is_binary(&new_raw);
+        let (ins, del) = if binary {
+            let deleted = if entry.old_oid == zero_oid() {
+                0
+            } else {
+                old_raw.len()
+            };
+            let added = if entry.new_oid == zero_oid() {
+                0
+            } else {
+                new_raw.len()
+            };
+            (added, deleted)
+        } else {
+            let mode_only = entry.status == DiffStatus::Modified
+                && entry.old_mode != entry.new_mode
+                && old_raw == new_raw;
+            if mode_only {
+                (0, 0)
+            } else {
+                stat_ins_del_for_entry(
+                    odb,
+                    entry,
+                    work_tree,
+                    break_rewrites,
+                    line_ignore,
+                    ws_mode,
+                    algo_ctx,
+                    algo_cli,
+                )
+            }
+        };
+        total_ins += ins;
+        total_del += del;
+        files.push(FileStatInput {
+            path_display: compact_summary_display_path(entry, quote_path_fully),
+            insertions: ins,
+            deletions: del,
+            is_binary: binary,
+        });
+    }
+
+    let cfg = ConfigSet::load(Some(git_dir), false).unwrap_or_else(|_| ConfigSet::new());
+    let stat_name_width = cfg
+        .get("diff.statNameWidth")
+        .and_then(|v| v.parse::<usize>().ok());
+    let stat_graph_width = cfg
+        .get("diff.statGraphWidth")
+        .and_then(|v| v.parse::<usize>().ok());
+    let opts = DiffstatOptions {
+        total_width: terminal_columns(),
+        line_prefix: "",
+        subtract_prefix_from_terminal: false,
+        stat_name_width,
+        stat_graph_width,
+        stat_count: None,
+        color_add: "",
+        color_del: "",
+        color_reset: "",
+        graph_bar_slack: 0,
+        graph_prefix_budget_slack: 0,
+    };
+    write_diffstat_block(out, &files, &opts)?;
+
+    let n = files.len();
+    let mut summary = format!(" {} file{} changed", n, if n == 1 { "" } else { "s" });
+    append_stat_counts(&mut summary, total_ins, total_del);
+    writeln!(out, "{summary}")?;
+
+    Ok(())
 }
 
 /// Write only the summary line: `N files changed, N insertions(+), N deletions(-)`.

--- a/grit/src/commands/diff_files.rs
+++ b/grit/src/commands/diff_files.rs
@@ -3,6 +3,10 @@
 //! Compares the working tree against the index.  This is the plumbing
 //! equivalent of `grit diff` (without `--cached`).
 
+use crate::commands::diff::{
+    diff_emit_unified_patch_from_plumbing_argv, parse_diff_files_format_argv,
+    resolve_dirstat_options_from_cli, write_dirstat, DiffFilesEmitKind, DiffFilesStatVariant,
+};
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::diff::{
@@ -10,6 +14,7 @@ use grit_lib::diff::{
     rewrite_dissimilarity_index_percent, should_break_rewrite_for_stat, stat_matches, unified_diff,
     zero_oid, DiffEntry, DiffStatus,
 };
+use grit_lib::diffstat::{terminal_columns, write_diffstat_block, DiffstatOptions, FileStatInput};
 use grit_lib::index::{
     Index, IndexEntry, MODE_EXECUTABLE, MODE_GITLINK, MODE_REGULAR, MODE_SYMLINK,
 };
@@ -20,7 +25,9 @@ use grit_lib::rev_parse::abbreviate_object_id;
 #[cfg(unix)]
 use libc;
 use std::collections::{BTreeMap, BTreeSet};
+use std::env;
 use std::fs;
+use std::io::Write;
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
@@ -127,68 +134,239 @@ pub fn run(mut args: Args) -> Result<()> {
         diff_entries = grit_lib::diff::detect_renames(&repo.odb, diff_entries, threshold);
     }
 
-    if options.summary {
-        print_diff_files_summary(&diff_entries)?;
-    }
-    if !options.quiet && options.suppress_diff {
-        if (options.exit_code || options.quiet) && !diff_entries.is_empty() {
-            std::process::exit(1);
-        }
-        return Ok(());
+    let emit_patch =
+        diff_emit_unified_patch_from_plumbing_argv("diff-files", &env::args().collect::<Vec<_>>());
+    let dirstat_cli_active =
+        !options.dirstat_cli.dirstat.is_empty() || options.dirstat_cli.dirstat_by_file.is_some();
+    let (dirstat_opts, dirstat_warnings) =
+        resolve_dirstat_options_from_cli(&options.dirstat_cli, &repo.git_dir, dirstat_cli_active)?;
+    for w in &dirstat_warnings {
+        eprintln!("warning: {w}");
     }
 
-    if !options.quiet && !options.suppress_diff {
-        match options.format {
-            OutputFormat::Raw => {
-                if options.summary && !options.explicit_raw {
-                    // `git diff-files --summary` replaces default raw output unless `--raw` is given.
-                } else {
+    let use_emit_queue = !options.emit_queue.is_empty();
+
+    if !options.quiet {
+        let mut wrote_any = false;
+        let mut need_blank_before_patch = false;
+
+        if use_emit_queue {
+            let mut out = std::io::stdout().lock();
+            for kind in &options.emit_queue {
+                match kind {
+                    DiffFilesEmitKind::Raw => {
+                        if options.suppress_diff {
+                            continue;
+                        }
+                        for entry in &diff_entries {
+                            writeln!(
+                                out,
+                                "{}",
+                                render_raw_diff_entry(
+                                    entry,
+                                    &repo,
+                                    options.abbrev,
+                                    options.reverse
+                                )?
+                            )?;
+                        }
+                        wrote_any = true;
+                        need_blank_before_patch = true;
+                    }
+                    DiffFilesEmitKind::Stat => {
+                        if options.suppress_diff {
+                            continue;
+                        }
+                        if options.stat_variant == DiffFilesStatVariant::CompactSummary {
+                            print_compact_summary_from_diff_entries(
+                                &diff_entries,
+                                &repo,
+                                &work_tree,
+                            )?;
+                        } else {
+                            print_stat_from_diff_entries(&diff_entries, &repo, &work_tree)?;
+                        }
+                        wrote_any = true;
+                        need_blank_before_patch = true;
+                    }
+                    DiffFilesEmitKind::NumStat => {
+                        if options.suppress_diff {
+                            continue;
+                        }
+                        print_numstat_from_diff_entries(&diff_entries, &repo, &work_tree)?;
+                        wrote_any = true;
+                        need_blank_before_patch = true;
+                    }
+                    DiffFilesEmitKind::Shortstat => {
+                        if options.suppress_diff {
+                            continue;
+                        }
+                        write_diff_files_shortstat_line(&diff_entries, &repo, &work_tree)?;
+                        wrote_any = true;
+                        need_blank_before_patch = true;
+                    }
+                    DiffFilesEmitKind::Dirstat => {
+                        if options.suppress_diff {
+                            continue;
+                        }
+                        if let Some(ref ds) = dirstat_opts {
+                            write_dirstat(
+                                &mut out,
+                                ds,
+                                &diff_entries,
+                                &repo.odb,
+                                Some(work_tree.as_path()),
+                                options.break_rewrites,
+                            )?;
+                        }
+                        wrote_any = true;
+                        need_blank_before_patch = true;
+                    }
+                    DiffFilesEmitKind::Summary => {
+                        print_diff_files_summary(&diff_entries)?;
+                        wrote_any = true;
+                        need_blank_before_patch = true;
+                    }
+                }
+            }
+            drop(out);
+
+            let show_patch = emit_patch && !options.suppress_diff;
+            if show_patch {
+                let prefix_raw = options.patch_with_raw
+                    && !options
+                        .emit_queue
+                        .iter()
+                        .any(|k| *k == DiffFilesEmitKind::Raw);
+                let prefix_stat = options.patch_with_stat
+                    && options.stat_variant != DiffFilesStatVariant::CompactSummary
+                    && !options
+                        .emit_queue
+                        .iter()
+                        .any(|k| *k == DiffFilesEmitKind::Stat);
+                if prefix_raw {
                     for entry in &diff_entries {
                         println!(
                             "{}",
                             render_raw_diff_entry(entry, &repo, options.abbrev, options.reverse)?
                         );
                     }
+                    wrote_any = true;
+                    need_blank_before_patch = true;
                 }
-            }
-            OutputFormat::NameOnly => {
-                for entry in &diff_entries {
-                    println!("{}", entry.path());
+                if prefix_stat {
+                    print_stat_from_diff_entries(&diff_entries, &repo, &work_tree)?;
+                    wrote_any = true;
+                    need_blank_before_patch = true;
                 }
-            }
-            OutputFormat::NameStatus => {
-                for entry in &diff_entries {
-                    match (entry.status, entry.score) {
-                        (DiffStatus::Renamed, Some(s)) => {
-                            println!(
-                                "R{s:03}\t{}\t{}",
-                                entry.old_path.as_deref().unwrap_or(""),
-                                entry.new_path.as_deref().unwrap_or("")
-                            );
-                        }
-                        (DiffStatus::Copied, Some(s)) => {
-                            println!(
-                                "C{s:03}\t{}\t{}",
-                                entry.old_path.as_deref().unwrap_or(""),
-                                entry.new_path.as_deref().unwrap_or("")
-                            );
-                        }
-                        _ => {
-                            println!("{}\t{}", entry.status.letter(), entry.path());
-                        }
-                    }
+                if need_blank_before_patch && wrote_any {
+                    println!();
                 }
-            }
-            OutputFormat::Patch => {
                 for entry in &diff_entries {
                     print_patch_from_diff_entry(entry, &repo, &work_tree, options.abbrev)?;
                 }
             }
-            OutputFormat::Stat => {
-                print_stat_from_diff_entries(&diff_entries, &repo, &work_tree)?;
+        } else {
+            if options
+                .emit_queue
+                .iter()
+                .any(|k| *k == DiffFilesEmitKind::Summary)
+            {
+                print_diff_files_summary(&diff_entries)?;
+                wrote_any = true;
+                need_blank_before_patch = true;
             }
-            OutputFormat::NumStat => {
-                print_numstat_from_diff_entries(&diff_entries, &repo, &work_tree)?;
+            if !options.suppress_diff {
+                match options.format {
+                    OutputFormat::Raw => {
+                        let summary_only = options
+                            .emit_queue
+                            .iter()
+                            .any(|k| *k == DiffFilesEmitKind::Summary);
+                        if !(summary_only && !options.explicit_raw) {
+                            for entry in &diff_entries {
+                                println!(
+                                    "{}",
+                                    render_raw_diff_entry(
+                                        entry,
+                                        &repo,
+                                        options.abbrev,
+                                        options.reverse
+                                    )?
+                                );
+                            }
+                        }
+                    }
+                    OutputFormat::NameOnly => {
+                        for entry in &diff_entries {
+                            println!("{}", entry.path());
+                        }
+                    }
+                    OutputFormat::NameStatus => {
+                        for entry in &diff_entries {
+                            match (entry.status, entry.score) {
+                                (DiffStatus::Renamed, Some(s)) => {
+                                    println!(
+                                        "R{s:03}\t{}\t{}",
+                                        entry.old_path.as_deref().unwrap_or(""),
+                                        entry.new_path.as_deref().unwrap_or("")
+                                    );
+                                }
+                                (DiffStatus::Copied, Some(s)) => {
+                                    println!(
+                                        "C{s:03}\t{}\t{}",
+                                        entry.old_path.as_deref().unwrap_or(""),
+                                        entry.new_path.as_deref().unwrap_or("")
+                                    );
+                                }
+                                _ => {
+                                    println!("{}\t{}", entry.status.letter(), entry.path());
+                                }
+                            }
+                        }
+                    }
+                    OutputFormat::Patch => {
+                        if options.patch_with_raw {
+                            for entry in &diff_entries {
+                                println!(
+                                    "{}",
+                                    render_raw_diff_entry(
+                                        entry,
+                                        &repo,
+                                        options.abbrev,
+                                        options.reverse
+                                    )?
+                                );
+                            }
+                            wrote_any = true;
+                            need_blank_before_patch = true;
+                        }
+                        if options.patch_with_stat {
+                            print_stat_from_diff_entries(&diff_entries, &repo, &work_tree)?;
+                            wrote_any = true;
+                            need_blank_before_patch = true;
+                        }
+                        if need_blank_before_patch && wrote_any {
+                            println!();
+                        }
+                        for entry in &diff_entries {
+                            print_patch_from_diff_entry(entry, &repo, &work_tree, options.abbrev)?;
+                        }
+                    }
+                    OutputFormat::Stat => {
+                        print_stat_from_diff_entries(&diff_entries, &repo, &work_tree)?;
+                    }
+                    OutputFormat::NumStat => {
+                        print_numstat_from_diff_entries(&diff_entries, &repo, &work_tree)?;
+                    }
+                }
+            } else if options.format == OutputFormat::Raw && options.explicit_raw {
+                for entry in &diff_entries {
+                    println!(
+                        "{}",
+                        render_raw_diff_entry(entry, &repo, options.abbrev, options.reverse)?
+                    );
+                }
             }
         }
     }
@@ -340,6 +518,16 @@ struct Options {
     explicit_raw: bool,
     /// Suppress diff output (-s / --no-patch).
     suppress_diff: bool,
+    /// Emit `--stat` or `--compact-summary` block (`--compact-summary` wins over `--stat`).
+    stat_variant: DiffFilesStatVariant,
+    /// Prefix patch with full `--stat` block (`---` separator before hunks).
+    patch_with_stat: bool,
+    /// Prefix patch with `--raw` lines.
+    patch_with_raw: bool,
+    /// `git diff-files` output format queue (order-preserving duplicate flags).
+    emit_queue: Vec<DiffFilesEmitKind>,
+    /// Parsed `--dirstat` / `--dirstat-by-file` / `--cumulative`.
+    dirstat_cli: crate::commands::diff::DirstatCliState,
     /// Optional diff-filter specification.
     diff_filter: Option<String>,
     /// Omit submodule entries (gitlinks) from the diff.
@@ -352,8 +540,6 @@ struct Options {
     find_copies_harder: bool,
     /// Swap old/new sides (reverse diff).
     reverse: bool,
-    /// Emit condensed summary lines (renames, mode changes, rewrites with `-B`).
-    summary: bool,
     /// Detect complete rewrites (`-B` / `--break-rewrites`) for summary/raw dissimilarity.
     break_rewrites: bool,
 }
@@ -380,14 +566,27 @@ struct Change {
 // ── Option parsing ───────────────────────────────────────────────────
 
 fn parse_options(argv: &[String]) -> Result<Options> {
+    let fmt = parse_diff_files_format_argv(&env::args().collect::<Vec<_>>());
     let mut pathspecs = Vec::new();
     let mut stage: u8 = 0;
     let mut quiet = false;
     let mut exit_code = false;
     let mut abbrev: Option<usize> = None;
-    let mut format = OutputFormat::Raw;
-    let mut explicit_raw = false;
-    let mut suppress_diff = false;
+    let format = match fmt.format {
+        crate::commands::diff::DiffFilesDefaultFormat::Raw => OutputFormat::Raw,
+        crate::commands::diff::DiffFilesDefaultFormat::Patch => OutputFormat::Patch,
+        crate::commands::diff::DiffFilesDefaultFormat::Stat => OutputFormat::Stat,
+        crate::commands::diff::DiffFilesDefaultFormat::NumStat => OutputFormat::NumStat,
+        crate::commands::diff::DiffFilesDefaultFormat::NameOnly => OutputFormat::NameOnly,
+        crate::commands::diff::DiffFilesDefaultFormat::NameStatus => OutputFormat::NameStatus,
+    };
+    let explicit_raw = fmt.explicit_raw;
+    let suppress_diff = fmt.suppress_diff;
+    let stat_variant = fmt.stat_variant;
+    let patch_with_raw = fmt.patch_with_raw;
+    let patch_with_stat = fmt.patch_with_stat;
+    let emit_queue = fmt.emit_queue;
+    let dirstat_cli = fmt.dirstat_cli;
     let mut diff_filter: Option<String> = None;
     let mut ignore_submodules = false;
     let mut find_renames: Option<u32> = None;
@@ -395,7 +594,6 @@ fn parse_options(argv: &[String]) -> Result<Options> {
     let mut find_copies_harder = false;
     let mut c_count = 0u32;
     let mut reverse = false;
-    let mut summary = false;
     let mut break_rewrites = false;
     let mut end_of_options = false;
 
@@ -410,32 +608,6 @@ fn parse_options(argv: &[String]) -> Result<Options> {
         if !end_of_options && arg.starts_with('-') {
             match arg.as_str() {
                 "-R" => reverse = true,
-                "--raw" => {
-                    format = OutputFormat::Raw;
-                    explicit_raw = true;
-                    suppress_diff = false;
-                }
-                "-p" | "--patch" | "-u" => {
-                    format = OutputFormat::Patch;
-                    suppress_diff = false;
-                }
-                "--stat" => {
-                    format = OutputFormat::Stat;
-                    suppress_diff = false;
-                }
-                "--numstat" => {
-                    format = OutputFormat::NumStat;
-                    suppress_diff = false;
-                }
-                "--name-only" => {
-                    format = OutputFormat::NameOnly;
-                    suppress_diff = false;
-                }
-                "--name-status" => {
-                    format = OutputFormat::NameStatus;
-                    suppress_diff = false;
-                }
-                "--summary" => summary = true,
                 "-B" | "--break-rewrites" => break_rewrites = true,
                 _ if arg.starts_with("--break-rewrites=") => break_rewrites = true,
                 _ if arg.starts_with("-B") && arg.len() > 2 => {
@@ -451,15 +623,6 @@ fn parse_options(argv: &[String]) -> Result<Options> {
                 }
                 "--exit-code" => exit_code = true,
                 "-q" | "--quiet" => quiet = true,
-                "-s" | "--no-patch" => suppress_diff = true,
-                "--patch-with-raw" => {
-                    format = OutputFormat::Patch;
-                    suppress_diff = false;
-                } // TODO: also show raw
-                "--patch-with-stat" => {
-                    format = OutputFormat::Patch;
-                    suppress_diff = false;
-                } // TODO: also show stat
                 "-0" => stage = 0,
                 "-1" => stage = 1,
                 "-2" => stage = 2,
@@ -482,7 +645,27 @@ fn parse_options(argv: &[String]) -> Result<Options> {
                 | "--full-index"
                 | "--no-ext-diff"
                 | "--no-prefix"
-                | "--no-abbrev" => {}
+                | "--no-abbrev"
+                | "-s"
+                | "--no-patch"
+                | "-p"
+                | "--patch"
+                | "-u"
+                | "--raw"
+                | "--stat"
+                | "--compact-summary"
+                | "--numstat"
+                | "--shortstat"
+                | "--name-only"
+                | "--name-status"
+                | "--summary"
+                | "--patch-with-raw"
+                | "--patch-with-stat"
+                | "--dirstat"
+                | "--dirstat-by-file"
+                | "--cumulative" => {}
+                s if s.starts_with("--dirstat=") => {}
+                s if s.starts_with("--dirstat-by-file=") => {}
                 "-M" | "--find-renames" => {
                     find_renames = Some(50);
                 }
@@ -547,6 +730,18 @@ fn parse_options(argv: &[String]) -> Result<Options> {
                 | "--glob-pathspecs"
                 | "--noglob-pathspecs"
                 | "--icase-pathspecs" => {}
+                _ if arg.starts_with('-')
+                    && !arg.starts_with("--")
+                    && arg.len() > 2
+                    && arg.as_bytes().get(1).is_some_and(|b| *b != b'-') =>
+                {
+                    const COMBINABLE: &[u8] = b"spuwqRb";
+                    let bytes = arg.as_bytes();
+                    let tail = &bytes[1..];
+                    if tail.is_empty() || !tail.iter().all(|b| COMBINABLE.contains(b)) {
+                        bail!("unsupported option: {arg}");
+                    }
+                }
                 _ if arg.starts_with("-G")
                     || arg.starts_with("-S")
                     || arg.starts_with("-O")
@@ -570,13 +765,17 @@ fn parse_options(argv: &[String]) -> Result<Options> {
         format,
         explicit_raw,
         suppress_diff,
+        stat_variant,
+        patch_with_raw,
+        patch_with_stat,
+        emit_queue,
+        dirstat_cli,
         diff_filter,
         ignore_submodules,
         find_renames,
         find_copies,
         find_copies_harder,
         reverse,
-        summary,
         break_rewrites,
     })
 }
@@ -952,6 +1151,11 @@ fn print_patch_from_diff_entry(
     match entry.status {
         DiffStatus::Deleted => {
             header.push_str(&format!("\ndeleted file mode {}", entry.old_mode));
+            header.push_str(&format!(
+                "\nindex {}..{}",
+                abbrev_oid_for_patch(&entry.old_oid, abbrev),
+                abbrev_oid_for_patch(&zero_oid(), abbrev),
+            ));
         }
         DiffStatus::Added => {
             header.push_str(&format!("\nnew file mode {}", entry.new_mode));
@@ -962,9 +1166,10 @@ fn print_patch_from_diff_entry(
                 entry.new_oid
             };
             header.push_str(&format!(
-                "\nindex {}..{}",
+                "\nindex {}..{} {}",
                 abbrev_oid_for_patch(&entry.old_oid, abbrev),
                 abbrev_oid_for_patch(&new_for_index, abbrev),
+                entry.new_mode
             ));
         }
         DiffStatus::Renamed => {
@@ -984,6 +1189,20 @@ fn print_patch_from_diff_entry(
                 header.push_str(&format!(
                     "\nold mode {}\nnew mode {}",
                     entry.old_mode, entry.new_mode
+                ));
+            }
+            if entry.old_mode == entry.new_mode {
+                header.push_str(&format!(
+                    "\nindex {}..{} {}",
+                    abbrev_oid_for_patch(&entry.old_oid, abbrev),
+                    abbrev_oid_for_patch(&entry.new_oid, abbrev),
+                    entry.new_mode
+                ));
+            } else {
+                header.push_str(&format!(
+                    "\nindex {}..{}",
+                    abbrev_oid_for_patch(&entry.old_oid, abbrev),
+                    abbrev_oid_for_patch(&entry.new_oid, abbrev),
                 ));
             }
         }
@@ -1064,6 +1283,177 @@ fn print_numstat_from_diff_entries(
         let (ins, del) = count_changes(&old, &new);
         println!("{}\t{}\t{}", ins, del, entry.path());
     }
+    Ok(())
+}
+
+fn append_diff_files_stat_totals(summary: &mut String, total_ins: usize, total_del: usize) {
+    if total_ins > 0 {
+        summary.push_str(&format!(
+            ", {} insertion{}(+)",
+            total_ins,
+            if total_ins == 1 { "" } else { "s" }
+        ));
+    }
+    if total_del > 0 {
+        summary.push_str(&format!(
+            ", {} deletion{}(-)",
+            total_del,
+            if total_del == 1 { "" } else { "s" }
+        ));
+    }
+    if total_ins == 0 && total_del == 0 {
+        summary.push_str(", 0 insertions(+), 0 deletions(-)");
+    }
+}
+
+fn write_diff_files_shortstat_line(
+    entries: &[DiffEntry],
+    repo: &Repository,
+    work_tree: &Path,
+) -> Result<()> {
+    if entries.is_empty() {
+        return Ok(());
+    }
+    let mut total_ins = 0usize;
+    let mut total_del = 0usize;
+    for entry in entries {
+        let (old, new) = load_patch_contents_for_diff_entry(entry, repo, work_tree)?;
+        let (ins, del) = count_changes(&old, &new);
+        total_ins += ins;
+        total_del += del;
+    }
+    let files = entries.len();
+    let mut line = format!(
+        " {} file{} changed",
+        files,
+        if files == 1 { "" } else { "s" }
+    );
+    append_diff_files_stat_totals(&mut line, total_ins, total_del);
+    println!("{line}");
+    Ok(())
+}
+
+fn mode_has_executable_bit(mode_str: &str) -> bool {
+    u32::from_str_radix(mode_str, 8)
+        .map(|m| m & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+fn compact_summary_path_display(entry: &DiffEntry) -> String {
+    let path = entry.path().to_owned();
+    match entry.status {
+        DiffStatus::Added => format!("{path} (new)"),
+        DiffStatus::Deleted => format!("{path} (gone)"),
+        _ => {
+            let old_x = mode_has_executable_bit(&entry.old_mode);
+            let new_x = mode_has_executable_bit(&entry.new_mode);
+            if new_x != old_x {
+                if new_x {
+                    format!("{path} (mode +x)")
+                } else {
+                    format!("{path} (mode -x)")
+                }
+            } else {
+                path
+            }
+        }
+    }
+}
+
+fn load_patch_bytes_for_diff_entry(
+    entry: &DiffEntry,
+    repo: &Repository,
+    work_tree: &Path,
+) -> Result<(Vec<u8>, Vec<u8>)> {
+    let old = if entry.status == DiffStatus::Added || entry.old_oid == zero_oid() {
+        Vec::new()
+    } else {
+        repo.odb
+            .read(&entry.old_oid)
+            .map(|o| o.data)
+            .unwrap_or_default()
+    };
+    let new = if entry.status == DiffStatus::Deleted {
+        Vec::new()
+    } else {
+        let path = entry.new_path.as_deref().unwrap_or(entry.path());
+        let abs = work_tree.join(path);
+        match fs::read(&abs) {
+            Ok(b) => b,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+            Err(e) => return Err(e.into()),
+        }
+    };
+    Ok((old, new))
+}
+
+fn print_compact_summary_from_diff_entries(
+    entries: &[DiffEntry],
+    repo: &Repository,
+    work_tree: &Path,
+) -> Result<()> {
+    if entries.is_empty() {
+        return Ok(());
+    }
+    let mut files: Vec<FileStatInput> = Vec::with_capacity(entries.len());
+    let mut total_ins = 0usize;
+    let mut total_del = 0usize;
+    for entry in entries {
+        let (old_b, new_b) = load_patch_bytes_for_diff_entry(entry, repo, work_tree)?;
+        let binary =
+            grit_lib::merge_file::is_binary(&old_b) || grit_lib::merge_file::is_binary(&new_b);
+        let (ins, del) = if binary {
+            let deleted = if entry.old_oid == zero_oid() {
+                0
+            } else {
+                old_b.len()
+            };
+            let added = if entry.new_oid == zero_oid() {
+                0
+            } else {
+                new_b.len()
+            };
+            (added, deleted)
+        } else {
+            let old_s = String::from_utf8_lossy(&old_b).into_owned();
+            let new_s = String::from_utf8_lossy(&new_b).into_owned();
+            count_changes(&old_s, &new_s)
+        };
+        total_ins += ins;
+        total_del += del;
+        files.push(FileStatInput {
+            path_display: compact_summary_path_display(entry),
+            insertions: ins,
+            deletions: del,
+            is_binary: binary,
+        });
+    }
+    let cfg = grit_lib::config::ConfigSet::load(Some(&repo.git_dir), false)
+        .unwrap_or_else(|_| grit_lib::config::ConfigSet::new());
+    let stat_name_width = cfg
+        .get("diff.statNameWidth")
+        .and_then(|v| v.parse::<usize>().ok());
+    let stat_graph_width = cfg
+        .get("diff.statGraphWidth")
+        .and_then(|v| v.parse::<usize>().ok());
+    let opts = DiffstatOptions {
+        total_width: terminal_columns(),
+        line_prefix: "",
+        subtract_prefix_from_terminal: false,
+        stat_name_width,
+        stat_graph_width,
+        stat_count: None,
+        color_add: "",
+        color_del: "",
+        color_reset: "",
+        graph_bar_slack: 0,
+        graph_prefix_budget_slack: 0,
+    };
+    write_diffstat_block(&mut std::io::stdout().lock(), &files, &opts)?;
+    let n = entries.len();
+    let mut summary = format!(" {} file{} changed", n, if n == 1 { "" } else { "s" });
+    append_diff_files_stat_totals(&mut summary, total_ins, total_del);
+    println!("{summary}");
     Ok(())
 }
 
@@ -1339,13 +1729,15 @@ fn matches_pathspec(path: &str, pathspecs: &[String]) -> bool {
     })
 }
 
-/// Return the file type category for a mode: 0=regular, 1=executable, 2=symlink, 3=submodule, 4=other
+/// Return the file type category for a mode: 0=blob (regular or executable), 2=symlink, 3=submodule, 4=other.
+///
+/// Git treats `100644` and `100755` as the same object kind for `diff-files` status (`M`, not `T`).
 fn mode_type(mode: u32) -> u32 {
-    match mode {
-        0o100644 => 0,
-        0o100755 => 1,
-        0o120000 => 2,
-        0o160000 => 3,
+    let m = canonicalize_mode(mode);
+    match m {
+        MODE_REGULAR | MODE_EXECUTABLE => 0,
+        MODE_SYMLINK => 2,
+        MODE_GITLINK => 3,
         _ => 4,
     }
 }

--- a/logs/2026-04-09_t4000-diff-format.md
+++ b/logs/2026-04-09_t4000-diff-format.md
@@ -1,0 +1,14 @@
+# t4000-diff-format
+
+## Goal
+Make `tests/t4000-diff-format.sh` pass all 41 cases (diff-files / diff output formats, `--no-patch`, combined formats).
+
+## Changes
+- **`diff-files`**: Single-pass argv parsing (`parse_diff_files_format_argv`) matching Git: `-s` clears queued formats; later flags re-enable; default is no patch until `-p` (plumbing default). Emit queue for raw/stat/numstat/shortstat/dirstat/summary; `--patch-with-raw` / `--patch-with-stat` prefixes; blank line before patch when needed. `--compact-summary` output. `index` lines on patches (including deletes/adds/mode-only). `mode_type` treats 100644/100755 as same kind (status `M` not `T`).
+- **`diff`**: `--compact-summary`, `--patch-with-raw`, `--patch-with-stat`; `write_compact_summary`; combined output order; `diff_show_unified_patch_last_wins` so e.g. `--stat` after `-p` suppresses patch (matches Git). Exported `write_dirstat`, shared dirstat resolution helpers.
+- **Harness**: `./scripts/run-tests.sh t4000-diff-format.sh` → 41/41.
+
+## Validation
+- `cargo fmt`, `cargo clippy -p grit-rs --fix --allow-dirty`
+- `cargo test -p grit-lib --lib`
+- `./scripts/run-tests.sh t4000-diff-format.sh`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible combined diff output so `t4000-diff-format` (41 tests) passes.

### `diff-files`
- Single-pass argv parsing that matches Git: `-s` / `--no-patch` clears queued format output; later flags re-enable; plumbing defaults to **no patch** until `-p` (unlike porcelain `git diff`).
- Order-preserving emit queue for `--raw`, `--stat`, `--compact-summary`, `--numstat`, `--shortstat`, `--dirstat*` / `--cumulative`, `--summary`; `--patch-with-raw` / `--patch-with-stat` prefixes; blank line before hunks when needed.
- `index` lines on patch headers (add/delete/mode/content) to match Git.
- `100644` ↔ `100755` is treated as modified (`M`), not type-changed (`T`).

### `git diff`
- New flags: `--compact-summary`, `--patch-with-raw`, `--patch-with-stat`.
- Last-wins patch emission (e.g. `-p` then `--stat` → stat only, no hunks).
- `write_compact_summary` and shared dirstat helpers (`write_dirstat` exported).

### Validation
- `cargo fmt`, `cargo clippy -p grit-rs --fix --allow-dirty`
- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t4000-diff-format.sh` → 41/41

## Log
- `logs/2026-04-09_t4000-diff-format.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7495651-d046-4c7e-be20-3fb6820cfbb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7495651-d046-4c7e-be20-3fb6820cfbb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

