### PR TITLE
fix: protocol v2 bundle-uri over git:// (t5731)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1025,7 +1025,7 @@ t5704-protocol-violations	t5	yes	3	3	0	true	ok	0
 t5705-session-id-in-capabilities	t5	yes	0	0	0	false	timeout	0
 t5710-promisor-remote-capability	t5	yes	22	1	21	false	ok	0
 t5730-protocol-v2-bundle-uri-file	t5	yes	8	8	0	true	ok	0
-t5731-protocol-v2-bundle-uri-git	t5	yes	8	2	6	false	ok	0
+t5731-protocol-v2-bundle-uri-git	t5	yes	8	8	0	true	ok	0
 t5732-protocol-v2-bundle-uri-http	t5	yes	9	3	6	false	ok	0
 t5750-bundle-uri-parse	t5	yes	13	13	0	true	ok	0
 t5801-remote-helpers	t5	skip	35	0	0	false	ok	1

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,692 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,692 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T22:04:22+00:00" class="gen-time" title="2026-04-09 22:04 UTC">2026-04-09 22:04 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,692</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">34/167 files · 17 skipped · 1,572/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:38.0%"></div></div>
+        <span class="group-pct pct-red">38.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35692 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,692 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T22:04:22+00:00" class="gen-time" title="2026-04-09 22:04 UTC">2026-04-09 22:04 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,692</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -10407,14 +10407,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="8" data-passed="2">
+<tr class="" data-group="t5" data-tests="8" data-passed="8" data-full-pass="1">
   <td class="mono">t5731-protocol-v2-bundle-uri-git</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">8</td>
