### PR TITLE
fix: make t1005-read-tree-reset fully pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -92,7 +92,7 @@ t1002-read-tree-m-u-2way	t1	yes	22	22	0	true	ok	0
 t10020-update-ref-stdin-batch	t1	yes	33	33	0	true	ok	0
 t1003-read-tree-prefix	t1	yes	3	3	0	true	ok	0
 t1004-read-tree-m-u-wf	t1	yes	17	16	1	false	ok	0
-t1005-read-tree-reset	t1	yes	7	3	4	false	ok	0
+t1005-read-tree-reset	t1	yes	7	7	0	true	ok	0
 t1006-cat-file	t1	yes	291	291	0	true	ok	0
 t10060-hash-object-determinism	t1	yes	34	34	0	true	ok	0
 t1007-hash-object	t1	yes	40	34	6	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,690 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,690 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T22:04:41+00:00" class="gen-time" title="2026-04-09 22:04 UTC">2026-04-09 22:04 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,690</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -197,11 +197,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">275/368 files · 8 skipped · 11,694/12,747 tests</span>
+        <span class="group-meta">276/368 files · 8 skipped · 11,698/12,747 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:91.7%"></div></div>
-        <span class="group-pct pct-green">91.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:91.8%"></div></div>
+        <span class="group-pct pct-green">91.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t2">
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35690 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,690 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T22:04:41+00:00" class="gen-time" title="2026-04-09 22:04 UTC">2026-04-09 22:04 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,690</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -1077,14 +1077,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:94.1%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="7" data-passed="3">
+<tr class="" data-group="t1" data-tests="7" data-passed="7" data-full-pass="1">
   <td class="mono">t1005-read-tree-reset</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">7</td>
-  <td class="right">3</td>
+  <td class="right">7</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:42.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="291" data-passed="291" data-full-pass="1">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit/src/commands/checkout.rs
+++ b/grit/src/commands/checkout.rs
@@ -2274,6 +2274,8 @@ fn force_reset_to_head(repo: &Repository) -> Result<()> {
         None => bail!("this operation must be run in a work tree"),
     };
 
+    let old_index = repo.load_index().unwrap_or_else(|_| Index::new());
+
     // Build index from the target tree and force-write all entries
     let new_entries = tree_to_flat_entries(repo, &target_tree, "")?;
     let mut new_index = Index::new();
@@ -2285,6 +2287,10 @@ fn force_reset_to_head(repo: &Repository) -> Result<()> {
         .iter()
         .filter(|e| e.stage() == 0 && e.mode != 0o160000)
         .count();
+
+    // Remove paths gone from the index (including unmerged-only conflict remnants) then match
+    // `force_reset_to_tree` / Git's `checkout -f` (t1005).
+    checkout_index_to_worktree(repo, &old_index, &new_index, &work_tree, true)?;
 
     // Write every entry to the worktree (force overwrite)
     for entry in &new_index.entries {
@@ -4715,6 +4721,54 @@ fn checkout_index_to_worktree(
             }
         }
         remove_empty_parent_dirs(work_tree, &abs);
+    }
+
+    // Paths that only had unmerged index entries (no stage 0) are not in `old_stage0`, so the
+    // removal loop above misses them. Drop their worktree files when they are gone from the new
+    // index (t1005-read-tree-reset, `checkout -f`).
+    let new_all_paths: std::collections::HashSet<Vec<u8>> =
+        new_index.entries.iter().map(|e| e.path.clone()).collect();
+    let old_unmerged_paths: std::collections::HashSet<Vec<u8>> = old_index
+        .entries
+        .iter()
+        .filter(|e| e.stage() != 0)
+        .map(|e| e.path.clone())
+        .collect();
+    for path in &old_unmerged_paths {
+        if !new_all_paths.contains(path) {
+            let rel = String::from_utf8_lossy(path).into_owned();
+            let abs = work_tree.join(&rel);
+            let path_through_symlink = {
+                let mut p = work_tree.to_path_buf();
+                let mut through_sym = false;
+                for component in std::path::Path::new(&rel).components() {
+                    p.push(component);
+                    if let Ok(meta) = std::fs::symlink_metadata(&p) {
+                        if meta.file_type().is_symlink() && p != abs {
+                            through_sym = true;
+                            break;
+                        }
+                    }
+                }
+                through_sym
+            };
+            if path_through_symlink {
+                continue;
+            }
+            if abs.is_file() || abs.is_symlink() {
+                let _ = std::fs::remove_file(&abs);
+            } else if abs.is_dir() {
+                let is_populated_submodule = old_index
+                    .entries
+                    .iter()
+                    .filter(|e| e.path == *path)
+                    .any(|e| e.mode == MODE_GITLINK && abs.join(".git").exists());
+                if !is_populated_submodule {
+                    let _ = std::fs::remove_dir_all(&abs);
+                }
+            }
+            remove_empty_parent_dirs(work_tree, &abs);
+        }
     }
 
     // Sparse checkout: paths still in the index but newly excluded must disappear from the work tree.

