### PR TITLE
fix(log): pass t4207-log-decoration-colors

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -828,7 +828,7 @@ t4205-log-pretty-formats	t4	yes	123	54	69	false	ok	2
 t4206-log-follow	t4	yes	26	26	0	true	ok	0
 t4206-log-follow-harder-copies	t4	yes	7	3	4	false	ok	0
 t4207-log-decoration	t4	yes	23	13	10	false	ok	0
-t4207-log-decoration-colors	t4	yes	4	1	3	false	ok	0
+t4207-log-decoration-colors	t4	yes	4	4	0	true	ok	0
 t4208-diff-pathspec-magic	t4	yes	22	21	1	false	ok	0
 t4208-log-magic-pathspec	t4	yes	21	13	8	false	ok	0
 t4209-log-pickaxe	t4	yes	48	47	1	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,689 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,689 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T22:01:37+00:00" class="gen-time" title="2026-04-09 22:01 UTC">2026-04-09 22:01 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,689</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -230,22 +230,22 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">73/178 files · 2 skipped · 2,862/4,438 tests</span>
+        <span class="group-meta">74/178 files · 2 skipped · 2,865/4,438 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.5%"></div></div>
-        <span class="group-pct pct-blue">64.5%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.6%"></div></div>
+        <span class="group-pct pct-blue">64.6%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35689 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,689 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T22:01:37+00:00" class="gen-time" title="2026-04-09 22:01 UTC">2026-04-09 22:01 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,689</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -8437,14 +8437,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.5%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="4" data-passed="1">
+<tr class="" data-group="t4" data-tests="4" data-passed="4" data-full-pass="1">
   <td class="mono">t4207-log-decoration-colors</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">4</td>
