### PR TITLE
fix: make t0040-parse-options pass (test-tool parse-options)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -32,7 +32,7 @@ t0031-lockfile-pid	t0	yes	7	7	0	true	ok	0
 t0033-safe-directory	t0	yes	22	20	2	false	ok	0
 t0034-root-safe-directory	t0	yes	0	0	0	false	ok	0
 t0035-safe-bare-repository	t0	yes	12	9	3	false	ok	0
-t0040-parse-options	t0	yes	94	85	9	false	ok	0
+t0040-parse-options	t0	yes	94	94	0	true	ok	0
 t0041-usage	t0	yes	16	8	8	false	ok	0
 t0050-filesystem	t0	yes	11	9	2	false	ok	2
 t0051-windows-named-pipe	t0	skip	1	0	0	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,695 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,695 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T22:30:06+00:00" class="gen-time" title="2026-04-09 22:30 UTC">2026-04-09 22:30 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,695</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -186,11 +186,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t0</span>
         <span class="group-desc">Absolute basics and global stuff</span>
-        <span class="group-meta">40/64 files · 21 skipped · 4,885/5,134 tests</span>
+        <span class="group-meta">41/64 files · 21 skipped · 4,894/5,134 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:95.1%"></div></div>
-        <span class="group-pct pct-green">95.1%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:95.3%"></div></div>
+        <span class="group-pct pct-green">95.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t1">
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35695 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,695 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T22:30:06+00:00" class="gen-time" title="2026-04-09 22:30 UTC">2026-04-09 22:30 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,695</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -477,14 +477,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:75.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t0" data-tests="94" data-passed="85">
+<tr class="" data-group="t0" data-tests="94" data-passed="94" data-full-pass="1">
   <td class="mono">t0040-parse-options</td>
   <td>t0</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">94</td>
-  <td class="right">85</td>
+  <td class="right">94</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t0" data-tests="16" data-passed="8">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/parse_options_test_tool/parse_options_cmd.rs
+++ b/grit-lib/src/parse_options_test_tool/parse_options_cmd.rs
@@ -13,6 +13,8 @@ pub type ParseOptionsStatus = i32;
 pub enum ParseOptionsToolError {
     /// `-h` / `--help`: help already printed to stdout, exit 129, empty stderr.
     Help,
+    /// Callback returned an error without printing (Git `parse_options` exit 1, empty stderr).
+    Silent,
     Fatal(String),
     Bug(String),
 }
@@ -21,6 +23,7 @@ impl std::fmt::Display for ParseOptionsToolError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ParseOptionsToolError::Help => f.write_str("(help)"),
+            ParseOptionsToolError::Silent => f.write_str("(silent)"),
             ParseOptionsToolError::Fatal(s) | ParseOptionsToolError::Bug(s) => f.write_str(s),
         }
     }
@@ -205,10 +208,7 @@ fn format_opt_display(name: &'static str, arg: Option<&str>, unset: bool) -> Str
 }
 
 fn usage_append() -> String {
-    let mut s = String::new();
-    s.push('\n');
-    s.push_str(PARSE_OPTIONS_HELP);
-    s
+    PARSE_OPTIONS_HELP.to_string()
 }
 
 /// Git's `usage_with_options` is attached only for some parse errors; t0040 expects a bare line
@@ -231,6 +231,7 @@ fn map_parse_fatal(e: ParseOptionsToolError) -> ParseOptionsToolError {
         ParseOptionsToolError::Fatal(m) => {
             ParseOptionsToolError::Fatal(append_usage_if_unknown(&m))
         }
+        ParseOptionsToolError::Silent => ParseOptionsToolError::Silent,
         o => o,
     }
 }
@@ -315,24 +316,6 @@ pub fn run_parse_options(args: &[String]) -> Result<ParseOptionsStatus, ParseOpt
                 i += 1;
                 rest.extend(argv[i..].iter().cloned());
                 return st.dump(&st.expect.clone(), &rest);
