### PR TITLE
fix: t4040-whitespace-status — diff-tree/diff-files -b support

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -718,7 +718,7 @@ t4036-format-patch-signer-mime	t4	yes	5	5	0	true	ok	0
 t4037-diff-r-t-dirs	t4	yes	2	2	0	true	ok	0
 t4038-diff-combined	t4	yes	25	6	19	false	ok	1
 t4039-diff-assume-unchanged	t4	yes	4	3	1	false	ok	0
-t4040-whitespace-status	t4	yes	11	9	2	false	ok	0
+t4040-whitespace-status	t4	yes	11	11	0	true	ok	0
 t4041-diff-submodule-option	t4	yes	47	17	30	false	ok	0
 t4042-diff-textconv-caching	t4	yes	8	7	1	false	ok	0
 t4043-diff-rename-binary	t4	yes	3	2	1	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,688 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,688 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T22:12:40+00:00" class="gen-time" title="2026-04-09 22:12 UTC">2026-04-09 22:12 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,688</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -230,7 +230,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">73/178 files · 2 skipped · 2,862/4,438 tests</span>
+        <span class="group-meta">74/178 files · 2 skipped · 2,864/4,438 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.5%"></div></div>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35688 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,688 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T22:12:40+00:00" class="gen-time" title="2026-04-09 22:12 UTC">2026-04-09 22:12 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,688</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -7337,14 +7337,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:75.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="11" data-passed="9">
+<tr class="" data-group="t4" data-tests="11" data-passed="11" data-full-pass="1">
   <td class="mono">t4040-whitespace-status</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">11</td>
-  <td class="right">9</td>
+  <td class="right">11</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:81.8%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="47" data-passed="17">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/diff.rs
+++ b/grit-lib/src/diff.rs
@@ -2398,6 +2398,42 @@ pub fn format_stat_line_width(
     }
 }
 
+/// Normalise one line like Git's `-b` / `--ignore-space-change`.
+#[must_use]
+pub fn normalize_ignore_space_change_line(line: &str) -> String {
+    let mut result = String::with_capacity(line.len());
+    let mut in_space = false;
+    for c in line.chars() {
+        if c.is_whitespace() {
+            if !in_space {
+                result.push(' ');
+                in_space = true;
+            }
+        } else {
+            result.push(c);
+            in_space = false;
+        }
+    }
+    while result.ends_with(' ') {
+        result.pop();
+    }
+    result
+}
+
+/// Normalise text like Git's `-b` / `--ignore-space-change`: on each line, collapse runs of
+/// whitespace to a single ASCII space and trim trailing spaces.
+///
+/// Line breaks are preserved by splitting on [`str::lines`] and rejoining with `\n` (same approach
+/// as the porcelain `diff` whitespace handling in `grit`).
+#[must_use]
+pub fn normalize_ignore_space_change(content: &str) -> String {
+    content
+        .lines()
+        .map(normalize_ignore_space_change_line)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 /// Count insertions and deletions between two strings.
 ///
 /// Returns `(insertions, deletions)`.

--- a/grit/src/commands/diff_files.rs
+++ b/grit/src/commands/diff_files.rs
@@ -7,8 +7,8 @@ use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::diff::{
     count_changes, detect_copies, empty_blob_oid, format_stat_line,
-    rewrite_dissimilarity_index_percent, should_break_rewrite_for_stat, stat_matches, unified_diff,
-    zero_oid, DiffEntry, DiffStatus,
+    normalize_ignore_space_change_line, rewrite_dissimilarity_index_percent,
+    should_break_rewrite_for_stat, stat_matches, unified_diff, zero_oid, DiffEntry, DiffStatus,
 };
 use grit_lib::index::{
     Index, IndexEntry, MODE_EXECUTABLE, MODE_GITLINK, MODE_REGULAR, MODE_SYMLINK,
@@ -127,6 +127,9 @@ pub fn run(mut args: Args) -> Result<()> {
         diff_entries = grit_lib::diff::detect_renames(&repo.odb, diff_entries, threshold);
     }
 
+    diff_entries =
+        filter_diff_files_whitespace_equivalent(diff_entries, &repo, &work_tree, &options)?;
+
     if options.summary {
         print_diff_files_summary(&diff_entries)?;
     }
@@ -181,14 +184,20 @@ pub fn run(mut args: Args) -> Result<()> {
             }
             OutputFormat::Patch => {
                 for entry in &diff_entries {
-                    print_patch_from_diff_entry(entry, &repo, &work_tree, options.abbrev)?;
+                    print_patch_from_diff_entry(
+                        entry,
+                        &repo,
+                        &work_tree,
+                        &options,
+                        options.abbrev,
+                    )?;
                 }
             }
             OutputFormat::Stat => {
-                print_stat_from_diff_entries(&diff_entries, &repo, &work_tree)?;
+                print_stat_from_diff_entries(&diff_entries, &repo, &work_tree, &options)?;
             }
             OutputFormat::NumStat => {
-                print_numstat_from_diff_entries(&diff_entries, &repo, &work_tree)?;
+                print_numstat_from_diff_entries(&diff_entries, &repo, &work_tree, &options)?;
             }
         }
     }