-  <td class="right">1</td>
+  <td class="right">4</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:25.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="22" data-passed="21">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit/src/commands/log.rs
+++ b/grit/src/commands/log.rs
@@ -10,7 +10,7 @@ use grit_lib::combined_tree_diff::{combined_diff_paths_filtered, CombinedTreeDif
 use grit_lib::commit_graph_file::{
     BloomPrecheck, BloomWalkStats, BloomWalkStatsHandle, CommitGraphChain,
 };
-use grit_lib::config::ConfigSet;
+use grit_lib::config::{parse_color, ConfigSet};
 use grit_lib::crlf::{get_file_attrs, load_gitattributes, DiffAttr};
 use grit_lib::diff::{
     count_changes, diff_trees, diff_trees_show_tree_entries, format_raw, unified_diff, zero_oid,
@@ -40,7 +40,7 @@ use grit_lib::rev_parse::{
 };
 use grit_lib::state::{resolve_head, HeadState};
 use regex::{Regex, RegexBuilder};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs::OpenOptions;
 use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
@@ -811,6 +811,13 @@ fn run_line_log(repo: &Repository, args: Args, _patch_context: usize) -> Result<
         c
     };
 
+    let head_state = resolve_head(&repo.git_dir).unwrap_or(HeadState::Invalid);
+    let decoration_paint = if use_color {
+        Some(load_decoration_paint(&repo.git_dir))
+    } else {
+        None
+    };
+
     let (start_oids, exclude_oids) = if args.all {
         (collect_all_ref_oids(&repo.git_dir)?, Vec::new())
     } else if args.revisions.is_empty() {
@@ -859,7 +866,7 @@ fn run_line_log(repo: &Repository, args: Args, _patch_context: usize) -> Result<
         .unwrap_or(50);
 
     let walk = walk_commits(
-        &repo.odb,
+        repo,
         &repo.git_dir,
         &[tip],
         None,
@@ -994,6 +1001,9 @@ fn run_line_log(repo: &Repository, args: Args, _patch_context: usize) -> Result<
                         decorations.as_ref(),
                         abbrev_len,
                         &parent_line,
+                        use_color,
+                        decoration_paint.as_ref(),
+                        &head_state,
                     );
                     writeln!(out, "{line_prefix}{line}{rendered}")?;
                     break;
@@ -1062,6 +1072,8 @@ fn run_line_log(repo: &Repository, args: Args, _patch_context: usize) -> Result<
             &args,
             decorations.as_ref(),
             use_color,
+            decoration_paint.as_ref(),
+            &head_state,
             &mut notes_cache,
             &repo.odb,
             parent_override.as_deref(),
@@ -1449,6 +1461,12 @@ fn run_graph_log(repo: &Repository, args: &Args, patch_context: usize) -> Result
     let line_prefix = args.line_prefix.as_deref().unwrap_or("");
     let abbrev_len = parse_abbrev(&args.abbrev);
     let use_color = log_resolve_stdout_color(args, &repo.git_dir);
+    let head_state = resolve_head(&repo.git_dir).unwrap_or(HeadState::Invalid);
+    let decoration_paint = if use_color {
+        Some(load_decoration_paint(&repo.git_dir))
+    } else {
+        None
+    };
     let show_commit_body = !args.suppress_diff
         && !args.no_patch
         && (args.patch
@@ -1491,6 +1509,9 @@ fn run_graph_log(repo: &Repository, args: &Args, patch_context: usize) -> Result
                     decorations.as_ref(),
                     abbrev_len,
                     &node.parents,
+                    use_color,
+                    decoration_paint.as_ref(),
+                    &head_state,
                 );
                 writeln!(out, "{line_prefix}{line}{rendered}")?;
                 break;
@@ -1517,6 +1538,8 @@ fn run_graph_log(repo: &Repository, args: &Args, patch_context: usize) -> Result
                 graph_stat_prefix.as_deref(),
                 decorations.as_ref(),
                 use_color,
+                decoration_paint.as_ref(),
+                &head_state,
                 &mut notes_cache,
                 patch_context,
             )?;
@@ -1880,17 +1903,42 @@ fn render_graph_commit_text(
     node: &GraphCommitNode,
     info: &CommitInfo,
     args: &Args,
-    decorations: Option<&std::collections::HashMap<String, Vec<String>>>,
+    decorations: Option<&DecorationMap>,
     abbrev_len: usize,
     parent_line: &[ObjectId],
+    use_color: bool,
+    decoration_paint: Option<&DecorationPaint>,
+    head_for_decor: &HeadState,
 ) -> String {
     let hex = node.oid.to_hex();
     if args.oneline || args.format.as_deref() == Some("oneline") {
         let first_line = info.message.lines().next().unwrap_or("");
-        let dec = format_decoration(&hex, decorations);
+        let oid_color = if use_color {
+            decoration_paint
+                .map(|p| p.commit.as_str())
+                .unwrap_or("\x1b[33m")
+        } else {
+            ""
+        };
+        let oid_reset = if use_color {
+            decoration_paint
+                .map(|p| p.reset.as_str())
+                .unwrap_or("\x1b[m")
+        } else {
+            ""
+        };
+        let dec = format_decoration(
+            &hex,
+            decorations,
+            use_color,
+            decoration_paint,
+            head_for_decor,
+        );
         return format!(
-            "{}{} {}",
+            "{}{}{}{} {}",
+            oid_color,
             &hex[..abbrev_len.min(hex.len())],
+            oid_reset,
             dec,
             first_line
         );
@@ -1912,7 +1960,9 @@ fn render_graph_commit_text(
                 decorations,
                 args.date.as_deref(),
                 abbrev_len,
-                false,
+                use_color,
+                decoration_paint,
+                head_for_decor,
                 None,
                 parent_line,
                 None,
@@ -1926,7 +1976,9 @@ fn render_graph_commit_text(
                 decorations,
                 args.date.as_deref(),
                 abbrev_len,
-                false,
+                use_color,
+                decoration_paint,
+                head_for_decor,
                 None,
                 parent_line,
                 None,
@@ -2618,6 +2670,12 @@ pub fn run(mut args: Args) -> Result<()> {
     let mut implied_pathspecs: Vec<String> = Vec::new();
 
     let use_color = log_resolve_stdout_color(&args, &repo.git_dir);
+    let head_state = resolve_head(&repo.git_dir).unwrap_or(HeadState::Invalid);
+    let decoration_paint = if use_color {
+        Some(load_decoration_paint(&repo.git_dir))
+    } else {
+        None
+    };
 
     if !args.walk_reflogs && !args.grep_reflog_patterns.is_empty() {
         anyhow::bail!("--grep-reflog can only be used with -g");
@@ -2947,6 +3005,7 @@ pub fn run(mut args: Args) -> Result<()> {
 
     if use_streaming_log {
         let mut iter = WalkCommitsIter::new(
+            &repo,
             &repo.odb,
             &repo.git_dir,
             &start_oids,
@@ -3012,6 +3071,8 @@ pub fn run(mut args: Args) -> Result<()> {
                 &args,
                 decoration_map_for_display.as_ref(),
                 use_color,
+                decoration_paint.as_ref(),
+                &head_state,
                 &mut notes_cache,
                 &repo.odb,
                 None,
@@ -3031,6 +3092,8 @@ pub fn run(mut args: Args) -> Result<()> {
                     None,
                     decoration_map_for_display.as_ref(),
                     use_color,
+                    decoration_paint.as_ref(),
+                    &head_state,
                     &mut notes_cache,
                     patch_context,
                 )?;
@@ -3042,7 +3105,7 @@ pub fn run(mut args: Args) -> Result<()> {
         }
     } else {
         let commits = walk_commits(
-            &repo.odb,
+            &repo,
             &repo.git_dir,
             &start_oids,
             if args.follow { None } else { args.max_count }, // follow needs full walk for rename tracking
@@ -3197,6 +3260,8 @@ pub fn run(mut args: Args) -> Result<()> {
                 &args,
                 decoration_map_for_display.as_ref(),
                 use_color,
+                decoration_paint.as_ref(),
+                &head_state,
                 &mut notes_cache,
                 &repo.odb,
                 None,
@@ -3216,6 +3281,8 @@ pub fn run(mut args: Args) -> Result<()> {
                     None,
                     decoration_map_for_display.as_ref(),
                     use_color,
+                    decoration_paint.as_ref(),
+                    &head_state,
                     &mut notes_cache,
                     patch_context,
                 )?;
@@ -3450,6 +3517,13 @@ pub fn run_no_walk(repo: &Repository, args: &Args, patch_context: usize) -> Resu
         || args.patch_with_stat;
 
     let mut notes_cache = NotesMapCache::new(repo);
+    let use_color = log_resolve_stdout_color(args, &repo.git_dir);
+    let head_state = resolve_head(&repo.git_dir).unwrap_or(HeadState::Invalid);
+    let decoration_paint = if use_color {
+        Some(load_decoration_paint(&repo.git_dir))
+    } else {
+        None
+    };
 
     for (i, (oid, commit_data)) in commits.iter().enumerate() {
         if is_format_separator && i > 0 {
@@ -3461,7 +3535,9 @@ pub fn run_no_walk(repo: &Repository, args: &Args, patch_context: usize) -> Resu
             commit_data,
             args,
             decorations.as_ref(),
-            false,
+            use_color,
+            decoration_paint.as_ref(),
+            &head_state,
             &mut notes_cache,
             &repo.odb,
             None,
@@ -3479,7 +3555,9 @@ pub fn run_no_walk(repo: &Repository, args: &Args, patch_context: usize) -> Resu
                 &args.pathspecs,
                 None,
                 decorations.as_ref(),
-                false,
+                use_color,
+                decoration_paint.as_ref(),
+                &head_state,
                 &mut notes_cache,
                 patch_context,
             )?;
@@ -4117,11 +4195,52 @@ struct CommitInfo {
     message: String,
 }
 
-/// Incremental commit walk matching [`walk_commits`] output order (date-ordered heap).
+/// Key for Git-style date ordering: newest committer (or author) date first; ties broken by FIFO
+/// (`seq`) then OID (matches `commit_list_insert_by_date` when timestamps collide).
+type CommitQueueKey = (std::cmp::Reverse<i64>, u64, ObjectId);
+
+/// Decoration category for `git log --decorate` coloring (`color.decorate.*`).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DecorationKind {
+    Branch,
+    RemoteBranch,
+    Tag,
+    Stash,
+    Head,
+    Grafted,
+}
+
+/// One ref (or synthetic label) attached to a commit for `--decorate` / `%d`.
+#[derive(Clone, Debug)]
+struct DecorationItem {
+    /// Full ref name when this came from a real ref (used for `HEAD -> branch` folding).
+    refname: Option<String>,
+    display: String,
+    kind: DecorationKind,
+}
+
+/// Parsed `color.decorate.*` and `diff.color.commit` sequences for log output.
+#[derive(Clone, Debug)]
+struct DecorationPaint {
+    commit: String,
+    reset: String,
+    branch: String,
+    remote_branch: String,
+    tag: String,
+    stash: String,
+    head: String,
+    grafted: String,
+}
+
+type DecorationMap = HashMap<String, Vec<DecorationItem>>;
+
+/// Incremental commit walk matching Git's `commit_list_insert_by_date` queue (not a max-heap on
+/// timestamp alone — ties preserve discovery order like upstream `revision.c`).
 ///
 /// Used by `grit log` to print commits as they are discovered instead of buffering
 /// the full history in a `Vec` first.
 struct WalkCommitsIter<'a> {
+    repo: &'a Repository,
     odb: &'a Odb,
     git_dir: &'a Path,
     pickaxe_args: Option<&'a Args>,
@@ -4133,8 +4252,10 @@ struct WalkCommitsIter<'a> {
     bloom_cwd: Option<String>,
     author_date_order: bool,
     shallow_boundaries: HashSet<ObjectId>,
-    visited: HashSet<ObjectId>,
-    queue: std::collections::BinaryHeap<(i64, ObjectId)>,
+    blocked: HashSet<ObjectId>,
+    enlisted: HashSet<ObjectId>,
+    queue: BTreeMap<CommitQueueKey, ()>,
+    next_seq: u64,
     skipped: usize,
     skip_n: usize,
     max_count: Option<usize>,
@@ -4152,6 +4273,7 @@ struct WalkCommitsIter<'a> {
 
 impl<'a> WalkCommitsIter<'a> {
     fn new(
+        repo: &'a Repository,
         odb: &'a Odb,
         git_dir: &'a Path,
         start: &[ObjectId],
@@ -4177,18 +4299,28 @@ impl<'a> WalkCommitsIter<'a> {
         author_date_order: bool,
     ) -> Self {
         let shallow_boundaries = load_shallow_boundaries(git_dir);
-        let visited: HashSet<ObjectId> = excluded.clone();
-        let mut queue: std::collections::BinaryHeap<(i64, ObjectId)> =
-            std::collections::BinaryHeap::new();
+        let blocked: HashSet<ObjectId> = excluded.clone();
+        let mut enlisted = HashSet::new();
+        let mut queue: BTreeMap<CommitQueueKey, ()> = BTreeMap::new();
+        let mut next_seq = 0u64;
         for oid in start {
+            if blocked.contains(oid) {
+                continue;
+            }
+            if !enlisted.insert(*oid) {
+                continue;
+            }
             let ts = if author_date_order {
-                read_author_timestamp(odb, oid)
+                read_author_timestamp_repo(repo, oid)
             } else {
-                read_commit_timestamp(odb, oid)
+                read_commit_timestamp_repo(repo, oid)
             };
-            queue.push((ts, *oid));
+            let key: CommitQueueKey = (std::cmp::Reverse(ts), next_seq, *oid);
+            next_seq = next_seq.saturating_add(1);
+            queue.insert(key, ());
         }
         Self {
+            repo,
             odb,
             git_dir,
             pickaxe_args,
@@ -4200,8 +4332,10 @@ impl<'a> WalkCommitsIter<'a> {
             bloom_cwd,
             author_date_order,
             shallow_boundaries,
-            visited,
+            blocked,
+            enlisted,
             queue,
+            next_seq,
             skipped: 0,
             skip_n: skip.unwrap_or(0),
             max_count,
@@ -4227,25 +4361,28 @@ impl<'a> WalkCommitsIter<'a> {
                 return Ok(None);
             }
         }
-        while let Some((_ts, oid)) = self.queue.pop() {
-            if !self.visited.insert(oid) {
-                continue;
-            }
+        while let Some((key, ())) = self.queue.pop_first() {
+            let oid = key.2;
 
-            let obj = self.odb.read(&oid)?;
+            let obj = self.repo.read_replaced(&oid)?;
             if obj.kind == ObjectKind::Tag {
                 let tag = parse_tag(&obj.data)?;
                 let mut target = tag.object;
                 loop {
-                    let t_obj = self.odb.read(&target)?;
+                    let t_obj = self.repo.read_replaced(&target)?;
                     match t_obj.kind {
                         ObjectKind::Commit => {
                             let ts = if self.author_date_order {
-                                read_author_timestamp(self.odb, &target)
+                                read_author_timestamp_repo(self.repo, &target)
                             } else {
-                                read_commit_timestamp(self.odb, &target)
+                                read_commit_timestamp_repo(self.repo, &target)
                             };
-                            self.queue.push((ts, target));
+                            if !self.blocked.contains(&target) && self.enlisted.insert(target) {
+                                let k: CommitQueueKey =
+                                    (std::cmp::Reverse(ts), self.next_seq, target);
+                                self.next_seq = self.next_seq.saturating_add(1);
+                                self.queue.insert(k, ());
+                            }
                             break;
                         }
                         ObjectKind::Tag => {
@@ -4270,22 +4407,28 @@ impl<'a> WalkCommitsIter<'a> {
             if !self.shallow_boundaries.contains(&oid) {
                 if self.first_parent {
                     if let Some(parent) = commit.parents.first() {
-                        let ts = if self.author_date_order {
-                            read_author_timestamp(self.odb, parent)
-                        } else {
-                            read_commit_timestamp(self.odb, parent)
-                        };
-                        self.queue.push((ts, *parent));
+                        if !self.blocked.contains(parent) && self.enlisted.insert(*parent) {
+                            let ts = if self.author_date_order {
+                                read_author_timestamp_repo(self.repo, parent)
+                            } else {
+                                read_commit_timestamp_repo(self.repo, parent)
+                            };
+                            let k: CommitQueueKey = (std::cmp::Reverse(ts), self.next_seq, *parent);
+                            self.next_seq = self.next_seq.saturating_add(1);
+                            self.queue.insert(k, ());
+                        }
                     }
                 } else {
                     for parent in &commit.parents {
-                        if !self.visited.contains(parent) {
+                        if !self.blocked.contains(parent) && self.enlisted.insert(*parent) {
                             let ts = if self.author_date_order {
-                                read_author_timestamp(self.odb, parent)
+                                read_author_timestamp_repo(self.repo, parent)
                             } else {
-                                read_commit_timestamp(self.odb, parent)
+                                read_commit_timestamp_repo(self.repo, parent)
                             };
-                            self.queue.push((ts, *parent));
+                            let k: CommitQueueKey = (std::cmp::Reverse(ts), self.next_seq, *parent);
+                            self.next_seq = self.next_seq.saturating_add(1);
+                            self.queue.insert(k, ());
                         }
                     }
                 }
@@ -4386,7 +4529,7 @@ fn collect_reachable(odb: &Odb, starts: &[ObjectId]) -> Result<HashSet<ObjectId>
 }
 
 fn walk_commits(
-    odb: &Odb,
+    repo: &Repository,
     git_dir: &Path,
     start: &[ObjectId],
     max_count: Option<usize>,
@@ -4413,7 +4556,9 @@ fn walk_commits(
     if max_count == Some(0) {
         return Ok(Vec::new());
     }
+    let odb = &repo.odb;
     let mut iter = WalkCommitsIter::new(
+        repo,
         odb,
         git_dir,
         start,
@@ -4578,8 +4723,28 @@ fn read_commit_timestamp(odb: &Odb, oid: &ObjectId) -> i64 {
     }
 }
 
+fn read_commit_timestamp_repo(repo: &Repository, oid: &ObjectId) -> i64 {
+    match repo.read_replaced(oid) {
+        Ok(obj) => match parse_commit(&obj.data) {
+            Ok(commit) => committer_unix_seconds_for_ordering(&commit.committer),
+            Err(_) => 0,
+        },
+        Err(_) => 0,
+    }
+}
+
 fn read_author_timestamp(odb: &Odb, oid: &ObjectId) -> i64 {
     match odb.read(oid) {
+        Ok(obj) => match parse_commit(&obj.data) {
+            Ok(commit) => committer_unix_seconds_for_ordering(&commit.author),
+            Err(_) => 0,
+        },
+        Err(_) => 0,
+    }
+}
+
+fn read_author_timestamp_repo(repo: &Repository, oid: &ObjectId) -> i64 {
+    match repo.read_replaced(oid) {
         Ok(obj) => match parse_commit(&obj.data) {
             Ok(commit) => committer_unix_seconds_for_ordering(&commit.author),
             Err(_) => 0,
@@ -5118,7 +5283,7 @@ fn commit_passes_post_walk_filters(
     diff_filter: Option<&str>,
     find_oid: Option<ObjectId>,
     find_object_tree_recursive: bool,
-    decorations: Option<&std::collections::HashMap<String, Vec<String>>>,
+    decorations: Option<&DecorationMap>,
     since_threshold: Option<i64>,
     until_threshold: Option<i64>,
 ) -> Result<bool> {
@@ -5244,6 +5409,13 @@ fn run_symmetric_log(repo: &Repository, args: &Args, _patch_context: usize) -> R
     let stdout = io::stdout();
     let mut out = stdout.lock();
     let mut notes_cache = NotesMapCache::new(repo);
+    let use_color = log_resolve_stdout_color(args, &repo.git_dir);
+    let head_state = resolve_head(&repo.git_dir).unwrap_or(HeadState::Invalid);
+    let decoration_paint = if use_color {
+        Some(load_decoration_paint(&repo.git_dir))
+    } else {
+        None
+    };
 
     for oid in ordered {
         let is_boundary = boundary_set.contains(&oid);
@@ -5263,7 +5435,9 @@ fn run_symmetric_log(repo: &Repository, args: &Args, _patch_context: usize) -> R
             &info,
             args,
             None,
-            false,
+            use_color,
+            decoration_paint.as_ref(),
+            &head_state,
             &mut notes_cache,
             &repo.odb,
             None,
@@ -5285,8 +5459,10 @@ fn format_commit(
     oid: &ObjectId,
     info: &CommitInfo,
     args: &Args,
-    decorations: Option<&std::collections::HashMap<String, Vec<String>>>,
+    decorations: Option<&DecorationMap>,
     use_color: bool,
+    decoration_paint: Option<&DecorationPaint>,
+    head_for_decor: &HeadState,
     notes_cache: &mut NotesMapCache<'_>,
     odb: &Odb,
     parent_line_override: Option<&[ObjectId]>,
@@ -5310,11 +5486,33 @@ fn format_commit(
 
     if args.oneline || args.format.as_deref() == Some("oneline") {
         let first_line = info.message.lines().next().unwrap_or("");
-        let dec = format_decoration(&hex, decorations);
+        let oid_color = if use_color {
+            decoration_paint
+                .map(|p| p.commit.as_str())
+                .unwrap_or("\x1b[33m")
+        } else {
+            ""
+        };
+        let oid_reset = if use_color {
+            decoration_paint
+                .map(|p| p.reset.as_str())
+                .unwrap_or("\x1b[m")
+        } else {
+            ""
+        };
+        let dec = format_decoration(
+            &hex,
+            decorations,
+            use_color,
+            decoration_paint,
+            head_for_decor,
+        );
         writeln!(
             out,
-            "{}{} {}",
+            "{}{}{}{} {}",
+            oid_color,
             &hex[..abbrev_len.min(hex.len())],
+            oid_reset,
             dec,
             first_line
         )?;
@@ -5341,6 +5539,8 @@ fn format_commit(
                 date_format,
                 abbrev_len,
                 use_color,
+                decoration_paint,
+                head_for_decor,
                 note_bytes,
                 display_parents,
                 log_marker,
@@ -5356,7 +5556,13 @@ fn format_commit(
             }
         }
         Some("short") => {
-            let dec = format_decoration(&hex, decorations);
+            let dec = format_decoration(
+                &hex,
+                decorations,
+                use_color,
+                decoration_paint,
+                head_for_decor,
+            );
             writeln!(out, "commit {hex}{merge_suffix}{dec}")?;
             if display_parents.len() > 1 {
                 let parent_abbrevs: Vec<String> = display_parents
@@ -5377,9 +5583,21 @@ fn format_commit(
             writeln!(out)?;
         }
         Some("medium") | None => {
-            let dec = format_decoration(&hex, decorations);
+            let dec = format_decoration(
+                &hex,
+                decorations,
+                use_color,
+                decoration_paint,
+                head_for_decor,
+            );
             if use_color {
-                writeln!(out, "\x1b[33mcommit {hex}{merge_suffix}\x1b[m{dec}")?;
+                let c = decoration_paint
+                    .map(|p| p.commit.as_str())
+                    .unwrap_or("\x1b[33m");
+                let r = decoration_paint
+                    .map(|p| p.reset.as_str())
+                    .unwrap_or("\x1b[m");
+                writeln!(out, "{c}commit {hex}{merge_suffix}{r}{dec}")?;
             } else {
                 writeln!(out, "commit {hex}{merge_suffix}{dec}")?;
             }
@@ -5406,7 +5624,13 @@ fn format_commit(
             write_notes(out, oid, notes_cache, args, odb)?;
         }
         Some("full") => {
-            let dec = format_decoration(&hex, decorations);
+            let dec = format_decoration(
+                &hex,
+                decorations,
+                use_color,
+                decoration_paint,
+                head_for_decor,
+            );
             writeln!(out, "commit {hex}{merge_suffix}{dec}")?;
             if display_parents.len() > 1 {
                 let parent_abbrevs: Vec<String> = display_parents
@@ -5428,7 +5652,13 @@ fn format_commit(
             writeln!(out)?;
         }
         Some("fuller") => {
-            let dec = format_decoration(&hex, decorations);
+            let dec = format_decoration(
+                &hex,
+                decorations,
+                use_color,
+                decoration_paint,
+                head_for_decor,
+            );
             writeln!(out, "commit {hex}{merge_suffix}{dec}")?;
             if display_parents.len() > 1 {
                 let parent_abbrevs: Vec<String> = display_parents
@@ -5480,6 +5710,8 @@ fn format_commit(
                 date_format,
                 abbrev_len,
                 use_color,
+                decoration_paint,
+                head_for_decor,
                 note_bytes,
                 display_parents,
                 log_marker,
@@ -5496,10 +5728,12 @@ fn apply_format_string(
     template: &str,
     oid: &ObjectId,
     info: &CommitInfo,
-    decorations: Option<&std::collections::HashMap<String, Vec<String>>>,
+    decorations: Option<&DecorationMap>,
     date_format: Option<&str>,
     abbrev_len: usize,
     use_color: bool,
+    decoration_paint: Option<&DecorationPaint>,
+    head_for_decor: &HeadState,
     notes_raw: Option<&[u8]>,
     display_parents: &[ObjectId],
     log_marker: Option<char>,
@@ -5864,13 +6098,25 @@ fn apply_format_string(
                 Some('d') => {
                     chars.next();
                     // Decorations
-                    let dec = format_decoration(&hex, decorations);
+                    let dec = format_decoration(
+                        &hex,
+                        decorations,
+                        use_color,
+                        decoration_paint,
+                        head_for_decor,
+                    );
                     result.push_str(&dec);
                 }
                 Some('D') => {
                     chars.next();
                     // Decorations without parens
-                    let dec = format_decoration_no_parens(&hex, decorations);
+                    let dec = format_decoration_no_parens(
+                        &hex,
+                        decorations,
+                        use_color,
+                        decoration_paint,
+                        head_for_decor,
+                    );
                     result.push_str(&dec);
                 }
                 Some('n') => {
@@ -6400,107 +6646,173 @@ fn is_likely_pathspec_during_rev_parse(token: &str) -> bool {
         || token.contains(']')
 }
 
-/// Collect ref name → OID decorations from the repository.
-fn collect_decorations(
-    repo: &Repository,
-    full: bool,
-) -> Result<std::collections::HashMap<String, Vec<String>>> {
-    let mut map: std::collections::HashMap<String, Vec<String>> = std::collections::HashMap::new();
-
-    // HEAD
-    let head = resolve_head(&repo.git_dir)?;
-    if let Some(oid) = head.oid() {
-        let hex = oid.to_hex();
-        let label = match &head {
-            HeadState::Branch { short_name, .. } => {
-                if full {
-                    format!("HEAD -> refs/heads/{short_name}")
-                } else {
-                    format!("HEAD -> {short_name}")
-                }
-            }
-            _ => "HEAD".to_owned(),
-        };
-        map.entry(hex).or_default().push(label);
+fn replace_ref_base() -> String {
+    let mut base =
+        std::env::var("GIT_REPLACE_REF_BASE").unwrap_or_else(|_| "refs/replace/".to_owned());
+    if !base.ends_with('/') {
+        base.push('/');
     }
-
-    if full {
-        collect_refs_from_dir(
-            &repo.odb,
-            &repo.git_dir.join("refs/heads"),
-            "refs/heads/",
-            "refs/heads/",
-            &mut map,
-        )?;
-        collect_refs_from_dir(
-            &repo.odb,
-            &repo.git_dir.join("refs/tags"),
-            "refs/tags/",
-            "tag: refs/tags/",
-            &mut map,
-        )?;
-    } else {
-        collect_refs_from_dir(
-            &repo.odb,
-            &repo.git_dir.join("refs/heads"),
-            "refs/heads/",
-            "",
-            &mut map,
-        )?;
-        collect_refs_from_dir(
-            &repo.odb,
-            &repo.git_dir.join("refs/tags"),
-            "refs/tags/",
-            "tag: ",
-            &mut map,
-        )?;
-    }
-
-    // De-duplicate while preserving order.
-    for refs in map.values_mut() {
-        let mut seen = std::collections::HashSet::new();
-        refs.retain(|r| seen.insert(r.clone()));
-    }
-
-    Ok(map)
+    base
 }
 
-/// Recursively collect refs from a directory.
-fn collect_refs_from_dir(
-    odb: &Odb,
-    dir: &std::path::Path,
-    strip_prefix: &str,
-    display_prefix: &str,
-    map: &mut std::collections::HashMap<String, Vec<String>>,
-) -> Result<()> {
-    let entries = match std::fs::read_dir(dir) {
-        Ok(e) => e,
-        Err(_) => return Ok(()),
+fn load_decoration_paint(git_dir: &Path) -> DecorationPaint {
+    let cfg = ConfigSet::load(Some(git_dir), true).unwrap_or_default();
+    let slot = |key: &str, default: &str| {
+        cfg.get(key)
+            .and_then(|s| parse_color(s.trim()).ok())
+            .unwrap_or_else(|| default.to_string())
     };
+    DecorationPaint {
+        commit: cfg
+            .get("diff.color.commit")
+            .and_then(|s| parse_color(s.trim()).ok())
+            .unwrap_or_else(|| "\x1b[33m".to_string()),
+        reset: slot("color.decorate.reset", "\x1b[m"),
+        branch: slot("color.decorate.branch", "\x1b[1;32m"),
+        remote_branch: slot("color.decorate.remoteBranch", "\x1b[1;31m"),
+        tag: slot("color.decorate.tag", "\x1b[1;33m"),
+        stash: slot("color.decorate.stash", "\x1b[1;35m"),
+        head: slot("color.decorate.HEAD", "\x1b[1;36m"),
+        grafted: slot("color.decorate.grafted", "\x1b[1;34m"),
+    }
+}
 
-    for entry in entries {
-        let entry = entry?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_refs_from_dir(odb, &path, strip_prefix, display_prefix, map)?;
-        } else if let Ok(content) = std::fs::read_to_string(&path) {
-            let hex = content.trim();
-            let full_ref = path.to_string_lossy();
-            if let Some(idx) = full_ref.find(strip_prefix) {
-                let name = &full_ref[idx + strip_prefix.len()..];
-                let label = format!("{display_prefix}{name}");
-                // Dereference annotated tags to the commit they point at
-                let resolved_hex = if display_prefix.contains("tag") {
-                    peel_to_commit_hex(odb, hex).unwrap_or_else(|| hex.to_owned())
-                } else {
-                    hex.to_owned()
-                };
-                map.entry(resolved_hex).or_default().push(label);
+fn color_for_decoration_kind(paint: &DecorationPaint, kind: DecorationKind) -> &str {
+    match kind {
+        DecorationKind::Branch => &paint.branch,
+        DecorationKind::RemoteBranch => &paint.remote_branch,
+        DecorationKind::Tag => &paint.tag,
+        DecorationKind::Stash => &paint.stash,
+        DecorationKind::Head => &paint.head,
+        DecorationKind::Grafted => &paint.grafted,
+    }
+}
+
+fn prepend_decoration(items: &mut Vec<DecorationItem>, item: DecorationItem) {
+    items.insert(0, item);
+}
+
+/// Collect ref decorations from the repository (heads, tags, remotes, stash, replace refs, HEAD).
+///
+/// Order matches Git's `refs_for_each_ref` walk: each ref is **prepended** in ascending ref-name
+/// order, so the final per-commit list matches upstream (e.g. `tag: A1` before `other/main` before
+/// `other/HEAD`).
+fn collect_decorations(repo: &Repository, full: bool) -> Result<DecorationMap> {
+    let mut map: DecorationMap = HashMap::new();
+    let git_dir = &repo.git_dir;
+    let odb = &repo.odb;
+
+    let head = resolve_head(git_dir)?;
+    let rep_base = replace_ref_base();
+
+    let mut all_refs = grit_lib::refs::list_refs(git_dir, "refs/")?;
+    all_refs.sort_by(|a, b| a.0.cmp(&b.0));
+
+    for (refname, oid) in all_refs {
+        if refname.starts_with(&rep_base) {
+            let Some(rest) = refname.strip_prefix(&rep_base) else {
+                continue;
+            };
+            let rest = rest.trim();
+            if rest.len() != 40 || rest.parse::<ObjectId>().is_err() {
+                continue;
             }
+            prepend_decoration(
+                map.entry(rest.to_owned()).or_default(),
+                DecorationItem {
+                    refname: None,
+                    display: "replaced".to_owned(),
+                    kind: DecorationKind::Grafted,
+                },
+            );
+            continue;
+        }
+
+        if refname == "refs/stash" || refname.starts_with("refs/stash/") {
+            let hex = peel_to_commit_hex(odb, &oid.to_hex()).unwrap_or_else(|| oid.to_hex());
+            prepend_decoration(
+                map.entry(hex).or_default(),
+                DecorationItem {
+                    refname: Some("refs/stash".to_string()),
+                    display: "refs/stash".to_owned(),
+                    kind: DecorationKind::Stash,
+                },
+            );
+            continue;
+        }
+
+        if let Some(rest) = refname.strip_prefix("refs/heads/") {
+            let display = if full {
+                refname.clone()
+            } else {
+                rest.to_owned()
+            };
+            let hex = peel_to_commit_hex(odb, &oid.to_hex()).unwrap_or_else(|| oid.to_hex());
+            prepend_decoration(
+                map.entry(hex).or_default(),
+                DecorationItem {
+                    refname: Some(refname.clone()),
+                    display,
+                    kind: DecorationKind::Branch,
+                },
+            );
+            continue;
+        }
+
+        if let Some(rest) = refname.strip_prefix("refs/tags/") {
+            let display = if full {
+                refname.clone()
+            } else {
+                rest.to_owned()
+            };
+            let peeled = peel_to_commit_hex(odb, &oid.to_hex()).unwrap_or_else(|| oid.to_hex());
+            prepend_decoration(
+                map.entry(peeled).or_default(),
+                DecorationItem {
+                    refname: Some(refname.clone()),
+                    display,
+                    kind: DecorationKind::Tag,
+                },
+            );
+            continue;
+        }
+
+        if let Some(rest) = refname.strip_prefix("refs/remotes/") {
+            let display = if full {
+                refname.clone()
+            } else {
+                rest.to_owned()
+            };
+            let peeled = peel_to_commit_hex(odb, &oid.to_hex()).unwrap_or_else(|| oid.to_hex());
+            prepend_decoration(
+                map.entry(peeled).or_default(),
+                DecorationItem {
+                    refname: Some(refname.clone()),
+                    display,
+                    kind: DecorationKind::RemoteBranch,
+                },
+            );
         }
     }
 
-    Ok(())
+    if let Some(oid) = head.oid() {
+        let hex = oid.to_hex();
+        prepend_decoration(
+            map.entry(hex).or_default(),
+            DecorationItem {
+                refname: Some("HEAD".to_string()),
+                display: "HEAD".to_owned(),
+                kind: DecorationKind::Head,
+            },
+        );
+    }
+
+    for items in map.values_mut() {
+        let mut seen = HashSet::new();
+        items.retain(|it| seen.insert(it.display.clone()));
+    }
+
+    Ok(map)
 }
 
 /// Peel an object (possibly a tag) down to a commit and return its hex.
@@ -6524,38 +6836,126 @@ fn peel_to_commit_hex(odb: &Odb, hex: &str) -> Option<String> {
     }
 }
 
-/// Format decoration string for a commit (with parentheses).
-fn format_decoration(
-    hex: &str,
-    decorations: Option<&std::collections::HashMap<String, Vec<String>>>,
-) -> String {
-    match decorations {
-        Some(map) => {
-            if let Some(refs) = map.get(hex) {
-                format!(" ({})", refs.join(", "))
-            } else {
-                String::new()
-            }
-        }
-        None => String::new(),
-    }
+fn current_branch_decoration_index(items: &[DecorationItem], head: &HeadState) -> Option<usize> {
+    let refname = match head {
+        HeadState::Branch { refname, .. } => refname.as_str(),
+        _ => return None,
+    };
+    items
+        .iter()
+        .position(|it| it.kind == DecorationKind::Branch && it.refname.as_deref() == Some(refname))
 }
 
-/// Format decoration string without parentheses (for %D).
-fn format_decoration_no_parens(
+/// Format decoration string for a commit (with parentheses), matching Git's `format_decorations`.
+fn format_decoration(
     hex: &str,
-    decorations: Option<&std::collections::HashMap<String, Vec<String>>>,
+    decorations: Option<&DecorationMap>,
+    use_color: bool,
+    paint: Option<&DecorationPaint>,
+    head: &HeadState,
 ) -> String {
-    match decorations {
-        Some(map) => {
-            if let Some(refs) = map.get(hex) {
-                refs.join(", ")
+    let Some(map) = decorations else {
+        return String::new();
+    };
+    let Some(items) = map.get(hex) else {
+        return String::new();
+    };
+    if items.is_empty() {
+        return String::new();
+    }
+
+    const TAG: &str = "tag: ";
+    const POINTER: &str = " -> ";
+    const SEP: &str = ", ";
+
+    let skip_idx = current_branch_decoration_index(items, head);
+    let paint_opt = if use_color { paint } else { None };
+
+    let mut out = String::new();
+    let mut sep_prefix: &str = " (";
+
+    for (i, it) in items.iter().enumerate() {
+        if skip_idx == Some(i) {
+            continue;
+        }
+
+        if let Some(p) = paint_opt {
+            out.push_str(&p.commit);
+            out.push_str(sep_prefix);
+            out.push_str(&p.reset);
+        } else {
+            out.push_str(sep_prefix);
+        }
+        sep_prefix = SEP;
+
+        if it.kind == DecorationKind::Tag {
+            if let Some(p) = paint_opt {
+                out.push_str(color_for_decoration_kind(p, DecorationKind::Tag));
+                out.push_str(TAG);
+                out.push_str(&p.reset);
             } else {
-                String::new()
+                out.push_str(TAG);
             }
         }
-        None => String::new(),
+
+        if let Some(p) = paint_opt {
+            out.push_str(color_for_decoration_kind(p, it.kind));
+            out.push_str(&it.display);
+            out.push_str(&p.reset);
+        } else {
+            out.push_str(&it.display);
+        }
+
+        if it.kind == DecorationKind::Head {
+            if let Some(bi) = skip_idx {
+                let branch = &items[bi];
+                if let Some(p) = paint_opt {
+                    out.push_str(&p.commit);
+                    out.push_str(POINTER);
+                    out.push_str(&p.reset);
+                    out.push_str(color_for_decoration_kind(p, branch.kind));
+                } else {
+                    out.push_str(POINTER);
+                }
+                let d = &branch.display;
+                if branch.kind == DecorationKind::Tag && d.starts_with(TAG) {
+                    out.push_str(d.trim_start_matches(TAG));
+                } else {
+                    out.push_str(d);
+                }
+                if let Some(p) = paint_opt {
+                    out.push_str(&p.reset);
+                }
+            }
+        }
     }
+
+    if !out.is_empty() {
+        if let Some(p) = paint_opt {
+            out.push_str(&p.commit);
+            out.push(')');
+            out.push_str(&p.reset);
+        } else {
+            out.push(')');
+        }
+    }
+    out
+}
+
+/// Format decoration string without parentheses (for `%D`).
+fn format_decoration_no_parens(
+    hex: &str,
+    decorations: Option<&DecorationMap>,
+    use_color: bool,
+    paint: Option<&DecorationPaint>,
+    head: &HeadState,
+) -> String {
+    let inner = format_decoration(hex, decorations, use_color, paint, head);
+    inner
+        .strip_prefix(" (")
+        .and_then(|s| s.strip_suffix(')'))
+        .unwrap_or("")
+        .to_owned()
 }
 
 // ── Diff output for log ──────────────────────────────────────────────
@@ -6637,8 +7037,10 @@ fn write_commit_diff(
     args: &Args,
     pathspecs: &[String],
     graph_stat_prefix: Option<&str>,
-    decorations: Option<&std::collections::HashMap<String, Vec<String>>>,
+    decorations: Option<&DecorationMap>,
     use_color: bool,
+    decoration_paint: Option<&DecorationPaint>,
+    head_for_decor: &HeadState,
     notes_cache: &mut NotesMapCache<'_>,
     patch_context: usize,
 ) -> Result<()> {
@@ -6701,6 +7103,8 @@ fn write_commit_diff(
                     args,
                     decorations,
                     use_color,
+                    decoration_paint,
+                    head_for_decor,
                     notes_cache,
                     odb,
                     None,
@@ -7153,82 +7557,34 @@ fn log_read_blob_pair(odb: &Odb, entry: &DiffEntry) -> Result<(String, String)> 
     Ok((old_content, new_content))
 }
 
-/// Collect all commit OIDs from all refs (branches, tags, etc.) for --all.
+/// Collect all commit OIDs from all refs (branches, tags, etc.) for `--all`.
+///
+/// Tips are returned in **sorted ref-name order** (like Git's `refs_for_each_ref`), not in
+/// arbitrary discovery order, so `log --all` matches upstream when committer dates tie.
 fn collect_all_ref_oids(git_dir: &std::path::Path) -> Result<Vec<ObjectId>> {
-    use std::fs;
-    let mut oids = Vec::new();
-    let mut seen = HashSet::new();
+    let mut pairs: Vec<(String, ObjectId)> = Vec::new();
 
-    // Reftable backend
     if grit_lib::reftable::is_reftable_repo(git_dir) {
         if let Ok(refs) = grit_lib::reftable::reftable_list_refs(git_dir, "refs/") {
-            for (_name, oid) in refs {
-                if seen.insert(oid) {
-                    oids.push(oid);
-                }
-            }
+            pairs.extend(refs);
         }
-        return Ok(oids);
-    }
-
-    // Loose refs
-    collect_oids_from_dir(git_dir, &git_dir.join("refs"), &mut oids, &mut seen)?;
-
-    // Packed refs
-    let packed_path = git_dir.join("packed-refs");
-    if let Ok(text) = fs::read_to_string(packed_path) {
-        for line in text.lines() {
-            if line.starts_with('#') || line.starts_with('^') || line.is_empty() {
-                continue;
-            }
-            if let Some(hex) = line.split_whitespace().next() {
-                if let Ok(oid) = hex.parse::<ObjectId>() {
-                    if seen.insert(oid) {
-                        oids.push(oid);
-                    }
-                }
-            }
+    } else {
+        pairs.extend(grit_lib::refs::list_refs(git_dir, "refs/")?);
+        if let Ok(head_oid) = grit_lib::refs::resolve_ref(git_dir, "HEAD") {
+            pairs.push(("HEAD".to_owned(), head_oid));
         }
     }
 
+    pairs.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut oids = Vec::new();
+    let mut seen = HashSet::new();
+    for (_, oid) in pairs {
+        if seen.insert(oid) {
+            oids.push(oid);
+        }
+    }
     Ok(oids)
-}
-
-fn collect_oids_from_dir(
-    git_dir: &std::path::Path,
-    dir: &std::path::Path,
-    oids: &mut Vec<ObjectId>,
-    seen: &mut HashSet<ObjectId>,
-) -> Result<()> {
-    use std::fs;
-    let entries = match fs::read_dir(dir) {
-        Ok(e) => e,
-        Err(_) => return Ok(()),
-    };
-    for entry in entries {
-        let entry = entry?;
-        let ft = entry.file_type()?;
-        if ft.is_dir() {
-            collect_oids_from_dir(git_dir, &entry.path(), oids, seen)?;
-        } else if ft.is_file() {
-            if let Ok(content) = fs::read_to_string(entry.path()) {
-                let raw = content.trim();
-                if let Some(target) = raw.strip_prefix("ref: ") {
-                    // Symbolic ref — resolve it
-                    if let Ok(oid) = grit_lib::refs::resolve_ref(git_dir, target) {
-                        if seen.insert(oid) {
-                            oids.push(oid);
-                        }
-                    }
-                } else if let Ok(oid) = raw.parse::<ObjectId>() {
-                    if seen.insert(oid) {
-                        oids.push(oid);
-                    }
-                }
-            }
-        }
-    }
-    Ok(())
 }
 
 /// Check if a commit does NOT have any changes of the excluded types (for lowercase diff-filter).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible `git log --decorate --color` behavior so `t4207-log-decoration-colors.sh` passes (4/4).

## Changes

- **Decoration collection**: Walk all `refs/` in sorted order (prepend per ref, like Git), including remotes (including `other/HEAD`), stash, replace refs (`GIT_REPLACE_REF_BASE`), and HEAD folding with the current branch.
- **ANSI coloring**: Parse `color.decorate.*` and `diff.color.commit`; format `%d` / oneline output to match Git's `format_decorations` structure (commit wrapper, tag prefix, `HEAD -> branch`).
- **Walk order**: Replace the old `(timestamp, oid)` max-heap with a `BTreeMap` queue keyed by `(Reverse(ts), seq, oid)` plus Git-style enlist tracking so equal timestamps preserve discovery order; `--all` tips come from refs sorted by name.
- **Replace objects**: `WalkCommitsIter` reads commits through `Repository::read_replaced` so `git replace` affects log history and replace decorations line up.

## Validation

- `./scripts/run-tests.sh t4207-log-decoration-colors.sh` → 4/4
- `cargo test -p grit-lib --lib`
- `cargo fmt` / `cargo clippy -p grit-rs --fix --allow-dirty`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48d0d582-c3ea-42c5-a397-fb4053f71ddd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48d0d582-c3ea-42c5-a397-fb4053f71ddd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

