### PR TITLE
fix: bisect porcelain improvements for t6030 (partial)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,6 +527,7 @@ dependencies = [
  "hungarian",
  "libc",
  "merge3",
+ "nix",
  "regex",
  "sha1",
  "shell-words",
@@ -969,6 +970,18 @@ dependencies = [
  "num-integer",
  "num-traits",
  "rawpointer",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ hungarian = "1.1.1"
 ureq = "2.12"
 icu_normalizer = "2.0.0"
 shell-words = "1.1"
+nix = { version = "0.29", default-features = false, features = ["fs"] }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1062,7 +1062,7 @@ t6019-rev-list-ancestry-path	t6	yes	18	5	13	false	ok	0
 t6020-bundle-misc	t6	yes	37	10	27	false	ok	0
 t6021-rev-list-exclude-hidden	t6	yes	62	1	61	false	ok	0
 t6022-rev-list-missing	t6	yes	40	4	36	false	ok	0
-t6030-bisect-porcelain	t6	yes	96	66	30	false	ok	0
+t6030-bisect-porcelain	t6	yes	96	84	12	false	ok	0
 t6040-tracking-info	t6	yes	44	35	9	false	ok	0
 t6041-bisect-submodule	t6	yes	14	6	8	false	ok	0
 t6050-replace	t6	skip	37	0	0	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,704 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,704 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T21:52:32+00:00" class="gen-time" title="2026-04-09 21:52 UTC">2026-04-09 21:52 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,704</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>758 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,33 +241,33 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
       <div class="group-line1">
         <span class="group-id">t6</span>
         <span class="group-desc">Revision tree commands (e.g. merge-base)</span>
-        <span class="group-meta">47/105 files · 3 skipped · 1,830/2,822 tests</span>
+        <span class="group-meta">47/105 files · 3 skipped · 1,848/2,822 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.8%"></div></div>
-        <span class="group-pct pct-blue">64.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:65.5%"></div></div>
+        <span class="group-pct pct-blue">65.5%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t7">
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35704 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,704 / 45,142 tests · 1,405 files in scope · 758 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T21:52:32+00:00" class="gen-time" title="2026-04-09 21:52 UTC">2026-04-09 21:52 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,704</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -10777,14 +10777,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:10.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t6" data-tests="96" data-passed="66">
+<tr class="" data-group="t6" data-tests="96" data-passed="84">
   <td class="mono">t6030-bisect-porcelain</td>
   <td>t6</td>
   <td></td>
   <td class="right">96</td>
-  <td class="right">66</td>
+  <td class="right">84</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:68.8%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:87.5%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t6" data-tests="44" data-passed="35">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/rev_parse.rs
+++ b/grit-lib/src/rev_parse.rs
@@ -846,7 +846,7 @@ fn resolve_revision_impl(
                 }
                 Err(e) => return Err(e),
             };
-            return resolve_tree_path(repo, &tree_oid, &clean_path)
+            return resolve_tree_path_rev_parse(repo, &tree_oid, &clean_path)
                 .map_err(|e| diagnose_tree_path_error(repo, before, after, &clean_path, e));
         }
     }
@@ -974,10 +974,49 @@ pub fn peel_to_tree(repo: &Repository, oid: ObjectId) -> Result<ObjectId> {
     }
 }
 
-/// Navigate a tree to find an object at a given path.
+/// Navigate a tree to find a blob at `path` (fails if the leaf is a subtree).
 fn resolve_tree_path(repo: &Repository, tree_oid: &ObjectId, path: &str) -> Result<ObjectId> {
     let (oid, _) = walk_tree_to_blob_entry(repo, tree_oid, path)?;
     Ok(oid)
+}
+
+/// Like Git `rev-parse` for `treeish:path`: the leaf may be a blob or a tree OID.
+fn resolve_tree_path_rev_parse(
+    repo: &Repository,
+    tree_oid: &ObjectId,
+    path: &str,
+) -> Result<ObjectId> {
+    let obj = repo.odb.read(tree_oid)?;
+    let entries = crate::objects::parse_tree(&obj.data)?;
+    let components: Vec<&str> = path.split('/').filter(|c| !c.is_empty()).collect();
+    if components.is_empty() {
+        return Err(Error::InvalidRef(format!(
+            "path '{path}' does not name an object in tree {tree_oid}"
+        )));
+    }
+
+    let first = components[0];
+    let rest: Vec<&str> = components[1..].to_vec();
+    for entry in entries {
+        let name = String::from_utf8_lossy(&entry.name);
+        if name == first {
+            if rest.is_empty() {
+                if entry.mode == crate::index::MODE_GITLINK {
+                    return Err(Error::InvalidRef(format!(
+                        "'{path}' is a gitlink, not a blob"
+                    )));
+                }
+                return Ok(entry.oid);
+            }
+            if entry.mode != crate::index::MODE_TREE {
+                return Err(Error::ObjectNotFound(path.to_owned()));
+            }
+            return resolve_tree_path_rev_parse(repo, &entry.oid, &rest.join("/"));
+        }
+    }
+    Err(Error::ObjectNotFound(format!(
+        "path '{path}' not found in tree {tree_oid}"
+    )))
 }
 
 /// Resolved blob (non-tree) at `treeish:path` for diff plumbing.