-  <td class="right">2</td>
+  <td class="right">8</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:25.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="9" data-passed="3">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit/src/commands/clone.rs
+++ b/grit/src/commands/clone.rs
@@ -1269,7 +1269,7 @@ fn run_git_clone(args: Args) -> Result<()> {
     let remote_name = resolve_remote_name(&args)?;
     let ref_storage = resolved_clone_ref_storage(&args)?;
     let url = args.repository.clone();
-    let parsed = crate::fetch_transport::parse_git_url(&url)?;
+    let parsed = crate::git_daemon_url::parse_git_url(&url)?;
     let path_tail = parsed.path.trim_start_matches('/');
     let base = Path::new(path_tail)
         .file_name()

--- a/grit/src/commands/ls_remote.rs
+++ b/grit/src/commands/ls_remote.rs
@@ -68,6 +68,10 @@ pub fn run(args: Args) -> Result<()> {
     }
 
     let repo_path_str = effective_path.to_string_lossy();
+    if repo_path_str.starts_with("git://") && crate::file_upload_pack_v2::client_wants_protocol_v2()
+    {
+        return crate::file_upload_pack_v2::ls_remote_git_v2(repo_path_str.as_ref(), &args);
+    }
     let is_file_url = repo_path_str.starts_with("file://");
     if is_file_url && crate::file_upload_pack_v2::client_wants_protocol_v2() {
         let path = PathBuf::from(

--- a/grit/src/commands/push.rs
+++ b/grit/src/commands/push.rs
@@ -651,7 +651,7 @@ fn push_to_url(
         wire_trace::trace_packet_push('<', "version 1");
     }
     if url.starts_with("git://") && protocol_wire::effective_client_protocol_version() == 1 {
-        if let Ok(parsed) = crate::fetch_transport::parse_git_url(url) {
+        if let Ok(parsed) = crate::git_daemon_url::parse_git_url(url) {
             let virtual_host = std::env::var("GIT_OVERRIDE_VIRTUAL_HOST")
                 .unwrap_or_else(|_| format!("{}:{}", parsed.host, parsed.port));
             let show = format!(

--- a/grit/src/fetch_transport.rs
+++ b/grit/src/fetch_transport.rs
@@ -4,10 +4,8 @@
 use std::cell::Cell;
 use std::collections::{HashMap, HashSet};
 use std::io::{Read, Write};
-use std::net::{TcpStream, ToSocketAddrs};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
 use grit_lib::diff::zero_oid;
@@ -991,66 +989,12 @@ pub(crate) fn fetch_upload_pack_negotiate_pack_bytes_with_streams(
 /// `git://host:port/repo` URL to that on-disk repository so local commands can open it.
 pub fn try_local_path_for_git_daemon_url(url: &str) -> Option<std::path::PathBuf> {
     let root = std::env::var("GIT_DAEMON_DOCUMENT_ROOT_PATH").ok()?;
-    let parsed = parse_git_url(url).ok()?;
+    let parsed = crate::git_daemon_url::parse_git_url(url).ok()?;
     let rel = parsed.path.trim_start_matches('/');
     if rel.is_empty() {
         return None;
     }
     Some(std::path::Path::new(&root).join(rel))
-}
-
-/// Parsed `git://host[:port]/path` (path includes leading `/`).
-pub struct GitDaemonUrl {
-    pub host: String,
-    pub port: u16,
-    pub path: String,
-}
-
-/// Parse `git://` URLs for the native Git daemon transport.
-pub fn parse_git_url(url: &str) -> Result<GitDaemonUrl> {
-    let rest = url
-        .strip_prefix("git://")
-        .with_context(|| format!("not a git:// URL: {url}"))?;
-    let (authority, path_part) = rest
-        .find('/')
-        .map(|i| (&rest[..i], &rest[i..]))
-        .unwrap_or((rest, "/"));
-    if path_part.is_empty() || path_part == "/" {
-        bail!("git:// URL missing repository path");
-    }
-    let path = path_part.to_string();
-    let (host, port) = if authority.starts_with('[') {
-        let end = authority
-            .find(']')
-            .with_context(|| format!("invalid git:// authority: {authority}"))?;
-        let host = authority[1..end].to_string();
-        let port = if let Some(p) = authority[end + 1..].strip_prefix(':') {
-            p.parse::<u16>()
-                .with_context(|| format!("invalid port in git:// URL: {url}"))?
-        } else {
-            9418
-        };
-        (host, port)
-    } else if let Some((h, p)) = authority.rsplit_once(':') {
-        let h = h.trim_end_matches(':');
-        if p.is_empty() {
-            (h.to_string(), 9418)
-        } else if p.chars().all(|c| c.is_ascii_digit()) {
-            (
-                h.to_string(),
-                p.parse::<u16>()
-                    .with_context(|| format!("invalid port in git:// URL: {url}"))?,
-            )
-        } else {
-            (authority.to_string(), 9418)
-        }
-    } else {
-        (authority.to_string(), 9418)
-    };
-    if host.is_empty() {
-        bail!("git:// URL has empty host");
-    }
-    Ok(GitDaemonUrl { host, port, path })
 }
 
 /// Fetch over `git://` (native daemon) using upload-pack negotiation.
@@ -1064,40 +1008,8 @@ pub fn fetch_via_git_protocol_skipping(
     Option<String>,
     Option<ObjectId>,
 )> {
-    let parsed = parse_git_url(url)?;
-    let addr = format!("{}:{}", parsed.host, parsed.port)
-        .to_socket_addrs()
-        .with_context(|| format!("could not resolve git://{}:{}", parsed.host, parsed.port))?
-        .next()
-        .with_context(|| format!("no addresses for git://{}:{}", parsed.host, parsed.port))?;
-    let mut stream = TcpStream::connect_timeout(&addr, Duration::from_secs(30))
-        .with_context(|| format!("could not connect to git://{}:{}", parsed.host, parsed.port))?;
-    let _ = stream.set_read_timeout(Some(Duration::from_secs(600)));
-    let _ = stream.set_write_timeout(Some(Duration::from_secs(600)));
-
-    let mut stream_w = stream
-        .try_clone()
-        .context("dup git:// socket for simultaneous read/write")?;
-    let client_proto = protocol_wire::effective_client_protocol_version();
-    let virtual_host = std::env::var("GIT_OVERRIDE_VIRTUAL_HOST")
-        .unwrap_or_else(|_| format!("{}:{}", parsed.host, parsed.port));
-    let mut inner: Vec<u8> = Vec::new();
-    inner.extend_from_slice(b"git-upload-pack ");
-    inner.extend_from_slice(parsed.path.as_bytes());
-    inner.push(0);
-    inner.extend_from_slice(b"host=");
-    inner.extend_from_slice(virtual_host.as_bytes());
-    inner.push(0);
-    if client_proto > 0 {
-        inner.push(0);
-        inner.extend_from_slice(format!("version={client_proto}\0").as_bytes());
-    }
-    pkt_line::write_packet_raw(&mut stream_w, &inner).context("write git:// request")?;
-    stream_w.flush().ok();
-
-    let trace_show = String::from_utf8_lossy(&inner)
-        .replace('\0', "\\0")
-        .replace('\n', "");
+    let (mut stream_w, mut stream, trace_show) =
+        crate::git_daemon_url::connect_git_daemon_upload_pack(url)?;
     trace_packet_fetch('>', &trace_show);
 
     let (advertised, head_symref) = read_advertisement(&mut stream)?;

--- a/grit/src/file_upload_pack_v2.rs
+++ b/grit/src/file_upload_pack_v2.rs
@@ -1,6 +1,9 @@
 //! Protocol v2 over local `grit upload-pack` for `file://` URLs (tests, `ls-remote`, clone).
+//!
+//! Also supports `git://` against a real `git-daemon` (or compatible) for the same v2 flows.
 
 use std::io::{Cursor, Read, Write};
+use std::net::Shutdown;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
@@ -596,6 +599,105 @@ pub(crate) fn fetch_bundle_uri_lines_file(repo_url: &str) -> Result<Vec<(String,
             "upload-pack exited with status {}",
             status.code().unwrap_or(-1)
         );
+    }
+    Ok(pairs)
+}
+
+/// Protocol v2 `ls-remote` over `git://` (system `git-daemon` + upstream `upload-pack`).
+pub(crate) fn ls_remote_git_v2(url: &str, args: &crate::commands::ls_remote::Args) -> Result<()> {
+    let default_hash = std::env::var("GIT_DEFAULT_HASH").unwrap_or_else(|_| "sha1".to_owned());
+    let (mut stdin, mut stdout, _) = crate::git_daemon_url::connect_git_daemon_upload_pack(url)?;
+    let caps = read_v2_capability_block(&mut stdout)?;
+    let bundle_advertised = server_advertises_bundle_uri(&caps);
+
+    if bundle_advertised && transfer_bundle_uri_enabled() {
+        let cap_send = cap_lines_for_bundle_request(&caps);
+        write_bundle_uri_command(&mut stdin, &cap_send)?;
+        drain_bundle_uri_response(&mut stdout)?;
+    }
+
+    pkt_line::write_line(&mut stdin, "command=ls-refs")?;
+    trace_packet_git('>', "command=ls-refs");
+    let agent = format!("agent=git/{}-", crate::version_string());
+    pkt_line::write_line(&mut stdin, &agent)?;
+    trace_packet_git('>', agent.trim_end());
+    pkt_line::write_line(&mut stdin, &format!("object-format={default_hash}"))?;
+    trace_packet_git('>', &format!("object-format={default_hash}"));
+    pkt_line::write_delim(&mut stdin)?;
+    trace_packet_git('>', "0001");
+    if args.symref {
+        pkt_line::write_line(&mut stdin, "symrefs")?;
+        trace_packet_git('>', "symrefs");
+    }
+    if !args.refs_only {
+        pkt_line::write_line(&mut stdin, "peel")?;
+        trace_packet_git('>', "peel");
+    }
+    if args.heads {
+        pkt_line::write_line(&mut stdin, "ref-prefix refs/heads/")?;
+        trace_packet_git('>', "ref-prefix refs/heads/");
+    }
+    if args.tags {
+        pkt_line::write_line(&mut stdin, "ref-prefix refs/tags/")?;
+        trace_packet_git('>', "ref-prefix refs/tags/");
+    }
+    for p in &args.patterns {
+        let line = format!("ref-prefix {p}");
+        pkt_line::write_line(&mut stdin, &line)?;
+        trace_packet_git('>', &line);
+    }
+    pkt_line::write_flush(&mut stdin)?;
+    trace_packet_git('>', "0000");
+    stdin.flush()?;
+    let mut buf = Vec::new();
+    read_pkt_lines_until_flush(&mut stdout, &mut buf, 512 * 1024)
+        .context("read v2 ls-refs response (git://)")?;
+    let _ = stdin.shutdown(Shutdown::Write);
+    let mut drain = Vec::new();
+    let _ = stdout.take(64 * 1024).read_to_end(&mut drain);
+
+    let entries = crate::commands::ls_remote::parse_v2_ls_refs_output(&buf, args)?;
+    if entries.is_empty() {
+        return Ok(());
+    }
+    if args.quiet {
+        return Ok(());
+    }
+    for entry in &entries {
+        if let Some(target) = &entry.symref_target {
+            println!("ref: {target}\t{}", entry.name);
+        }
+        println!("{}\t{}", entry.oid, entry.name);
+    }
+    Ok(())
+}
+
+/// Fetch `bundle.*` lines from a `git://` remote via upload-pack v2.
+pub(crate) fn fetch_bundle_uri_lines_git(repo_url: &str) -> Result<Vec<(String, String)>> {
+    let (mut stdin, mut stdout, _) =
+        crate::git_daemon_url::connect_git_daemon_upload_pack(repo_url)?;
+    let caps = read_v2_capability_block(&mut stdout)?;
+    if !server_advertises_bundle_uri(&caps) {
+        bail!("server does not advertise bundle-uri");
+    }
+    let cap_send = cap_lines_for_bundle_request(&caps);
+    write_bundle_uri_command(&mut stdin, &cap_send)?;
+    let _ = stdin.shutdown(Shutdown::Write);
+    let mut pairs = Vec::new();
+    loop {
+        match pkt_line::read_packet(&mut stdout).context("read bundle-uri response")? {
+            None => break,
+            Some(pkt_line::Packet::Flush) => break,
+            Some(pkt_line::Packet::Data(line)) => {
+                trace_packet_git('<', &line);
+                let (k, v) = line
+                    .split_once('=')
+                    .filter(|(k, v)| !k.is_empty() && !v.is_empty())
+                    .ok_or_else(|| anyhow::anyhow!("malformed bundle-uri line: {line}"))?;
+                pairs.push((k.to_string(), v.to_string()));
+            }
+            Some(other) => bail!("unexpected bundle-uri packet: {other:?}"),
+        }
     }
     Ok(pairs)
 }

--- a/grit/src/git_daemon_url.rs
+++ b/grit/src/git_daemon_url.rs
@@ -1,0 +1,107 @@
+//! Parse `git://` URLs and connect to a Git daemon (upload-pack).
+
+use std::io::Write;
+use std::net::{TcpStream, ToSocketAddrs};
+use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+
+use crate::pkt_line;
+use crate::protocol_wire;
+
+/// Parsed `git://host[:port]/path` (path includes leading `/`).
+pub struct GitDaemonUrl {
+    pub host: String,
+    pub port: u16,
+    pub path: String,
+}
+
+/// Parse `git://` URLs for the native Git daemon transport.
+pub fn parse_git_url(url: &str) -> Result<GitDaemonUrl> {
+    let rest = url
+        .strip_prefix("git://")
+        .with_context(|| format!("not a git:// URL: {url}"))?;
+    let (authority, path_part) = rest
+        .find('/')
+        .map(|i| (&rest[..i], &rest[i..]))
+        .unwrap_or((rest, "/"));
+    if path_part.is_empty() || path_part == "/" {
+        bail!("git:// URL missing repository path");
+    }
+    let path = path_part.to_string();
+    let (host, port) = if authority.starts_with('[') {
+        let end = authority
+            .find(']')
+            .with_context(|| format!("invalid git:// authority: {authority}"))?;
+        let host = authority[1..end].to_string();
+        let port = if let Some(p) = authority[end + 1..].strip_prefix(':') {
+            p.parse::<u16>()
+                .with_context(|| format!("invalid port in git:// URL: {url}"))?
+        } else {
+            9418
+        };
+        (host, port)
+    } else if let Some((h, p)) = authority.rsplit_once(':') {
+        let h = h.trim_end_matches(':');
+        if p.is_empty() {
+            (h.to_string(), 9418)
+        } else if p.chars().all(|c| c.is_ascii_digit()) {
+            (
+                h.to_string(),
+                p.parse::<u16>()
+                    .with_context(|| format!("invalid port in git:// URL: {url}"))?,
+            )
+        } else {
+            (authority.to_string(), 9418)
+        }
+    } else {
+        (authority.to_string(), 9418)
+    };
+    if host.is_empty() {
+        bail!("git:// URL has empty host");
+    }
+    Ok(GitDaemonUrl { host, port, path })
+}
+
+/// Open a TCP connection to `git://` and complete the daemon request line so upload-pack speaks
+/// pkt-line on the socket (duplex read/write halves).
+///
+/// The third return value is the request payload (NULs escaped) for `GIT_TRACE_PACKET` when matching
+/// upstream `git fetch` / `git clone` traces.
+pub fn connect_git_daemon_upload_pack(url: &str) -> Result<(TcpStream, TcpStream, String)> {
+    let parsed = parse_git_url(url)?;
+    let addr = format!("{}:{}", parsed.host, parsed.port)
+        .to_socket_addrs()
+        .with_context(|| format!("could not resolve git://{}:{}", parsed.host, parsed.port))?
+        .next()
+        .with_context(|| format!("no addresses for git://{}:{}", parsed.host, parsed.port))?;
+    let stream = TcpStream::connect_timeout(&addr, Duration::from_secs(30))
+        .with_context(|| format!("could not connect to git://{}:{}", parsed.host, parsed.port))?;
+    let _ = stream.set_read_timeout(Some(Duration::from_secs(600)));
+    let _ = stream.set_write_timeout(Some(Duration::from_secs(600)));
+
+    let mut stream_w = stream
+        .try_clone()
+        .context("dup git:// socket for simultaneous read/write")?;
+    let client_proto = protocol_wire::effective_client_protocol_version();
+    let virtual_host = std::env::var("GIT_OVERRIDE_VIRTUAL_HOST")
+        .unwrap_or_else(|_| format!("{}:{}", parsed.host, parsed.port));
+    let mut inner: Vec<u8> = Vec::new();
+    inner.extend_from_slice(b"git-upload-pack ");
+    inner.extend_from_slice(parsed.path.as_bytes());
+    inner.push(0);
+    inner.extend_from_slice(b"host=");
+    inner.extend_from_slice(virtual_host.as_bytes());
+    inner.push(0);
+    if client_proto > 0 {
+        inner.push(0);
+        inner.extend_from_slice(format!("version={client_proto}\0").as_bytes());
+    }
+    pkt_line::write_packet_raw(&mut stream_w, &inner).context("write git:// request")?;
+    stream_w.flush().ok();
+
+    let trace_show = String::from_utf8_lossy(&inner)
+        .replace('\0', "\\0")
+        .replace('\n', "");
+    Ok((stream_w, stream, trace_show))
+}

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -25,6 +25,7 @@ mod fetch_transport;
 mod file_upload_pack_v2;
 mod git_column;
 mod git_commit_encoding;
+mod git_daemon_url;
 mod git_path;
 mod grit_exe;
 mod http_bundle_uri;
@@ -4710,6 +4711,8 @@ pub(crate) fn dispatch(subcmd: &str, rest: &[String], opts: &GlobalOpts) -> Resu
                             }
                             let pairs = if url.starts_with("file://") {
                                 crate::file_upload_pack_v2::fetch_bundle_uri_lines_file(url)
+                            } else if url.starts_with("git://") {
+                                crate::file_upload_pack_v2::fetch_bundle_uri_lines_git(url)
                             } else {
                                 crate::http_bundle_uri::fetch_bundle_uri_lines_http(url)
                             }

--- a/logs/2026-04-09_t5731-git-bundle-uri.md
+++ b/logs/2026-04-09_t5731-git-bundle-uri.md
@@ -1,0 +1,5 @@
+# t5731-protocol-v2-bundle-uri-git
+
+- **Issue:** `ls-remote` and `test-tool bundle-uri ls-remote` only handled `file://` and HTTP; `git://` fell through to local path open and failed. Packet traces for v2 caps used wrong identity in some paths.
+- **Change:** Added `git_daemon_url` module (parse `git://`, connect + daemon request pkt). `file_upload_pack_v2`: `ls_remote_git_v2`, `fetch_bundle_uri_lines_git` reusing same v2 bundle-uri + ls-refs flow as `file://`. Wired `ls_remote` and test-tool dispatch. `fetch_transport` uses shared connect helper.
+- **Verify:** `./scripts/run-tests.sh t5731-protocol-v2-bundle-uri-git.sh` → 8/8; `cargo test -p grit-lib --lib`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t5731-protocol-v2-bundle-uri-git` exercises protocol v2 `bundle-uri` over the native `git://` transport (system `git-daemon`). Grit only spoke v2 `ls-refs` / `bundle-uri` for `file://` and HTTP, so `ls-remote` and `test-tool bundle-uri ls-remote` failed on `git://`.

## Changes

- Add `grit/src/git_daemon_url.rs`: parse `git://` URLs, open TCP, send the daemon request pkt-line (with `GIT_OVERRIDE_VIRTUAL_HOST` / `protocol.version`), return duplex streams plus the trace string for fetch.
- Refactor `fetch_transport` to use the shared connector (removes duplicated parse/connect).
- In `file_upload_pack_v2`: `ls_remote_git_v2` and `fetch_bundle_uri_lines_git` mirror the existing `file://` v2 flow (cap block, optional `bundle-uri` command when `transfer.bundleURI` is on, then `ls-refs` for ls-remote).
- Wire `ls-remote` and `test-tool bundle-uri ls-remote` for `git://` URLs.

## Verification

- `./scripts/run-tests.sh t5731-protocol-v2-bundle-uri-git.sh` → 8/8
- `cargo test -p grit-lib --lib`
- `cargo clippy -p grit-rs`

Dashboard CSV/HTML updated from the harness run.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0e8603e-7f03-427a-9188-d25f90885eb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0e8603e-7f03-427a-9188-d25f90885eb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

