### PR TITLE
fix: make t4203-mailmap fully pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -821,7 +821,7 @@ t4201-log-graph	t4	yes	23	22	1	false	ok	0
 t4201-shortlog	t4	yes	32	3	29	false	ok	0
 t4202-log	t4	skip	145	0	0	false	ok	0
 t4203-log-diff-filter	t4	yes	7	7	0	true	ok	0
-t4203-mailmap	t4	yes	74	21	53	false	ok	0
+t4203-mailmap	t4	yes	74	74	0	true	ok	0
 t4204-log-follow	t4	yes	5	5	0	true	ok	0
 t4204-patch-id	t4	yes	26	26	0	true	ok	0
 t4205-log-pretty-formats	t4	yes	123	54	69	false	ok	2

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.2% of harness tests passing (35,739 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.2% of harness tests passing (35,739 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T22:31:25+00:00" class="gen-time" title="2026-04-09 22:31 UTC">2026-04-09 22:31 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.2%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,739</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.2%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -230,22 +230,22 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">73/178 files · 2 skipped · 2,862/4,438 tests</span>
+        <span class="group-meta">74/178 files · 2 skipped · 2,915/4,438 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.5%"></div></div>
-        <span class="group-pct pct-blue">64.5%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:65.7%"></div></div>
+        <span class="group-pct pct-blue">65.7%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35739 of 45142 tests passing across 1405 harness files (79.2% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.2% pass rate · 35,739 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T22:31:25+00:00" class="gen-time" title="2026-04-09 22:31 UTC">2026-04-09 22:31 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,739</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -8367,14 +8367,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="74" data-passed="21">
+<tr class="" data-group="t4" data-tests="74" data-passed="74" data-full-pass="1">
   <td class="mono">t4203-mailmap</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">74</td>
-  <td class="right">21</td>
+  <td class="right">74</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:28.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="5" data-passed="5" data-full-pass="1">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/mailmap.rs
+++ b/grit-lib/src/mailmap.rs
@@ -1,16 +1,22 @@
 //! Parse `.mailmap` and resolve author/committer identities (Git-compatible).
+//!
+//! Behaviour matches Git's `mailmap.c`: load order, `mailmap.blob` default in bare repos,
+//! nofollow for in-tree `.mailmap`, and case-insensitive email/name matching with
+//! per-email buckets (simple remap vs name-specific entries).
 
 use crate::config::ConfigSet;
 use crate::error::Error as GustError;
 use crate::objects::ObjectKind;
 use crate::repo::Repository;
 use crate::rev_parse::resolve_revision;
+use std::collections::BTreeMap;
 use std::fs;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 
 type Result<T> = std::result::Result<T, GustError>;
 
-/// One line from a `.mailmap` file after parsing.
+/// Legacy line-shaped entry kept for API compatibility; prefer [`MailmapTable`].
 #[derive(Debug, Clone)]
 pub struct MailmapEntry {
     /// Canonical name (`None` = keep original).
@@ -23,101 +29,230 @@ pub struct MailmapEntry {
     pub match_email: String,
 }
 
-struct EmailSpan {
-    value: String,
-    start: usize,
-    end: usize,
+#[derive(Debug, Default, Clone)]
+struct MailmapInfo {
+    name: Option<String>,
+    email: Option<String>,
 }
 
-fn extract_emails(line: &str) -> Vec<EmailSpan> {
-    let mut emails = Vec::new();
-    let mut search_from = 0;
+#[derive(Debug, Default, Clone)]
+struct MailmapBucket {
+    /// Simple entry: remap any name with this email (`old_name == None` lines).
+    simple: MailmapInfo,
+    /// Name-specific remaps keyed by lowercased old name.
+    by_name: BTreeMap<String, MailmapInfo>,
+}
 
-    while let Some(start) = line[search_from..].find('<') {
-        let abs_start = search_from + start;
-        if let Some(end) = line[abs_start..].find('>') {
-            let abs_end = abs_start + end + 1;
-            let email = line[abs_start + 1..abs_end - 1].to_string();
-            emails.push(EmailSpan {
-                value: email,
-                start: abs_start,
-                end: abs_end,
-            });
-            search_from = abs_end;
+/// Parsed mailmap as a lookup table (Git `string_list` + nested `namemap`).
+#[derive(Debug, Default, Clone)]
+pub struct MailmapTable {
+    /// Key: lowercased match email.
+    buckets: BTreeMap<String, MailmapBucket>,
+}
+
+impl MailmapTable {
+    /// Returns true when no mappings are configured.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.buckets.is_empty()
+    }
+
+    /// Apply mailmap to a name/email pair (both may be empty strings).
+    ///
+    /// Returns `(mapped_name, mapped_email)` after applying the same rules as Git's `map_user`.
+    #[must_use]
+    pub fn map_user(&self, mut name: String, mut email: String) -> (String, String) {
+        let key = email.to_ascii_lowercase();
+        let Some(bucket) = self.buckets.get(&key) else {
+            return (name, email);
+        };
+
+        let info = if !bucket.by_name.is_empty() {
+            let nk = name.to_ascii_lowercase();
+            bucket.by_name.get(&nk).or_else(|| {
+                if bucket.simple.name.is_some() || bucket.simple.email.is_some() {
+                    Some(&bucket.simple)
+                } else {
+                    None
+                }
+            })
         } else {
-            break;
-        }
-    }
-
-    emails
-}
-
-fn parse_mailmap_line(line: &str) -> Option<MailmapEntry> {
-    let emails = extract_emails(line);
-
-    match emails.len() {
-        1 => {
-            let email = &emails[0];
-            let before = line[..email.start].trim();
-            let canonical_name = if before.is_empty() {
-                None
+            if bucket.simple.name.is_some() || bucket.simple.email.is_some() {
+                Some(&bucket.simple)
             } else {
-                Some(before.to_string())
-            };
-            Some(MailmapEntry {
-                canonical_name,
-                canonical_email: Some(email.value.clone()),
-                match_name: None,
-                match_email: email.value.clone(),
-            })
-        }
-        2 => {
-            let canonical_email = &emails[0];
-            let match_email = &emails[1];
-
-            let before_first = line[..canonical_email.start].trim();
-            let between = line[canonical_email.end..match_email.start].trim();
-
-            let canonical_name = if before_first.is_empty() {
                 None
-            } else {
-                Some(before_first.to_string())
-            };
+            }
+        };
 
-            let match_name = if between.is_empty() {
-                None
-            } else {
-                Some(between.to_string())
-            };
-
-            Some(MailmapEntry {
-                canonical_name,
-                canonical_email: Some(canonical_email.value.clone()),
-                match_name,
-                match_email: match_email.value.clone(),
-            })
+        let Some(info) = info else {
+            return (name, email);
+        };
+        if info.name.is_none() && info.email.is_none() {
+            return (name, email);
         }
-        _ => None,
+        if let Some(ref e) = info.email {
+            email.clone_from(e);
+        }
+        if let Some(ref n) = info.name {
+            name.clone_from(n);
+        }
+        (name, email)
     }
 }
 
-/// Parse a `.mailmap` file body into entries (comments and blanks skipped).
+fn ascii_lowercase_owned(s: &str) -> String {
+    s.chars().map(|c| c.to_ascii_lowercase()).collect()
+}
+
+fn add_mapping(
+    table: &mut MailmapTable,
+    new_name: Option<String>,
+    new_email: Option<String>,
+    old_name: Option<String>,
+    old_email: Option<String>,
+) {
+    // Match Git `add_mapping`: when the line has only one `<email>` pair, `old_email` is NULL and
+    // the canonical email is the lookup key (`old_email = new_email; new_email = NULL`).
+    let (old_email, new_email) = match (old_email, new_email) {
+        (None, Some(e)) => (e, None),
+        (Some(old), new) => (old, new),
+        (None, None) => return,
+    };
+
+    let key = ascii_lowercase_owned(&old_email);
+    let bucket = table.buckets.entry(key).or_default();
+
+    if let Some(old_n) = old_name {
+        let nk = ascii_lowercase_owned(&old_n);
+        let mut mi = MailmapInfo::default();
+        mi.name = new_name;
+        mi.email = new_email;
+        bucket.by_name.insert(nk, mi);
+    } else {
+        if let Some(n) = new_name {
+            bucket.simple.name = Some(n);
+        }
+        if let Some(e) = new_email {
+            bucket.simple.email = Some(e);
+        }
+    }
+}
+
+/// Parse `buffer` like Git's `parse_name_and_email` (second pair uses `allow_empty_email`).
+fn parse_name_and_email(
+    buffer: &str,
+    allow_empty_email: bool,
+) -> Option<(Option<String>, Option<String>, &str)> {
+    let left = buffer.find('<')?;
+    let rest = &buffer[left + 1..];
+    let right_rel = rest.find('>')?;
+    if !allow_empty_email && right_rel == 0 {
+        return None;
+    }
+    // Do not trim inside `<>` — Git keeps spaces as part of the map key so
+    // `< a@example.com >` does not match a commit's `a@example.com` (t4203).
+    let email = rest[..right_rel].to_string();
+    let right = left + 1 + right_rel;
+    let name_part = buffer[..left].trim_end_matches(|c: char| c.is_ascii_whitespace());
+    let name = if name_part.is_empty() {
+        None
+    } else {
+        Some(name_part.to_string())
+    };
+    let after = buffer.get(right + 1..).unwrap_or("");
+    Some((name, Some(email), after))
+}
+
+fn read_mailmap_line_into(table: &mut MailmapTable, line: &str) {
+    let line = line.trim_end_matches(['\r', '\n']);
+    let line = line.trim_start();
+    if line.is_empty() || line.starts_with('#') {
+        return;
+    }
+
+    // Match Git `read_mailmap_line`: the first pair uses `allow_empty_email=0`, so a line whose
+    // first `<>` is empty (e.g. `Cee <> <c@example.com>`) is ignored entirely — only the second
+    // pair is parsed with `allow_empty_email=1`.
+    let (name1, email1, rest1) = match parse_name_and_email(line, false) {
+        Some(x) => x,
+        None => return,
+    };
+
+    let (name2, email2) = if rest1.trim().is_empty() {
+        (None, None)
+    } else {
+        match parse_name_and_email(rest1.trim_start(), true) {
+            Some((n, e, tail)) if tail.trim().is_empty() => (n, e),
+            _ => return,
+        }
+    };
+
+    add_mapping(table, name1, email1, name2, email2);
+}
+
+/// Append mappings from a mailmap file body (Git `read_mailmap_string`).
+pub fn read_mailmap_string(table: &mut MailmapTable, buf: &str) {
+    let mut start = 0usize;
+    for (i, ch) in buf.char_indices() {
+        if ch == '\n' {
+            read_mailmap_line_into(table, &buf[start..i]);
+            start = i + 1;
+        }
+    }
+    if start < buf.len() {
+        read_mailmap_line_into(table, &buf[start..]);
+    }
+}
+
+/// Convert a legacy vector of line entries into a table (last-wins per Git order is already in vec order).
+#[must_use]
+pub fn table_from_entries(entries: &[MailmapEntry]) -> MailmapTable {
+    let mut table = MailmapTable::default();
+    for e in entries {
+        add_mapping(
+            &mut table,
+            e.canonical_name.clone(),
+            e.canonical_email.clone(),
+            e.match_name.clone(),
+            Some(e.match_email.clone()),
+        );
+    }
+    table
+}
+
+/// Parse a `.mailmap` file body into legacy line entries (for compatibility).
 #[must_use]
 pub fn parse_mailmap(content: &str) -> Vec<MailmapEntry> {
-    let mut entries = Vec::new();
+    table_to_entries(&build_mailmap_table_from_str(content))
+}
 
-    for line in content.lines() {
-        let line = line.trim();
-        if line.is_empty() || line.starts_with('#') {
-            continue;
+fn build_mailmap_table_from_str(content: &str) -> MailmapTable {
+    let mut table = MailmapTable::default();
+    read_mailmap_string(&mut table, content);
+    table
+}
+
+fn table_to_entries(table: &MailmapTable) -> Vec<MailmapEntry> {
+    let mut out = Vec::new();
+    for (email_lc, bucket) in &table.buckets {
+        if bucket.simple.name.is_some() || bucket.simple.email.is_some() {
+            out.push(MailmapEntry {
+                canonical_name: bucket.simple.name.clone(),
+                canonical_email: bucket.simple.email.clone(),
+                match_name: None,
+                match_email: email_lc.clone(),
+            });
         }
-
-        if let Some(entry) = parse_mailmap_line(line) {
-            entries.push(entry);
+        for (name_lc, mi) in &bucket.by_name {
+            out.push(MailmapEntry {
+                canonical_name: mi.name.clone(),
+                canonical_email: mi.email.clone(),
+                match_name: Some(name_lc.clone()),
+                match_email: email_lc.clone(),
+            });
         }
     }
-
-    entries
+    out
 }
 
 /// Parse a contact string `Name <email>` or `<email>`.
@@ -149,34 +284,38 @@ pub fn parse_contact(contact: &str) -> (Option<String>, Option<String>) {
     (Some(contact.to_string()), None)
 }
 
-/// Map `(name, email)` through the mailmap; last matching rule wins (Git order).
+/// Map `(name, email)` through the mailmap; uses [`MailmapTable`] internally.
 #[must_use]
 pub fn map_contact(
     name: Option<&str>,
     email: Option<&str>,
     mailmap: &[MailmapEntry],
 ) -> (String, String) {
-    let orig_name = name.unwrap_or("");
-    let orig_email = email.unwrap_or("");
-
-    for entry in mailmap.iter().rev() {
-        if !entry.match_email.eq_ignore_ascii_case(orig_email) {
-            continue;
-        }
-
-        if let Some(ref match_name) = entry.match_name {
-            if !match_name.eq_ignore_ascii_case(orig_name) {
-                continue;
-            }
-        }
-
-        let result_name = entry.canonical_name.as_deref().unwrap_or(orig_name);
-        let result_email = entry.canonical_email.as_deref().unwrap_or(orig_email);
-
-        return (result_name.to_string(), result_email.to_string());
+    let mut table = MailmapTable::default();
+    for e in mailmap {
+        add_mapping(
+            &mut table,
+            e.canonical_name.clone(),
+            e.canonical_email.clone(),
+            e.match_name.clone(),
+            Some(e.match_email.clone()),
+        );
     }
+    let n = name.unwrap_or("").to_string();
+    let e = email.unwrap_or("").to_string();
+    table.map_user(n, e)
+}
 
-    (orig_name.to_string(), orig_email.to_string())
+/// Map using a pre-built table.
+#[must_use]
+pub fn map_contact_table(
+    name: Option<&str>,
+    email: Option<&str>,
+    table: &MailmapTable,
+) -> (String, String) {
+    let n = name.unwrap_or("").to_string();
+    let e = email.unwrap_or("").to_string();
+    table.map_user(n, e)
 }
 
 /// Format a contact for display (`check-mailmap` style).
@@ -200,12 +339,46 @@ fn resolve_mailmap_path(base: &Path, value: &str) -> PathBuf {
     }
 }
 
-fn read_optional_mailmap_file(path: &Path) -> Result<String> {
-    if path.exists() {
+fn read_mailmap_file_nofollow(path: &Path) -> Result<String> {
+    #[cfg(unix)]
+    {
+        use std::ffi::CString;
+        use std::os::unix::io::FromRawFd;
+
+        let path_str = path
+            .to_str()
+            .ok_or_else(|| GustError::PathError(path.display().to_string()))?;
+        let c_path =
+            CString::new(path_str).map_err(|_| GustError::PathError(path.display().to_string()))?;
+        let fd = unsafe { libc::open(c_path.as_ptr(), libc::O_RDONLY | libc::O_NOFOLLOW, 0) };
+        if fd < 0 {
+            return Err(GustError::PathError(format!(
+                "unable to open mailmap at {}",
+                path.display()
+            )));
+        }
+        let mut file = unsafe { fs::File::from_raw_fd(fd) };
+        let mut s = String::new();
+        file.read_to_string(&mut s)
+            .map_err(|e| GustError::PathError(format!("reading {}: {e}", path.display())))?;
+        Ok(s)
+    }
+    #[cfg(not(unix))]
+    {
         fs::read_to_string(path)
             .map_err(|e| GustError::PathError(format!("reading {}: {e}", path.display())))
+    }
+}
+
+fn read_optional_mailmap_file(path: &Path, nofollow: bool) -> Result<String> {
+    if !path.exists() {
+        return Ok(String::new());
+    }
+    if nofollow {
+        read_mailmap_file_nofollow(path)
     } else {
-        Ok(String::new())
+        fs::read_to_string(path)
+            .map_err(|e| GustError::PathError(format!("reading {}: {e}", path.display())))
     }
 }
 
@@ -219,49 +392,231 @@ pub fn read_mailmap_blob(repo: &Repository, spec: &str) -> Result<String> {
         .map_err(|e| GustError::PathError(format!("reading mailmap blob '{spec}': {e}")))?;
     if obj.kind != ObjectKind::Blob {
         return Err(GustError::PathError(format!(
-            "mailmap.blob '{spec}' does not resolve to a blob object"
+            "mailmap is not a blob: {spec}"
         )));
     }
     Ok(String::from_utf8_lossy(&obj.data).into_owned())
 }
 
-/// Load and concatenate all configured mailmap sources for a repository.
-pub fn load_mailmap_raw(repo: &Repository) -> Result<String> {
-    let mut mailmap_content = String::new();
+fn try_read_mailmap_blob(repo: &Repository, spec: &str) -> Result<Option<String>> {
+    let oid = match resolve_revision(repo, spec) {
+        Ok(o) => o,
+        Err(_) => return Ok(None),
+    };
+    let obj = repo
+        .odb
+        .read(&oid)
+        .map_err(|e| GustError::PathError(format!("reading mailmap blob '{spec}': {e}")))?;
+    if obj.kind != ObjectKind::Blob {
+        return Err(GustError::PathError(format!(
+            "mailmap is not a blob: {spec}"
+        )));
+    }
+    Ok(Some(String::from_utf8_lossy(&obj.data).into_owned()))
+}
 
-    if let Some(ref wt) = repo.work_tree {
-        mailmap_content.push_str(&read_optional_mailmap_file(&wt.join(".mailmap"))?);
-        if !mailmap_content.ends_with('\n') && !mailmap_content.is_empty() {
-            mailmap_content.push('\n');
-        }
+/// Load mailmap from the repository using Git's source order and merge rules.
+pub fn load_mailmap_table(repo: &Repository) -> Result<MailmapTable> {
+    let mut table = MailmapTable::default();
+    load_mailmap_into(repo, &mut table)?;
+    Ok(table)
+}
+
+/// Merge Git's configured mailmap sources into `table`.
+pub fn load_mailmap_into(repo: &Repository, table: &mut MailmapTable) -> Result<()> {
+    let config = ConfigSet::load(Some(&repo.git_dir), true)?;
+    let mut mailmap_blob = config.get("mailmap.blob");
+    let is_bare = repo.work_tree.is_none();
+    if mailmap_blob.is_none() && is_bare {
+        mailmap_blob = Some("HEAD:.mailmap".to_string());
     }
 
-    let config = ConfigSet::load(Some(&repo.git_dir), true)?;
     let base_dir = repo
         .work_tree
         .as_deref()
         .unwrap_or(repo.git_dir.as_path())
         .to_path_buf();
 
-    if let Some(file) = config.get("mailmap.file") {
-        mailmap_content.push_str(&read_optional_mailmap_file(&resolve_mailmap_path(
-            &base_dir, &file,
-        ))?);
-        if !mailmap_content.ends_with('\n') && !mailmap_content.is_empty() {
-            mailmap_content.push('\n');
-        }
+    if let Some(ref wt) = repo.work_tree {
+        let in_tree = wt.join(".mailmap");
+        let body = read_optional_mailmap_file(&in_tree, true)?;
+        read_mailmap_string(table, &body);
     }
-    if let Some(blob) = config.get("mailmap.blob") {
-        mailmap_content.push_str(&read_mailmap_blob(repo, &blob)?);
-        if !mailmap_content.ends_with('\n') && !mailmap_content.is_empty() {
-            mailmap_content.push('\n');
+
+    if let Some(ref blob) = mailmap_blob {
+        match try_read_mailmap_blob(repo, blob) {
+            Ok(Some(content)) => read_mailmap_string(table, &content),
+            Ok(None) => {}
+            Err(e) => {
+                // Git's `read_mailmap` ignores the aggregated error from `read_mailmap_blob`, but
+                // still emits `error("mailmap is not a blob: ...")` to stderr for wrong object types.
+                let msg = e.to_string();
+                if msg.contains("mailmap is not a blob") {
+                    eprintln!("{msg}");
+                } else {
+                    return Err(e);
+                }
+            }
         }
     }
 
-    Ok(mailmap_content)
+    if let Some(file) = config.get("mailmap.file") {
+        read_mailmap_string(
+            table,
+            &read_optional_mailmap_file(&resolve_mailmap_path(&base_dir, &file), false)?,
+        );
+    }
+
+    Ok(())
+}
+
+/// Concatenated raw mailmap text (legacy); sources joined in Git load order.
+pub fn load_mailmap_raw(repo: &Repository) -> Result<String> {
+    let config = ConfigSet::load(Some(&repo.git_dir), true)?;
+    let mut mailmap_blob = config.get("mailmap.blob");
+    let is_bare = repo.work_tree.is_none();
+    if mailmap_blob.is_none() && is_bare {
+        mailmap_blob = Some("HEAD:.mailmap".to_string());
+    }
+
+    let base_dir = repo
+        .work_tree
+        .as_deref()
+        .unwrap_or(repo.git_dir.as_path())
+        .to_path_buf();
+
+    let mut out = String::new();
+
+    if let Some(ref wt) = repo.work_tree {
+        let body = read_optional_mailmap_file(&wt.join(".mailmap"), true)?;
+        if !body.is_empty() {
+            out.push_str(&body);
+            if !out.ends_with('\n') {
+                out.push('\n');
+            }
+        }
+    }
+
+    if let Some(ref blob) = mailmap_blob {
+        match try_read_mailmap_blob(repo, blob) {
+            Ok(Some(content)) => {
+                if !content.is_empty() {
+                    out.push_str(&content);
+                    if !out.ends_with('\n') {
+                        out.push('\n');
+                    }
+                }
+            }
+            Ok(None) => {}
+            Err(e) => {
+                let msg = e.to_string();
+                if msg.contains("mailmap is not a blob") {
+                    eprintln!("{msg}");
+                } else {
+                    return Err(e);
+                }
+            }
+        }
+    }
+
+    if let Some(file) = config.get("mailmap.file") {
+        let body = read_optional_mailmap_file(&resolve_mailmap_path(&base_dir, &file), false)?;
+        if !body.is_empty() {
+            out.push_str(&body);
+            if !out.ends_with('\n') {
+                out.push('\n');
+            }
+        }
+    }
+
+    Ok(out)
 }
 
 /// Parsed mailmap for the repository (default `.mailmap` + config).
 pub fn load_mailmap(repo: &Repository) -> Result<Vec<MailmapEntry>> {
-    Ok(parse_mailmap(&load_mailmap_raw(repo)?))
+    let table = load_mailmap_table(repo)?;
+    Ok(table_to_entries(&table))
+}
+
+/// Rewrite `author ` / `committer ` / `tagger ` header lines in a commit or tag object buffer.
+///
+/// Git applies mailmap only to the `Name <email>` prefix; the trailing ` <epoch> <tz>` is preserved.
+#[must_use]
+pub fn apply_mailmap_to_commit_or_tag_bytes(data: &[u8], mailmap: &MailmapTable) -> Vec<u8> {
+    if mailmap.is_empty() {
+        return data.to_vec();
+    }
+    let Some(pos) = data.windows(2).position(|w| w == b"\n\n") else {
+        return data.to_vec();
+    };
+    let (headers, rest) = data.split_at(pos + 1);
+    let header_text = String::from_utf8_lossy(headers);
+    let mut out = String::with_capacity(data.len() + 64);
+    for line in header_text.lines() {
+        let rewritten = rewrite_identity_header_line(line, mailmap);
+        out.push_str(&rewritten);
+        out.push('\n');
+    }
+    out.push('\n');
+    out.push_str(&String::from_utf8_lossy(&rest[1..]));
+    out.into_bytes()
+}
+
+fn rewrite_identity_header_line(line: &str, mailmap: &MailmapTable) -> String {
+    for pref in ["author ", "committer ", "tagger "] {
+        if let Some(rest) = line.strip_prefix(pref) {
+            let rest = rest.trim_end_matches('\r');
+            let Some(gt) = rest.rfind('>') else {
+                return line.to_string();
+            };
+            let ident = &rest[..=gt];
+            let tail = rest[gt + 1..].trim_start();
+            let (name, email) = parse_contact(ident);
+            let (n, e) = map_contact_table(name.as_deref(), email.as_deref(), mailmap);
+            let new_ident = render_contact(&n, &e);
+            if tail.is_empty() {
+                return format!("{pref}{new_ident}");
+            }
+            return format!("{pref}{new_ident} {tail}");
+        }
+    }
+    line.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_entry_after_email_merges() {
+        let mut t = MailmapTable::default();
+        read_mailmap_string(
+            &mut t,
+            "<bugs@company.xy> <bugs@company.xx>\nInternal Guy <bugs@company.xx>\n",
+        );
+        let (n, e) = t.map_user("nick1".into(), "bugs@company.xx".into());
+        assert_eq!(n, "Internal Guy");
+        assert_eq!(e, "bugs@company.xy");
+    }
+
+    #[test]
+    fn single_pair_line_maps_name_only() {
+        let mut t = MailmapTable::default();
+        read_mailmap_string(&mut t, "Committed <committer@example.com>\n");
+        let (n, e) = t.map_user("C O Mitter".into(), "committer@example.com".into());
+        assert_eq!(n, "Committed");
+        assert_eq!(e, "committer@example.com");
+    }
+
+    #[test]
+    fn whitespace_inside_angle_brackets_is_part_of_map_key() {
+        let mut t = MailmapTable::default();
+        read_mailmap_string(&mut t, "Ah <ah@example.com> < a@example.com >\n");
+        let (n, e) = t.map_user("A".into(), "a@example.com".into());
+        assert_eq!(n, "A");
+        assert_eq!(e, "a@example.com");
+        let (n2, e2) = t.map_user("A".into(), " a@example.com ".into());
+        assert_eq!(n2, "Ah");
+        assert_eq!(e2, "ah@example.com");
+    }
 }

--- a/grit-lib/src/rev_parse.rs
+++ b/grit-lib/src/rev_parse.rs
@@ -899,10 +899,24 @@ fn normalize_path_components(path: PathBuf) -> PathBuf {
     out
 }
 
+fn normalize_colon_path_for_bare_tree_path(raw_path: &str) -> String {
+    let mut stack: Vec<&str> = Vec::new();
+    for part in raw_path.split('/').filter(|p| !p.is_empty() && *p != ".") {
+        if part == ".." {
+            let _ = stack.pop();
+        } else {
+            stack.push(part);
+        }
+    }
+    stack.join("/")
+}
+
 fn normalize_colon_path_for_tree(repo: &Repository, raw_path: &str) -> Result<String> {
-    let work_tree = repo.work_tree.as_ref().ok_or_else(|| {
-        Error::InvalidRef("relative path syntax can't be used outside working tree".to_owned())
-    })?;
+    let Some(work_tree) = repo.work_tree.as_ref() else {
+        return Ok(normalize_colon_path_for_bare_tree_path(
+            raw_path.trim_start_matches('/'),
+        ));
+    };
 
     let cwd = std::env::current_dir().map_err(Error::Io)?;
     let wt_canon = work_tree.canonicalize().map_err(Error::Io)?;

--- a/grit/src/commands/blame.rs
+++ b/grit/src/commands/blame.rs
@@ -9,6 +9,7 @@ use grit_lib::crlf::{
     ConversionConfig, GitAttributes,
 };
 use grit_lib::git_date::approx::approxidate_careful;
+use grit_lib::mailmap::load_mailmap_table;
 use grit_lib::objects::{parse_commit, parse_tree, CommitData, ObjectId, ObjectKind};
 use grit_lib::odb::Odb;
 use grit_lib::repo::Repository;
@@ -359,6 +360,45 @@ impl BlameMetaEncoding {
                 commit_encoding::reencode_utf8_to_label(label, &line)
                     .ok_or_else(|| anyhow::anyhow!("unsupported blame output encoding: {label}"))
             }
+        }
+    }
+
+    /// Author name bytes after optional mailmap (UTF-8 canonical name from map).
+    fn author_name_bytes_mailmapped(
+        &self,
+        commit: &CommitData,
+        mailmap: &grit_lib::mailmap::MailmapTable,
+    ) -> Result<Vec<u8>> {
+        if mailmap.is_empty() {
+            return self.author_name_bytes(commit);
+        }
+        let ai = parse_author_field(&commit.author);
+        let (n, _) = mailmap.map_user(ai.name, ai.email);
+        match self {
+            Self::Utf8 => Ok(n.into_bytes()),
+            Self::Raw => self.author_name_bytes(commit),
+            Self::Reencode(label) => commit_encoding::reencode_utf8_to_label(label, &n)
+                .ok_or_else(|| anyhow::anyhow!("unsupported blame output encoding: {label}")),
+        }
+    }
+
+    /// `author-mail` bytes after optional mailmap.
+    fn author_mail_bytes_mailmapped(
+        &self,
+        commit: &CommitData,
+        mailmap: &grit_lib::mailmap::MailmapTable,
+    ) -> Result<Vec<u8>> {
+        if mailmap.is_empty() {
+            return self.author_mail_bytes(commit);
+        }
+        let ai = parse_author_field(&commit.author);
+        let (_, e) = mailmap.map_user(ai.name, ai.email);
+        let line = format!("<{e}>");
+        match self {
+            Self::Utf8 => Ok(line.into_bytes()),
+            Self::Raw => self.author_mail_bytes(commit),
+            Self::Reencode(label) => commit_encoding::reencode_utf8_to_label(label, &line)
+                .ok_or_else(|| anyhow::anyhow!("unsupported blame output encoding: {label}")),
         }
     }
 
@@ -2406,6 +2446,7 @@ pub fn run(mut args: Args) -> Result<()> {
     }
 
     let meta_enc = BlameMetaEncoding::from_config_and_cli(&config, args.encoding.as_deref())?;
+    let mailmap = load_mailmap_table(&repo).unwrap_or_default();
 
     if args.porcelain || args.line_porcelain || args.incremental {
         write_porcelain(
@@ -2416,17 +2457,26 @@ pub fn run(mut args: Args) -> Result<()> {
             args.line_porcelain,
             args.incremental,
             &meta_enc,
+            &mailmap,
             mark_unblamable,
             mark_ignored,
         )?;
     } else if args.annotate_output {
-        write_annotate(&mut out, &blame_lines, &commits, &args, &file_path)?;
+        write_annotate(
+            &mut out,
+            &blame_lines,
+            &commits,
+            &args,
+            &mailmap,
+            &file_path,
+        )?;
     } else {
         write_default(
             &mut out,
             &blame_lines,
             &commits,
             &args,
+            &mailmap,
             &blame_color_style,
             &file_path,
             mark_unblamable,
@@ -3215,6 +3265,7 @@ fn write_porcelain(
     line_porcelain: bool,
     incremental: bool,
     meta_enc: &BlameMetaEncoding,
+    mailmap: &grit_lib::mailmap::MailmapTable,
     mark_unblamable: bool,
     mark_ignored: bool,
 ) -> Result<()> {
@@ -3257,10 +3308,10 @@ fn write_porcelain(
             let committer = parse_author_field(&commit.committer);
 
             out.write_all(b"author ")?;
-            out.write_all(&meta_enc.author_name_bytes(commit)?)?;
+            out.write_all(&meta_enc.author_name_bytes_mailmapped(commit, mailmap)?)?;
             out.write_all(b"\n")?;
             out.write_all(b"author-mail ")?;
-            out.write_all(&meta_enc.author_mail_bytes(commit)?)?;
+            out.write_all(&meta_enc.author_mail_bytes_mailmapped(commit, mailmap)?)?;
             out.write_all(b"\n")?;
             writeln!(out, "author-time {}", author.timestamp)?;
             writeln!(out, "author-tz {}", author.tz)?;
@@ -3305,13 +3356,14 @@ fn write_annotate(
     lines: &[BlameLine],
     commits: &HashMap<ObjectId, CommitData>,
     args: &Args,
+    mailmap: &grit_lib::mailmap::MailmapTable,
     _file_path: &str,
 ) -> Result<()> {
     let zero = grit_lib::diff::zero_oid();
 
     let mut author_field_width: usize = 10;
     for bl in lines {
-        let w = annotate_author_field_width(bl, commits, args);
+        let w = annotate_author_field_width(bl, commits, args, mailmap);
         author_field_width = author_field_width.max(w);
     }
 
@@ -3322,7 +3374,7 @@ fn write_annotate(
             bl.oid.to_hex()[..8].to_string()
         };
 
-        let (author_display, ts) = annotate_author_and_time(bl, commits, args);
+        let (author_display, ts) = annotate_author_and_time(bl, commits, args, mailmap);
         let author_padded = format!("{author_display:>author_field_width$}");
 
         writeln!(
@@ -3339,8 +3391,9 @@ fn annotate_author_field_width(
     bl: &BlameLine,
     commits: &HashMap<ObjectId, CommitData>,
     args: &Args,
+    mailmap: &grit_lib::mailmap::MailmapTable,
 ) -> usize {
-    let (name, _ts) = annotate_author_and_time(bl, commits, args);
+    let (name, _ts) = annotate_author_and_time(bl, commits, args, mailmap);
     name.chars().count().max(1)
 }
 
@@ -3348,6 +3401,7 @@ fn annotate_author_and_time(
     bl: &BlameLine,
     commits: &HashMap<ObjectId, CommitData>,
     args: &Args,
+    mailmap: &grit_lib::mailmap::MailmapTable,
 ) -> (String, String) {
     let zero = grit_lib::diff::zero_oid();
     if bl.external_contents {
@@ -3361,11 +3415,12 @@ fn annotate_author_and_time(
     }
     let commit = &commits[&bl.oid];
     let ai = parse_author_field(&commit.author);
-    let who = if args.email {
-        format!("<{}>", ai.email)
+    let (n, e) = if !mailmap.is_empty() {
+        mailmap.map_user(ai.name, ai.email)
     } else {
-        ai.name.clone()
+        (ai.name, ai.email)
     };
+    let who = if args.email { format!("<{e}>") } else { n };
     let ts = format_time(ai.timestamp, &ai.tz);
     (who, ts)
 }
@@ -3386,6 +3441,7 @@ fn write_default(
     lines: &[BlameLine],
     commits: &HashMap<ObjectId, CommitData>,
     args: &Args,
+    mailmap: &grit_lib::mailmap::MailmapTable,
     color_style: &BlameColorStyle,
     file_path: &str,
     mark_unblamable: bool,
@@ -3471,11 +3527,12 @@ fn write_default(
         } else {
             let commit = &commits[&bl.oid];
             let ai = parse_author_field(&commit.author);
-            let who = if args.email {
-                format!("<{}>", ai.email)
+            let (n, e) = if !mailmap.is_empty() {
+                mailmap.map_user(ai.name, ai.email)
             } else {
-                ai.name.clone()
+                (ai.name, ai.email)
             };
+            let who = if args.email { format!("<{e}>") } else { n };
             let ts = format_time(ai.timestamp, &ai.tz);
 
             writeln!(

--- a/grit/src/commands/cat_file.rs
+++ b/grit/src/commands/cat_file.rs
@@ -6,6 +6,7 @@ use grit_lib::config::ConfigSet;
 use grit_lib::crlf::{self, DiffAttr};
 use grit_lib::error::Error as LibError;
 use grit_lib::error::Result as LibResult;
+use grit_lib::mailmap::{apply_mailmap_to_commit_or_tag_bytes, load_mailmap_table, MailmapTable};
 use grit_lib::merge_diff::{convert_blob_to_worktree_for_path, run_textconv_raw};
 use grit_lib::pack;
 use grit_lib::rev_list::{self, ObjectFilter};
@@ -129,6 +130,16 @@ pub struct Args {
     #[arg(long)]
     pub unordered: bool,
 
+    /// Apply `.mailmap` when printing commit/tag objects (`-p`, `-s`, batch).
+    #[arg(long = "use-mailmap", visible_alias = "mailmap")]
+    pub use_mailmap: bool,
+
+    #[arg(long = "no-use-mailmap", hide = true)]
+    pub no_use_mailmap: bool,
+
+    #[arg(long = "no-mailmap", hide = true)]
+    pub no_mailmap: bool,
+
     /// Either `<type>` (when followed by `<object>`) or `<object>`.
     pub type_or_object: Option<String>,
 
@@ -235,18 +246,39 @@ pub fn run(args: Args) -> Result<()> {
         Err(e) => exit_cat_file_read_error(&e, &args, obj_str, &repo, &oid),
     };
 
+    let use_mailmap = args.use_mailmap && !args.no_use_mailmap && !args.no_mailmap;
+    let mailmap = if use_mailmap {
+        match load_mailmap_table(&repo) {
+            Ok(m) => m,
+            Err(e) => {
+                eprintln!("{e}");
+                std::process::exit(128);
+            }
+        }
+    } else {
+        MailmapTable::default()
+    };
+
     if args.show_type {
         println!("{}", obj.kind);
         return Ok(());
     }
 
     if args.size {
-        println!("{}", obj.data.len());
+        let sz = if use_mailmap
+            && !mailmap.is_empty()
+            && matches!(obj.kind, ObjectKind::Commit | ObjectKind::Tag)
+        {
+            apply_mailmap_to_commit_or_tag_bytes(&obj.data, &mailmap).len()
+        } else {
+            obj.data.len()
+        };
+        println!("{sz}");
         return Ok(());
     }
 
     if args.pretty {
-        pretty_print(&obj.kind, &obj.data)?;
+        pretty_print(&obj.kind, &obj.data, use_mailmap.then_some(&mailmap))?;
         return Ok(());
     }
 
@@ -311,20 +343,30 @@ pub fn run(args: Args) -> Result<()> {
 
         // Pretty-print or output the dereferenced object
         if args.pretty {
-            pretty_print(&current_obj.kind, &current_obj.data)?;
+            pretty_print(
+                &current_obj.kind,
+                &current_obj.data,
+                use_mailmap.then_some(&mailmap),
+            )?;
             return Ok(());
         }
 
         let stdout = io::stdout();
         let mut out = stdout.lock();
-        out.write_all(&current_obj.data)?;
+        write_commit_tag_maybe_mailmapped(
+            &mut out,
+            &current_obj.kind,
+            &current_obj.data,
+            use_mailmap,
+            &mailmap,
+        )?;
         return Ok(());
     }
 
     // Default: print raw content
     let stdout = io::stdout();
     let mut out = stdout.lock();
-    out.write_all(&obj.data)?;
+    write_commit_tag_maybe_mailmapped(&mut out, &obj.kind, &obj.data, use_mailmap, &mailmap)?;
 
     Ok(())
 }
@@ -740,6 +782,8 @@ struct BatchWriteOpts<'a> {
     objects_filter: Option<&'a ObjectFilter>,
     batch_textconv: bool,
     batch_filters: bool,
+    use_mailmap: bool,
+    mailmap: &'a MailmapTable,
 }
 
 fn loose_object_file(objects_dir: &Path, oid: &ObjectId) -> PathBuf {
@@ -804,6 +848,13 @@ fn run_batch(repo: &Repository, args: &Args) -> Result<()> {
 
     let batch_transform = args.textconv || args.filters;
 
+    let use_mailmap = args.use_mailmap && !args.no_use_mailmap && !args.no_mailmap;
+    let mailmap = if use_mailmap {
+        load_mailmap_table(repo)?
+    } else {
+        MailmapTable::default()
+    };
+
     let write_opts = BatchWriteOpts {
         ignore_replace: args.batch_all_objects,
         follow_symlinks: args.follow_symlinks,
@@ -811,6 +862,8 @@ fn run_batch(repo: &Repository, args: &Args) -> Result<()> {
         objects_filter: objects_filter.as_ref(),
         batch_textconv: args.textconv,
         batch_filters: args.filters,
+        use_mailmap,
+        mailmap: &mailmap,
     };
 
     let mut handle_line = |line: &str, disk_override: Option<u64>| -> Result<()> {
@@ -1101,12 +1154,25 @@ fn emit_batch_object_lines(
     disk_size_override: Option<u64>,
     rest: &str,
     content_override: Option<&[u8]>,
+    write_opts: BatchWriteOpts<'_>,
     out: &mut impl Write,
 ) -> Result<()> {
     let eol: &[u8] = if nul_output { b"\0" } else { b"\n" };
     let oid_str = oid.to_string();
     let kind_str = obj.kind.to_string();
-    let size = obj.data.len();
+    let raw_size = obj.data.len();
+    let mapped_data = if write_opts.use_mailmap
+        && !write_opts.mailmap.is_empty()
+        && matches!(obj.kind, ObjectKind::Commit | ObjectKind::Tag)
+    {
+        Some(apply_mailmap_to_commit_or_tag_bytes(
+            &obj.data,
+            write_opts.mailmap,
+        ))
+    } else {
+        None
+    };
+    let size = mapped_data.as_ref().map(|b| b.len()).unwrap_or(raw_size);
     let mode_str = match mode {
         Some(m) => format!("{:o}", m),
         None => String::new(),
@@ -1144,7 +1210,13 @@ fn emit_batch_object_lines(
     }
     out.write_all(eol)?;
     if include_content {
-        let payload = content_override.unwrap_or(obj.data.as_slice());
+        let payload = if let Some(co) = content_override {
+            co
+        } else if let Some(ref m) = mapped_data {
+            m.as_slice()
+        } else {
+            obj.data.as_slice()
+        };
         out.write_all(payload)?;
         out.write_all(eol)?;
     }
@@ -1191,6 +1263,7 @@ fn print_batch_follow_symlinks(
                             None,
                             rest,
                             None,
+                            opts,
                             out,
                         )?;
                     }
@@ -1241,6 +1314,7 @@ fn print_batch_follow_symlinks(
                 None,
                 rest,
                 None,
+                opts,
                 out,
             )?;
         }
@@ -1412,6 +1486,7 @@ fn print_batch_entry(
                     disk_size_override,
                     rest,
                     None,
+                    opts,
                     out,
                 )?;
             }
@@ -1471,6 +1546,7 @@ fn print_batch_entry(
                             disk_size_override,
                             rest,
                             None,
+                            opts,
                             out,
                         )?;
                         eprintln!("fatal: missing path for '{}'", oid.to_hex());
@@ -1491,6 +1567,7 @@ fn print_batch_entry(
                                 disk_size_override,
                                 rest,
                                 None,
+                                opts,
                                 out,
                             )?;
                             let flag = if opts.batch_textconv {
@@ -1516,6 +1593,7 @@ fn print_batch_entry(
                             disk_size_override,
                             rest,
                             Some(payload.as_slice()),
+                            opts,
                             out,
                         )?;
                         return Ok(());
@@ -1534,6 +1612,7 @@ fn print_batch_entry(
                     disk_size_override,
                     rest,
                     None,
+                    opts,
                     out,
                 )?;
             }
@@ -1630,7 +1709,24 @@ fn object_disk_size(
         .unwrap_or(0))
 }
 
-fn pretty_print(kind: &ObjectKind, data: &[u8]) -> Result<()> {
+/// Write object bytes to `out`, applying mailmap to commit/tag payloads when requested.
+fn write_commit_tag_maybe_mailmapped(
+    out: &mut impl io::Write,
+    kind: &ObjectKind,
+    data: &[u8],
+    use_mailmap: bool,
+    mailmap: &MailmapTable,
+) -> Result<()> {
+    if use_mailmap && !mailmap.is_empty() && matches!(kind, ObjectKind::Commit | ObjectKind::Tag) {
+        let mapped = apply_mailmap_to_commit_or_tag_bytes(data, mailmap);
+        out.write_all(&mapped)?;
+    } else {
+        out.write_all(data)?;
+    }
+    Ok(())
+}
+
+fn pretty_print(kind: &ObjectKind, data: &[u8], mailmap: Option<&MailmapTable>) -> Result<()> {
     let stdout = io::stdout();
     let mut out = stdout.lock();
 
@@ -1646,10 +1742,14 @@ fn pretty_print(kind: &ObjectKind, data: &[u8]) -> Result<()> {
                 writeln!(out, "{:06o} {kind_str} {}\t{name}", e.mode, e.oid)?;
             }
         }
-        ObjectKind::Commit => {
-            out.write_all(data)?;
-        }
-        ObjectKind::Tag => {
+        ObjectKind::Commit | ObjectKind::Tag => {
+            if let Some(mm) = mailmap {
+                if !mm.is_empty() {
+                    let mapped = apply_mailmap_to_commit_or_tag_bytes(data, mm);
+                    out.write_all(&mapped)?;
+                    return Ok(());
+                }
+            }
             out.write_all(data)?;
         }
     }

--- a/grit/src/commands/check_mailmap.rs
+++ b/grit/src/commands/check_mailmap.rs
@@ -10,7 +10,8 @@
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::mailmap::{
-    load_mailmap_raw, map_contact, parse_contact, parse_mailmap, read_mailmap_blob, render_contact,
+    load_mailmap_into, map_contact_table, parse_contact, read_mailmap_blob, read_mailmap_string,
+    render_contact, MailmapTable,
 };
 use grit_lib::repo::Repository;
 use std::fs;
@@ -60,7 +61,8 @@ fn read_optional_mailmap_file(path: &Path) -> Result<String> {
 /// Run the `check-mailmap` command.
 pub fn run(args: Args) -> Result<()> {
     let repo = Repository::discover(None)?;
-    let mut mailmap_content = load_mailmap_raw(&repo)?;
+    let mut mailmap = MailmapTable::default();
+    load_mailmap_into(&repo, &mut mailmap)?;
 
     let base_dir = repo
         .work_tree
@@ -69,21 +71,14 @@ pub fn run(args: Args) -> Result<()> {
         .to_path_buf();
 
     if let Some(ref file) = args.mailmap_file {
-        mailmap_content.push_str(&read_optional_mailmap_file(&resolve_mailmap_path(
-            &base_dir, file,
-        ))?);
-        if !mailmap_content.ends_with('\n') && !mailmap_content.is_empty() {
-            mailmap_content.push('\n');
-        }
+        read_mailmap_string(
+            &mut mailmap,
+            &read_optional_mailmap_file(&resolve_mailmap_path(&base_dir, file))?,
+        );
     }
     if let Some(ref blob) = args.mailmap_blob {
-        mailmap_content.push_str(&read_mailmap_blob(&repo, blob)?);
-        if !mailmap_content.ends_with('\n') && !mailmap_content.is_empty() {
-            mailmap_content.push('\n');
-        }
+        read_mailmap_string(&mut mailmap, &read_mailmap_blob(&repo, blob)?);
     }
-
-    let mailmap = parse_mailmap(&mailmap_content);
 
     let stdout = io::stdout();
     let mut out = stdout.lock();
@@ -94,7 +89,7 @@ pub fn run(args: Args) -> Result<()> {
 
     for contact in &args.contacts {
         let (name, email) = parse_contact(contact);
-        let (cn, ce) = map_contact(name.as_deref(), email.as_deref(), &mailmap);
+        let (cn, ce) = map_contact_table(name.as_deref(), email.as_deref(), &mailmap);
         writeln!(out, "{}", render_contact(&cn, &ce))?;
     }
 
@@ -107,7 +102,7 @@ pub fn run(args: Args) -> Result<()> {
                 continue;
             }
             let (name, email) = parse_contact(line);
-            let (cn, ce) = map_contact(name.as_deref(), email.as_deref(), &mailmap);
+            let (cn, ce) = map_contact_table(name.as_deref(), email.as_deref(), &mailmap);
             writeln!(out, "{}", render_contact(&cn, &ce))?;
         }
     }

--- a/grit/src/commands/cherry_pick.rs
+++ b/grit/src/commands/cherry_pick.rs
@@ -22,7 +22,8 @@ use grit_lib::ident::parse_signature_times;
 use grit_lib::index::{Index, IndexEntry, MODE_EXECUTABLE, MODE_SYMLINK};
 use grit_lib::merge_file::{merge, ConflictStyle, MergeFavor, MergeInput};
 use grit_lib::merge_trees::{
-    merge_trees_three_way, TheirsConflictLabel, TreeMergeConflictPresentation, WhitespaceMergeOptions,
+    merge_trees_three_way, TheirsConflictLabel, TreeMergeConflictPresentation,
+    WhitespaceMergeOptions,
 };
 use grit_lib::objects::{
     parse_commit, parse_tree, serialize_commit, CommitData, ObjectId, ObjectKind,

--- a/grit/src/commands/commit.rs
+++ b/grit/src/commands/commit.rs
@@ -13,11 +13,14 @@ use grit_lib::diff::{
 use grit_lib::error::Error;
 use grit_lib::hooks::{run_hook, HookResult};
 use grit_lib::index::Index;
-use grit_lib::objects::{serialize_commit, CommitData, ObjectId, ObjectKind};
+use grit_lib::mailmap::load_mailmap_table;
+use grit_lib::objects::{parse_commit, serialize_commit, CommitData, ObjectId, ObjectKind};
 use grit_lib::refs::{append_reflog, list_refs};
 use grit_lib::repo::Repository;
+use grit_lib::rev_list::{rev_list, RevListOptions};
 use grit_lib::rev_parse::resolve_revision;
 use grit_lib::state::{detect_in_progress, resolve_head, HeadState};
+use regex::RegexBuilder;
 
 use crate::commands::cherry_pick::try_resume_pick_sequence_after_commit;
 use crate::commands::revert::try_resume_revert_sequence_after_commit;
@@ -2522,18 +2525,69 @@ fn parse_force_author_parameter(author: &str) -> Result<(String, String)> {
     if gt <= lt {
         bail!("malformed --author parameter");
     }
-    let name = author[..lt].trim_end();
+    // Git trims both ends of the name (`split_ident_line`); leading spaces must not be stored.
+    let name = author[..lt].trim();
     let email = author[lt + 1..gt].trim();
     if name.is_empty() {
         bail!("empty ident name (for <author>) not allowed");
     }
-    if email.is_empty() {
-        bail!("malformed --author parameter");
-    }
+    // Git accepts an empty email in `Name <>` (see split_ident_line / t4203 empty-syntax tests).
     if lt > 0 && author.as_bytes()[lt - 1] != b' ' {
         bail!("malformed --author parameter");
     }
     Ok((name.to_string(), email.to_string()))
+}
+
+/// Resolve `git commit --author=nick` when `nick` is not `Name <email>` (Git `find_author_by_nickname`).
+fn find_author_by_nickname(repo: &Repository, nick: &str) -> Result<String> {
+    let mailmap = load_mailmap_table(repo)?;
+    let pat = regex::escape(nick);
+    let re = RegexBuilder::new(&pat)
+        .case_insensitive(true)
+        .build()
+        .map_err(|e| anyhow::anyhow!("invalid author nickname pattern: {e}"))?;
+
+    let mut tips: Vec<String> = list_refs(&repo.git_dir, "refs/")?
+        .into_iter()
+        .map(|(_, oid)| oid.to_hex())
+        .collect();
+    if tips.is_empty() {
+        let head = resolve_head(&repo.git_dir)?;
+        if let Some(oid) = head.oid() {
+            tips.push(oid.to_hex());
+        }
+    }
+    if tips.is_empty() {
+        bail!(
+            "--author '{}' is not 'Name <email>' and matches no existing author",
+            nick
+        );
+    }
+
+    let opts = RevListOptions {
+        all_refs: false,
+        first_parent: false,
+        ordering: grit_lib::rev_list::OrderingMode::Topo,
+        ..RevListOptions::default()
+    };
+    let result = rev_list(repo, &tips, &[], &opts)
+        .map_err(|_| anyhow::anyhow!("revision walk setup failed"))?;
+
+    for oid in result.commits {
+        let obj = repo.odb.read(&oid)?;
+        let commit = parse_commit(&obj.data)?;
+        let (name, email, _) = split_stored_author_line(&commit.author)?;
+        let (mn, me) = mailmap.map_user(name, email);
+        let mapped_line = format!("{mn} <{me}>");
+        if re.is_match(&mapped_line) {
+            return Ok(mapped_line);
+        }
+    }
+
+    bail!(
+        "--author '{}' is not 'Name <email>' and matches no existing author",
+        nick
+    );
 }
 
 /// Split a stored author line (`name <email> <epoch> <tz>`) into name, email, and optional date tail.
@@ -2625,7 +2679,12 @@ fn resolve_author(
     now: OffsetDateTime,
 ) -> Result<String> {
     if let Some(ref author) = args.author {
-        let (name, email) = parse_force_author_parameter(author)?;
+        let author = if author.contains('>') {
+            author.clone()
+        } else {
+            find_author_by_nickname(repo, author)?
+        };
+        let (name, email) = parse_force_author_parameter(&author)?;
         validate_ident_name(&name, "author")?;
         let date_str = args
             .date

--- a/grit/src/commands/for_each_ref.rs
+++ b/grit/src/commands/for_each_ref.rs
@@ -5,7 +5,7 @@ use clap::Args as ClapArgs;
 use grit_lib::error::Error as GustError;
 use grit_lib::git_date::show::{date_mode_release, parse_date_format, show_date};
 use grit_lib::git_date::tm::atoi_bytes;
-use grit_lib::mailmap::{load_mailmap, map_contact, parse_contact, MailmapEntry};
+use grit_lib::mailmap::{load_mailmap_table, map_contact_table, parse_contact, MailmapTable};
 use grit_lib::merge_base::{ancestor_closure, is_ancestor};
 use grit_lib::objects::{
     parse_commit, parse_tag, tag_header_field, tag_object_line_oid, ObjectId, ObjectKind,
@@ -62,7 +62,7 @@ fn run_with_invocation(args: Args, inv: ForEachRefInvocation) -> Result<()> {
         }
     };
 
-    let mailmap = load_mailmap(&repo).unwrap_or_else(|_| Vec::new());
+    let mailmap = load_mailmap_table(&repo).unwrap_or_default();
 
     let mut patterns = opts.patterns.clone();
     if opts.stdin {
@@ -839,7 +839,7 @@ fn expand_format(
     entry: &RefEntry,
     format: &str,
     head_branch: &Option<String>,
-    mailmap: &[MailmapEntry],
+    mailmap: &MailmapTable,
     quote_style: Option<QuoteStyle>,
 ) -> Result<String, FormatError> {
     let mut out = String::new();
@@ -873,7 +873,7 @@ fn atom_value(
     entry: &RefEntry,
     atom: &str,
     head_branch: &Option<String>,
-    mailmap: &[MailmapEntry],
+    mailmap: &MailmapTable,
 ) -> Result<String, FormatError> {
     // Handle deref atoms: %(* objectname), %(*objecttype), etc.
     // These dereference the pointed-to object (peel tags).
@@ -1099,7 +1099,7 @@ fn atom_value(
             match modifier {
                 Some("mailmap") => commit_field_for_oid(repo, entry, oid, |c| {
                     let (n, e) = parse_contact(&c.author);
-                    Ok(map_contact(n.as_deref(), e.as_deref(), mailmap).0)
+                    Ok(map_contact_table(n.as_deref(), e.as_deref(), mailmap).0)
                 }),
                 None => {
                     commit_field_for_oid(repo, entry, oid, |c| Ok(parse_identity_name(&c.author)))
@@ -1151,7 +1151,7 @@ fn atom_value(
             match modifier {
                 Some("mailmap") => commit_field_for_oid(repo, entry, oid, |c| {
                     let (n, e) = parse_contact(&c.committer);
-                    Ok(map_contact(n.as_deref(), e.as_deref(), mailmap).0)
+                    Ok(map_contact_table(n.as_deref(), e.as_deref(), mailmap).0)
                 }),
                 None => commit_field_for_oid(repo, entry, oid, |c| {
                     Ok(parse_identity_name(&c.committer))
@@ -1219,7 +1219,7 @@ fn atom_value(
             match modifier {
                 Some("mailmap") => {
                     let (n, e) = parse_contact(raw);
-                    Ok(map_contact(n.as_deref(), e.as_deref(), mailmap).0)
+                    Ok(map_contact_table(n.as_deref(), e.as_deref(), mailmap).0)
                 }
                 None => Ok(parse_identity_name(raw)),
                 Some(other) => Err(FormatError::Fatal(format!(
@@ -1383,7 +1383,7 @@ fn deref_atom_value(
     entry: &RefEntry,
     atom: &str,
     head_branch: &Option<String>,
-    mailmap: &[MailmapEntry],
+    mailmap: &MailmapTable,
 ) -> Result<String, FormatError> {
     use grit_lib::objects::ObjectKind;
     // Read the object to check if it's a tag
@@ -1628,10 +1628,10 @@ fn copy_email_git(raw: &str, trim: bool, localpart: bool) -> String {
     inner[..end].to_owned()
 }
 
-fn format_email_with_opts(raw: &str, opts: &EmailFormatOpts, mailmap: &[MailmapEntry]) -> String {
+fn format_email_with_opts(raw: &str, opts: &EmailFormatOpts, mailmap: &MailmapTable) -> String {
     let line = if opts.mailmap {
         let (name, email) = parse_contact(raw);
-        let (cn, ce) = map_contact(name.as_deref(), email.as_deref(), mailmap);
+        let (cn, ce) = map_contact_table(name.as_deref(), email.as_deref(), mailmap);
         grit_lib::mailmap::render_contact(&cn, &ce)
     } else {
         raw.to_owned()

--- a/grit/src/commands/init.rs
+++ b/grit/src/commands/init.rs
@@ -34,6 +34,9 @@ fn guess_repository_type(git_dir: &Path, cwd: &Path, raw_git_dir_env: Option<&st
     if git_dir == Path::new(".git") {
         return false;
     }
+    // Any nested `.git` directory (e.g. `repo/sub/.git`) is a non-bare work tree, even when the
+    // init target directory is named the same as the current working directory (t4203 `init space`
+    // from `trash/space/`).
     if git_dir.file_name() == Some(std::ffi::OsStr::new(".git")) {
         return false;
     }

--- a/grit/src/commands/log.rs
+++ b/grit/src/commands/log.rs
@@ -10,7 +10,7 @@ use grit_lib::combined_tree_diff::{combined_diff_paths_filtered, CombinedTreeDif
 use grit_lib::commit_graph_file::{
     BloomPrecheck, BloomWalkStats, BloomWalkStatsHandle, CommitGraphChain,
 };
-use grit_lib::config::ConfigSet;
+use grit_lib::config::{parse_bool, ConfigSet};
 use grit_lib::crlf::{get_file_attrs, load_gitattributes, DiffAttr};
 use grit_lib::diff::{
     count_changes, diff_trees, diff_trees_show_tree_entries, format_raw, unified_diff, zero_oid,
@@ -25,6 +25,7 @@ use grit_lib::ident::{
 use grit_lib::line_log::{
     format_line_log_diff, line_log_filter_commits, parse_line_log_ranges, rewritten_first_parent,
 };
+use grit_lib::mailmap::{load_mailmap_table, MailmapTable};
 use grit_lib::merge_base::is_ancestor;
 use grit_lib::merge_diff::{blob_text_for_diff, is_binary_for_diff};
 use grit_lib::objects::{parse_commit, parse_tag, ObjectId, ObjectKind};
@@ -64,6 +65,14 @@ pub struct Args {
     /// Pretty-print format.
     #[arg(long = "format", alias = "pretty")]
     pub format: Option<String>,
+
+    /// Use `.mailmap` when showing author/committer (default: `log.mailmap`).
+    #[arg(long = "use-mailmap", alias = "mailmap")]
+    pub use_mailmap: bool,
+
+    /// Disable mailmap for log output.
+    #[arg(long = "no-use-mailmap")]
+    pub no_use_mailmap: bool,
 
     /// Show in reverse order.
     #[arg(long = "reverse")]
@@ -776,7 +785,64 @@ fn log_resolve_stdout_color(args: &Args, git_dir: &Path) -> bool {
     c
 }
 
-fn run_line_log(repo: &Repository, args: Args, _patch_context: usize) -> Result<()> {
+fn effective_use_mailmap(args: &Args, cfg: &ConfigSet) -> bool {
+    if args.no_use_mailmap {
+        return false;
+    }
+    if args.use_mailmap {
+        return true;
+    }
+    cfg.get("log.mailmap")
+        .map(|v| parse_bool(&v).unwrap_or(true))
+        .unwrap_or(true)
+}
+
+/// Rebuild a signature line with a new `Name <email>` prefix, preserving the timestamp tail.
+fn ident_with_mapped_contact(raw: &str, new_name: &str, new_email: &str) -> String {
+    let Some(gt) = raw.rfind('>') else {
+        if new_email.is_empty() {
+            return new_name.to_string();
+        }
+        return format!("{new_name} <{new_email}>");
+    };
+    let tail = raw.get(gt + 1..).unwrap_or("");
+    format!("{new_name} <{new_email}>{tail}")
+}
+
+fn ident_for_mailmap_match(mailmap: &MailmapTable, raw: &str) -> String {
+    if mailmap.is_empty() {
+        return raw.to_string();
+    }
+    let name = extract_name(raw);
+    let email = extract_email(raw);
+    let (n, e) = mailmap.map_user(name, email);
+    ident_with_mapped_contact(raw, &n, &e)
+}
+
+fn ident_matches_header_patterns(
+    patterns: &[Regex],
+    raw: &str,
+    mailmap: &MailmapTable,
+    use_mailmap: bool,
+) -> bool {
+    if patterns.is_empty() {
+        return true;
+    }
+    let haystack = if use_mailmap && !mailmap.is_empty() {
+        ident_for_mailmap_match(mailmap, raw)
+    } else {
+        raw.to_string()
+    };
+    patterns.iter().any(|re| re.is_match(&haystack))
+}
+
+fn run_line_log(
+    repo: &Repository,
+    args: Args,
+    _patch_context: usize,
+    use_mailmap: bool,
+    mailmap: &MailmapTable,
+) -> Result<()> {
     if !args.pathspecs.is_empty() {
         anyhow::bail!("-L<range>:<file> cannot be used with pathspec");
     }
@@ -870,6 +936,8 @@ fn run_line_log(repo: &Repository, args: Args, _patch_context: usize) -> Result<
         &[],
         false,
         false,
+        mailmap,
+        use_mailmap,
         args.no_merges,
         args.merges,
         &[][..],
@@ -991,6 +1059,8 @@ fn run_line_log(repo: &Repository, args: Args, _patch_context: usize) -> Result<
                         &node,
                         &info,
                         &args,
+                        use_mailmap,
+                        mailmap,
                         decorations.as_ref(),
                         abbrev_len,
                         &parent_line,
@@ -1060,6 +1130,8 @@ fn run_line_log(repo: &Repository, args: Args, _patch_context: usize) -> Result<
             oid,
             &info,
             &args,
+            use_mailmap,
+            &mailmap,
             decorations.as_ref(),
             use_color,
             &mut notes_cache,
@@ -1221,7 +1293,13 @@ fn resolve_decoration_display(args: &Args, format_requires_decorations: bool) ->
     (show, full)
 }
 
-fn run_graph_log(repo: &Repository, args: &Args, patch_context: usize) -> Result<()> {
+fn run_graph_log(
+    repo: &Repository,
+    args: &Args,
+    patch_context: usize,
+    use_mailmap: bool,
+    mailmap: &MailmapTable,
+) -> Result<()> {
     let mut implied_pathspecs: Vec<String> = Vec::new();
     let mut revision_specs = Vec::new();
     for rev in &args.revisions {
@@ -1363,6 +1441,50 @@ fn run_graph_log(repo: &Repository, args: &Args, patch_context: usize) -> Result
         }
     }
 
+    let mut author_res_graph: Vec<Regex> = Vec::new();
+    for p in &args.authors {
+        let pat = if args.fixed_strings {
+            regex::escape(p)
+        } else {
+            p.clone()
+        };
+        let re = RegexBuilder::new(&pat)
+            .case_insensitive(true)
+            .build()
+            .with_context(|| format!("invalid --author regex: {p}"))?;
+        author_res_graph.push(re);
+    }
+    let mut committer_res_graph: Vec<Regex> = Vec::new();
+    for p in &args.committers {
+        let pat = if args.fixed_strings {
+            regex::escape(p)
+        } else {
+            p.clone()
+        };
+        let re = RegexBuilder::new(&pat)
+            .case_insensitive(true)
+            .build()
+            .with_context(|| format!("invalid --committer regex: {p}"))?;
+        committer_res_graph.push(re);
+    }
+    if !author_res_graph.is_empty() || !committer_res_graph.is_empty() {
+        result.commits.retain(|oid| {
+            let Ok(obj) = repo.odb.read(oid) else {
+                return false;
+            };
+            let Ok(c) = parse_commit(&obj.data) else {
+                return false;
+            };
+            ident_matches_header_patterns(&author_res_graph, &c.author, mailmap, use_mailmap)
+                && ident_matches_header_patterns(
+                    &committer_res_graph,
+                    &c.committer,
+                    mailmap,
+                    use_mailmap,
+                )
+        });
+    }
+
     let included: HashSet<ObjectId> = result.commits.iter().copied().collect();
     let ordered_boundaries = if args.boundary {
         order_boundary_commits_for_graph(
@@ -1488,6 +1610,8 @@ fn run_graph_log(repo: &Repository, args: &Args, patch_context: usize) -> Result
                     &node,
                     &info,
                     args,
+                    use_mailmap,
+                    mailmap,
                     decorations.as_ref(),
                     abbrev_len,
                     &node.parents,
@@ -1513,6 +1637,8 @@ fn run_graph_log(repo: &Repository, args: &Args, patch_context: usize) -> Result
                 &node.oid,
                 &info,
                 args,
+                use_mailmap,
+                mailmap,
                 &combined_pathspecs,
                 graph_stat_prefix.as_deref(),
                 decorations.as_ref(),
@@ -1880,6 +2006,8 @@ fn render_graph_commit_text(
     node: &GraphCommitNode,
     info: &CommitInfo,
     args: &Args,
+    use_mailmap: bool,
+    mailmap: &MailmapTable,
     decorations: Option<&std::collections::HashMap<String, Vec<String>>>,
     abbrev_len: usize,
     parent_line: &[ObjectId],
@@ -1916,6 +2044,8 @@ fn render_graph_commit_text(
                 None,
                 parent_line,
                 None,
+                mailmap,
+                use_mailmap,
             );
         }
         if fmt.contains('%') {
@@ -1930,6 +2060,8 @@ fn render_graph_commit_text(
                 None,
                 parent_line,
                 None,
+                mailmap,
+                use_mailmap,
             );
         }
     }
@@ -2596,23 +2728,25 @@ pub fn run(mut args: Args) -> Result<()> {
     }
     normalize_log_merge_diff_args(&mut args, &repo.git_dir)?;
     validate_log_pickaxe_options(&repo, &args)?;
+    let cfg = ConfigSet::load(Some(&repo.git_dir), true).context("loading git config")?;
     let patch_context = if let Some(u) = args.unified {
         u
     } else {
-        let cfg = ConfigSet::load(Some(&repo.git_dir), true).context("loading git config")?;
         grit_lib::config::resolve_diff_context_lines(&cfg)
             .map_err(|m| anyhow::anyhow!(m))?
             .unwrap_or(3)
     };
+    let use_mailmap = effective_use_mailmap(&args, &cfg);
+    let mailmap = load_mailmap_table(&repo).unwrap_or_default();
     if !args.line_range.is_empty() {
-        return run_line_log(&repo, args, patch_context);
+        return run_line_log(&repo, args, patch_context, use_mailmap, &mailmap);
     }
     if args
         .revisions
         .iter()
         .any(|r| r != "--" && is_symmetric_diff(r))
     {
-        return run_symmetric_log(&repo, &args, patch_context);
+        return run_symmetric_log(&repo, &args, patch_context, use_mailmap, &mailmap);
     }
     validate_pathspec_scope(&repo, &args.pathspecs)?;
     let mut implied_pathspecs: Vec<String> = Vec::new();
@@ -2720,16 +2854,18 @@ pub fn run(mut args: Args) -> Result<()> {
             &committer_res,
             &grep_res,
             &grep_reflog_res,
+            use_mailmap,
+            &mailmap,
         );
     }
 
     // Handle --no-walk: show given commits without walking parents
     if args.no_walk.is_some() {
-        return run_no_walk(&repo, &args, patch_context);
+        return run_no_walk(&repo, &args, patch_context, use_mailmap, &mailmap);
     }
 
     if args.graph {
-        return run_graph_log(&repo, &args, patch_context);
+        return run_graph_log(&repo, &args, patch_context, use_mailmap, &mailmap);
     }
 
     // Determine starting points and excluded commits.
@@ -2958,6 +3094,8 @@ pub fn run(mut args: Args) -> Result<()> {
             &grep_res,
             args.all_match,
             args.invert_grep,
+            &mailmap,
+            use_mailmap,
             args.no_merges,
             args.merges,
             effective_pathspecs,
@@ -3010,6 +3148,8 @@ pub fn run(mut args: Args) -> Result<()> {
                 &oid,
                 &commit_data,
                 &args,
+                use_mailmap,
+                &mailmap,
                 decoration_map_for_display.as_ref(),
                 use_color,
                 &mut notes_cache,
@@ -3027,6 +3167,8 @@ pub fn run(mut args: Args) -> Result<()> {
                     &oid,
                     &commit_data,
                     &args,
+                    use_mailmap,
+                    &mailmap,
                     effective_pathspecs,
                     None,
                     decoration_map_for_display.as_ref(),
@@ -3053,6 +3195,8 @@ pub fn run(mut args: Args) -> Result<()> {
             &grep_res,
             args.all_match,
             args.invert_grep,
+            &mailmap,
+            use_mailmap,
             args.no_merges,
             args.merges,
             effective_pathspecs,
@@ -3195,6 +3339,8 @@ pub fn run(mut args: Args) -> Result<()> {
                 oid,
                 commit_data,
                 &args,
+                use_mailmap,
+                &mailmap,
                 decoration_map_for_display.as_ref(),
                 use_color,
                 &mut notes_cache,
@@ -3212,6 +3358,8 @@ pub fn run(mut args: Args) -> Result<()> {
                     oid,
                     commit_data,
                     &args,
+                    use_mailmap,
+                    &mailmap,
                     &combined_pathspecs,
                     None,
                     decoration_map_for_display.as_ref(),
@@ -3376,7 +3524,13 @@ fn normalize_path(path: &Path) -> PathBuf {
 }
 
 /// Run `--no-walk` mode: show the given commits without walking their parents.
-pub fn run_no_walk(repo: &Repository, args: &Args, patch_context: usize) -> Result<()> {
+pub fn run_no_walk(
+    repo: &Repository,
+    args: &Args,
+    patch_context: usize,
+    use_mailmap: bool,
+    mailmap: &MailmapTable,
+) -> Result<()> {
     let mut oids = Vec::new();
     if args.revisions.is_empty() {
         let head = resolve_head(&repo.git_dir)?;
@@ -3460,6 +3614,8 @@ pub fn run_no_walk(repo: &Repository, args: &Args, patch_context: usize) -> Resu
             oid,
             commit_data,
             args,
+            use_mailmap,
+            mailmap,
             decorations.as_ref(),
             false,
             &mut notes_cache,
@@ -3476,6 +3632,8 @@ pub fn run_no_walk(repo: &Repository, args: &Args, patch_context: usize) -> Resu
                 oid,
                 commit_data,
                 args,
+                use_mailmap,
+                &mailmap,
                 &args.pathspecs,
                 None,
                 decorations.as_ref(),
@@ -3594,6 +3752,8 @@ fn run_reflog_walk(
     committer_res: &[Regex],
     grep_res: &[Regex],
     grep_reflog_res: &[Regex],
+    use_mailmap: bool,
+    mailmap: &MailmapTable,
 ) -> Result<()> {
     // Determine which ref to walk
     let refname = if args.revisions.is_empty() {
@@ -3748,14 +3908,16 @@ fn run_reflog_walk(
         }
 
         let author_ok =
-            author_res.is_empty() || author_res.iter().any(|re| re.is_match(&commit_data.author));
+            ident_matches_header_patterns(author_res, &commit_data.author, mailmap, use_mailmap);
         if !author_ok {
             continue;
         }
-        let committer_ok = committer_res.is_empty()
-            || committer_res
-                .iter()
-                .any(|re| re.is_match(&commit_data.committer));
+        let committer_ok = ident_matches_header_patterns(
+            committer_res,
+            &commit_data.committer,
+            mailmap,
+            use_mailmap,
+        );
         if !committer_ok {
             continue;
         }
@@ -3804,7 +3966,13 @@ fn run_reflog_walk(
                 }
                 "short" => {
                     writeln!(out, "commit {}", entry.new_oid.to_hex())?;
-                    let author_name = extract_name(&commit_data.author);
+                    let author_name = if use_mailmap && !mailmap.is_empty() {
+                        let n = extract_name(&commit_data.author);
+                        let e = extract_email(&commit_data.author);
+                        mailmap.map_user(n, e).0
+                    } else {
+                        extract_name(&commit_data.author)
+                    };
                     writeln!(out, "Author: {author_name}")?;
                     writeln!(out)?;
                     for line in commit_data.message.lines().take(1) {
@@ -3817,7 +3985,7 @@ fn run_reflog_walk(
                     writeln!(
                         out,
                         "Author: {}",
-                        format_ident_for_header(&commit_data.author)
+                        format_ident_for_header_mailmap(mailmap, &commit_data.author, use_mailmap)
                     )?;
                     let date = format_date_for_header(&commit_data.author);
                     writeln!(out, "Date:   {}", date)?;
@@ -3832,12 +4000,16 @@ fn run_reflog_walk(
                     writeln!(
                         out,
                         "Author: {}",
-                        format_ident_for_header(&commit_data.author)
+                        format_ident_for_header_mailmap(mailmap, &commit_data.author, use_mailmap)
                     )?;
                     writeln!(
                         out,
                         "Commit: {}",
-                        format_ident_for_header(&commit_data.committer)
+                        format_ident_for_header_mailmap(
+                            mailmap,
+                            &commit_data.committer,
+                            use_mailmap
+                        )
                     )?;
                     writeln!(out)?;
                     for line in commit_data.message.lines() {
@@ -3850,7 +4022,7 @@ fn run_reflog_walk(
                     writeln!(
                         out,
                         "Author:     {}",
-                        format_ident_for_header(&commit_data.author)
+                        format_ident_for_header_mailmap(mailmap, &commit_data.author, use_mailmap)
                     )?;
                     writeln!(
                         out,
@@ -3860,7 +4032,11 @@ fn run_reflog_walk(
                     writeln!(
                         out,
                         "Commit:     {}",
-                        format_ident_for_header(&commit_data.committer)
+                        format_ident_for_header_mailmap(
+                            mailmap,
+                            &commit_data.committer,
+                            use_mailmap
+                        )
                     )?;
                     writeln!(
                         out,
@@ -3882,7 +4058,7 @@ fn run_reflog_walk(
                     writeln!(
                         out,
                         "From: {}",
-                        format_ident_for_header(&commit_data.author)
+                        format_ident_for_header_mailmap(mailmap, &commit_data.author, use_mailmap)
                     )?;
                     let date = format_date_for_header(&commit_data.author);
                     writeln!(out, "Date: {}", date)?;
@@ -3924,6 +4100,8 @@ fn run_reflog_walk(
                         &selector,
                         &entry.message,
                         &entry.identity,
+                        mailmap,
+                        use_mailmap,
                     );
                     writeln!(out, "{}", line)?;
                 }
@@ -3956,7 +4134,7 @@ fn run_reflog_walk(
             writeln!(
                 out,
                 "Author: {}",
-                format_ident_for_header(&commit_data.author)
+                format_ident_for_header_mailmap(mailmap, &commit_data.author, use_mailmap)
             )?;
             let date = format_date_for_header(&commit_data.author);
             writeln!(out, "Date:   {}", date)?;
@@ -3980,6 +4158,8 @@ fn apply_reflog_format_string(
     selector: &str,
     reflog_msg: &str,
     reflog_identity: &str,
+    mailmap: &MailmapTable,
+    use_mailmap: bool,
 ) -> String {
     let hex = oid.to_hex();
     let short = &hex[..7.min(hex.len())];
@@ -4056,9 +4236,42 @@ fn apply_reflog_format_string(
                             chars.next();
                             result.push_str(&extract_name(&commit.author));
                         }
+                        Some('N') => {
+                            chars.next();
+                            let mapped = if use_mailmap && !mailmap.is_empty() {
+                                let n = extract_name(&commit.author);
+                                let e = extract_email(&commit.author);
+                                mailmap.map_user(n, e).0
+                            } else {
+                                extract_name(&commit.author)
+                            };
+                            result.push_str(&mapped);
+                        }
                         Some('e') => {
                             chars.next();
                             result.push_str(&extract_email(&commit.author));
+                        }
+                        Some('E') => {
+                            chars.next();
+                            let mapped = if use_mailmap && !mailmap.is_empty() {
+                                let n = extract_name(&commit.author);
+                                let e = extract_email(&commit.author);
+                                mailmap.map_user(n, e).1
+                            } else {
+                                extract_email(&commit.author)
+                            };
+                            result.push_str(&mapped);
+                        }
+                        Some('l') => {
+                            chars.next();
+                            let email = if use_mailmap && !mailmap.is_empty() {
+                                let n = extract_name(&commit.author);
+                                let e = extract_email(&commit.author);
+                                mailmap.map_user(n, e).1
+                            } else {
+                                extract_email(&commit.author)
+                            };
+                            result.push_str(&local_part_of_email(&email));
                         }
                         _ => {
                             result.push_str("%a");
@@ -4072,9 +4285,42 @@ fn apply_reflog_format_string(
                             chars.next();
                             result.push_str(&extract_name(&commit.committer));
                         }
+                        Some('N') => {
+                            chars.next();
+                            let mapped = if use_mailmap && !mailmap.is_empty() {
+                                let n = extract_name(&commit.committer);
+                                let e = extract_email(&commit.committer);
+                                mailmap.map_user(n, e).0
+                            } else {
+                                extract_name(&commit.committer)
+                            };
+                            result.push_str(&mapped);
+                        }
                         Some('e') => {
                             chars.next();
                             result.push_str(&extract_email(&commit.committer));
+                        }
+                        Some('E') => {
+                            chars.next();
+                            let mapped = if use_mailmap && !mailmap.is_empty() {
+                                let n = extract_name(&commit.committer);
+                                let e = extract_email(&commit.committer);
+                                mailmap.map_user(n, e).1
+                            } else {
+                                extract_email(&commit.committer)
+                            };
+                            result.push_str(&mapped);
+                        }
+                        Some('l') => {
+                            chars.next();
+                            let email = if use_mailmap && !mailmap.is_empty() {
+                                let n = extract_name(&commit.committer);
+                                let e = extract_email(&commit.committer);
+                                mailmap.map_user(n, e).1
+                            } else {
+                                extract_email(&commit.committer)
+                            };
+                            result.push_str(&local_part_of_email(&email));
                         }
                         _ => {
                             result.push_str("%c");
@@ -4100,6 +4346,24 @@ fn format_ident_for_header(ident: &str) -> String {
         name
     } else {
         format!("{name} <{email}>")
+    }
+}
+
+fn format_ident_for_header_mailmap(
+    mailmap: &MailmapTable,
+    ident: &str,
+    use_mailmap: bool,
+) -> String {
+    if !use_mailmap || mailmap.is_empty() {
+        return format_ident_for_header(ident);
+    }
+    let name = extract_name(ident);
+    let email = extract_email(ident);
+    let (n, e) = mailmap.map_user(name, email);
+    if e.is_empty() {
+        n
+    } else {
+        format!("{n} <{e}>")
     }
 }
 
@@ -4144,6 +4408,8 @@ struct WalkCommitsIter<'a> {
     grep_res: &'a [Regex],
     all_match_grep: bool,
     invert_grep: bool,
+    mailmap: &'a MailmapTable,
+    use_mailmap: bool,
     no_merges: bool,
     merges_only: bool,
     pathspecs: &'a [String],
@@ -4163,6 +4429,8 @@ impl<'a> WalkCommitsIter<'a> {
         grep_res: &'a [Regex],
         all_match_grep: bool,
         invert_grep: bool,
+        mailmap: &'a MailmapTable,
+        use_mailmap: bool,
         no_merges: bool,
         merges_only: bool,
         pathspecs: &'a [String],
@@ -4211,6 +4479,8 @@ impl<'a> WalkCommitsIter<'a> {
             grep_res,
             all_match_grep,
             invert_grep,
+            mailmap,
+            use_mailmap,
             no_merges,
             merges_only,
             pathspecs,
@@ -4298,16 +4568,21 @@ impl<'a> WalkCommitsIter<'a> {
             if self.merges_only && !is_merge {
                 continue;
             }
-            let author_ok = self.author_res.is_empty()
-                || self.author_res.iter().any(|re| re.is_match(&info.author));
+            let author_ok = ident_matches_header_patterns(
+                self.author_res,
+                &info.author,
+                self.mailmap,
+                self.use_mailmap,
+            );
             if !author_ok {
                 continue;
             }
-            let committer_ok = self.committer_res.is_empty()
-                || self
-                    .committer_res
-                    .iter()
-                    .any(|re| re.is_match(&info.committer));
+            let committer_ok = ident_matches_header_patterns(
+                self.committer_res,
+                &info.committer,
+                self.mailmap,
+                self.use_mailmap,
+            );
             if !committer_ok {
                 continue;
             }
@@ -4397,6 +4672,8 @@ fn walk_commits(
     grep_res: &[Regex],
     all_match_grep: bool,
     invert_grep: bool,
+    mailmap: &MailmapTable,
+    use_mailmap: bool,
     no_merges: bool,
     merges_only: bool,
     pathspecs: &[String],
@@ -4425,6 +4702,8 @@ fn walk_commits(
         grep_res,
         all_match_grep,
         invert_grep,
+        mailmap,
+        use_mailmap,
         no_merges,
         merges_only,
         pathspecs,
@@ -5188,7 +5467,13 @@ fn commit_passes_post_walk_filters(
     Ok(true)
 }
 
-fn run_symmetric_log(repo: &Repository, args: &Args, _patch_context: usize) -> Result<()> {
+fn run_symmetric_log(
+    repo: &Repository,
+    args: &Args,
+    _patch_context: usize,
+    use_mailmap: bool,
+    mailmap: &MailmapTable,
+) -> Result<()> {
     let mut lhs: Option<String> = None;
     let mut rhs: Option<String> = None;
     for rev in &args.revisions {
@@ -5262,6 +5547,8 @@ fn run_symmetric_log(repo: &Repository, args: &Args, _patch_context: usize) -> R
             &oid,
             &info,
             args,
+            use_mailmap,
+            &mailmap,
             None,
             false,
             &mut notes_cache,
@@ -5285,6 +5572,8 @@ fn format_commit(
     oid: &ObjectId,
     info: &CommitInfo,
     args: &Args,
+    use_mailmap: bool,
+    mailmap: &MailmapTable,
     decorations: Option<&std::collections::HashMap<String, Vec<String>>>,
     use_color: bool,
     notes_cache: &mut NotesMapCache<'_>,
@@ -5344,6 +5633,8 @@ fn format_commit(
                 note_bytes,
                 display_parents,
                 log_marker,
+                mailmap,
+                use_mailmap,
             );
             if is_tformat {
                 if args.null_terminator {
@@ -5368,7 +5659,7 @@ fn format_commit(
                     .collect();
                 writeln!(out, "Merge: {}", parent_abbrevs.join(" "))?;
             }
-            let author_name = extract_name(&info.author);
+            let author_name = format_ident_display_mailmap(mailmap, &info.author, use_mailmap);
             writeln!(out, "Author: {author_name}")?;
             writeln!(out)?;
             for line in info.message.lines().take(1) {
@@ -5393,7 +5684,11 @@ fn format_commit(
                     .collect();
                 writeln!(out, "Merge: {}", parent_abbrevs.join(" "))?;
             }
-            writeln!(out, "Author: {}", format_ident_display(&info.author))?;
+            writeln!(
+                out,
+                "Author: {}",
+                format_ident_display_mailmap(mailmap, &info.author, use_mailmap)
+            )?;
             writeln!(
                 out,
                 "Date:   {}",
@@ -5418,8 +5713,16 @@ fn format_commit(
                     .collect();
                 writeln!(out, "Merge: {}", parent_abbrevs.join(" "))?;
             }
-            writeln!(out, "Author: {}", format_ident_display(&info.author))?;
-            writeln!(out, "Commit: {}", format_ident_display(&info.committer))?;
+            writeln!(
+                out,
+                "Author: {}",
+                format_ident_display_mailmap(mailmap, &info.author, use_mailmap)
+            )?;
+            writeln!(
+                out,
+                "Commit: {}",
+                format_ident_display_mailmap(mailmap, &info.committer, use_mailmap)
+            )?;
             writeln!(out)?;
             for line in info.message.lines() {
                 writeln!(out, "    {line}")?;
@@ -5440,13 +5743,21 @@ fn format_commit(
                     .collect();
                 writeln!(out, "Merge: {}", parent_abbrevs.join(" "))?;
             }
-            writeln!(out, "Author:     {}", format_ident_display(&info.author))?;
+            writeln!(
+                out,
+                "Author:     {}",
+                format_ident_display_mailmap(mailmap, &info.author, use_mailmap)
+            )?;
             writeln!(
                 out,
                 "AuthorDate: {}",
                 format_author_date_internal(&info.author, date_format, true)
             )?;
-            writeln!(out, "Commit:     {}", format_ident_display(&info.committer))?;
+            writeln!(
+                out,
+                "Commit:     {}",
+                format_ident_display_mailmap(mailmap, &info.committer, use_mailmap)
+            )?;
             writeln!(
                 out,
                 "CommitDate: {}",
@@ -5483,6 +5794,8 @@ fn format_commit(
                 note_bytes,
                 display_parents,
                 log_marker,
+                mailmap,
+                use_mailmap,
             );
             writeln!(out, "{formatted}")?;
         }
@@ -5503,6 +5816,8 @@ fn apply_format_string(
     notes_raw: Option<&[u8]>,
     display_parents: &[ObjectId],
     log_marker: Option<char>,
+    mailmap: &MailmapTable,
+    use_mailmap: bool,
 ) -> String {
     let hex = oid.to_hex();
 
@@ -5736,7 +6051,14 @@ fn apply_format_string(
                         }
                         Some('N') => {
                             chars.next();
-                            result.push_str(&extract_name(&info.author));
+                            let mapped = if use_mailmap && !mailmap.is_empty() {
+                                let n = extract_name(&info.author);
+                                let e = extract_email(&info.author);
+                                mailmap.map_user(n, e).0
+                            } else {
+                                extract_name(&info.author)
+                            };
+                            result.push_str(&mapped);
                         }
                         Some('e') => {
                             chars.next();
@@ -5744,11 +6066,25 @@ fn apply_format_string(
                         }
                         Some('E') => {
                             chars.next();
-                            result.push_str(&extract_email(&info.author));
+                            let mapped = if use_mailmap && !mailmap.is_empty() {
+                                let n = extract_name(&info.author);
+                                let e = extract_email(&info.author);
+                                mailmap.map_user(n, e).1
+                            } else {
+                                extract_email(&info.author)
+                            };
+                            result.push_str(&mapped);
                         }
                         Some('l') => {
                             chars.next();
-                            result.push_str(&extract_email_local(&info.author));
+                            let email = if use_mailmap && !mailmap.is_empty() {
+                                let n = extract_name(&info.author);
+                                let e = extract_email(&info.author);
+                                mailmap.map_user(n, e).1
+                            } else {
+                                extract_email(&info.author)
+                            };
+                            result.push_str(&local_part_of_email(&email));
                         }
                         Some('d') => {
                             chars.next();
@@ -5791,7 +6127,14 @@ fn apply_format_string(
                         }
                         Some('N') => {
                             chars.next();
-                            result.push_str(&extract_name(&info.committer));
+                            let mapped = if use_mailmap && !mailmap.is_empty() {
+                                let n = extract_name(&info.committer);
+                                let e = extract_email(&info.committer);
+                                mailmap.map_user(n, e).0
+                            } else {
+                                extract_name(&info.committer)
+                            };
+                            result.push_str(&mapped);
                         }
                         Some('e') => {
                             chars.next();
@@ -5799,11 +6142,25 @@ fn apply_format_string(
                         }
                         Some('E') => {
                             chars.next();
-                            result.push_str(&extract_email(&info.committer));
+                            let mapped = if use_mailmap && !mailmap.is_empty() {
+                                let n = extract_name(&info.committer);
+                                let e = extract_email(&info.committer);
+                                mailmap.map_user(n, e).1
+                            } else {
+                                extract_email(&info.committer)
+                            };
+                            result.push_str(&mapped);
                         }
                         Some('l') => {
                             chars.next();
-                            result.push_str(&extract_email_local(&info.committer));
+                            let email = if use_mailmap && !mailmap.is_empty() {
+                                let n = extract_name(&info.committer);
+                                let e = extract_email(&info.committer);
+                                mailmap.map_user(n, e).1
+                            } else {
+                                extract_email(&info.committer)
+                            };
+                            result.push_str(&local_part_of_email(&email));
                         }
                         Some('d') => {
                             chars.next();
@@ -6145,11 +6502,14 @@ fn format_ansi_color_spec(spec: &str) -> String {
 
 /// Extract the local part (before @) of the email from a Git ident string.
 fn extract_email_local(ident: &str) -> String {
-    let email = extract_email(ident);
+    local_part_of_email(&extract_email(ident))
+}
+
+fn local_part_of_email(email: &str) -> String {
     if let Some(at) = email.find('@') {
         email[..at].to_owned()
     } else {
-        email
+        email.to_owned()
     }
 }
 
@@ -6158,6 +6518,16 @@ fn format_ident_display(ident: &str) -> String {
     let name = extract_name(ident);
     let email = extract_email(ident);
     format!("{name} <{email}>")
+}
+
+fn format_ident_display_mailmap(mailmap: &MailmapTable, ident: &str, use_mailmap: bool) -> String {
+    if !use_mailmap || mailmap.is_empty() {
+        return format_ident_display(ident);
+    }
+    let name = extract_name(ident);
+    let email = extract_email(ident);
+    let (n, e) = mailmap.map_user(name, email);
+    format!("{n} <{e}>")
 }
 
 /// Format the date from an ident string for display, with optional date mode.
@@ -6635,6 +7005,8 @@ fn write_commit_diff(
     commit_oid: &ObjectId,
     info: &CommitInfo,
     args: &Args,
+    use_mailmap: bool,
+    mailmap: &MailmapTable,
     pathspecs: &[String],
     graph_stat_prefix: Option<&str>,
     decorations: Option<&std::collections::HashMap<String, Vec<String>>>,
@@ -6699,6 +7071,8 @@ fn write_commit_diff(
                     commit_oid,
                     info,
                     args,
+                    use_mailmap,
+                    mailmap,
                     decorations,
                     use_color,
                     notes_cache,

--- a/grit/src/commands/reflog.rs
+++ b/grit/src/commands/reflog.rs
@@ -256,6 +256,8 @@ fn run_show(args: ShowArgs) -> Result<()> {
         max_count: args.max_count,
         oneline,
         format,
+        use_mailmap: false,
+        no_use_mailmap: false,
         reverse: false,
         first_parent: false,
         root: false,

--- a/grit/src/commands/shortlog.rs
+++ b/grit/src/commands/shortlog.rs
@@ -5,6 +5,7 @@
 
 use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
+use grit_lib::mailmap::{load_mailmap_table, read_mailmap_string, MailmapTable};
 use grit_lib::objects::{parse_commit, ObjectId};
 use grit_lib::odb::Odb;
 use grit_lib::repo::Repository;
@@ -52,26 +53,35 @@ pub fn run(args: Args) -> Result<()> {
     let stdin = io::stdin();
     let use_stdin = !stdin.is_terminal() && args.revisions.is_empty();
 
+    let mailmap = match Repository::discover(None) {
+        Ok(repo) => load_mailmap_table(&repo)?,
+        Err(_) => {
+            let mut t = MailmapTable::default();
+            if let Ok(body) = std::fs::read_to_string(".mailmap") {
+                read_mailmap_string(&mut t, &body);
+            }
+            t
+        }
+    };
+
     let (entries, from_stdin) = if use_stdin {
-        (collect_from_stdin(&stdin, &args)?, true)
+        (collect_from_stdin(&stdin, &args, &mailmap)?, true)
     } else {
-        (collect_from_repo(&args)?, false)
+        (collect_from_repo(&args, &mailmap)?, false)
     };
 
     let mut grouped = group_entries(entries, from_stdin);
 
-    // Sort
     if args.numbered {
-        // By count descending, then alphabetical for ties
         grouped.sort_by(|a, b| {
             b.commits
                 .len()
                 .cmp(&a.commits.len())
-                .then_with(|| a.key.to_lowercase().cmp(&b.key.to_lowercase()))
+                .then_with(|| a.key.cmp(&b.key))
         });
     } else {
-        // Alphabetical by key (case-insensitive)
-        grouped.sort_by(|a, b| a.key.to_lowercase().cmp(&b.key.to_lowercase()));
+        // Git keeps groups in `string_list` order: sorted by mapped ident string (`strcmp`).
+        grouped.sort_by(|a, b| a.key.cmp(&b.key));
     }
 
     let stdout = io::stdout();
@@ -90,12 +100,15 @@ pub fn run(args: Args) -> Result<()> {
             }
         }
     }
+    if !args.summary && !grouped.is_empty() {
+        writeln!(out)?;
+    }
 
     Ok(())
 }
 
 /// Collect commits from the repository by walking the commit graph.
-fn collect_from_repo(args: &Args) -> Result<Vec<(String, String)>> {
+fn collect_from_repo(args: &Args, mailmap: &MailmapTable) -> Result<Vec<(String, String)>> {
     let repo = Repository::discover(None).context("not a git repository")?;
 
     // Pre-process revisions: expand --glob and --glob=<pattern>
@@ -148,7 +161,7 @@ fn collect_from_repo(args: &Args) -> Result<Vec<(String, String)>> {
             "committer" => committer,
             _ => author,
         };
-        let key = format_key(ident, args.email);
+        let key = format_key(ident, args.email, mailmap);
         let desc = format_description(message, args.format.as_deref());
         result.push((key, desc));
     }
@@ -161,7 +174,11 @@ fn collect_from_repo(args: &Args) -> Result<Vec<(String, String)>> {
 /// Supports two input formats:
 /// 1. `git log --format=raw` — lines starting with "commit ", "author ", etc.
 /// 2. Default `git log` output — "commit <hash>", "Author: ...", blank line, indented message
-fn collect_from_stdin(stdin: &io::Stdin, args: &Args) -> Result<Vec<(String, String)>> {
+fn collect_from_stdin(
+    stdin: &io::Stdin,
+    args: &Args,
+    mailmap: &MailmapTable,
+) -> Result<Vec<(String, String)>> {
     let reader = stdin.lock();
     let mut result = Vec::new();
 
@@ -183,7 +200,7 @@ fn collect_from_stdin(stdin: &io::Stdin, args: &Args) -> Result<Vec<(String, Str
                     "committer" => &current_committer,
                     _ => &current_author,
                 };
-                let key = format_key(ident, args.email);
+                let key = format_key(ident, args.email, mailmap);
                 let desc = format_description(current_message.trim(), args.format.as_deref());
                 result.push((key, desc));
             }
@@ -262,7 +279,7 @@ fn collect_from_stdin(stdin: &io::Stdin, args: &Args) -> Result<Vec<(String, Str
             "committer" => &current_committer,
             _ => &current_author,
         };
-        let key = format_key(ident, args.email);
+        let key = format_key(ident, args.email, mailmap);
         let desc = format_description(current_message.trim(), args.format.as_deref());
         result.push((key, desc));
     }
@@ -296,11 +313,11 @@ fn group_entries(entries: Vec<(String, String)>, reverse_within: bool) -> Vec<Sh
         .collect()
 }
 
-/// Format the grouping key from an ident string.
-fn format_key(ident: &str, show_email: bool) -> String {
+fn format_key(ident: &str, show_email: bool, mailmap: &MailmapTable) -> String {
     let name = extract_name(ident);
+    let email = extract_email(ident);
+    let (name, email) = mailmap.map_user(name, email);
     if show_email {
-        let email = extract_email(ident);
         if email.is_empty() {
             name
         } else {

--- a/logs/2026-04-09_t4203-mailmap.md
+++ b/logs/2026-04-09_t4203-mailmap.md
@@ -1,0 +1,9 @@
+# t4203-mailmap
+
+- **Mailmap**: `MailmapTable` + Git-style `add_mapping` (single-pair `Committed <email>` lines), `load_mailmap_into` logs wrong-type `mailmap.blob` to stderr without aborting shortlog, first `<>` empty + second pair lines ignored like C Git, emails inside `<>` not trimmed (prefix match / t4203 whitespace).
+- **rev-parse**: `rev:path` in bare repos normalizes path without work tree (`HEAD:.mailmap`).
+- **init**: nested `.git` (e.g. `init space` from cwd `space/`) is non-bare.
+- **commit**: `--author` trims name like Git; allow empty email in `Name <>`.
+- **cat-file**: raw output + type-dereference path apply mailmap via `write_commit_tag_maybe_mailmapped`.
+
+Harness: `./scripts/run-tests.sh t4203-mailmap.sh` → 74/74.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible mailmap behavior and wires it through commands exercised by `t4203-mailmap.sh`.

### Key changes

- **Mailmap core** (`grit-lib/src/mailmap.rs`): `MailmapTable` with Git-style `add_mapping` (including single-pair `Committed <email>` lines), correct load/merge order, stderr for wrong-type `mailmap.blob` without failing the whole command, no trimming inside `<>` so spaced emails in the map do not spuriously match canonical addresses, and lines with empty first `<>` + second pair ignored like C Git.
- **Rev-parse** (`grit-lib/src/rev_parse.rs`): resolve `rev:path` in bare repos using a simple path normalizer so default `HEAD:.mailmap` works.
- **Init** (`grit/src/commands/init.rs`): treat nested `.git` directories (e.g. `git init space` from `space/`) as non-bare.
- **Commit** (`grit/src/commands/commit.rs`): `--author` name trimming matches Git; allow empty email in `Name <>`.
- **Porcelain** (`cat_file`, `log`, `shortlog`, `blame`, `for_each_ref`, `check_mailmap`, etc.): consistent mailmap loading and application.

### Validation

- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t4203-mailmap.sh` → **74/74**

Branch: `cursor/t4203-mailmap-test-passing-34a3`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-296b21dc-0de7-4026-ac87-5c98a4211321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-296b21dc-0de7-4026-ac87-5c98a4211321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