--- a/grit/Cargo.toml
+++ b/grit/Cargo.toml
@@ -21,6 +21,7 @@ workspace = true
 
 [dependencies]
 libc = { workspace = true }
+nix = { workspace = true }
 grit-lib = { version = "0.1.0", path = "../grit-lib" }
 anyhow.workspace = true
 clap.workspace = true

--- a/grit/src/commands/bisect.rs
+++ b/grit/src/commands/bisect.rs
@@ -7,15 +7,18 @@ use crate::explicit_exit::ExplicitExit;
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::check_ref_format::{check_refname_format, RefNameOptions};
+use grit_lib::index::MODE_TREE;
 use grit_lib::merge_base::{is_ancestor, merge_bases_first_vs_rest};
-use grit_lib::objects::{parse_commit, ObjectId};
+use grit_lib::objects::{parse_commit, parse_tree, ObjectId, ObjectKind};
 use grit_lib::refs;
 use grit_lib::repo::Repository;
-use grit_lib::rev_list::{rev_list, OrderingMode, RevListOptions};
-use grit_lib::rev_parse::resolve_revision;
+use grit_lib::rev_list::{rev_list, split_revision_token, OrderingMode, RevListOptions};
+use grit_lib::rev_parse::{resolve_revision, resolve_revision_as_commit};
 use std::collections::HashSet;
 use std::fs;
-use std::io::{stdin, IsTerminal, Write};
+use std::io::{stdin, stdout, IsTerminal, Write};
+#[cfg(unix)]
+use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
@@ -77,6 +80,38 @@ fn bisect_state_dir(git_dir: &Path) -> PathBuf {
     refs::common_dir(git_dir).unwrap_or_else(|| git_dir.to_path_buf())
 }
 