-            }
-            // -NUM (OPTION_NUMBER): entire argv is `-` followed by decimal digits
-            let tail = &arg[1..];
-            if !tail.is_empty() && tail.chars().all(|c| c.is_ascii_digit()) {
-                let n: i32 = -tail.parse::<i32>().map_err(|_| {
-                    ParseOptionsToolError::Fatal("error: invalid number\n".to_string())
-                })?;
-                st.touch_integer(
-                    n,
-                    OptMeta {
-                        name: "NUM",
-                        is_cmdmode: false,
-                    },
-                    None,
-                    false,
-                )?;
-                i += 1;
-                continue;
             }
             i = match parse_short(&mut st, argv, i, prefix, disallow_abbrev) {
                 Ok(n) => n,
@@ -507,12 +490,11 @@ fn long_exact(
             hit = true;
         }
         "length" => {
-            let v = take_val(eq_val, argv, i, "length")?;
             if u {
-                return Err(ParseOptionsToolError::Fatal(
-                    "error: option `no-length' isn't available\n".to_string(),
-                ));
+                no_eq(eq_val.as_deref(), "no-length", u)?;
+                return Err(ParseOptionsToolError::Silent);
             }
+            let v = take_val(eq_val, argv, i, "length")?;
             st.length_cb_called = true;
             st.length_cb_arg = Some(v.clone());
             st.length_cb_unset = false;
@@ -547,10 +529,11 @@ fn long_exact(
             hit = true;
         }
         "list" => {
-            let v = take_val(eq_val, argv, i, "list")?;
             if u {
+                no_eq(eq_val.as_deref(), "list", u)?;
                 st.list.clear();
             } else {
+                let v = take_val(eq_val, argv, i, "list")?;
                 st.list.push(v);
             }
             hit = true;
@@ -591,10 +574,8 @@ fn long_exact(
             no_eq(eq_val.as_deref(), "quiet", u)?;
             if u {
                 st.quiet = 0;
-            } else if st.quiet <= 0 {
-                st.quiet -= 1;
             } else {
-                st.quiet = -1;
+                st.quiet = st.quiet.saturating_add(1);
             }
             hit = true;
         }
@@ -846,20 +827,246 @@ fn set_u16(st: &mut PoState, raw: &str) -> Result<(), ParseOptionsToolError> {
     }
 }
 
-/// Mirrors `check_typos` in `parse-options.c` for single-dash typos (`-boolean`, …).
-fn check_typos(full_suffix: &str) -> Result<(), ParseOptionsToolError> {
-    if full_suffix.len() < 3 {
+/// Git `starts_with(long_name, arg)` for typo detection: byte prefix of `long_name`.
+fn long_name_starts_with_user_typos(user: &str, long_name: &str) -> bool {
+    long_name
+        .as_bytes()
+        .get(..user.len())
+        .is_some_and(|pfx| pfx == user.as_bytes())
+}
+
+/// Git `check_typos(arg + 1, …)` for a short-option cluster: `cluster` is the full argv suffix
+/// after `-` (e.g. `boolean` for `-boolean`), not the unconsumed tail.
+fn check_typos_short_cluster(cluster: &str) -> Result<(), ParseOptionsToolError> {
+    if cluster.len() < 3 {
         return Ok(());
     }
-    if full_suffix.starts_with("no-") {
+    if cluster.starts_with("no-") {
         return Err(ParseOptionsToolError::Fatal(format!(
-            "error: did you mean `--{full_suffix}` (with two dashes)?\n"
+            "error: did you mean `--{cluster}` (with two dashes)?\n"
         )));
     }
     for ln in LONG_NAMES {
-        if ln.starts_with(full_suffix) {
+        if long_name_starts_with_user_typos(cluster, ln) {
             return Err(ParseOptionsToolError::Fatal(format!(
-                "error: did you mean `--{full_suffix}` (with two dashes)?\n"
+                "error: did you mean `--{cluster}` (with two dashes)?\n"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// One step of Git `parse_short_opt`: explicit short options win; otherwise a digit run is
+/// `OPTION_NUMBER`.
+fn parse_short_opt_step(
+    st: &mut PoState,
+    full_suffix: &str,
+    o: &mut usize,
+    local_i: &mut usize,
+    argv: &[String],
+    prefix: &str,
+) -> Result<(), ParseOptionsToolError> {
+    let Some(first) = full_suffix[*o..].chars().next() else {
+        return Ok(());
+    };
+    let flen = first.len_utf8();
+
+    match first {
+        'h' => {
+            print!("{PARSE_OPTIONS_HELP}");
+            return Err(ParseOptionsToolError::Help);
+        }
+        's' => {
+            let v = if *o + flen < full_suffix.len() {
+                full_suffix[*o + flen..].to_string()
+            } else if *local_i + 1 < argv.len() {
+                *local_i += 1;
+                argv[*local_i].clone()
+            } else {
+                return Err(ParseOptionsToolError::Fatal(
+                    "error: switch `s' requires a value\n".to_string(),
+                ));
+            };
+            *o = full_suffix.len();
+            st.string = Some(v);
+        }
+        'b' => {
+            st.boolean = st.boolean.saturating_add(1);
+            *o += flen;
+        }
+        'i' => {
+            let tail = &full_suffix[*o + flen..];
+            let v = if !tail.is_empty() {
+                tail.to_string()
+            } else if *local_i + 1 < argv.len() {
+                *local_i += 1;
+                argv[*local_i].clone()
+            } else {
+                return Err(ParseOptionsToolError::Fatal(
+                    "error: switch `i' requires a value\n".to_string(),
+                ));
+            };
+            set_int(st, &v, "integer")?;
+            *o = full_suffix.len();
+        }
+        'j' => {
+            let tail = &full_suffix[*o + flen..];
+            let v = if !tail.is_empty() {
+                tail.to_string()
+            } else if *local_i + 1 < argv.len() {
+                *local_i += 1;
+                argv[*local_i].clone()
+            } else {
+                return Err(ParseOptionsToolError::Fatal(
+                    "error: switch `j' requires a value\n".to_string(),
+                ));
+            };
+            set_int(st, &v, "j")?;
+            *o = full_suffix.len();
+        }
+        'u' => {
+            let tail = &full_suffix[*o + flen..];
+            let v = if !tail.is_empty() {
+                tail.to_string()
+            } else if *local_i + 1 < argv.len() {
+                *local_i += 1;
+                argv[*local_i].clone()
+            } else {
+                return Err(ParseOptionsToolError::Fatal(
+                    "error: switch `u' requires a value\n".to_string(),
+                ));
+            };
+            set_unsigned(st, &v)?;
+            *o = full_suffix.len();
+        }
+        'v' => {
+            st.verbose = if st.verbose < 0 { 1 } else { st.verbose + 1 };
+            *o += flen;
+        }
+        'n' => {
+            st.dry_run = 1;
+            *o += flen;
+        }
+        'q' => {
+            st.quiet = st.quiet.saturating_add(1);
+            *o += flen;
+        }
+        'D' => {
+            st.boolean = 1;
+            *o += flen;
+        }
+        'B' => {
+            st.boolean = 1;
+            *o += flen;
+        }
+        '4' => {
+            st.boolean |= 4;
+            *o += flen;
+        }
+        'L' => {
+            let v = if *o + flen < full_suffix.len() {
+                full_suffix[*o + flen..].to_string()
+            } else if *local_i + 1 < argv.len() {
+                *local_i += 1;
+                argv[*local_i].clone()
+            } else {
+                return Err(ParseOptionsToolError::Fatal(
+                    "error: switch `L' requires a value\n".to_string(),
+                ));
+            };
+            *o = full_suffix.len();
+            st.length_cb_called = true;
+            st.length_cb_arg = Some(v.clone());
+            st.length_cb_unset = false;
+            st.touch_integer(v.len() as i32, opt("length", false), None, false)?;
+        }
+        'F' => {
+            let v = if *o + flen < full_suffix.len() {
+                full_suffix[*o + flen..].to_string()
+            } else if *local_i + 1 < argv.len() {
+                *local_i += 1;
+                argv[*local_i].clone()
+            } else {
+                return Err(ParseOptionsToolError::Fatal(
+                    "error: switch `F' requires a value\n".to_string(),
+                ));
+            };
+            *o = full_suffix.len();
+            st.file = Some(format!("{prefix}{v}"));
+        }
+        'A' => {
+            let v = if *o + flen < full_suffix.len() {
+                full_suffix[*o + flen..].to_string()
+            } else if *local_i + 1 < argv.len() {
+                *local_i += 1;
+                argv[*local_i].clone()
+            } else {
+                return Err(ParseOptionsToolError::Fatal(
+                    "error: switch `A' requires a value\n".to_string(),
+                ));
+            };
+            *o = full_suffix.len();
+            st.string = Some(v);
+        }
+        'Z' => {
+            let v = if *o + flen < full_suffix.len() {
+                full_suffix[*o + flen..].to_string()
+            } else if *local_i + 1 < argv.len() {
+                *local_i += 1;
+                argv[*local_i].clone()
+            } else {
+                return Err(ParseOptionsToolError::Fatal(
+                    "error: switch `Z' requires a value\n".to_string(),
+                ));
+            };
+            *o = full_suffix.len();
+            st.string = Some(v);
+        }
+        'o' => {
+            let v = if *o + flen < full_suffix.len() {
+                full_suffix[*o + flen..].to_string()
+            } else if *local_i + 1 < argv.len() {
+                *local_i += 1;
+                argv[*local_i].clone()
+            } else {
+                return Err(ParseOptionsToolError::Fatal(
+                    "error: switch `o' requires a value\n".to_string(),
+                ));
+            };
+            *o = full_suffix.len();
+            st.string = Some(v);
+        }
+        '+' => {
+            st.boolean = st.boolean.saturating_add(1);
+            *o += flen;
+        }
+        c if c.is_ascii_digit() => {
+            let start = *o;
+            let mut end = start;
+            while end < full_suffix.len() && full_suffix.as_bytes()[end].is_ascii_digit() {
+                end += 1;
+            }
+            let digits = &full_suffix[start..end];
+            let n: i32 = digits
+                .parse()
+                .map_err(|_| ParseOptionsToolError::Fatal("error: invalid number\n".to_string()))?;
+            st.touch_integer(
+                n,
+                OptMeta {
+                    name: "NUM",
+                    is_cmdmode: false,
+                },
+                None,
+                false,
+            )?;
+            *o = end;
+        }
+        _ => {
+            if *o == 0 {
+                check_typos_short_cluster(full_suffix)?;
+            }
+            return Err(ParseOptionsToolError::Fatal(format!(
+                "error: unknown switch `{first}'\n"
             )));
         }
     }
@@ -884,230 +1091,14 @@ fn parse_short(
     let mut o = 0usize;
     let mut local_i = i;
 
-    // First short option (Git calls `check_typos(arg+1)` when remainder after first match)
-    let first = full_suffix.chars().next().unwrap();
-    let flen = first.len_utf8();
-    match first {
-        'h' => {
-            print!("{PARSE_OPTIONS_HELP}");
-            return Err(ParseOptionsToolError::Help);
-        }
-        's' => {
-            let v = if full_suffix.len() > flen {
-                full_suffix[flen..].to_string()
-            } else if local_i + 1 < argv.len() {
-                local_i += 1;
-                argv[local_i].clone()
-            } else {
-                return Err(ParseOptionsToolError::Fatal(
-                    "error: switch `s' requires a value\n".to_string(),
-                ));
-            };
-            o = full_suffix.len();
-            st.string = Some(v);
-        }
-        'b' => {
-            st.boolean = st.boolean.saturating_add(1);
-            o += flen;
-        }
-        'i' => {
-            let tail = &full_suffix[flen..];
-            let v = if !tail.is_empty() {
-                tail.to_string()
-            } else if local_i + 1 < argv.len() {
-                local_i += 1;
-                argv[local_i].clone()
-            } else {
-                return Err(ParseOptionsToolError::Fatal(
-                    "error: switch `i' requires a value\n".to_string(),
-                ));
-            };
-            set_int(st, &v, "integer")?;
-            o = full_suffix.len();
-        }
-        'j' => {
-            let tail = &full_suffix[flen..];
-            let v = if !tail.is_empty() {
-                tail.to_string()
-            } else if local_i + 1 < argv.len() {
-                local_i += 1;
-                argv[local_i].clone()
-            } else {
-                return Err(ParseOptionsToolError::Fatal(
-                    "error: switch `j' requires a value\n".to_string(),
-                ));
-            };
-            set_int(st, &v, "j")?;
-            o = full_suffix.len();
-        }
-        'u' => {
-            let tail = &full_suffix[flen..];
-            let v = if !tail.is_empty() {
-                tail.to_string()
-            } else if local_i + 1 < argv.len() {
-                local_i += 1;
-                argv[local_i].clone()
-            } else {
-                return Err(ParseOptionsToolError::Fatal(
-                    "error: switch `u' requires a value\n".to_string(),
-                ));
-            };
-            set_unsigned(st, &v)?;
-            o = full_suffix.len();
-        }
-        'v' => {
-            st.verbose = if st.verbose < 0 { 1 } else { st.verbose + 1 };
-            o += flen;
-        }
-        'n' => {
-            st.dry_run = 1;
-            o += flen;
-        }
-        'q' => {
-            if st.quiet <= 0 {
-                st.quiet -= 1;
-            } else {
-                st.quiet = -1;
-            }
-            o += flen;
-        }
-        'D' => {
-            st.boolean = 1;
-            o += flen;
-        }
-        'B' => {
-            st.boolean = 1;
-            o += flen;
-        }
-        '4' => {
-            st.boolean |= 4;
-            o += flen;
-        }
-        'L' => {
-            let v = if full_suffix.len() > flen {
-                full_suffix[flen..].to_string()
-            } else if local_i + 1 < argv.len() {
-                local_i += 1;
-                argv[local_i].clone()
-            } else {
-                return Err(ParseOptionsToolError::Fatal(
-                    "error: switch `L' requires a value\n".to_string(),
-                ));
-            };
-            o = full_suffix.len();
-            st.length_cb_called = true;
-            st.length_cb_arg = Some(v.clone());
-            st.length_cb_unset = false;
-            st.touch_integer(v.len() as i32, opt("length", false), None, false)?;
-        }
-        'F' => {
-            let v = if full_suffix.len() > flen {
-                full_suffix[flen..].to_string()
-            } else if local_i + 1 < argv.len() {
-                local_i += 1;
-                argv[local_i].clone()
-            } else {
-                return Err(ParseOptionsToolError::Fatal(
-                    "error: switch `F' requires a value\n".to_string(),
-                ));
-            };
-            o = full_suffix.len();
-            st.file = Some(format!("{prefix}{v}"));
-        }
-        'A' => {
-            let v = if full_suffix.len() > flen {
-                full_suffix[flen..].to_string()
-            } else if local_i + 1 < argv.len() {
-                local_i += 1;
-                argv[local_i].clone()
-            } else {
-                return Err(ParseOptionsToolError::Fatal(
-                    "error: switch `A' requires a value\n".to_string(),
-                ));
-            };
-            o = full_suffix.len();
-            st.string = Some(v);
-        }
-        'Z' => {
-            let v = if full_suffix.len() > flen {
-                full_suffix[flen..].to_string()
-            } else if local_i + 1 < argv.len() {
-                local_i += 1;
-                argv[local_i].clone()
-            } else {
-                return Err(ParseOptionsToolError::Fatal(
-                    "error: switch `Z' requires a value\n".to_string(),
-                ));
-            };
-            o = full_suffix.len();
-            st.string = Some(v);
-        }
-        'o' => {
-            let v = if full_suffix.len() > flen {
-                full_suffix[flen..].to_string()
-            } else if local_i + 1 < argv.len() {
-                local_i += 1;
-                argv[local_i].clone()
-            } else {
-                return Err(ParseOptionsToolError::Fatal(
-                    "error: switch `o' requires a value\n".to_string(),
-                ));
-            };
-            o = full_suffix.len();
-            st.string = Some(v);
-        }
-        '+' => {
-            st.boolean = st.boolean.saturating_add(1);
-            o += flen;
-        }
-        _ => {
-            return Err(ParseOptionsToolError::Fatal(format!(
-                "error: unknown switch `{first}'\n"
-            )));
-        }
-    }
-
+    parse_short_opt_step(st, full_suffix, &mut o, &mut local_i, argv, prefix)?;
     if o < full_suffix.len() {
-        check_typos(full_suffix)?;
+        check_typos_short_cluster(full_suffix)?;
     }
-
     while o < full_suffix.len() {
-        let c = full_suffix[o..].chars().next().unwrap();
-        let clen = c.len_utf8();
-        match c {
-            'b' => {
-                st.boolean = st.boolean.saturating_add(1);
-                o += clen;
-            }
-            'v' => {
-                st.verbose = if st.verbose < 0 { 1 } else { st.verbose + 1 };
-                o += clen;
-            }
-            'n' => {
-                st.dry_run = 1;
-                o += clen;
-            }
-            'q' => {
-                if st.quiet <= 0 {
-                    st.quiet -= 1;
-                } else {
-                    st.quiet = -1;
-                }
-                o += clen;
-            }
-            '4' => {
-                st.boolean |= 4;
-                o += clen;
-            }
-            '+' => {
-                st.boolean = st.boolean.saturating_add(1);
-                o += clen;
-            }
-            _ => {
-                return Err(ParseOptionsToolError::Fatal(format!(
-                    "error: unknown switch `{c}'\n"
-                )));
-            }
+        parse_short_opt_step(st, full_suffix, &mut o, &mut local_i, argv, prefix)?;
+        if o < full_suffix.len() {
+            check_typos_short_cluster(full_suffix)?;
         }
     }
 

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -4431,6 +4431,10 @@ pub(crate) fn dispatch(subcmd: &str, rest: &[String], opts: &GlobalOpts) -> Resu
                             let _ = std::io::stdout().flush();
                             std::process::exit(129);
                         }
+                        Err(ParseOptionsToolError::Silent) => {
+                            let _ = std::io::stderr().flush();
+                            std::process::exit(1);
+                        }
                         Err(ParseOptionsToolError::Fatal(s)) => {
                             eprint!("{s}");
                             let _ = std::io::stderr().flush();
@@ -4455,6 +4459,10 @@ pub(crate) fn dispatch(subcmd: &str, rest: &[String], opts: &GlobalOpts) -> Resu
                             let _ = std::io::stdout().flush();
                             std::process::exit(129);
                         }
+                        Err(ParseOptionsToolError::Silent) => {
+                            let _ = std::io::stderr().flush();
+                            std::process::exit(1);
+                        }
                         Err(ParseOptionsToolError::Fatal(s)) => {
                             eprint!("{s}");
                             let _ = std::io::stderr().flush();
@@ -4478,6 +4486,10 @@ pub(crate) fn dispatch(subcmd: &str, rest: &[String], opts: &GlobalOpts) -> Resu
                         Err(ParseOptionsToolError::Help) => {
                             let _ = std::io::stdout().flush();
                             std::process::exit(129);
+                        }
+                        Err(ParseOptionsToolError::Silent) => {
+                            let _ = std::io::stderr().flush();
+                            std::process::exit(1);
                         }
                         Err(ParseOptionsToolError::Fatal(s)) => {
                             eprint!("{s}");

--- a/logs/2026-04-09_t0040-parse-options-fix.md
+++ b/logs/2026-04-09_t0040-parse-options-fix.md
@@ -1,0 +1,19 @@
+# t0040-parse-options fix
+
+## Summary
+
+Aligned `test-tool parse-options` with Git `parse-options.c` behavior so `tests/t0040-parse-options.sh` passes 94/94.
+
+## Changes
+
+- Short options: explicit letters win over `OPTION_NUMBER` digit runs (`-b-4` → boolean then bit, not `-b` + `-4` as number).
+- Typo detection: `check_typos` on full cluster after `-` (e.g. `-boolean`, `-ambiguous`); prefix match uses `starts_with(long_name, user)` semantics.
+- `--no-list` clears list without requiring `=`; quiet uses positive count-up like Git.
+- `--no-length`: callback error exits 1 with empty stderr (`ParseOptionsToolError::Silent`).
+- Usage appended after unknown-option errors: no extra blank line before help text.
+
+## Validation
+
+- `cargo test -p grit-lib --lib`
+- `cargo clippy -p grit-lib -p grit-rs`
+- `./scripts/run-tests.sh t0040-parse-options.sh` → 94/94


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Brings `grit test-tool parse-options` in line with Git `parse-options.c` so `tests/t0040-parse-options.sh` passes **94/94**.

## Key changes

- **Short options:** Scan explicit short letters first; only treat a digit run as `OPTION_NUMBER` when no short option matches (fixes `-DB`, `-b-4`, `-12345`).
- **Typo detection:** Run `check_typos` on the full argv suffix after `-` (e.g. `-boolean`, `-ambiguous`), using Git-style prefix matching (`starts_with(long_name, user)`).
- **`--no-list`:** Clears the list without requiring `=`.
- **`--quiet`:** Count-up matches Git (positive integers).
- **`--no-length`:** Callback failure exits **1** with **empty stderr** (`ParseOptionsToolError::Silent`).
- **Usage after errors:** No extra blank line between the error line and appended help (matches `check_unknown_i18n` expectations).

## Validation

- `cargo test -p grit-lib --lib`
- `cargo clippy -p grit-lib -p grit-rs`
- `./scripts/run-tests.sh t0040-parse-options.sh` → 94/94
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b20ffa5-8071-4a9c-8c37-91899c88859d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b20ffa5-8071-4a9c-8c37-91899c88859d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