@@ -356,6 +365,10 @@ struct Options {
     summary: bool,
     /// Detect complete rewrites (`-B` / `--break-rewrites`) for summary/raw dissimilarity.
     break_rewrites: bool,
+    ignore_all_space: bool,
+    ignore_space_change: bool,
+    ignore_space_at_eol: bool,
+    ignore_blank_lines: bool,
 }
 
 /// A single changed file: index side vs working tree.
@@ -397,6 +410,10 @@ fn parse_options(argv: &[String]) -> Result<Options> {
     let mut reverse = false;
     let mut summary = false;
     let mut break_rewrites = false;
+    let mut ignore_all_space = false;
+    let mut ignore_space_change = false;
+    let mut ignore_space_at_eol = false;
+    let mut ignore_blank_lines = false;
     let mut end_of_options = false;
 
     let mut idx = 0usize;
@@ -472,17 +489,12 @@ fn parse_options(argv: &[String]) -> Result<Options> {
                         .with_context(|| format!("invalid --abbrev value: `{value}`"))?;
                     abbrev = Some(parsed);
                 }
+                "-w" | "--ignore-all-space" => ignore_all_space = true,
+                "-b" | "--ignore-space-change" => ignore_space_change = true,
+                "--ignore-space-at-eol" => ignore_space_at_eol = true,
+                "--ignore-blank-lines" => ignore_blank_lines = true,
                 // Silently accept diff options we don't fully implement yet
-                "-w"
-                | "--ignore-all-space"
-                | "-b"
-                | "--ignore-space-change"
-                | "--ignore-space-at-eol"
-                | "--ignore-blank-lines"
-                | "--full-index"
-                | "--no-ext-diff"
-                | "--no-prefix"
-                | "--no-abbrev" => {}
+                "--full-index" | "--no-ext-diff" | "--no-prefix" | "--no-abbrev" => {}
                 "-M" | "--find-renames" => {
                     find_renames = Some(50);
                 }
@@ -578,7 +590,82 @@ fn parse_options(argv: &[String]) -> Result<Options> {
         reverse,
         summary,
         break_rewrites,
+        ignore_all_space,
+        ignore_space_change,
+        ignore_space_at_eol,
+        ignore_blank_lines,
     })
+}
+
+fn diff_files_ws_any(o: &Options) -> bool {
+    o.ignore_all_space || o.ignore_space_change || o.ignore_space_at_eol || o.ignore_blank_lines
+}
+
+fn diff_files_normalize_content(s: &str, o: &Options) -> String {
+    if !diff_files_ws_any(o) {
+        return s.to_owned();
+    }
+    let mut lines: Vec<String> = s
+        .lines()
+        .map(|line| {
+            if o.ignore_all_space {
+                line.chars().filter(|c| !c.is_whitespace()).collect()
+            } else if o.ignore_space_change {
+                normalize_ignore_space_change_line(line)
+            } else if o.ignore_space_at_eol {
+                line.trim_end().to_owned()
+            } else {
+                line.to_owned()
+            }
+        })
+        .collect();
+    if o.ignore_blank_lines {
+        lines.retain(|l| !l.trim().is_empty());
+    }
+    lines.join("\n")
+}
+
+fn diff_files_ws_content_matches_index_wt(
+    repo: &Repository,
+    idx_oid: &ObjectId,
+    wt_bytes: &[u8],
+    o: &Options,
+) -> Result<bool> {
+    let old = if *idx_oid == zero_oid() {
+        String::new()
+    } else {
+        let obj = repo.odb.read(idx_oid)?;
+        String::from_utf8_lossy(&obj.data).into_owned()
+    };
+    let new = String::from_utf8_lossy(wt_bytes).into_owned();
+    Ok(diff_files_normalize_content(&old, o) == diff_files_normalize_content(&new, o))
+}
+
+fn filter_diff_files_whitespace_equivalent(
+    entries: Vec<DiffEntry>,
+    repo: &Repository,
+    work_tree: &Path,
+    o: &Options,
+) -> Result<Vec<DiffEntry>> {
+    if !diff_files_ws_any(o) {
+        return Ok(entries);
+    }
+    let mut out = Vec::with_capacity(entries.len());
+    for e in entries {
+        if e.status != DiffStatus::Modified {
+            out.push(e);
+            continue;
+        }
+        if e.old_mode != e.new_mode {
+            out.push(e);
+            continue;
+        }
+        let (old, new) = load_patch_contents_for_diff_entry(&e, repo, work_tree)?;
+        if diff_files_normalize_content(&old, o) != diff_files_normalize_content(&new, o) {
+            out.push(e);
+        }
+    }
+    Ok(out)
 }
 
 // ── Core diff logic ──────────────────────────────────────────────────