+/// Returns `Ok(())` when every tree reachable from `commit_oid` exists in the object database.
+///
+/// Matches Git's `unable to read tree` error used by bisect when a commit points at a missing tree.
+fn verify_commit_tree_fully_readable(repo: &Repository, commit_oid: ObjectId) -> Result<()> {
+    let object = repo
+        .odb
+        .read(&commit_oid)
+        .with_context(|| format!("read commit {commit_oid}"))?;
+    if object.kind != ObjectKind::Commit {
+        bail!("fatal: unable to read tree ({commit_oid})");
+    }
+    let commit = parse_commit(&object.data)?;
+    verify_tree_fully_readable(repo, commit.tree)
+}
+
+fn verify_tree_fully_readable(repo: &Repository, tree_oid: ObjectId) -> Result<()> {
+    let object = repo
+        .odb
+        .read(&tree_oid)
+        .map_err(|_| anyhow::anyhow!("fatal: unable to read tree ({tree_oid})"))?;
+    if object.kind != ObjectKind::Tree {
+        return Ok(());
+    }
+    let entries = parse_tree(&object.data)?;
+    for entry in entries {
+        if entry.mode == MODE_TREE {
+            verify_tree_fully_readable(repo, entry.oid)?;
+        }
+    }
+    Ok(())
+}
+
 /// `true` when `git_dir` is a linked worktree's administrative directory (`…/worktrees/<id>`),
 /// which contains a `commondir` file. The primary repository's `.git` does not.
 fn is_linked_worktree_git_dir(git_dir: &Path) -> bool {
@@ -105,6 +140,14 @@ fn hello_sed_p_env(work_dir: &Path) -> Option<String> {
 }
 
 /// Parse one line of `BISECT_NAMES` (shell-quoted words) into pathspec tokens.
+fn first_bisect_replay_token_and_rest(line: &str) -> (&str, &str) {
+    let s = line.trim_start();
+    let word_end = s.find(char::is_whitespace).unwrap_or_else(|| s.len());
+    let word = &s[..word_end];
+    let rest = s[word_end..].trim_start();
+    (word, rest)
+}
+
 fn parse_bisect_names_line(line: &str) -> Result<Vec<String>> {
     let line = line.trim();
     if line.is_empty() {
@@ -188,13 +231,15 @@ fn check_term_format(term: &str, orig: &str) -> Result<()> {
     if RESERVED.contains(&term) {
         bail!("can't use the builtin command '{term}' as a term");
     }
-    if orig == "bad" && matches!(term, "bad" | "new") {
-        return Ok(());
+    // Match `check_term_format` in Git's `bisect.c`: forbid swapping the canonical
+    // good/bad words onto the opposite role; allow aliases new/old for bad/good.
+    if orig != "bad" && matches!(term, "bad" | "new") {
+        bail!("can't change the meaning of the term '{orig}'");
     }
-    if orig == "good" && matches!(term, "good" | "old") {
-        return Ok(());
+    if orig != "good" && matches!(term, "good" | "old") {
+        bail!("can't change the meaning of the term '{orig}'");
     }
-    bail!("can't change the meaning of the term '{orig}'");
+    Ok(())
 }
 
 fn write_terms_file(git_dir: &Path, bad: &str, good: &str) -> Result<()> {
@@ -243,6 +288,18 @@ fn log_commit_line(git_dir: &Path, label: &str, oid: ObjectId, subject: &str) ->
     append_bisect_log_raw(git_dir, &format!("# {label}: [{oid}] {subject}"))
 }
 
+fn bisect_state_is_bad_side(terms: &BisectTerms, state: &str) -> bool {
+    state == terms.term_bad
+        || (terms.term_bad == "bad" && state == "bad")
+        || (terms.term_bad == "new" && state == "new")
+}
+
+fn bisect_state_is_good_side(terms: &BisectTerms, state: &str) -> bool {
+    state == terms.term_good
+        || (terms.term_good == "good" && state == "good")
+        || (terms.term_good == "old" && state == "old")
+}
+
 fn bisect_write(
     repo: &Repository,
     git_dir: &Path,
@@ -251,12 +308,14 @@ fn bisect_write(
     rev: &str,
     nolog: bool,
 ) -> Result<()> {
-    let oid = resolve_revision(repo, rev)
+    let oid = resolve_revision_as_commit(repo, rev)
         .with_context(|| format!("couldn't get the oid of the rev '{rev}'"))?;
-    let tag = if state == terms.term_bad {
+    let tag = if bisect_state_is_bad_side(terms, state) {
         format!("refs/bisect/{}", terms.term_bad)
-    } else if state == terms.term_good || state == "skip" {
-        format!("refs/bisect/{state}-{oid}")
+    } else if bisect_state_is_good_side(terms, state) {
+        format!("refs/bisect/{}-{oid}", terms.term_good)
+    } else if state == "skip" {
+        format!("refs/bisect/skip-{oid}")
     } else {
         bail!("Bad bisect_write argument: {state}");
     };
@@ -400,6 +459,21 @@ fn ensure_bisecting(git_dir: &Path) -> Result<()> {
     Ok(())
 }
 
+/// True when `BISECT_START` exists and is non-empty (Git: `bisect_autostart` gate).
+fn bisect_start_nonempty(git_dir: &Path) -> bool {
+    let p = bisect_state_dir(git_dir).join("BISECT_START");
+    fs::read_to_string(p)
+        .map(|s| !s.trim().is_empty())
+        .unwrap_or(false)
+}
+
+fn ensure_bisect_start_present(git_dir: &Path) -> Result<()> {
+    if bisect_start_nonempty(git_dir) {
+        return Ok(());
+    }
+    bail!("You need to start by \"git bisect start\"\n");
+}
+
 fn expected_rev_matches(git_dir: &Path, oid: ObjectId) -> bool {
     let path = bisect_state_dir(git_dir).join("BISECT_EXPECTED_REV");
     let Ok(s) = fs::read_to_string(path) else {
@@ -497,6 +571,7 @@ fn check_merge_bases(
         if no_checkout {
             refs::write_ref(git_dir, "BISECT_HEAD", &mb)?;
         } else {
+            verify_commit_tree_fully_readable(repo, mb)?;
             detach_head(repo, &mb, false).with_context(|| format!("checkout {}", mb.to_hex()))?;
         }
         bisect_checkout_show_commit(repo, mb)?;
@@ -755,6 +830,7 @@ fn bisect_next_all(repo: &Repository, git_dir: &Path, terms: &BisectTerms) -> Re
     if no_checkout {
         refs::write_ref(git_dir, "BISECT_HEAD", &mid_oid)?;
     } else {
+        verify_commit_tree_fully_readable(repo, mid_oid)?;
         detach_head(repo, &mid_oid, false)
             .with_context(|| format!("checkout {}", mid_oid.to_hex()))?;
     }
@@ -814,6 +890,7 @@ fn cmd_next(repo: &Repository, args: &[String]) -> Result<()> {
     }
     let git_dir = &repo.git_dir;
     ensure_bisecting(git_dir)?;
+    ensure_bisect_start_present(git_dir)?;
     let terms = BisectTerms::read(git_dir);
     match bisect_next_check(git_dir, &terms, Some(&terms.term_good), false)? {
         BisectNextGate::Proceed => {}
@@ -976,7 +1053,7 @@ fn cmd_start(repo: &Repository, args: &[String]) -> Result<()> {
                 bail!("unrecognized option: '{a}'");
             }
             _ => {
-                if resolve_revision(repo, arg).is_ok() {
+                if resolve_revision_as_commit(repo, arg).is_ok() {
                     positional_revs.push(arg.clone());
                     i += 1;
                 } else if has_double_dash {
@@ -1060,19 +1137,33 @@ fn cmd_start(repo: &Repository, args: &[String]) -> Result<()> {
         write_terms_file(git_dir, &terms.term_bad, &terms.term_good)?;
     }
 
-    let mut log = fs::OpenOptions::new()
+    fs::OpenOptions::new()
         .create(true)
         .write(true)
         .truncate(true)
         .open(state_dir.join("BISECT_LOG"))?;
+    if !no_checkout {
+        let start_oid = resolve_revision_as_commit(repo, &start_point)?;
+        verify_commit_tree_fully_readable(repo, start_oid)?;
+    }
     if !positional_revs.is_empty() {
+        if !no_checkout {
+            let bad_oid = resolve_revision_as_commit(repo, &positional_revs[0])?;
+            verify_commit_tree_fully_readable(repo, bad_oid)?;
+            for g in &positional_revs[1..] {
+                let oid = resolve_revision_as_commit(repo, g)?;
+                verify_commit_tree_fully_readable(repo, oid)?;
+            }
+        }
         let bad_rev = positional_revs[0].clone();
         bisect_write(repo, git_dir, &terms, &terms.term_bad, &bad_rev, true)?;
         for g in &positional_revs[1..] {
             bisect_write(repo, git_dir, &terms, &terms.term_good, g, true)?;
         }
-        writeln!(log, "git bisect start {}", sq_quote_argv(&raw_for_log))?;
-        drop(log);
+        append_bisect_log_raw(
+            git_dir,
+            &format!("git bisect start {}", sq_quote_argv(&raw_for_log)),
+        )?;
         let code = match bisect_next_all(repo, git_dir, &terms) {
             Ok(c) => c,
             Err(e) => {
@@ -1103,8 +1194,10 @@ fn cmd_start(repo: &Repository, args: &[String]) -> Result<()> {
         return Ok(());
     }
 
-    writeln!(log, "git bisect start {}", sq_quote_argv(&raw_for_log))?;
-    drop(log);
+    append_bisect_log_raw(
+        git_dir,
+        &format!("git bisect start {}", sq_quote_argv(&raw_for_log)),
+    )?;
     match bisect_auto_next(repo, git_dir, &terms) {
         Ok(_) => Ok(()),
         Err(e) => {
@@ -1134,7 +1227,8 @@ fn replay_bisect_state_line(
         .ok()
         .and_then(|s| ObjectId::from_hex(s.trim()).ok());
     for rev in &revs {
-        let oid = resolve_revision(repo, rev).with_context(|| format!("Bad rev input: {rev}"))?;
+        let oid = resolve_revision_as_commit(repo, rev)
+            .with_context(|| format!("Bad rev input: {rev}"))?;
         bisect_write(repo, git_dir, terms, cmd, rev, false)?;
         if verify_expected && Some(oid) != expected {
             let _ = fs::remove_file(state_dir.join("BISECT_ANCESTORS_OK"));
@@ -1152,6 +1246,7 @@ fn passive_state_cmd(
     args: &[String],
 ) -> Result<i32> {
     let git_dir = &repo.git_dir;
+    ensure_bisect_start_present(git_dir)?;
     check_and_set_terms(repo, git_dir, terms, cmd)?;
     if cmd == terms.term_bad && args.len() > 1 {
         bail!("'git bisect {cmd}' can take only one argument.");
@@ -1163,7 +1258,8 @@ fn passive_state_cmd(
     };
     let mut resolved: Vec<(String, ObjectId)> = Vec::with_capacity(revs.len());
     for rev in &revs {
-        let oid = resolve_revision(repo, rev).with_context(|| format!("Bad rev input: {rev}"))?;
+        let oid = resolve_revision_as_commit(repo, rev)
+            .with_context(|| format!("Bad rev input: {rev}"))?;
         resolved.push((rev.clone(), oid));
     }
     let state_dir = bisect_state_dir(git_dir);
@@ -1203,9 +1299,12 @@ fn expand_skip_args(repo: &Repository, args: &[String]) -> Result<Vec<String>> {
 }
 
 fn expand_range_to_commits(repo: &Repository, spec: &str) -> Result<Vec<ObjectId>> {
-    let mut opts = RevListOptions::default();
-    opts.reverse = true;
-    let res = rev_list(repo, &[spec.to_string()], &[], &opts)?;
+    let (positive, negative) = split_revision_token(spec);
+    if positive.is_empty() && negative.is_empty() {
+        return Ok(Vec::new());
+    }
+    let opts = RevListOptions::default();
+    let res = rev_list(repo, &positive, &negative, &opts)?;
     Ok(res.commits)
 }
 
@@ -1245,23 +1344,26 @@ fn check_and_set_terms(
 }
 
 fn cmd_bad(repo: &Repository, args: &[String]) -> Result<()> {
-    let git_dir = &repo.git_dir;
-    ensure_bisecting(git_dir)?;
-    let mut terms = BisectTerms::read(git_dir);
-    let state = terms.term_bad.clone();
-    let code = passive_state_cmd(repo, &mut terms, &state, args)?;
-    if code == 2 {
-        std::process::exit(2);
-    }
-    Ok(())
+    cmd_state_literal(repo, "bad", args)
+}
+
+fn cmd_new(repo: &Repository, args: &[String]) -> Result<()> {
+    cmd_state_literal(repo, "new", args)
 }
 
 fn cmd_good(repo: &Repository, args: &[String]) -> Result<()> {
+    cmd_state_literal(repo, "good", args)
+}
+
+fn cmd_old(repo: &Repository, args: &[String]) -> Result<()> {
+    cmd_state_literal(repo, "old", args)
+}
+
+fn cmd_state_literal(repo: &Repository, literal: &str, args: &[String]) -> Result<()> {
     let git_dir = &repo.git_dir;
     ensure_bisecting(git_dir)?;
     let mut terms = BisectTerms::read(git_dir);
-    let state = terms.term_good.clone();
-    let code = passive_state_cmd(repo, &mut terms, &state, args)?;
+    let code = passive_state_cmd(repo, &mut terms, literal, args)?;
     if code == 2 {
         std::process::exit(2);
     }
@@ -1270,6 +1372,7 @@ fn cmd_good(repo: &Repository, args: &[String]) -> Result<()> {
 
 fn bisect_skip_inner(repo: &Repository, args: &[String]) -> Result<i32> {
     let git_dir = &repo.git_dir;
+    ensure_bisect_start_present(git_dir)?;
     let mut terms = BisectTerms::read(git_dir);
     check_and_set_terms(repo, git_dir, &mut terms, "skip")?;
     let revs: Vec<String> = if args.is_empty() {
@@ -1279,7 +1382,8 @@ fn bisect_skip_inner(repo: &Repository, args: &[String]) -> Result<i32> {
     };
     let mut resolved: Vec<(String, ObjectId)> = Vec::with_capacity(revs.len());
     for rev in &revs {
-        let oid = resolve_revision(repo, rev).with_context(|| format!("skip revision: {rev}"))?;
+        let oid = resolve_revision_as_commit(repo, rev)
+            .with_context(|| format!("skip revision: {rev}"))?;
         resolved.push((rev.clone(), oid));
     }
     let state_dir = bisect_state_dir(git_dir);
@@ -1331,36 +1435,42 @@ fn cmd_replay(repo: &Repository, args: &[String]) -> Result<()> {
             continue;
         }
         let line = line.trim_start();
-        let rest = if let Some(r) = line.strip_prefix("git bisect ") {
+        let rest = if let Some(r) = line.strip_prefix("git bisect") {
             r
-        } else if let Some(r) = line.strip_prefix("git-bisect ") {
+        } else if let Some(r) = line.strip_prefix("git-bisect") {
             r
         } else {
             continue;
         };
-        let mut parts = rest.split_whitespace();
-        let Some(word) = parts.next() else { continue };
-        let rev_part = parts.collect::<Vec<_>>().join(" ");
+        let rest = rest.trim_start();
+        if rest.is_empty() {
+            continue;
+        }
+        let (word, rev_part) = first_bisect_replay_token_and_rest(rest);
+        if word.is_empty() {
+            continue;
+        }
         let mut terms = BisectTerms::read(git_dir);
         match word {
             "start" => {
                 let argv: Vec<String> = if rev_part.is_empty() {
                     Vec::new()
                 } else {
-                    parse_bisect_names_line(&rev_part)?
+                    parse_bisect_names_line(rev_part)?
                 };
                 cmd_start(repo, &argv)?;
             }
-            w if w == terms.term_bad => {
+            "terms" => {
+                let argv: Vec<String> = if rev_part.is_empty() {
+                    Vec::new()
+                } else {
+                    parse_bisect_names_line(rev_part)?
+                };
+                cmd_terms(repo, &argv)?;
+            }
+            w => {
                 replay_bisect_state_line(repo, git_dir, &mut terms, w, rev_part.trim())?;
             }
-            w if w == terms.term_good => {
-                replay_bisect_state_line(repo, git_dir, &mut terms, w, rev_part.trim())?;
-            }
-            "skip" => {
-                replay_bisect_state_line(repo, git_dir, &mut terms, "skip", rev_part.trim())?;
-            }
-            _ => {}
         }
     }
     let terms = BisectTerms::read(git_dir);
@@ -1400,11 +1510,32 @@ fn cmd_terms(repo: &Repository, args: &[String]) -> Result<()> {
         }
     }
     println!(
-        "Your current terms are {} for the old state\n\
-         and {} for the new state.\n",
+        "Your current terms are {} for the old state\nand {} for the new state.",
         terms.term_good, terms.term_bad
     );
     Ok(())
+}
+
+/// Redirects the process stdout to `fd` for the duration of `f`, then restores the original stdout.
+#[cfg(unix)]
+fn with_stdout_redirected_to_fd<T>(
+    fd: std::os::fd::RawFd,
+    f: impl FnOnce() -> Result<T>,
+) -> Result<T> {
+    use nix::unistd::{close, dup, dup2};
+    let _ = stdout().flush();
+    let out_target = stdout().as_raw_fd();
+    let saved = dup(out_target).context("dup stdout")?;
+    dup2(fd, out_target).context("dup2 stdout to bisect run file")?;
+    let result = f();
+    let _ = dup2(saved, out_target).context("restore stdout");
+    let _ = close(saved);
+    result
+}
+
+#[cfg(not(unix))]
+fn with_stdout_redirected_to_fd<T>(_fd: i32, f: impl FnOnce() -> Result<T>) -> Result<T> {
+    f()
 }
 
 fn cmd_run(repo: &Repository, args: &[String]) -> Result<()> {
@@ -1440,15 +1571,15 @@ fn cmd_run(repo: &Repository, args: &[String]) -> Result<()> {
         let mut child = sh_cmd
             .spawn()
             .with_context(|| format!("failed to execute: {display_cmd}"))?;
-        let stdout = child.stdout.take().context("bisect run stdout")?;
+        let child_stdout = child.stdout.take().context("bisect run stdout")?;
         let mut child = child;
         let (status, out) = std::thread::scope(|s| {
-            let h = s.spawn(|| std::io::read_to_string(stdout));
+            let h = s.spawn(|| std::io::read_to_string(child_stdout));
             let status = child.wait().expect("wait");
             let out = h.join().expect("join").unwrap_or_default();
             (status, out)
         });
-        let code = status.code().unwrap_or(1);
+        let code = status.code().unwrap_or(-1);
 
         if is_first && (code == 126 || code == 127) {
             is_first = false;
@@ -1461,15 +1592,11 @@ fn cmd_run(repo: &Repository, args: &[String]) -> Result<()> {
             }
         }
 
-        if !(0..128).contains(&code) {
+        if code < 0 || code >= 128 {
             bail!("bisect run failed: exit code {code} from {display_cmd} is < 0 or >= 128");
         }
 
-        let run_path = bisect_state_dir(git_dir).join("BISECT_RUN");
-        fs::write(&run_path, &out)?;
-        print!("{out}");
-
-        let new_state = if code == 125 {
+        let new_state_for_msg = if code == 125 {
             "skip"
         } else if code == 0 {
             "good"
@@ -1477,20 +1604,49 @@ fn cmd_run(repo: &Repository, args: &[String]) -> Result<()> {
             "bad"
         };
 
-        let next_code = if code == 125 {
-            bisect_skip_inner(repo, &[])?
-        } else if code == 0 {
-            let mut t = BisectTerms::read(git_dir);
-            let tg = t.term_good.clone();
-            passive_state_cmd(repo, &mut t, &tg, &[])?
-        } else {
-            let mut t = BisectTerms::read(git_dir);
-            let tb = t.term_bad.clone();
-            passive_state_cmd(repo, &mut t, &tb, &[])?
-        };
+        let run_path = bisect_state_dir(git_dir).join("BISECT_RUN");
+        let run_file = fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&run_path)
+            .context("BISECT_RUN")?;
+        let run_fd = run_file.as_raw_fd();
 
+        let next_result = with_stdout_redirected_to_fd(run_fd, || {
+            if code == 125 {
+                bisect_skip_inner(repo, &[])
+            } else if code == 0 {
+                let mut t = BisectTerms::read(git_dir);
+                let tg = t.term_good.clone();
+                passive_state_cmd(repo, &mut t, &tg, &[])
+            } else {
+                let mut t = BisectTerms::read(git_dir);
+                let tb = t.term_bad.clone();
+                passive_state_cmd(repo, &mut t, &tb, &[])
+            }
+        });
+
+        print!("{out}");
         let captured = fs::read_to_string(&run_path).unwrap_or_default();
         print!("{captured}");
+
+        let next_code = match next_result {
+            Ok(c) => c,
+            Err(_) if code == 0 && !bisect_log_exists(git_dir) => {
+                return Err(anyhow::Error::new(ExplicitExit {
+                    code: 1,
+                    message:
+                        "error: bisect run failed: 'git bisect good' exited with error code -1"
+                            .to_owned(),
+                }));
+            }
+            Err(e) => return Err(e),
+        };
+
+        if !bisect_log_exists(git_dir) {
+            break;
+        }
 
         if next_code == 2 {
             eprintln!("bisect run cannot continue any more");
@@ -1508,11 +1664,7 @@ fn cmd_run(repo: &Repository, args: &[String]) -> Result<()> {
             continue;
         }
         if next_code == 4 {
-            bail!("bisect run failed: 'git bisect {new_state}' exited with error code 4");
-        }
-
-        if !bisect_log_exists(git_dir) {
-            break;
+            bail!("bisect run failed: 'git bisect {new_state_for_msg}' exited with error code 4");
         }
     }
     Ok(())
@@ -1560,19 +1712,26 @@ fn cmd_visualize(repo: &Repository, args: &[String]) -> Result<()> {
             bail!("bisect visualize: need both good and bad");
         }
     }
+    let user = crate::preprocess_log_argv_for_spawn(args);
+    let split_at = user.iter().position(|a| a == "--");
+    let (before_dd, after_dd) = match split_at {
+        Some(i) => (&user[..i], &user[i + 1..]),
+        None => (user.as_slice(), &[][..]),
+    };
     let mut cmd_args: Vec<String> = Vec::new();
-    if args.is_empty() {
+    if before_dd.is_empty() {
         cmd_args.push("log".to_owned());
-    } else if args[0].starts_with('-') {
+    } else if before_dd[0].starts_with('-') {
         cmd_args.push("log".to_owned());
-        cmd_args.extend(args.iter().cloned());
+        cmd_args.extend(before_dd.iter().cloned());
     } else {
-        cmd_args.extend(args.iter().cloned());
+        cmd_args.extend(before_dd.iter().cloned());
     }
     cmd_args.push("--bisect".to_owned());
     cmd_args.push("--".to_owned());
     let names = read_bisect_pathspecs(git_dir)?;
     cmd_args.extend(names);
+    cmd_args.extend(after_dd.iter().cloned());
 
     let self_exe = std::env::current_exe().context("current_exe")?;
     let status = std::process::Command::new(&self_exe)
@@ -1602,6 +1761,12 @@ pub fn run(args: Args) -> Result<()> {
     }
 
     if subcmd.starts_with("--") {
+        if subcmd == "--help" || subcmd == "-h" {
+            println!(
+                "usage: git bisect [start|bad|good|skip|reset|log|run|terms|replay|visualize|view]"
+            );
+            return Ok(());
+        }
         bail!(
             "unknown option '{subcmd}'\n\
              usage: git bisect [reset|visualize|replay|...]"
@@ -1612,8 +1777,10 @@ pub fn run(args: Args) -> Result<()> {
 
     match subcmd {
         "start" => cmd_start(&repo, &rest),
-        "bad" | "new" => cmd_bad(&repo, &rest),
-        "good" | "old" => cmd_good(&repo, &rest),
+        "bad" => cmd_bad(&repo, &rest),
+        "new" => cmd_new(&repo, &rest),
+        "good" => cmd_good(&repo, &rest),
+        "old" => cmd_old(&repo, &rest),
         "skip" => cmd_skip(&repo, &rest),
         "reset" => cmd_reset(&repo, &rest),
         "log" => cmd_log(&repo),

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -3550,6 +3550,11 @@ fn preprocess_log_pickaxe_args(rest: Vec<String>) -> Vec<String> {
     out
 }
 
+/// Preprocess `git log` argv fragments (before clap) for spawning a child `grit log` process.
+pub(crate) fn preprocess_log_argv_for_spawn(rest: &[String]) -> Vec<String> {
+    preprocess_log_pickaxe_args(preprocess_log_args(rest))
+}
+
 fn preprocess_log_args(rest: &[String]) -> Vec<String> {
     let mut result = Vec::new();
     let mut saw_graph = false;
@@ -4094,7 +4099,11 @@ pub(crate) fn dispatch(subcmd: &str, rest: &[String], opts: &GlobalOpts) -> Resu
         "apply" => commands::apply::run(parse_cmd_args(subcmd, rest)),
         "archive" => commands::archive::run_from_argv(rest),
         "backfill" => commands::backfill::run(parse_cmd_args(subcmd, rest)),
-        "bisect" => commands::bisect::run(parse_cmd_args(subcmd, rest)),
+        // Bisect is parsed manually: upstream tests pass unknown `--bisect-*` flags that must
+        // reach `bisect::run` as Git-style "unknown option" errors, not clap parse failures.
+        "bisect" => commands::bisect::run(commands::bisect::Args {
+            args: rest.to_vec(),
+        }),
         "blame" => commands::blame::run(parse_cmd_args(subcmd, rest)),
         "branch" => commands::branch::run(parse_cmd_args(subcmd, rest)),
         "bugreport" => commands::bugreport::run(parse_cmd_args(subcmd, rest)),

--- a/logs/2026-04-09_t6030-bisect-porcelain.md
+++ b/logs/2026-04-09_t6030-bisect-porcelain.md
@@ -1,20 +1,27 @@
-# t6030-bisect-porcelain work log (2026-04-09)
+# t6030-bisect-porcelain (partial pass)
 
-## Changes
+## Summary
 
-- **Bisect state path**: All `BISECT_*` files use `bisect_state_dir` (common git dir) so linked worktrees share one session; `clean_bisect_state` removes loose `refs/bisect` under common dir.
-- **`bisect start`**: Skip restoring `BISECT_START` checkout from linked worktrees (`commondir` present) so test 8 pathspec-on-main does not move wt1 off `shared`. Use `--ignore-other-worktrees` when restoring saved branch from main repo. Removed premature `is_ancestor` check before state write; clean state on `bisect_auto_next` / `bisect_next_all` failure after writes. `detach_head(..., false)` for bisect checkouts so dirty trees fail like Git.
-- **`bisect replay`**: `cmd_reset` first; parse `git bisect start` args via `parse_bisect_names_line`; replay lines use `replay_bisect_state_line` (`bisect_write` only, no `bisect_auto_next` per line); final `bisect_auto_next`; use `ExplicitExit` for code 2 instead of `process::exit` inside replay.
-- **`bisect run`**: Shell execution via `sh -c` with `sq_quote_argv` command string; `ExplicitExit` for exit 2 when only skips remain (nested runs); stderr messages without extra quotes for t6030 `sed` filters; optional `p` env as `Np` from `hello` line count for `sed -ne $p` scripts.
-- **`git branch`**: List local/remotes via `refs::list_refs` so packed refs appear after `pack-refs` (fixes tests 15–19).
-- **`checkout`**: `switch_branch` respects `--ignore-other-worktrees` (bisect reset to branch checked out elsewhere).
-- **Refs/state**: Bisect refs and `state` bisect detection aligned with common dir where applicable.
+Improved `git bisect` compatibility for harness `t6030-bisect-porcelain.sh`.
 
-## Tests
+### Changes
 
-- Many early t6030 cases pass (through ~38 in direct `bash t6030` runs); full file still hits **FATAL** around **test 39** (`bisect run & skip: cannot tell between 2`) — needs further alignment with Git’s skip/ambiguous-commit listing (`error_if_skipped_commits` / rev walk).
-- `./scripts/run-tests.sh t6030-bisect-porcelain.sh` hits default **120s timeout** (file is large); use higher `--timeout` for harness runs.
+- **BISECT_LOG**: append `git bisect start …` after `bisect_write` lines (avoid truncating appended log).
+- **Terms**: align `check_term_format` with upstream C; fix `bisect terms` paragraph newline.
+- **State commands**: route literal `bad`/`good`/`new`/`old` through `passive_state_cmd`; map synonyms in `bisect_write` for custom terms.
+- **Replay**: tokenize replay lines like Git (`git bisect` + whitespace); handle `terms` subcommand; support CRLF.
+- **Skip ranges**: expand `A..B` via `split_revision_token` + `rev_list` (positive/negative), not single-spec resolve.
+- **bisect run**: redirect stdout to `BISECT_RUN` during state updates (dup2 via `nix`); detect cleared state via missing `BISECT_START`; match Git error for script deleting state.
+- **Main**: bypass clap for `bisect` argv so unknown `--bisect-*` matches Git usage.
+- **rev-parse**: `treeish:path` for rev-parse resolves directory leaves to subtree OID (`resolve_tree_path_rev_parse`); blob-at-path still uses blob-only walk.
+- **Bisect**: recursive `verify_commit_tree_fully_readable` for checkout-mode start/next; `bisect visualize` uses `preprocess_log_argv_for_spawn` and passes user `--` pathspecs after bisect names.
 
-## Note
+### Test result
 
-Reverted accidental `cargo clippy --fix` edits to unrelated commands (`cherry_pick`, `clean`, `sequencer`) before commit.
+`./scripts/run-tests.sh t6030-bisect-porcelain.sh`: **84/96** passing at last run.
+
+Remaining failures (12): path-restricted bisect / parallel skip chain, several `--no-checkout` broken-tree scenarios, ambiguous `bisect run`, skip-only log ordering, `bad HEAD` on parallel branch, custom-term skip, visualize with dash+space path.
+
+## Reason stopped
+
+`blocked` on remaining edge cases (pathspec/OR semantics vs Git for multi-path bisect, no-checkout broken trees, bisect run ambiguity) without further scope in this iteration.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves `git bisect` behavior to match upstream tests in `t6030-bisect-porcelain.sh`. Harness result after this change: **84/96** tests passing.

## Key changes

- **BISECT_LOG**: write `git bisect start` after `bisect_write` so the log is not truncated by a second open handle.
- **Terms / state**: Git-aligned term validation; literal `bad`/`good`/`new`/`old` subcommands; synonym handling in `bisect_write` for custom terms.
- **Replay**: Git-style line splitting; handle `terms` lines and CRLF logs; fix skip range expansion using `split_revision_token`.
- **bisect run**: capture stdout during state transitions to `BISECT_RUN` (via `nix` dup2); fail with Git-style message when the run script wipes bisect state (`BISECT_START` check).
- **CLI**: route `bisect` without clap so unknown `--bisect-*` options match Git’s usage text.
- **rev-parse**: `treeish:path` resolves a directory path to the subtree OID for `rev-parse`-style resolution (blob plumbing still requires a blob at the leaf).
- **Checkout bisect**: verify commits’ trees are fully readable before checkout-mode start; preprocess log argv for `bisect visualize`.

## Remaining failures (12)

Path-restricted bisect on parallel history, several `--no-checkout` broken-tree flows, ambiguous `bisect run`, skip-only log ordering, `bisect bad HEAD` on parallel branch, custom-term skip, and visualize with `-hello 2`-style pathspecs.

## Testing

- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t6030-bisect-porcelain.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9859739-15b8-4af8-8471-eda88eb754a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9859739-15b8-4af8-8471-eda88eb754a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

