### PR TITLE
fix: Git-compatible mailinfo and mailsplit (t5100-mailinfo)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -860,7 +860,7 @@ t5002-archive-attr-pattern	t5	yes	19	19	0	true	ok	0
 t5003-archive-zip	t5	yes	82	75	7	false	ok	0
 t5004-archive-corner-cases	t5	yes	14	14	0	true	ok	0
 t5100-count-objects	t5	yes	26	24	2	false	ok	0
-t5100-mailinfo	t5	yes	52	7	45	false	ok	0
+t5100-mailinfo	t5	yes	52	52	0	true	ok	0
 t5150-request-pull	t5	yes	10	1	9	false	ok	0
 t5200-update-server-info	t5	yes	8	5	3	false	ok	0
 t5300-pack-object	t5	yes	63	40	23	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.2% of harness tests passing (35,731 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.2% of harness tests passing (35,731 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T23:11:43+00:00" class="gen-time" title="2026-04-09 23:11 UTC">2026-04-09 23:11 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.2%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,731</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.2%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">34/167 files · 17 skipped · 1,611/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:38.9%"></div></div>
+        <span class="group-pct pct-red">38.9%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35731 of 45142 tests passing across 1405 harness files (79.2% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.2% pass rate · 35,731 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T23:11:43+00:00" class="gen-time" title="2026-04-09 23:11 UTC">2026-04-09 23:11 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,731</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -8757,14 +8757,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:92.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="52" data-passed="7">
+<tr class="" data-group="t5" data-tests="52" data-passed="52" data-full-pass="1">
   <td class="mono">t5100-mailinfo</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">52</td>
-  <td class="right">7</td>
+  <td class="right">52</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:13.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="10" data-passed="1">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/lib.rs
+++ b/grit-lib/src/lib.rs
@@ -50,6 +50,7 @@ pub mod index_name_hash_lazy;
 pub mod interpret_trailers;
 pub mod line_log;
 pub mod ls_remote;
+pub mod mailinfo;
 pub mod mailmap;
 pub mod merge_base;
 pub mod merge_diff;

--- a/grit-lib/src/mailinfo.rs
+++ b/grit-lib/src/mailinfo.rs
@@ -1,0 +1,1629 @@
+//! Email parsing for `mailinfo` (aligned with Git's `mailinfo.c` for `t5100-mailinfo`).
+//!
+//! The [`mailinfo`] function reads one raw RFC822/MIME message and writes the commit message
+//! body, extracted patch, and metadata summary the way Git's plumbing does.
+
+use std::io::{self, Write};
+
+use crate::commit_encoding::{decode_bytes, reencode_utf8_to_label};
+use crate::config::ConfigSet;
+
+/// Quoted-printable / base64 body: what to do with decoded CRLF when not format=flowed.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum QuotedCrAction {
+    #[default]
+    Warn,
+    NoWarn,
+    Strip,
+}
+
+impl QuotedCrAction {
+    #[must_use]
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "warn" => Some(Self::Warn),
+            "nowarn" => Some(Self::NoWarn),
+            "strip" => Some(Self::Strip),
+            _ => None,
+        }
+    }
+}
+
+/// Options controlling subject cleanup, scissors, in-body headers, charset handling, and
+/// quoted-printable CRLF warnings — mirrors Git's `struct mailinfo` / CLI flags.
+#[derive(Debug, Clone)]
+pub struct MailinfoOptions {
+    pub keep_subject: bool,
+    pub keep_non_patch_brackets_in_subject: bool,
+    pub add_message_id: bool,
+    pub metainfo_charset: Option<String>,
+    pub use_scissors: bool,
+    pub use_inbody_headers: bool,
+    pub quoted_cr: QuotedCrAction,
+}
+
+impl Default for MailinfoOptions {
+    fn default() -> Self {
+        Self {
+            keep_subject: false,
+            keep_non_patch_brackets_in_subject: false,
+            add_message_id: false,
+            metainfo_charset: Some("utf-8".to_string()),
+            use_scissors: false,
+            use_inbody_headers: true,
+            quoted_cr: QuotedCrAction::Warn,
+        }
+    }
+}
+
+/// Reads `mailinfo.scissors` and `mailinfo.quotedcr` (or `mailinfo.quotedCr`) from `cfg`.
+pub fn apply_mailinfo_config(cfg: &ConfigSet, opts: &mut MailinfoOptions) {
+    if let Some(v) = cfg.get("mailinfo.scissors") {
+        if let Ok(b) = parse_bool_loose(v.as_str()) {
+            opts.use_scissors = b;
+        }
+    }
+    if let Some(v) = cfg
+        .get("mailinfo.quotedcr")
+        .or_else(|| cfg.get("mailinfo.quotedCr"))
+    {
+        if let Some(a) = QuotedCrAction::parse(v.trim()) {
+            opts.quoted_cr = a;
+        }
+    }
+}
+
+fn parse_bool_loose(s: &str) -> Result<bool, ()> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "true" | "yes" | "on" | "1" => Ok(true),
+        "false" | "no" | "off" | "0" => Ok(false),
+        _ => Err(()),
+    }
+}
+
+struct Input<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Input<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, pos: 0 }
+    }
+
+    fn eof(&self) -> bool {
+        self.pos >= self.bytes.len()
+    }
+
+    fn skip_leading_ws(&mut self) {
+        while self
+            .bytes
+            .get(self.pos)
+            .is_some_and(|b| b.is_ascii_whitespace())
+        {
+            self.pos += 1;
+        }
+    }
+
+    fn peek(&self) -> Option<u8> {
+        self.bytes.get(self.pos).copied()
+    }
+
+    /// Read one LF-terminated line (or rest of file); strip trailing CR/LF from buffer.
+    fn read_line(&mut self, out: &mut Vec<u8>) -> io::Result<bool> {
+        out.clear();
+        if self.pos >= self.bytes.len() {
+            return Ok(false);
+        }
+        let start = self.pos;
+        while self.pos < self.bytes.len() {
+            let b = self.bytes[self.pos];
+            self.pos += 1;
+            out.push(b);
+            if b == b'\n' {
+                break;
+            }
+        }
+        trim_end_crlf(out);
+        Ok(self.pos > start)
+    }
+
+    /// Like [`Self::read_line`] but keep a single trailing `\n` (only normalize CRLF → LF).
+    fn read_line_keep_lf(&mut self, out: &mut Vec<u8>) -> io::Result<bool> {
+        out.clear();
+        if self.pos >= self.bytes.len() {
+            return Ok(false);
+        }
+        let start = self.pos;
+        while self.pos < self.bytes.len() {
+            let b = self.bytes[self.pos];
+            self.pos += 1;
+            out.push(b);
+            if b == b'\n' {
+                break;
+            }
+        }
+        if out.len() >= 2 && out[out.len() - 2] == b'\r' && out[out.len() - 1] == b'\n' {
+            out.remove(out.len() - 2);
+        }
+        Ok(self.pos > start)
+    }
+}
+
+fn trim_end_crlf(line: &mut Vec<u8>) {
+    while line.last() == Some(&b'\r') || line.last() == Some(&b'\n') {
+        line.pop();
+    }
+}
+
+fn is_rfc2822_header(line: &[u8]) -> bool {
+    if line.starts_with(b"From ") || line.starts_with(b">From ") {
+        return true;
+    }
+    let mut i = 0;
+    while i < line.len() {
+        let ch = line[i];
+        if ch == b':' {
+            return true;
+        }
+        if (33..=57).contains(&ch) || (59..=126).contains(&ch) {
+            i += 1;
+            continue;
+        }
+        break;
+    }
+    false
+}
+
+fn read_header_line(inp: &mut Input<'_>, line: &mut Vec<u8>) -> io::Result<bool> {
+    line.clear();
+    if !inp.read_line(line)? {
+        return Ok(false);
+    }
+    if line.is_empty() || !is_rfc2822_header(line) {
+        line.push(b'\n');
+        return Ok(false);
+    }
+    loop {
+        match inp.peek() {
+            Some(b' ') | Some(b'\t') => {
+                inp.pos += 1;
+                let mut cont = Vec::new();
+                if !inp.read_line(&mut cont)? {
+                    break;
+                }
+                line.push(b' ');
+                line.extend_from_slice(&cont);
+            }
+            _ => break,
+        }
+    }
+    Ok(true)
+}
+
+#[derive(Default, Clone)]
+struct OptHdr(Option<String>);
+
+impl OptHdr {
+    fn set_if_empty(&mut self, v: String) {
+        if self.0.is_none() {
+            self.0 = Some(v);
+        }
+    }
+    fn clear(&mut self) {
+        self.0 = None;
+    }
+    fn as_opt(&self) -> Option<&str> {
+        self.0.as_deref()
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Default)]
+enum TE {
+    #[default]
+    DontCare,
+    Qp,
+    Base64,
+}
+
+
+struct Mime {
+    boundaries: Vec<Vec<u8>>,
+    charset: String,
+    te: TE,
+    format_flowed: bool,
+    delsp: bool,
+}
+
+impl Default for Mime {
+    fn default() -> Self {
+        Self {
+            boundaries: Vec::new(),
+            charset: String::new(),
+            te: TE::DontCare,
+            format_flowed: false,
+            delsp: false,
+        }
+    }
+}
+
+/// Extract author/subject/date and split message vs patch.
+///
+/// # Parameters
+///
+/// - `input` — full message bytes (may contain NULs in bodies).
+/// - `opts` — behaviour flags and optional UTF-8 metadata re-encoding target.
+/// - `msg_out` — commit message body (before the patch).
+/// - `patch_out` — diff text; binary-identical to Git where tests require it.
+/// - `info_out` — `Author:` / `Email:` / `Subject:` / `Date:` block.
+/// - `stderr` — receives `warning: quoted CRLF detected` when applicable.
+///
+/// # Errors
+///
+/// Returns an I/O error with kind [`io::ErrorKind::InvalidData`] for empty input or malformed
+/// RFC2047 (matching Git's `input_error` behaviour).
+pub fn mailinfo(
+    input: &[u8],
+    opts: &MailinfoOptions,
+    mut msg_out: impl Write,
+    mut patch_out: impl Write,
+    mut info_out: impl Write,
+    mut stderr: impl Write,
+) -> io::Result<()> {
+    let mut inp = Input::new(input);
+    inp.skip_leading_ws();
+    if inp.eof() {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "empty patch"));
+    }
+
+    let mut p_from = OptHdr::default();
+    let mut p_subj = OptHdr::default();
+    let mut p_date = OptHdr::default();
+    let mut message_id: Option<String> = None;
+    let mut mime = Mime::default();
+    let mut header_err = false;
+
+    let mut hl = Vec::new();
+    while read_header_line(&mut inp, &mut hl)? {
+        let ls = String::from_utf8_lossy(&hl).into_owned();
+        if !parse_rfc_header(
+            &ls,
+            opts,
+            &mut p_from,
+            &mut p_subj,
+            &mut p_date,
+            &mut mime,
+            &mut message_id,
+        ) {
+            header_err = true;
+        }
+    }
+    if header_err {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "mailinfo: bad header",
+        ));
+    }
+
+    let mut s_from = OptHdr::default();
+    let mut s_subj = OptHdr::default();
+    let mut s_date = OptHdr::default();
+    let mut log = Vec::new();
+    let mut patch_lines: u64 = 0;
+    let mut have_quoted_cr = false;
+    let mut body_err = false;
+
+    let mut st = BodyState {
+        filter_stage: 0,
+        header_stage: true,
+        inbody_accum: String::new(),
+        qp_carry: Vec::new(),
+        flowed_prev: Vec::new(),
+        body_done: false,
+    };
+
+    let mut line = Vec::new();
+    let mut need_first_boundary = !mime.boundaries.is_empty();
+    loop {
+        if need_first_boundary {
+            need_first_boundary = false;
+            if !find_boundary_line(&mut inp, &mime, &mut line)? {
+                flush_inbody_accum(
+                    &mut st.inbody_accum,
+                    opts,
+                    &mut s_from,
+                    &mut s_subj,
+                    &mut s_date,
+                );
+                break;
+            }
+        } else if !inp.read_line_keep_lf(&mut line)? {
+            break;
+        }
+        process_body_raw_line(
+            &mut inp,
+            &mut line,
+            opts,
+            &mut mime,
+            &mut st,
+            &mut s_from,
+            &mut s_subj,
+            &mut s_date,
+            &mut message_id,
+            &mut log,
+            &mut patch_out,
+            &mut patch_lines,
+            &mut have_quoted_cr,
+            &mut body_err,
+        )?;
+        if body_err {
+            break;
+        }
+        if st.body_done {
+            break;
+        }
+    }
+
+    flush_qp_tail(
+        opts,
+        &mime,
+        &mut st,
+        &mut s_from,
+        &mut s_subj,
+        &mut s_date,
+        &mut message_id,
+        &mut log,
+        &mut patch_out,
+        &mut patch_lines,
+        &mut have_quoted_cr,
+    )?;
+    if !st.flowed_prev.is_empty() {
+        let p = std::mem::take(&mut st.flowed_prev);
+        handle_filter(
+            opts,
+            &p,
+            &mut s_from,
+            &mut s_subj,
+            &mut s_date,
+            &mut message_id,
+            &mut log,
+            &mut patch_out,
+            &mut patch_lines,
+            &mut st.filter_stage,
+            &mut st.header_stage,
+            &mut st.inbody_accum,
+            &mime,
+        )?;
+    }
+    flush_inbody_accum(
+        &mut st.inbody_accum,
+        opts,
+        &mut s_from,
+        &mut s_subj,
+        &mut s_date,
+    );
+
+    if have_quoted_cr && opts.quoted_cr == QuotedCrAction::Warn {
+        writeln!(stderr, "warning: quoted CRLF detected")?;
+    }
+    if body_err {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "mailinfo: bad body",
+        ));
+    }
+
+    msg_out.write_all(&log)?;
+    write_info(
+        opts,
+        patch_lines,
+        &p_from,
+        &p_subj,
+        &p_date,
+        &s_from,
+        &s_subj,
+        &s_date,
+        &mut info_out,
+    )?;
+    Ok(())
+}
+
+struct BodyState {
+    filter_stage: u8,
+    header_stage: bool,
+    inbody_accum: String,
+    qp_carry: Vec<u8>,
+    flowed_prev: Vec<u8>,
+    /// Set when Git would leave `handle_body` (no more MIME body to read).
+    body_done: bool,
+}
+
+fn parse_rfc_header(
+    line: &str,
+    opts: &MailinfoOptions,
+    p_from: &mut OptHdr,
+    p_subj: &mut OptHdr,
+    p_date: &mut OptHdr,
+    mime: &mut Mime,
+    message_id: &mut Option<String>,
+) -> bool {
+    let Some(colon) = line.find(':') else {
+        return true;
+    };
+    let name = line[..colon].trim();
+    let val = line[colon + 1..].trim_start();
+
+    if name.eq_ignore_ascii_case("From") {
+        let mut v = val.to_string();
+        if decode_rfc2047(opts, &mut v).is_err() {
+            return false;
+        }
+        p_from.set_if_empty(v);
+        return true;
+    }
+    if name.eq_ignore_ascii_case("Subject") {
+        let mut v = val.to_string();
+        if decode_rfc2047(opts, &mut v).is_err() {
+            return false;
+        }
+        p_subj.set_if_empty(v);
+        return true;
+    }
+    if name.eq_ignore_ascii_case("Date") {
+        let mut v = val.to_string();
+        if decode_rfc2047(opts, &mut v).is_err() {
+            return false;
+        }
+        p_date.set_if_empty(v);
+        return true;
+    }
+    if name.eq_ignore_ascii_case("Content-Type") {
+        mime.format_flowed = has_attr_ci(line, "format=", "flowed");
+        mime.delsp = has_attr_ci(line, "delsp=", "yes");
+        if let Some(b) = slurp_attr_ci(line, "boundary=") {
+            let mut full = vec![b'-', b'-'];
+            full.extend_from_slice(b.as_bytes());
+            if mime.boundaries.len() < 5 {
+                mime.boundaries.push(full);
+            }
+        }
+        if let Some(cs) = slurp_attr_ci(line, "charset=") {
+            mime.charset = cs;
+        }
+        return true;
+    }
+    if name.eq_ignore_ascii_case("Content-Transfer-Encoding") {
+        let lower = val.to_ascii_lowercase();
+        mime.te = if lower.contains("base64") {
+            TE::Base64
+        } else if lower.contains("quoted-printable") {
+            TE::Qp
+        } else {
+            TE::DontCare
+        };
+        return true;
+    }
+    if opts.add_message_id
+        && (name.eq_ignore_ascii_case("Message-ID") || name.eq_ignore_ascii_case("Message-Id"))
+    {
+        let mut v = val.to_string();
+        if decode_rfc2047(opts, &mut v).is_err() {
+            return false;
+        }
+        *message_id = Some(v);
+    }
+    true
+}
+
+fn slurp_attr_ci(line: &str, name: &str) -> Option<String> {
+    let lower = line.to_ascii_lowercase();
+    let needle = name.to_ascii_lowercase();
+    let pos = lower.find(&needle)?;
+    let mut ap = &line[pos + needle.len()..];
+    if ap.starts_with('"') {
+        ap = &ap[1..];
+        let end = ap.find('"')?;
+        Some(ap[..end].to_string())
+    } else {
+        let end = ap
+            .find([';', ' ', '\t'])
+            .unwrap_or(ap.len());
+        let s = ap[..end].trim();
+        (!s.is_empty()).then(|| s.to_string())
+    }
+}
+
+fn has_attr_ci(line: &str, name: &str, value: &str) -> bool {
+    slurp_attr_ci(line, name).is_some_and(|s| s.eq_ignore_ascii_case(value))
+}
+
+fn decode_rfc2047(opts: &MailinfoOptions, s: &mut String) -> Result<(), ()> {
+    let Some(out) = decode_rfc2047_inner(s, opts.metainfo_charset.as_deref()) else {
+        return Err(());
+    };
+    *s = out;
+    Ok(())
+}
+
+fn decode_rfc2047_inner(input: &str, metainfo: Option<&str>) -> Option<String> {
+    let mut out = String::new();
+    let mut pos = 0usize;
+    while let Some(rel) = input[pos..].find("=?") {
+        let ep = pos + rel;
+        let before = &input[pos..ep];
+        if !before.is_empty() {
+            let only_ws = before.chars().all(|c| c.is_whitespace());
+            if !only_ws || pos == 0 {
+                out.push_str(before);
+            }
+        }
+        let rest = &input[ep + 2..];
+        let d1 = rest.find('?')?;
+        let charset = &rest[..d1];
+        let after = &rest[d1 + 1..];
+        let d2 = after.find('?')?;
+        let enc = after[..d2].to_ascii_lowercase();
+        let after_enc = &after[d2 + 1..];
+        let end = after_enc.find("?=")?;
+        let payload = &after_enc[..end];
+        pos = ep + 2 + d1 + 1 + d2 + 1 + end + 2;
+        let bytes = match enc.as_str() {
+            "q" => decode_qp(payload, true),
+            "b" => base64_decode(payload),
+            _ => return None,
+        };
+        let mut piece = decode_bytes(Some(charset), &bytes);
+        if let Some(target) = metainfo {
+            if let Some(raw) = reencode_utf8_to_label(target, &piece) {
+                piece = decode_bytes(Some(target), &raw);
+            }
+        }
+        out.push_str(&piece);
+    }
+    out.push_str(&input[pos..]);
+    Some(out)
+}
+
+fn decode_qp(input: &str, rfc2047: bool) -> Vec<u8> {
+    let mut out = Vec::new();
+    let bytes = input.as_bytes();
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if rfc2047 && b == b'_' {
+            out.push(b' ');
+            i += 1;
+            continue;
+        }
+        if b == b'=' {
+            let d1 = bytes.get(i + 1).copied();
+            if d1 == Some(b'\n') {
+                i += 2;
+                continue;
+            }
+            if d1 == Some(b'\r') && bytes.get(i + 2) == Some(&b'\n') {
+                i += 3;
+                continue;
+            }
+            if d1.is_none() || d1 == Some(b'\n') {
+                break;
+            }
+            let h1 = d1;
+            let h2 = bytes.get(i + 2).copied();
+            if let (Some(a), Some(c)) = (h1, h2) {
+                if let (Some(hi), Some(lo)) = (hex_nibble(a), hex_nibble(c)) {
+                    out.push((hi << 4) | lo);
+                    i += 3;
+                    continue;
+                }
+            }
+            out.push(b'=');
+            i += 1;
+            continue;
+        }
+        out.push(b);
+        i += 1;
+    }
+    out
+}
+
+fn hex_nibble(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn base64_decode(input: &str) -> Vec<u8> {
+    const T: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut o = Vec::new();
+    let mut buf: u32 = 0;
+    let mut bits: u32 = 0;
+    for &byte in input.as_bytes() {
+        if byte == b'=' {
+            break;
+        }
+        if byte.is_ascii_whitespace() {
+            continue;
+        }
+        let Some(v) = T.iter().position(|&c| c == byte) else {
+            continue;
+        };
+        buf = (buf << 6) | v as u32;
+        bits += 6;
+        if bits >= 8 {
+            bits -= 8;
+            o.push((buf >> bits) as u8);
+            buf &= (1 << bits) - 1;
+        }
+    }
+    o
+}
+
+#[allow(clippy::too_many_arguments)]
+fn process_body_raw_line(
+    inp: &mut Input<'_>,
+    raw: &mut Vec<u8>,
+    opts: &MailinfoOptions,
+    mime: &mut Mime,
+    st: &mut BodyState,
+    s_from: &mut OptHdr,
+    s_subj: &mut OptHdr,
+    s_date: &mut OptHdr,
+    message_id: &mut Option<String>,
+    log: &mut Vec<u8>,
+    patch_out: &mut impl Write,
+    patch_lines: &mut u64,
+    have_quoted_cr: &mut bool,
+    body_err: &mut bool,
+) -> io::Result<()> {
+    if let Some(boundary) = mime.boundaries.last().cloned() {
+        if raw.len() >= boundary.len() && raw[..boundary.len()] == boundary[..] {
+            let after = &raw[boundary.len()..];
+            let is_closing = after.starts_with(b"--");
+            if is_closing {
+                mime.boundaries.pop();
+                if mime.boundaries.is_empty() {
+                    handle_filter(
+                        opts,
+                        b"\n",
+                        s_from,
+                        s_subj,
+                        s_date,
+                        message_id,
+                        log,
+                        patch_out,
+                        patch_lines,
+                        &mut st.filter_stage,
+                        &mut st.header_stage,
+                        &mut st.inbody_accum,
+                        mime,
+                    )?;
+                }
+                loop {
+                    if !find_boundary_line(inp, mime, raw)? {
+                        flush_inbody_accum(&mut st.inbody_accum, opts, s_from, s_subj, s_date);
+                        st.body_done = true;
+                        return Ok(());
+                    }
+                    let Some(b) = mime.boundaries.last() else {
+                        break;
+                    };
+                    if raw.len() >= b.len() + 2
+                        && raw[..b.len()] == b[..]
+                        && &raw[b.len()..b.len() + 2] == b"--"
+                    {
+                        mime.boundaries.pop();
+                        if mime.boundaries.is_empty() {
+                            handle_filter(
+                                opts,
+                                b"\n",
+                                s_from,
+                                s_subj,
+                                s_date,
+                                message_id,
+                                log,
+                                patch_out,
+                                patch_lines,
+                                &mut st.filter_stage,
+                                &mut st.header_stage,
+                                &mut st.inbody_accum,
+                                mime,
+                            )?;
+                        }
+                        continue;
+                    }
+                    break;
+                }
+            } else {
+                *have_quoted_cr = false;
+            }
+            mime.te = TE::DontCare;
+            mime.charset.clear();
+            mime.format_flowed = false;
+            mime.delsp = false;
+            read_part_headers(inp, mime, raw, opts, body_err)?;
+            if *body_err {
+                return Ok(());
+            }
+            if !inp.read_line_keep_lf(raw)? {
+                flush_inbody_accum(&mut st.inbody_accum, opts, s_from, s_subj, s_date);
+                st.body_done = true;
+                return Ok(());
+            }
+        }
+    }
+
+    if st.body_done {
+        return Ok(());
+    }
+
+    let mut decoded = raw.clone();
+    match mime.te {
+        TE::Qp => {
+            let s = String::from_utf8_lossy(&decoded).into_owned();
+            decoded = decode_qp(&s, false);
+        }
+        TE::Base64 => {
+            let s: String = String::from_utf8_lossy(&decoded)
+                .chars()
+                .filter(|c| !c.is_ascii_whitespace())
+                .collect();
+            decoded = base64_decode(&s);
+        }
+        TE::DontCare => {}
+    }
+
+    match mime.te {
+        TE::Qp | TE::Base64 => {
+            st.qp_carry.extend_from_slice(&decoded);
+            split_qp_carry(
+                opts,
+                mime,
+                st,
+                s_from,
+                s_subj,
+                s_date,
+                message_id,
+                log,
+                patch_out,
+                patch_lines,
+                have_quoted_cr,
+            )?;
+        }
+        TE::DontCare => {
+            if !decoded.ends_with(b"\n") && !decoded.is_empty() {
+                decoded.push(b'\n');
+            }
+            process_decoded_physical_line(
+                opts,
+                mime,
+                st,
+                &decoded,
+                s_from,
+                s_subj,
+                s_date,
+                message_id,
+                log,
+                patch_out,
+                patch_lines,
+                have_quoted_cr,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn find_boundary_line(inp: &mut Input<'_>, mime: &Mime, line: &mut Vec<u8>) -> io::Result<bool> {
+    let Some(b) = mime.boundaries.last() else {
+        return Ok(false);
+    };
+    loop {
+        line.clear();
+        if !inp.read_line_keep_lf(line)? {
+            return Ok(false);
+        }
+        if line.len() >= b.len() && line[..b.len()] == b[..] {
+            return Ok(true);
+        }
+    }
+}
+
+fn read_part_headers(
+    inp: &mut Input<'_>,
+    mime: &mut Mime,
+    line: &mut Vec<u8>,
+    opts: &MailinfoOptions,
+    body_err: &mut bool,
+) -> io::Result<()> {
+    while read_header_line(inp, line)? {
+        let ls = String::from_utf8_lossy(line).into_owned();
+        let mut d1 = OptHdr::default();
+        let mut d2 = OptHdr::default();
+        let mut d3 = OptHdr::default();
+        if !parse_rfc_header(&ls, opts, &mut d1, &mut d2, &mut d3, mime, &mut None) {
+            *body_err = true;
+            return Ok(());
+        }
+    }
+    Ok(())
+}
+
+fn split_qp_carry(
+    opts: &MailinfoOptions,
+    mime: &Mime,
+    st: &mut BodyState,
+    s_from: &mut OptHdr,
+    s_subj: &mut OptHdr,
+    s_date: &mut OptHdr,
+    message_id: &mut Option<String>,
+    log: &mut Vec<u8>,
+    patch_out: &mut impl Write,
+    patch_lines: &mut u64,
+    have_quoted_cr: &mut bool,
+) -> io::Result<()> {
+    let mut start = 0;
+    let mut i = 0;
+    while i < st.qp_carry.len() {
+        if st.qp_carry[i] == b'\n' {
+            let chunk = st.qp_carry[start..=i].to_vec();
+            start = i + 1;
+            process_decoded_physical_line(
+                opts,
+                mime,
+                st,
+                &chunk,
+                s_from,
+                s_subj,
+                s_date,
+                message_id,
+                log,
+                patch_out,
+                patch_lines,
+                have_quoted_cr,
+            )?;
+        }
+        i += 1;
+    }
+    st.qp_carry.drain(..start);
+    Ok(())
+}
+
+fn flush_qp_tail(
+    opts: &MailinfoOptions,
+    mime: &Mime,
+    st: &mut BodyState,
+    s_from: &mut OptHdr,
+    s_subj: &mut OptHdr,
+    s_date: &mut OptHdr,
+    message_id: &mut Option<String>,
+    log: &mut Vec<u8>,
+    patch_out: &mut impl Write,
+    patch_lines: &mut u64,
+    have_quoted_cr: &mut bool,
+) -> io::Result<()> {
+    if st.qp_carry.is_empty() {
+        return Ok(());
+    }
+    let mut chunk = std::mem::take(&mut st.qp_carry);
+    if !chunk.ends_with(b"\n") {
+        chunk.push(b'\n');
+    }
+    process_decoded_physical_line(
+        opts,
+        mime,
+        st,
+        &chunk,
+        s_from,
+        s_subj,
+        s_date,
+        message_id,
+        log,
+        patch_out,
+        patch_lines,
+        have_quoted_cr,
+    )
+}
+
+fn process_decoded_physical_line(
+    opts: &MailinfoOptions,
+    mime: &Mime,
+    st: &mut BodyState,
+    line: &[u8],
+    s_from: &mut OptHdr,
+    s_subj: &mut OptHdr,
+    s_date: &mut OptHdr,
+    message_id: &mut Option<String>,
+    log: &mut Vec<u8>,
+    patch_out: &mut impl Write,
+    patch_lines: &mut u64,
+    have_quoted_cr: &mut bool,
+) -> io::Result<()> {
+    if mime.format_flowed {
+        handle_filter_flowed(
+            opts,
+            mime,
+            line,
+            st,
+            s_from,
+            s_subj,
+            s_date,
+            message_id,
+            log,
+            patch_out,
+            patch_lines,
+            have_quoted_cr,
+        )
+    } else {
+        let mut l = line.to_vec();
+        if l.len() >= 2 && l[l.len() - 2] == b'\r' && l[l.len() - 1] == b'\n' {
+            *have_quoted_cr = true;
+            if opts.quoted_cr == QuotedCrAction::Strip {
+                l.truncate(l.len() - 2);
+                l.push(b'\n');
+            }
+        }
+        handle_filter(
+            opts,
+            &l,
+            s_from,
+            s_subj,
+            s_date,
+            message_id,
+            log,
+            patch_out,
+            patch_lines,
+            &mut st.filter_stage,
+            &mut st.header_stage,
+            &mut st.inbody_accum,
+            mime,
+        )
+    }
+}
+
+fn bytes_to_log_text(line: &[u8], mime: &Mime) -> String {
+    let cs = (!mime.charset.trim().is_empty()).then_some(mime.charset.as_str());
+    decode_bytes(cs, line)
+}
+
+fn handle_filter_flowed(
+    opts: &MailinfoOptions,
+    mime: &Mime,
+    line: &[u8],
+    st: &mut BodyState,
+    s_from: &mut OptHdr,
+    s_subj: &mut OptHdr,
+    s_date: &mut OptHdr,
+    message_id: &mut Option<String>,
+    log: &mut Vec<u8>,
+    patch_out: &mut impl Write,
+    patch_lines: &mut u64,
+    have_quoted_cr: &mut bool,
+) -> io::Result<()> {
+    let mut len = line.len();
+    if len > 0 && line[len - 1] == b'\n' {
+        len -= 1;
+        if len > 0 && line[len - 1] == b'\r' {
+            len -= 1;
+        }
+    }
+
+    if line.len() >= 3 && &line[..3] == b"-- " && len == 3 {
+        if !st.flowed_prev.is_empty() {
+            let p = std::mem::take(&mut st.flowed_prev);
+            handle_filter(
+                opts,
+                &p,
+                s_from,
+                s_subj,
+                s_date,
+                message_id,
+                log,
+                patch_out,
+                patch_lines,
+                &mut st.filter_stage,
+                &mut st.header_stage,
+                &mut st.inbody_accum,
+                mime,
+            )?;
+        }
+        return handle_filter(
+            opts,
+            line,
+            s_from,
+            s_subj,
+            s_date,
+            message_id,
+            log,
+            patch_out,
+            patch_lines,
+            &mut st.filter_stage,
+            &mut st.header_stage,
+            &mut st.inbody_accum,
+            mime,
+        );
+    }
+
+    if len > 0 && line[0] == b' ' {
+        let mut l = line[1..].to_vec();
+        if !l.ends_with(b"\n") {
+            l.push(b'\n');
+        }
+        return process_decoded_physical_line(
+            opts,
+            &Mime {
+                format_flowed: false,
+                charset: mime.charset.clone(),
+                ..Default::default()
+            },
+            st,
+            &l,
+            s_from,
+            s_subj,
+            s_date,
+            message_id,
+            log,
+            patch_out,
+            patch_lines,
+            have_quoted_cr,
+        );
+    }
+
+    if len > 0 && line[len - 1] == b' ' {
+        let take = len - usize::from(mime.delsp);
+        st.flowed_prev.extend_from_slice(&line[..take]);
+        return Ok(());
+    }
+
+    let mut combined = Vec::new();
+    combined.extend_from_slice(&st.flowed_prev);
+    combined.extend_from_slice(&line[..len]);
+    st.flowed_prev.clear();
+    if !combined.ends_with(b"\n") {
+        combined.push(b'\n');
+    }
+    process_decoded_physical_line(
+        opts,
+        &Mime {
+            format_flowed: false,
+            charset: mime.charset.clone(),
+            ..Default::default()
+        },
+        st,
+        &combined,
+        s_from,
+        s_subj,
+        s_date,
+        message_id,
+        log,
+        patch_out,
+        patch_lines,
+        have_quoted_cr,
+    )
+}
+
+fn handle_filter(
+    opts: &MailinfoOptions,
+    line: &[u8],
+    s_from: &mut OptHdr,
+    s_subj: &mut OptHdr,
+    s_date: &mut OptHdr,
+    message_id: &mut Option<String>,
+    log: &mut Vec<u8>,
+    patch_out: &mut impl Write,
+    patch_lines: &mut u64,
+    filter_stage: &mut u8,
+    header_stage: &mut bool,
+    inbody_accum: &mut String,
+    mime: &Mime,
+) -> io::Result<()> {
+    match *filter_stage {
+        0 => {
+            if !handle_commit_msg(
+                opts,
+                line,
+                mime,
+                s_from,
+                s_subj,
+                s_date,
+                message_id,
+                log,
+                header_stage,
+                inbody_accum,
+            )? {
+                return Ok(());
+            }
+            *filter_stage = 1;
+            patch_out.write_all(line)?;
+            *patch_lines += 1;
+            Ok(())
+        }
+        1 => {
+            patch_out.write_all(line)?;
+            *patch_lines += 1;
+            Ok(())
+        }
+        _ => Ok(()),
+    }
+}
+
+fn handle_commit_msg(
+    opts: &MailinfoOptions,
+    line: &[u8],
+    mime: &Mime,
+    s_from: &mut OptHdr,
+    s_subj: &mut OptHdr,
+    s_date: &mut OptHdr,
+    message_id: &mut Option<String>,
+    log: &mut Vec<u8>,
+    header_stage: &mut bool,
+    inbody_accum: &mut String,
+) -> io::Result<bool> {
+    let text = bytes_to_log_text(line, mime);
+
+    if *header_stage {
+        let only_ws = text.chars().all(|c| c.is_whitespace());
+        if only_ws {
+            if !inbody_accum.is_empty() {
+                flush_inbody_accum(inbody_accum, opts, s_from, s_subj, s_date);
+                *header_stage = false;
+            }
+            return Ok(false);
+        }
+    }
+
+    if opts.use_inbody_headers && *header_stage {
+        *header_stage = check_inbody(opts, &text, inbody_accum, s_from, s_subj, s_date);
+        if *header_stage {
+            return Ok(false);
+        }
+    } else {
+        *header_stage = false;
+    }
+
+    if opts.use_scissors && is_scissors_line(&text) {
+        log.clear();
+        *header_stage = true;
+        s_from.clear();
+        s_subj.clear();
+        s_date.clear();
+        return Ok(false);
+    }
+
+    if patchbreak(line) {
+        if let Some(mid) = message_id.clone() {
+            log.extend_from_slice(format!("Message-ID: {mid}\n").as_bytes());
+        }
+        return Ok(true);
+    }
+
+    log.extend_from_slice(text.as_bytes());
+    Ok(false)
+}
+
+fn flush_inbody_accum(
+    acc: &mut String,
+    opts: &MailinfoOptions,
+    s_from: &mut OptHdr,
+    s_subj: &mut OptHdr,
+    s_date: &mut OptHdr,
+) {
+    if acc.is_empty() {
+        return;
+    }
+    let line = std::mem::take(acc);
+    apply_inbody_line(&line, opts, s_from, s_subj, s_date);
+}
+
+fn apply_inbody_line(
+    line: &str,
+    opts: &MailinfoOptions,
+    s_from: &mut OptHdr,
+    s_subj: &mut OptHdr,
+    s_date: &mut OptHdr,
+) {
+    let Some(colon) = line.find(':') else {
+        return;
+    };
+    let name = line[..colon].trim();
+    let mut val = line[colon + 1..].trim_start().to_string();
+    let _ = decode_rfc2047(opts, &mut val);
+    if name.eq_ignore_ascii_case("From") && s_from.as_opt().is_none() {
+        s_from.set_if_empty(val);
+    } else if name.eq_ignore_ascii_case("Subject") && s_subj.as_opt().is_none() {
+        s_subj.set_if_empty(val);
+    } else if name.eq_ignore_ascii_case("Date") && s_date.as_opt().is_none() {
+        s_date.set_if_empty(val);
+    }
+}
+
+fn inbody_header_candidate(line: &str, s_from: &OptHdr, s_subj: &OptHdr, s_date: &OptHdr) -> bool {
+    let Some(colon) = line.find(':') else {
+        return false;
+    };
+    let name = line[..colon].trim();
+    (name.eq_ignore_ascii_case("From") && s_from.as_opt().is_none())
+        || (name.eq_ignore_ascii_case("Subject") && s_subj.as_opt().is_none())
+        || (name.eq_ignore_ascii_case("Date") && s_date.as_opt().is_none())
+}
+
+fn check_inbody(
+    opts: &MailinfoOptions,
+    line: &str,
+    accum: &mut String,
+    s_from: &mut OptHdr,
+    s_subj: &mut OptHdr,
+    s_date: &mut OptHdr,
+) -> bool {
+    if !accum.is_empty() && (line.starts_with(' ') || line.starts_with('\t')) {
+        if opts.use_scissors && is_scissors_line(line) {
+            flush_inbody_accum(accum, opts, s_from, s_subj, s_date);
+            return false;
+        }
+        while accum.ends_with('\n') {
+            accum.pop();
+        }
+        accum.push_str(line);
+        return true;
+    }
+    flush_inbody_accum(accum, opts, s_from, s_subj, s_date);
+
+    if line.starts_with(">From ") {
+        let rest = &line[1..];
+        if is_format_patch_sep(rest) {
+            return true;
+        }
+    }
+    if line.starts_with("[PATCH] ") {
+        s_subj.set_if_empty(line.to_string());
+        return true;
+    }
+    if inbody_header_candidate(line, s_from, s_subj, s_date) {
+        accum.push_str(line);
+        return true;
+    }
+    false
+}
+
+fn is_format_patch_sep(line: &str) -> bool {
+    const TAIL: &str = " Mon Sep 17 00:00:00 2001\n";
+    if !line.starts_with("From ") || line.len() != 5 + 40 + TAIL.len() {
+        return false;
+    }
+    let hex = &line[5..45];
+    hex.chars().all(|c| c.is_ascii_hexdigit()) && &line[45..] == TAIL
+}
+
+fn patchbreak(line: &[u8]) -> bool {
+    if line.starts_with(b"diff -") || line.starts_with(b"Index: ") {
+        return true;
+    }
+    if line.len() < 4 || !line.starts_with(b"---") {
+        return false;
+    }
+    if line.len() > 3 && line[3] == b' ' {
+        return line.len() > 4 && !line[4].is_ascii_whitespace();
+    }
+    for i in 3..line.len() {
+        match line[i] {
+            b'\n' => return true,
+            b if !b.is_ascii_whitespace() => break,
+            _ => {}
+        }
+    }
+    false
+}
+
+fn is_scissors_line(line: &str) -> bool {
+    let mut scissors = 0;
+    let mut gap = 0;
+    let mut first_nb = None;
+    let mut last_nb = None;
+    let mut perforation: usize = 0;
+    let mut in_perf = false;
+    let c: Vec<char> = line.chars().collect();
+    let mut i = 0;
+    while i < c.len() {
+        let ch = c[i];
+        if ch.is_whitespace() {
+            if in_perf {
+                perforation += 1;
+                gap += 1;
+            }
+            i += 1;
+            continue;
+        }
+        last_nb = Some(i);
+        if first_nb.is_none() {
+            first_nb = Some(i);
+        }
+        if ch == '-' {
+            in_perf = true;
+            perforation += 1;
+            i += 1;
+            continue;
+        }
+        let rest: String = c[i..].iter().collect();
+        if rest.starts_with(">8")
+            || rest.starts_with("8<")
+            || rest.starts_with(">%")
+            || rest.starts_with("%<")
+        {
+            in_perf = true;
+            perforation += 2;
+            scissors += 2;
+            i += 2;
+            continue;
+        }
+        in_perf = false;
+        i += 1;
+    }
+    let visible = match (first_nb, last_nb) {
+        (Some(a), Some(b)) => b - a + 1,
+        _ => 0,
+    };
+    scissors > 0 && visible >= 8 && visible < perforation.saturating_mul(3) && gap * 2 < perforation
+}
+
+fn write_info(
+    opts: &MailinfoOptions,
+    patch_lines: u64,
+    p_from: &OptHdr,
+    p_subj: &OptHdr,
+    p_date: &OptHdr,
+    s_from: &OptHdr,
+    s_subj: &OptHdr,
+    s_date: &OptHdr,
+    out: &mut impl Write,
+) -> io::Result<()> {
+    for (hdr, val) in [
+        (
+            "From",
+            if patch_lines > 0 && s_from.as_opt().is_some() {
+                s_from.as_opt()
+            } else {
+                p_from.as_opt()
+            },
+        ),
+        (
+            "Subject",
+            if patch_lines > 0 && s_subj.as_opt().is_some() {
+                s_subj.as_opt()
+            } else {
+                p_subj.as_opt()
+            },
+        ),
+        (
+            "Date",
+            if patch_lines > 0 && s_date.as_opt().is_some() {
+                s_date.as_opt()
+            } else {
+                p_date.as_opt()
+            },
+        ),
+    ] {
+        let Some(val) = val else { continue };
+        if val.as_bytes().contains(&0) {
+            return Err(io::Error::new(io::ErrorKind::InvalidData, "NUL in header"));
+        }
+        match hdr {
+            "Subject" => {
+                let mut subj = val.to_string();
+                if !opts.keep_subject {
+                    cleanup_subject(opts, &mut subj);
+                    cleanup_space(&mut subj);
+                }
+                for part in subj.split('\n') {
+                    writeln!(out, "Subject: {part}")?;
+                }
+            }
+            "From" => {
+                let mut f = val.to_string();
+                cleanup_space(&mut f);
+                let (name, email) = handle_from(&f);
+                writeln!(out, "Author: {name}")?;
+                writeln!(out, "Email: {email}")?;
+            }
+            _ => {
+                let mut d = val.to_string();
+                cleanup_space(&mut d);
+                writeln!(out, "{hdr}: {d}")?;
+            }
+        }
+    }
+    writeln!(out)?;
+    Ok(())
+}
+
+fn cleanup_space(s: &mut String) {
+    let chs: Vec<char> = s.chars().collect();
+    let mut out = String::new();
+    let mut i = 0;
+    while i < chs.len() {
+        if chs[i].is_whitespace() {
+            out.push(' ');
+            i += 1;
+            while i < chs.len() && chs[i].is_whitespace() {
+                i += 1;
+            }
+        } else {
+            out.push(chs[i]);
+            i += 1;
+        }
+    }
+    *s = out;
+}
+
+fn cleanup_subject(opts: &MailinfoOptions, subject: &mut String) {
+    let mut at = 0;
+    while at < subject.len() {
+        let rest = &subject[at..];
+        let Some(ch0) = rest.chars().next() else {
+            break;
+        };
+        match ch0 {
+            'r' | 'R' => {
+                let b = rest.as_bytes();
+                if rest.len() >= 3 && (b[1] == b'e' || b[1] == b'E') && b[2] == b':' {
+                    subject.drain(at..at + 3);
+                    continue;
+                }
+                at += ch0.len_utf8();
+            }
+            ' ' | '\t' | ':' => {
+                subject.remove(at);
+                continue;
+            }
+            '[' => {
+                let Some(end_rel) = rest.find(']') else {
+                    break;
+                };
+                let remove = end_rel + 1;
+                let bracket = &rest[..remove];
+                let strip = !opts.keep_non_patch_brackets_in_subject
+                    || (remove >= 7 && bracket.to_ascii_uppercase().contains("PATCH"));
+                if strip {
+                    subject.drain(at..at + remove);
+                } else {
+                    at += remove;
+                    if at < subject.len() && subject[at..].starts_with(|c: char| c.is_whitespace())
+                    {
+                        at += 1;
+                    }
+                }
+                continue;
+            }
+            _ => break,
+        }
+    }
+    *subject = subject.trim().to_string();
+}
+
+fn handle_from(from: &str) -> (String, String) {
+    let mut f = unquote_quoted_pair(from);
+    let Some(mut at) = f.find('@') else {
+        return parse_bogus_from(from);
+    };
+    if f[at + 1..].contains('@') {
+        return (String::new(), String::new());
+    }
+    let mut bytes = std::mem::take(&mut f).into_bytes();
+    while at > 0 {
+        let prev = bytes[at - 1];
+        if prev.is_ascii_whitespace() {
+            break;
+        }
+        if prev == b'<' {
+            bytes[at - 1] = b' ';
+            break;
+        }
+        at -= 1;
+    }
+    let el = bytes[at..]
+        .iter()
+        .take_while(|&&b| !b.is_ascii_whitespace() && b != b'>')
+        .count();
+    let email = String::from_utf8_lossy(&bytes[at..at + el]).into_owned();
+    let skip = bytes
+        .get(at + el)
+        .filter(|&&b| b == b'>')
+        .map(|_| 1)
+        .unwrap_or(0);
+    let remove = el + skip;
+    let mut name = String::new();
+    name.push_str(&String::from_utf8_lossy(&bytes[..at]));
+    name.push_str(&String::from_utf8_lossy(&bytes[at + remove..]));
+    cleanup_space(&mut name);
+    let mut name = name.trim().to_string();
+    if name.starts_with('(') && name.len() > 1 && name.ends_with(')') {
+        name = name[1..name.len() - 1].to_string();
+    }
+    let mut disp = name.clone();
+    if disp.is_empty()
+        || disp.len() > 60
+        || disp.contains('@')
+        || disp.contains('<')
+        || disp.contains('>')
+    {
+        disp.clone_from(&email);
+    }
+    (disp, email)
+}
+
+fn parse_bogus_from(line: &str) -> (String, String) {
+    let Some(bra) = line.find('<') else {
+        return (String::new(), String::new());
+    };
+    let Some(k) = line[bra + 1..].find('>') else {
+        return (String::new(), String::new());
+    };
+    let ket = bra + 1 + k;
+    let email = line[bra + 1..ket].to_string();
+    let mut name = line[..bra].trim().trim_matches('"').to_string();
+    if name.is_empty()
+        || name.len() > 60
+        || name.contains('@')
+        || name.contains('<')
+        || name.contains('>')
+    {
+        name.clone_from(&email);
+    }
+    (name, email)
+}
+
+fn unquote_quoted_pair(input: &str) -> String {
+    let mut out = String::new();
+    let mut it = input.chars().peekable();
+    while let Some(c) = it.next() {
+        match c {
+            '"' => {
+                while let Some(d) = it.next() {
+                    if d == '\\' {
+                        if let Some(e) = it.next() {
+                            out.push(e);
+                        }
+                    } else if d == '"' {
+                        break;
+                    } else {
+                        out.push(d);
+                    }
+                }
+            }
+            '(' => {
+                out.push('(');
+                let mut depth = 1;
+                let mut lit = false;
+                for d in it.by_ref() {
+                    if lit {
+                        out.push(d);
+                        lit = false;
+                        continue;
+                    }
+                    if d == '\\' {
+                        lit = true;
+                        continue;
+                    }
+                    match d {
+                        '(' => {
+                            out.push('(');
+                            depth += 1;
+                        }
+                        ')' => {
+                            out.push(')');
+                            depth -= 1;
+                            if depth == 0 {
+                                break;
+                            }
+                        }
+                        _ => out.push(d),
+                    }
+                }
+            }
+            _ => out.push(c),
+        }
+    }
+    out
+}

--- a/grit/src/commands/mailinfo.rs
+++ b/grit/src/commands/mailinfo.rs
@@ -1,200 +1,128 @@
 //! `grit mailinfo` — extract patch from email message.
-//!
-//! Reads an email message from stdin, separates it into a commit message
-//! (written to `<msg>`) and a patch (written to `<patch>`), and prints
-//! author/subject metadata to stdout.  This is the plumbing behind
-//! `git am`.
 
 use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
-use std::io::{self, BufRead, Write};
+use grit_lib::config::ConfigSet;
+use grit_lib::mailinfo::{apply_mailinfo_config, mailinfo, MailinfoOptions, QuotedCrAction};
+use grit_lib::repo::Repository;
+use std::fs::File;
+use std::io::{self, Read};
 use std::path::PathBuf;
 
-/// Arguments for `grit mailinfo`.
 #[derive(Debug, ClapArgs)]
 #[command(
     about = "Extract patch from a single email message",
     override_usage = "grit mailinfo [OPTIONS] <msg> <patch>"
 )]
 pub struct Args {
-    /// Keep non-UTF-8 charsets as-is (do not re-encode).
     #[arg(short = 'k', long)]
     pub keep: bool,
 
-    /// Keep everything in the body before a `---` line.
     #[arg(short = 'b', long)]
     pub keep_body: bool,
 
-    /// Do not strip brackets from Subject.
-    #[arg(short = 'u', long)]
-    pub encoding: bool,
+    /// Re-code metadata to `i18n.commitEncoding` (default UTF-8).
+    #[arg(short = 'u')]
+    pub reencode_metadata: bool,
 
-    /// Scissors mode: look for `-- >8 --` and discard everything before.
+    /// Do not re-encode metadata.
+    #[arg(short = 'n', long = "no-reencode")]
+    pub no_reencode: bool,
+
+    /// Re-code metadata to this encoding.
+    #[arg(long = "encoding", value_name = "ENCODING")]
+    pub explicit_encoding: Option<String>,
+
+    #[arg(short = 'm', long = "message-id")]
+    pub message_id: bool,
+
     #[arg(long)]
     pub scissors: bool,
 
-    /// Disable scissors mode.
     #[arg(long = "no-scissors")]
     pub no_scissors: bool,
 
-    /// Decode quoted-printable (default; ignored for compat).
-    #[arg(long = "quoted-cr", hide = true)]
+    #[arg(long = "no-inbody-headers")]
+    pub no_inbody_headers: bool,
+
+    #[arg(long = "quoted-cr")]
     pub quoted_cr: Option<String>,
 
-    /// File to write the commit-message body to.
     pub msg: PathBuf,
 
-    /// File to write the patch (diff) to.
     pub patch: PathBuf,
 }
 
-/// Run `grit mailinfo`.
 pub fn run(args: Args) -> Result<()> {
-    let stdin = io::stdin();
-    let lines: Vec<String> = stdin
-        .lock()
-        .lines()
-        .collect::<Result<Vec<_>, _>>()
-        .context("reading stdin")?;
+    let mut opts = MailinfoOptions::default();
+    opts.keep_subject = args.keep;
+    opts.keep_non_patch_brackets_in_subject = args.keep_body;
+    opts.add_message_id = args.message_id;
 
-    let mut from = String::new();
-    let mut subject = String::new();
-    let mut date = String::new();
-    let mut message_id = String::new();
-
-    let mut body_lines: Vec<String> = Vec::new();
-    let mut patch_lines: Vec<String> = Vec::new();
-    let mut in_headers = true;
-    let mut in_patch = false;
-    let mut past_scissors = false;
-
-    for line in &lines {
-        if in_headers {
-            if line.is_empty() {
-                in_headers = false;
-                continue;
-            }
-            if let Some(rest) = strip_header(line, "From:") {
-                from = rest.trim().to_string();
-            } else if let Some(rest) = strip_header(line, "Subject:") {
-                subject = clean_subject(rest.trim(), args.keep);
-            } else if let Some(rest) = strip_header(line, "Date:") {
-                date = rest.trim().to_string();
-            } else if let Some(rest) = strip_header(line, "Message-Id:") {
-                message_id = rest.trim().to_string();
-            } else if let Some(rest) = strip_header(line, "Message-ID:") {
-                message_id = rest.trim().to_string();
-            }
-            continue;
-        }
-
-        // Handle scissors: discard everything before `-- >8 --`
-        if args.scissors && !past_scissors && (line.contains("-- >8 --") || line.contains("-->8--"))
-        {
-            body_lines.clear();
-            patch_lines.clear();
-            past_scissors = true;
-            continue;
-        }
-
-        if !in_patch {
-            // Detect the start of the patch
-            if line.starts_with("diff --git ")
-                || line.starts_with("diff -")
-                || line.starts_with("--- ")
-                || line.starts_with("Index: ")
-            {
-                in_patch = true;
-                patch_lines.push(line.clone());
-            } else if line == "---" && !args.keep_body {
-                // Separator between body and diffstat/patch — skip the `---` line,
-                // body is everything before it.
-                in_patch = true;
-            } else {
-                body_lines.push(line.clone());
-            }
-        } else {
-            patch_lines.push(line.clone());
-        }
+    if args.no_reencode {
+        opts.metainfo_charset = None;
+    } else if args.reencode_metadata {
+        opts.metainfo_charset = Some("utf-8".to_string());
+    }
+    if let Some(enc) = args.explicit_encoding.as_ref() {
+        opts.metainfo_charset = Some(enc.clone());
     }
 
-    // Write the commit message body
-    let mut msg_file = std::fs::File::create(&args.msg).context("creating msg file")?;
-    for line in &body_lines {
-        writeln!(msg_file, "{}", line)?;
+    if args.scissors {
+        opts.use_scissors = true;
+    }
+    if args.no_scissors {
+        opts.use_scissors = false;
+    }
+    if args.no_inbody_headers {
+        opts.use_inbody_headers = false;
     }
 
-    // Write the patch
-    let mut patch_file = std::fs::File::create(&args.patch).context("creating patch file")?;
-    for line in &patch_lines {
-        writeln!(patch_file, "{}", line)?;
+    if let Some(ref s) = args.quoted_cr {
+        let a =
+            QuotedCrAction::parse(s).with_context(|| format!("bad action for --quoted-cr: {s}"))?;
+        opts.quoted_cr = a;
     }
 
-    // Print metadata to stdout
+    if let Ok(repo) = Repository::discover(None) {
+        let cfg = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+        apply_mailinfo_config(&cfg, &mut opts);
+    }
+
+    if args.scissors {
+        opts.use_scissors = true;
+    }
+    if args.no_scissors {
+        opts.use_scissors = false;
+    }
+    if args.no_inbody_headers {
+        opts.use_inbody_headers = false;
+    }
+    if let Some(ref s) = args.quoted_cr {
+        opts.quoted_cr =
+            QuotedCrAction::parse(s).with_context(|| format!("bad action for --quoted-cr: {s}"))?;
+    }
+
+    let mut stdin = io::stdin();
+    let mut input = Vec::new();
+    stdin.read_to_end(&mut input).context("reading stdin")?;
+
+    let mut msg_file = File::create(&args.msg).context("creating msg file")?;
+    let mut patch_file = File::create(&args.patch).context("creating patch file")?;
     let stdout = io::stdout();
     let mut out = stdout.lock();
-    if !from.is_empty() {
-        let (name, email) = parse_author(&from);
-        writeln!(out, "Author: {}", name)?;
-        writeln!(out, "Email: {}", email)?;
-    }
-    if !subject.is_empty() {
-        writeln!(out, "Subject: {}", subject)?;
-    }
-    if !date.is_empty() {
-        writeln!(out, "Date: {}", date)?;
-    }
-    if !message_id.is_empty() {
-        writeln!(out, "Message-Id: {}", message_id)?;
-    }
+    let stderr = io::stderr();
+    let mut err = stderr.lock();
+
+    mailinfo(
+        &input,
+        &opts,
+        &mut msg_file,
+        &mut patch_file,
+        &mut out,
+        &mut err,
+    )
+    .map_err(|e| anyhow::anyhow!("{e}"))?;
 
     Ok(())
-}
-
-/// Case-insensitive header stripping.
-fn strip_header<'a>(line: &'a str, header: &str) -> Option<&'a str> {
-    if line.len() >= header.len() && line[..header.len()].eq_ignore_ascii_case(header) {
-        Some(&line[header.len()..])
-    } else {
-        None
-    }
-}
-
-/// Clean up a Subject line: remove `[PATCH ...]` prefixes and similar.
-fn clean_subject(s: &str, keep: bool) -> String {
-    if keep {
-        return s.to_string();
-    }
-    let mut result = s.to_string();
-    // Strip leading [PATCH ...] or [RFC ...] brackets
-    while result.starts_with('[') {
-        if let Some(end) = result.find(']') {
-            result = result[end + 1..].trim_start().to_string();
-        } else {
-            break;
-        }
-    }
-    // Strip leading "Re: " etc.
-    loop {
-        let lower = result.to_lowercase();
-        if lower.starts_with("re: ") || lower.starts_with("re:") {
-            result = result[3..].trim_start().to_string();
-        } else {
-            break;
-        }
-    }
-    result
-}
-
-/// Parse an author field like `Name <email>` or just `email`.
-fn parse_author(from: &str) -> (String, String) {
-    if let Some(start) = from.find('<') {
-        if let Some(end) = from.find('>') {
-            let name = from[..start].trim().trim_matches('"').to_string();
-            let email = from[start + 1..end].to_string();
-            return (name, email);
-        }
-    }
-    // No angle brackets — treat the whole thing as email
-    (String::new(), from.to_string())
 }

--- a/grit/src/commands/mailsplit.rs
+++ b/grit/src/commands/mailsplit.rs
@@ -1,116 +1,258 @@
 //! `grit mailsplit` — split mbox into individual messages.
-//!
-//! Reads an mbox-format file and splits it into numbered message files
-//! in the output directory, printing the count to stdout.
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use std::fs;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::PathBuf;
 
-/// Arguments for `grit mailsplit`.
 #[derive(Debug, ClapArgs)]
 #[command(
     about = "Split mbox into individual messages",
-    override_usage = "grit mailsplit -o<dir> [--keep-cr] <mbox>..."
+    override_usage = "grit mailsplit [-d<prec>] [-f<n>] [-b] [--keep-cr] [--mboxrd] -o<dir> [<mbox>...]"
 )]
 pub struct Args {
-    /// Output directory for split messages (e.g., `-odir`).
     #[arg(short = 'o', long = "output")]
-    pub output: PathBuf,
+    pub output: Option<PathBuf>,
 
-    /// Preserve CR at end of lines.
     #[arg(long = "keep-cr")]
     pub keep_cr: bool,
 
-    /// Skip first N messages.
-    #[arg(short = 'd', long = "skip", default_value = "0")]
-    pub skip: usize,
+    /// Filename width (3–9), not a skip count (matches Git `-d`).
+    #[arg(short = 'd', default_value = "4")]
+    pub nr_prec: u32,
 
-    /// The mbox file(s) to split. Uses stdin if omitted.
+    /// Initial counter for numbering (matches Git `-f`; first file is counter + 1).
+    #[arg(short = 'f', default_value = "0")]
+    pub first_nr: u32,
+
+    #[arg(short = 'b', long)]
+    pub allow_bare: bool,
+
+    #[arg(long = "mboxrd")]
+    pub mboxrd: bool,
+
+    #[arg(value_name = "MBOX")]
     pub mbox: Vec<PathBuf>,
 }
 
-/// Run `grit mailsplit`.
 pub fn run(args: Args) -> Result<()> {
-    // Ensure the output directory exists
-    fs::create_dir_all(&args.output)
-        .with_context(|| format!("creating output dir {:?}", args.output))?;
+    if !(3..10).contains(&args.nr_prec) {
+        bail!("mailsplit: -d must be between 3 and 9");
+    }
 
-    let mut count: usize = 0;
+    let (dir, files) = resolve_paths(&args)?;
 
-    if args.mbox.is_empty() {
-        // Read from stdin
-        let data = {
-            use std::io::Read;
-            let mut buf = String::new();
-            std::io::stdin().read_to_string(&mut buf)?;
-            buf
+    fs::create_dir_all(&dir).with_context(|| format!("creating {:?}", dir))?;
+
+    let mut seq = args.first_nr;
+    let mut total_written = 0u32;
+
+    for file in files {
+        let data = if file.as_os_str() == "-" {
+            let mut v = Vec::new();
+            std::io::stdin()
+                .read_to_end(&mut v)
+                .context("reading stdin")?;
+            v
+        } else {
+            fs::read(&file).with_context(|| format!("reading {:?}", file))?
         };
-        count = split_mbox(&data, &args.output, count, args.skip, args.keep_cr)?;
-    } else {
-        for mbox_path in &args.mbox {
-            let data = fs::read_to_string(mbox_path)
-                .with_context(|| format!("reading mbox {:?}", mbox_path))?;
-            count = split_mbox(&data, &args.output, count, args.skip, args.keep_cr)?;
+
+        if data.is_empty() && file.as_os_str() != "-" {
+            bail!("empty mbox: '{}'", file.display());
+        }
+
+        let mut pos = skip_leading_ws(&data);
+        if pos >= data.len() {
+            if file.as_os_str() == "-" {
+                println!("{total_written}");
+                return Ok(());
+            }
+            bail!("empty mbox: '{}'", file.display());
+        }
+        pos = skip_preamble_to_first_from(&data, pos, args.keep_cr);
+
+        let mut file_done = false;
+        while !file_done {
+            seq += 1;
+            let name = format!("{:0width$}", seq, width = args.nr_prec as usize);
+            let path = dir.join(&name);
+            let mut out =
+                fs::File::create_new(&path).with_context(|| format!("creating {:?}", path))?;
+            file_done = split_one_message(
+                &data,
+                &mut pos,
+                &mut out,
+                args.allow_bare,
+                args.keep_cr,
+                args.mboxrd,
+            )?;
+            total_written += 1;
         }
     }
 
-    println!("{}", count);
+    println!("{total_written}");
     Ok(())
 }
 
-/// Split mbox content into numbered files.
-/// Returns the total count of messages written (cumulative from `start`).
-fn split_mbox(
-    data: &str,
-    output: &std::path::Path,
-    start: usize,
-    skip: usize,
-    _keep_cr: bool,
-) -> Result<usize> {
-    let mut messages: Vec<String> = Vec::new();
-    let mut current: Option<String> = None;
-
-    for line in data.lines() {
-        if is_mbox_from_line(line) {
-            // Start a new message
-            if let Some(msg) = current.take() {
-                messages.push(msg);
-            }
-            current = Some(format!("{}\n", line));
-        } else if let Some(ref mut msg) = current {
-            msg.push_str(line);
-            msg.push('\n');
-        }
-        // Lines before the first From line are ignored (mbox preamble)
+fn resolve_paths(args: &Args) -> Result<(PathBuf, Vec<PathBuf>)> {
+    match (&args.output, args.mbox.len()) {
+        (Some(dir), 0) => Ok((dir.clone(), vec![PathBuf::from("-")])),
+        (Some(dir), _) => Ok((dir.clone(), args.mbox.clone())),
+        (None, 1) => Ok((args.mbox[0].clone(), vec![PathBuf::from("-")])),
+        (None, 2) => Ok((args.mbox[1].clone(), vec![args.mbox[0].clone()])),
+        _ => bail!("mailsplit: need -o<dir> or legacy <mbox> <dir> usage"),
     }
-    // Don't forget the last message
-    if let Some(msg) = current.take() {
-        messages.push(msg);
-    }
-
-    let mut count = start;
-    for (i, msg) in messages.into_iter().enumerate() {
-        if i < skip {
-            continue;
-        }
-        count += 1;
-        let filename = format!("{:04}", count);
-        let path = output.join(&filename);
-        let mut f = fs::File::create(&path).with_context(|| format!("creating {:?}", path))?;
-        f.write_all(msg.as_bytes())?;
-    }
-
-    Ok(count)
 }
 
-/// Check if a line is an mbox "From " separator.
-///
-/// Traditional mbox format: lines starting with "From " followed by an
-/// email address and a date are message separators.
-fn is_mbox_from_line(line: &str) -> bool {
-    // Git uses a simple heuristic: line starts with "From "
-    line.starts_with("From ")
+fn skip_leading_ws(data: &[u8]) -> usize {
+    let mut i = 0;
+    while i < data.len() && data[i].is_ascii_whitespace() {
+        i += 1;
+    }
+    i
+}
+
+fn skip_preamble_to_first_from(data: &[u8], mut pos: usize, keep_cr: bool) -> usize {
+    while pos < data.len() {
+        let start = pos;
+        let end = data[pos..]
+            .iter()
+            .position(|&b| b == b'\n')
+            .map(|p| pos + p + 1)
+            .unwrap_or(data.len());
+        let mut line = data[start..end].to_vec();
+        if !keep_cr {
+            strip_crlf_end(&mut line);
+        }
+        if is_from_line(&line) {
+            return start;
+        }
+        pos = end;
+    }
+    pos
+}
+
+fn strip_crlf_end(line: &mut Vec<u8>) {
+    if line.len() >= 2 && line.ends_with(b"\n") && line[line.len() - 2] == b'\r' {
+        line.truncate(line.len() - 2);
+        line.push(b'\n');
+    }
+}
+
+fn is_from_line(line: &[u8]) -> bool {
+    if line.len() < 20 || !line.starts_with(b"From ") {
+        return false;
+    }
+    if line.len() < 2 {
+        return false;
+    }
+    let mut colon = line.len() - 2;
+    let start = 5usize;
+    loop {
+        if colon < start {
+            return false;
+        }
+        if line[colon] == b':' {
+            break;
+        }
+        colon -= 1;
+    }
+    if colon < 4 {
+        return false;
+    }
+    if !line[colon - 4].is_ascii_digit()
+        || !line[colon - 2].is_ascii_digit()
+        || !line[colon - 1].is_ascii_digit()
+        || !line[colon + 1].is_ascii_digit()
+        || !line[colon + 2].is_ascii_digit()
+    {
+        return false;
+    }
+    let tail = std::str::from_utf8(&line[colon + 3..]).unwrap_or("");
+    let year_str = tail.trim_start();
+    let year_digits: String = year_str
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect();
+    let Ok(year) = year_digits.parse::<i64>() else {
+        return false;
+    };
+    year > 90
+}
+
+fn is_gtfrom(buf: &[u8]) -> bool {
+    let min = b">From ".len();
+    if buf.len() < min {
+        return false;
+    }
+    let ngt = buf.iter().take_while(|&&b| b == b'>').count();
+    ngt > 0 && buf[ngt..].starts_with(b"From ")
+}
+
+fn split_one_message(
+    data: &[u8],
+    pos: &mut usize,
+    out: &mut fs::File,
+    allow_bare: bool,
+    keep_cr: bool,
+    mboxrd: bool,
+) -> Result<bool> {
+    let mut line = read_line_bytes(data, pos)?;
+    if !keep_cr && line.len() > 1 && line.ends_with(b"\n") && line[line.len() - 2] == b'\r' {
+        line.truncate(line.len() - 2);
+        line.push(b'\n');
+    }
+    let is_bare = !is_from_line(&line);
+
+    if is_bare && !allow_bare {
+        bail!("corrupt mailbox");
+    }
+
+    loop {
+        let mut write_line = line.clone();
+        if !keep_cr
+            && write_line.len() > 1
+            && write_line.ends_with(b"\n")
+            && write_line[write_line.len() - 2] == b'\r'
+        {
+            write_line.truncate(write_line.len() - 2);
+            write_line.push(b'\n');
+        }
+        if mboxrd && is_gtfrom(&write_line) {
+            write_line.remove(0);
+        }
+        out.write_all(&write_line)
+            .context("writing split message")?;
+
+        line = read_line_bytes(data, pos)?;
+        if line.is_empty() {
+            return Ok(true);
+        }
+        if !keep_cr && line.len() > 1 && line.ends_with(b"\n") && line[line.len() - 2] == b'\r' {
+            line.truncate(line.len() - 2);
+            line.push(b'\n');
+        }
+        if !is_bare && is_from_line(&line) {
+            let rewind = line.len();
+            *pos = (*pos).saturating_sub(rewind);
+            return Ok(false);
+        }
+    }
+}
+
+fn read_line_bytes(data: &[u8], pos: &mut usize) -> Result<Vec<u8>> {
+    if *pos >= data.len() {
+        return Ok(Vec::new());
+    }
+    let start = *pos;
+    while *pos < data.len() {
+        let b = data[*pos];
+        *pos += 1;
+        if b == b'\n' {
+            break;
+        }
+    }
+    Ok(data[start..*pos].to_vec())
 }

--- a/logs/2026-04-09_t5100-mailinfo.md
+++ b/logs/2026-04-09_t5100-mailinfo.md
@@ -1,0 +1,6 @@
+# t5100-mailinfo
+
+- Added `grit-lib::mailinfo` implementing Git-compatible mail parsing (headers, RFC2047, MIME multipart, QP/base64 bodies, scissors, in-body headers, quoted-CR handling).
+- Rewrote `grit mailsplit` to match Git: `From` line detection, CRLF normalization, rewind on next message, `-d` precision / `-f` counter, `--mboxrd`, binary-safe reads.
+- Wired `grit mailinfo` through the library with repo config (`mailinfo.scissors`, `mailinfo.quotedcr`).
+- Harness: `./scripts/run-tests.sh t5100-mailinfo.sh` — 52/52 pass.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements `mailinfo` and `mailsplit` behavior to match upstream Git’s `mailinfo.c` / `builtin/mailsplit.c` so **`tests/t5100-mailinfo.sh` passes all 52 tests**.

## Changes

- **`grit-lib`**: new `mailinfo` module — RFC822 headers (folding, value trim rules), RFC2047 (including LWS between encoded-words), MIME multipart boundaries, quoted-printable (soft line breaks) and base64 body decoding, `format=flowed`, scissors / in-body headers, NUL-safe bodies, quoted CRLF warn/strip, metadata output matching Git.
- **`grit`**: `mailinfo` delegates to the library; reads repo config for `mailinfo.scissors` and `mailinfo.quotedcr`.
- **`mailsplit`**: rewritten — Git `From` line heuristic, CRLF normalization for detection, rewind when hitting the next separator, `-d` width / `-f` counter semantics, `--mboxrd`.
- **Harness**: refreshed `data/test-files.csv` and dashboards after a green run.

## Validation

- `./scripts/run-tests.sh t5100-mailinfo.sh` — 52/52
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4700ad0c-6245-4a2e-bad1-c0b48e33a7f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4700ad0c-6245-4a2e-bad1-c0b48e33a7f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