@@ -675,18 +762,27 @@ fn collect_changes(
                     } else {
                         // Same blob and mode on disk as in the index, but index stat is
                         // uninitialized (e.g. post-`read-tree` checkout without `-u`).
-                        changes.insert(
-                            path.clone(),
-                            Change {
-                                path: path.clone(),
-                                status: 'M',
-                                old_mode: idx_canonical,
-                                new_mode: wt_mode,
-                                old_oid: *idx_oid,
-                                new_oid: wt_oid,
-                                intent_to_add: false,
-                            },
-                        );
+                        let ws_only = diff_files_ws_any(options)
+                            && fs::read(&abs).ok().is_some_and(|bytes| {
+                                diff_files_ws_content_matches_index_wt(
+                                    repo, idx_oid, &bytes, options,
+                                )
+                                .unwrap_or(false)
+                            });
+                        if !ws_only {
+                            changes.insert(
+                                path.clone(),
+                                Change {
+                                    path: path.clone(),
+                                    status: 'M',
+                                    old_mode: idx_canonical,
+                                    new_mode: wt_mode,
+                                    old_oid: *idx_oid,
+                                    new_oid: wt_oid,
+                                    intent_to_add: false,
+                                },
+                            );
+                        }
                     }
                 }
                 WorktreeStatus::Missing => {
@@ -926,6 +1022,7 @@ fn print_patch_from_diff_entry(
     entry: &DiffEntry,
     repo: &Repository,
     work_tree: &Path,
+    ws_opts: &Options,
     abbrev: Option<usize>,
 ) -> Result<()> {
     let (old_content, new_content) = load_patch_contents_for_diff_entry(entry, repo, work_tree)?;
@@ -1003,9 +1100,16 @@ fn print_patch_from_diff_entry(
     {
         println!("{header}");
     } else if old_content != new_content {
-        let patch = unified_diff(&old_content, &new_content, display_path, display_path, 3);
-        let body: String = patch.lines().skip(2).map(|l| format!("\n{l}")).collect();
-        println!("{header}\n--- {old_label}\n+++ {new_label}{body}");
+        let ws_equivalent = diff_files_ws_any(ws_opts)
+            && diff_files_normalize_content(&old_content, ws_opts)
+                == diff_files_normalize_content(&new_content, ws_opts);
+        if !ws_equivalent {
+            let patch = unified_diff(&old_content, &new_content, display_path, display_path, 3);
+            let body: String = patch.lines().skip(2).map(|l| format!("\n{l}")).collect();
+            println!("{header}\n--- {old_label}\n+++ {new_label}{body}");
+        } else {
+            println!("{header}\n--- {old_label}\n+++ {new_label}");
+        }
     } else {
         println!("{header}\n--- {old_label}\n+++ {new_label}");
     }
@@ -1016,6 +1120,7 @@ fn print_stat_from_diff_entries(
     entries: &[DiffEntry],
     repo: &Repository,
     work_tree: &Path,
+    ws_opts: &Options,
 ) -> Result<()> {
     if entries.is_empty() {
         return Ok(());
@@ -1025,6 +1130,14 @@ fn print_stat_from_diff_entries(
     let mut total_del = 0usize;
     for entry in entries {
         let (old, new) = load_patch_contents_for_diff_entry(entry, repo, work_tree)?;
+        let (old, new) = if diff_files_ws_any(ws_opts) {
+            (
+                diff_files_normalize_content(&old, ws_opts),
+                diff_files_normalize_content(&new, ws_opts),
+            )
+        } else {
+            (old, new)
+        };
         let (ins, del) = count_changes(&old, &new);
         total_ins += ins;
         total_del += del;
@@ -1058,9 +1171,18 @@ fn print_numstat_from_diff_entries(
     entries: &[DiffEntry],
     repo: &Repository,
     work_tree: &Path,
+    ws_opts: &Options,
 ) -> Result<()> {
     for entry in entries {
         let (old, new) = load_patch_contents_for_diff_entry(entry, repo, work_tree)?;
+        let (old, new) = if diff_files_ws_any(ws_opts) {
+            (
+                diff_files_normalize_content(&old, ws_opts),
+                diff_files_normalize_content(&new, ws_opts),
+            )
+        } else {
+            (old, new)
+        };
         let (ins, del) = count_changes(&old, &new);
         println!("{}\t{}\t{}", ins, del, entry.path());
     }

--- a/grit/src/commands/diff_tree.rs
+++ b/grit/src/commands/diff_tree.rs
@@ -15,8 +15,8 @@ use grit_lib::combined_tree_diff::{
 use grit_lib::config::ConfigSet;
 use grit_lib::diff::{
     count_changes, detect_copies as lib_detect_copies, detect_renames, diff_trees,
-    diff_trees_show_tree_entries, format_raw, format_raw_abbrev, unified_diff_with_prefix,
-    DiffEntry, DiffStatus,
+    diff_trees_show_tree_entries, format_raw, format_raw_abbrev,
+    normalize_ignore_space_change_line, unified_diff_with_prefix, DiffEntry, DiffStatus,
 };
 use grit_lib::merge_base::merge_bases_first_vs_rest;
 use grit_lib::merge_diff::{
@@ -141,6 +141,65 @@ struct Options {
     submodule_mode: Option<String>,
     /// Object id spec for `--find-object` (resolved against the repo before the walk).
     find_object: Option<String>,
+    /// `-w` / `--ignore-all-space` — ignore all whitespace when comparing blob content.
+    ignore_all_space: bool,
+    /// `-b` / `--ignore-space-change` — collapse whitespace runs when comparing.
+    ignore_space_change: bool,
+    /// `--ignore-space-at-eol` — strip trailing whitespace per line when comparing.
+    ignore_space_at_eol: bool,
+    /// `--ignore-blank-lines` — drop blank lines when comparing.
+    ignore_blank_lines: bool,
+}
+
+/// Whitespace comparison options for plumbing `diff-tree` (aligned with porcelain `git diff`).
+struct WhitespaceCompare {
+    ignore_all_space: bool,
+    ignore_space_change: bool,
+    ignore_space_at_eol: bool,
+    ignore_blank_lines: bool,
+}
+
+impl WhitespaceCompare {
+    fn from_opts(opts: &Options) -> Self {
+        Self {
+            ignore_all_space: opts.ignore_all_space,
+            ignore_space_change: opts.ignore_space_change,
+            ignore_space_at_eol: opts.ignore_space_at_eol,
+            ignore_blank_lines: opts.ignore_blank_lines,
+        }
+    }
+
+    fn any(&self) -> bool {
+        self.ignore_all_space
+            || self.ignore_space_change
+            || self.ignore_space_at_eol
+            || self.ignore_blank_lines
+    }
+
+    fn normalize_line(&self, line: &str) -> String {
+        let s = line.to_owned();
+        if self.ignore_all_space {
+            return s.chars().filter(|c| !c.is_whitespace()).collect();
+        }
+        if self.ignore_space_change {
+            return normalize_ignore_space_change_line(&s);
+        }
+        if self.ignore_space_at_eol {
+            return s.trim_end().to_owned();
+        }
+        s
+    }
+
+    fn normalize(&self, content: &str) -> String {
+        if !self.any() {
+            return content.to_owned();
+        }
+        let mut lines: Vec<String> = content.lines().map(|l| self.normalize_line(l)).collect();
+        if self.ignore_blank_lines {
+            lines.retain(|l| !l.trim().is_empty());
+        }
+        lines.join("\n")
+    }
 }
 
 impl Default for Options {
@@ -184,6 +243,10 @@ impl Default for Options {
             pickaxe_all: false,
             submodule_mode: None,
             find_object: None,
+            ignore_all_space: false,
+            ignore_space_change: false,
+            ignore_space_at_eol: false,
+            ignore_blank_lines: false,
         }
     }
 }
@@ -402,6 +465,10 @@ fn parse_options(repo: &Repository, argv: &[String]) -> Result<Options> {
                 _ if arg.starts_with("--submodule=") => {
                     opts.submodule_mode = Some(arg["--submodule=".len()..].to_string());
                 }
+                "-w" | "--ignore-all-space" => opts.ignore_all_space = true,
+                "-b" | "--ignore-space-change" => opts.ignore_space_change = true,
+                "--ignore-space-at-eol" => opts.ignore_space_at_eol = true,
+                "--ignore-blank-lines" => opts.ignore_blank_lines = true,
                 _ => bail!("unknown option: {arg}"),
             }
             i += 1;
@@ -2017,6 +2084,39 @@ fn read_blob_pair(odb: &Odb, entry: &DiffEntry) -> Result<(String, String)> {
     Ok((old_content, new_content))
 }
 
+/// Drop modified blob pairs that are identical after whitespace rules (`-b`, `-w`, etc.).
+fn filter_whitespace_equivalent_blob_pairs(
+    odb: &Odb,
+    entries: Vec<DiffEntry>,
+    ws: &WhitespaceCompare,
+) -> Result<Vec<DiffEntry>> {
+    if !ws.any() {
+        return Ok(entries);
+    }
+    let mut out = Vec::with_capacity(entries.len());
+    for e in entries {
+        if e.status != DiffStatus::Modified {
+            out.push(e);
+            continue;
+        }
+        if e.old_mode != e.new_mode {
+            out.push(e);
+            continue;
+        }
+        let (old, new) = match read_blob_pair(odb, &e) {
+            Ok(pair) => pair,
+            Err(_) => {
+                out.push(e);
+                continue;
+            }
+        };
+        if ws.normalize(&old) != ws.normalize(&new) {
+            out.push(e);
+        }
+    }
+    Ok(out)
+}
+
 /// Apply post-diff filters: pathspecs, max-depth, and pickaxe (`-S` / `-G`).
 fn filter_entries(
     odb: &Odb,
@@ -2029,7 +2129,8 @@ fn filter_entries(
         filtered = filter_max_depth(filtered, depth, &opts.pathspecs);
     }
     let filtered = apply_pickaxe_filter(odb, filtered, opts)?;
-    apply_find_object_filter(repo, filtered, opts)
+    let filtered = apply_find_object_filter(repo, filtered, opts)?;
+    filter_whitespace_equivalent_blob_pairs(odb, filtered, &WhitespaceCompare::from_opts(opts))
 }
 
 /// Keep entries whose old or new blob OID matches `--find-object` (non-combined diffs).

--- a/logs/2026-04-09_t4040-whitespace-status.md
+++ b/logs/2026-04-09_t4040-whitespace-status.md
@@ -1,0 +1,17 @@
+# t4040-whitespace-status
+
+## Failures
+
+- `git diff-tree -b` rejected `-b` (unknown option).
+- `git diff-files -b` accepted `-b` but did not ignore whitespace-only index↔worktree changes, so `--exit-code` still exited 1 and `-p` still printed a hunk.
+
+## Fix
+
+- `grit-lib`: `normalize_ignore_space_change_line` + `normalize_ignore_space_change` for shared `-b` line normalisation.
+- `diff-tree`: parse `-w/-b/--ignore-space-at-eol/--ignore-blank-lines`; filter modified blob pairs whose normalised content matches (after pathspec/pickaxe/`--find-object`).
+- `diff-files`: track the same flags; skip bogus `M` when stat-untrusted but ws-normalised content matches index; post-filter entries; suppress patch hunks when ws-equivalent; use normalised text for stat/numstat when flags active.
+
+## Verification
+
+- `./scripts/run-tests.sh t4040-whitespace-status.sh` → 11/11
+- `cargo test -p grit-lib --lib`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t4040-whitespace-status` was failing because `diff-tree` rejected `-b` and `diff-files` ignored whitespace options when deciding exit status and patch output.

## Changes

- **grit-lib** (`diff.rs`): add `normalize_ignore_space_change_line` and `normalize_ignore_space_change` for Git-style `-b` line normalisation (shared with porcelain logic).
- **diff-tree**: parse `-w`, `-b`, `--ignore-space-at-eol`, `--ignore-blank-lines`; after pathspec/pickaxe/`--find-object`, drop modified blob pairs whose normalised content matches (so `--exit-code` / `--quiet` match Git).
- **diff-files**: honour the same flags—skip bogus `M` when index stat is untrusted but ws-normalised index vs worktree match; post-filter entries; suppress hunks when ws-equivalent; use normalised text for `--stat` / `--numstat` when active.

## Testing

- `./scripts/run-tests.sh t4040-whitespace-status.sh` → **11/11**
- `cargo test -p grit-lib --lib`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f1a8a82-d6e8-4d10-89a2-10fc9f25aaae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f1a8a82-d6e8-4d10-89a2-10fc9f25aaae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