--- a/grit/src/commands/read_tree.rs
+++ b/grit/src/commands/read_tree.rs
@@ -872,6 +872,8 @@ fn checkout_index_entries(repo: &Repository, old_index: &Index, new_index: &Inde
         .filter(|e| e.stage() == 0)
         .map(|e| e.path.clone())
         .collect();
+    let new_all_paths: HashSet<Vec<u8>> =
+        new_index.entries.iter().map(|e| e.path.clone()).collect();
     let old_stage0 = stage0_index_map(old_index);
     let config = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
     let conv = crlf::ConversionConfig::from_config(&config);
@@ -893,6 +895,28 @@ fn checkout_index_entries(repo: &Repository, old_index: &Index, new_index: &Inde
             let _ = std::fs::remove_dir_all(&abs);
         }
         remove_empty_parent_dirs(&work_tree, &abs);
+    }
+
+    // Paths that only existed as unmerged stages in the old index (no stage 0) are invisible to
+    // the stage-0 diff above; remove their worktree files when they drop out of the index
+    // entirely (matches `git read-tree -u --reset` / `reset --hard`, t1005).
+    let old_unmerged_paths: HashSet<Vec<u8>> = old_index
+        .entries
+        .iter()
+        .filter(|e| e.stage() != 0)
+        .map(|e| e.path.clone())
+        .collect();
+    for path in &old_unmerged_paths {
+        if !new_all_paths.contains(path) {
+            let rel = String::from_utf8_lossy(path).into_owned();
+            let abs = work_tree.join(&rel);
+            if abs.is_file() || abs.is_symlink() {
+                let _ = std::fs::remove_file(&abs);
+            } else if abs.is_dir() {
+                let _ = std::fs::remove_dir_all(&abs);
+            }
+            remove_empty_parent_dirs(&work_tree, &abs);
+        }
     }
 
     // Remove files that now have skip-worktree set

--- a/logs/2026-04-09_t1005-read-tree-reset.md
+++ b/logs/2026-04-09_t1005-read-tree-reset.md
@@ -1,0 +1,18 @@
+# t1005-read-tree-reset
+
+## Symptom
+
+Harness showed 3/7 passing: `read-tree -u --reset` and `read-tree -u --reset HEAD HEAD` did not remove working-tree files for paths that existed only as unmerged index entries (stages 1+3, no stage 0). `reset --hard` already passed because `reset.rs` removes such paths.
+
+## Fix
+
+1. **`read_tree::checkout_index_entries`**: After removing stage-0 paths absent from the new index, also remove worktree paths that had only unmerged entries in the old index and no index entry at all in the new index.
+
+2. **`checkout::checkout_index_to_worktree`**: Same unmerged-only cleanup so `checkout -f` on a branch switch path uses consistent removal logic.
+
+3. **`force_reset_to_head`**: Load the previous index and call `checkout_index_to_worktree` before force-writing HEAD tree entries, so `checkout -f` / `checkout -f HEAD` deletes paths dropped from the index (Git parity with `force_reset_to_tree`).
+
+## Verification
+
+- `bash tests/t1005-read-tree-reset.sh` — 7/7
+- `./scripts/run-tests.sh t1005-read-tree-reset.sh` — 7/7, CSV/dashboards updated

--- a/progress.md
+++ b/progress.md
@@ -15,6 +15,7 @@ Task lines in `PLAN.md`: 325 completed (`[x]`), 5 in progress (`[~]`), 441 remai
 
 ## Recently completed
 
+- `t1005-read-tree-reset` — 7/7 tests pass (`read-tree -u --reset` / two-tree reset: remove worktree files for paths that only had unmerged index stages; `checkout -f` loads old index and runs `checkout_index_to_worktree` before rewriting from HEAD so conflict remnants are removed like `reset --hard`)
 - `t3309-notes-merge-auto-resolve` — 31/31 tests pass (`notes merge`: `union` / `cat_sort_uniq` blob combine like Git; successful merge commits use two parents; `notes.mergeStrategy` config errors match upstream expectations)
 - `t4063-diff-blobs` — 18/18 tests pass (`diff`: blob↔blob and `rev:path` pairs without treating blobs as trees; `HEAD:one..HEAD:two` range split; `rev:path` vs worktree file uses tree path + modes + `write_patch_with_prefix`; raw blob OID vs existing file uses filename as old path; `rev_parse::resolve_treeish_blob_at_path` for tree walks)
 - `t5524-pull-msg` — 3/3 tests pass (`git pull --no-rebase --log` merge message preserves `$` in subject lines; `--log=1` limits shortlog; harness CSV/dashboards refreshed; `PLAN.md` marked complete)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t1005-read-tree-reset` failed when the index contained merge-conflict remnants: paths with only unmerged stages (no stage 0) and a corresponding file on disk. `read-tree -u --reset` and `read-tree -u --reset HEAD HEAD` must remove those worktree files when the new index has no entry for that path. `reset --hard` already did this via `reset::checkout_index_to_worktree`.

## Changes

- **`read_tree::checkout_index_entries`**: After the stage-0 removal pass, remove worktree paths that had only unmerged entries in the old index and are absent from the new index (any stage).
- **`checkout::checkout_index_to_worktree`**: Same unmerged-only cleanup for branch-switch style checkouts.
- **`force_reset_to_head`**: Load the previous index and call `checkout_index_to_worktree` before force-writing from `HEAD`, matching `force_reset_to_tree` / Git’s `checkout -f` behavior.

Harness: `./scripts/run-tests.sh t1005-read-tree-reset.sh` → 7/7. CSV and dashboards refreshed; `progress.md` + task log updated.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76c9f978-64e8-49c5-a64d-e53674e6b6b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76c9f978-64e8-49c5-a64d-e53674e6b6b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

