### PR TITLE
fix: t3009 ls-files --others preserves trailing slash for nested repos

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -539,7 +539,7 @@ t3005-ls-files-relative	t3	yes	4	4	0	true	ok	0
 t3006-ls-files-long	t3	yes	3	3	0	true	ok	0
 t3007-ls-files-recurse-submodules	t3	yes	24	7	17	false	ok	0
 t3008-ls-files-lazy-init-name-hash	t3	yes	1	1	0	true	ok	0
-t3009-ls-files-others-nonsubmodule	t3	yes	2	1	1	false	ok	0
+t3009-ls-files-others-nonsubmodule	t3	yes	2	2	0	true	ok	0
 t3010-ls-files-killed-modified	t3	yes	6	3	3	false	ok	0
 t3011-common-prefixes-and-directory-traversal	t3	yes	20	8	12	false	ok	1
 t3011-ls-files-staged	t3	yes	29	29	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,687 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,687 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T23:11:06+00:00" class="gen-time" title="2026-04-09 23:11 UTC">2026-04-09 23:11 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,687</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -219,7 +219,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">56/141 files · 2 skipped · 4,052/5,398 tests</span>
+        <span class="group-meta">57/141 files · 2 skipped · 4,053/5,398 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:75.1%"></div></div>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35687 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,687 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T23:11:06+00:00" class="gen-time" title="2026-04-09 23:11 UTC">2026-04-09 23:11 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,687</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -5547,14 +5547,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="2" data-passed="1">
+<tr class="" data-group="t3" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t3009-ls-files-others-nonsubmodule</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">2</td>
-  <td class="right">1</td>
+  <td class="right">2</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="6" data-passed="3">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit/src/commands/ls_files.rs
+++ b/grit/src/commands/ls_files.rs
@@ -1036,7 +1036,14 @@ fn pathdiff_from_repo_for_display(
     work_tree: &Path,
     repo_rel: &[u8],
 ) -> Result<Vec<u8>> {
-    let rel_str = std::str::from_utf8(repo_rel).unwrap_or("");
+    // Directory markers from `walk_worktree` end with `/`. `Path::join` drops that trailing
+    // separator, so we must re-attach it after the relative path is computed (t3009).
+    let dir_marker = repo_rel.ends_with(b"/");
+    let rel_for_path = repo_rel
+        .strip_suffix(b"/")
+        .filter(|s| !s.is_empty())
+        .unwrap_or(repo_rel);
+    let rel_str = std::str::from_utf8(rel_for_path).unwrap_or("");
     let target = work_tree.join(rel_str);
     let s = if cwd.strip_prefix(work_tree).is_ok() {
         pathdiff_relative_lexical(cwd, &target)?
@@ -1050,7 +1057,11 @@ fn pathdiff_from_repo_for_display(
     } else {
         pathdiff_relative_lexical(cwd, &target)?
     };
-    Ok(s.into_bytes())
+    let mut out = s.into_bytes();
+    if dir_marker && !out.ends_with(b"/") {
+        out.push(b'/');
+    }
+    Ok(out)
 }
 
 /// Relative path from directory `from` to path `to` (forward slashes), without resolving symlinks.

--- a/logs/2026-04-09-t3009-ls-files-others-nonsubmodule.md
+++ b/logs/2026-04-09-t3009-ls-files-others-nonsubmodule.md
@@ -1,0 +1,19 @@
+# t3009-ls-files-others-nonsubmodule
+
+## Issue
+
+`git ls-files -o` listed nested untracked repositories without a trailing `/` (e.g. `repo-no-commit-no-files` instead of `repo-no-commit-no-files/`).
+
+## Root cause
+
+`pathdiff_from_repo_for_display` used `work_tree.join(rel_str)` where `rel_str` included a trailing `/`. Rust `Path::join` normalizes that away, so the computed cwd-relative path lost the directory marker.
+
+## Fix
+
+Strip trailing `/` only for `Path::join`, then append `/` back to the result when the input was a directory marker.
+
+## Verification
+
+- `./scripts/run-tests.sh t3009-ls-files-others-nonsubmodule.sh` — pass (2/2)
+- `./scripts/run-tests.sh t3005-ls-files-relative.sh` — pass (4/4)
+- `cargo test -p grit-lib --lib` — pass


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`git ls-files -o` must list untracked nested Git repositories with a trailing `/` (opaque directory entries). Grit was emitting paths like `repo/` from the worktree walk, but `pathdiff_from_repo_for_display` used `Path::join`, which strips a trailing separator—so output lost the `/`.

## Changes

- **`pathdiff_from_repo_for_display`**: strip `/` only for joining paths, then re-append `/` when the input was a directory marker.
- Refreshed harness artifacts for `t3009-ls-files-others-nonsubmodule.sh` (now 2/2).
- Log: `logs/2026-04-09-t3009-ls-files-others-nonsubmodule.md`

## Verification

- `./scripts/run-tests.sh t3009-ls-files-others-nonsubmodule.sh`
- `./scripts/run-tests.sh t3005-ls-files-relative.sh` (regression check)
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97d82dfe-4a6b-4186-827d-8ce78b909dc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97d82dfe-4a6b-4186-827d-8ce78b909dc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

