### PR TITLE
fix: make t1500-rev-parse fully pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -434,7 +434,7 @@ t1460-refs-migrate	t1	skip	22	0	0	false	ok	0
 t1461-refs-list	t1	yes	428	342	86	false	ok	0
 t1462-refs-exists	t1	yes	12	12	0	true	ok	0
 t1463-refs-optimize	t1	yes	47	10	37	false	ok	0
-t1500-rev-parse	t1	yes	81	70	11	false	ok	0
+t1500-rev-parse	t1	yes	81	81	0	true	ok	0
 t1501-work-tree	t1	yes	39	39	0	true	ok	0
 t1502-rev-parse-parseopt	t1	yes	37	37	0	true	ok	0
 t1503-rev-parse-verify	t1	yes	12	10	2	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,697 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,697 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T23:17:20+00:00" class="gen-time" title="2026-04-09 23:17 UTC">2026-04-09 23:17 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,697</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -197,11 +197,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">275/368 files · 8 skipped · 11,694/12,747 tests</span>
+        <span class="group-meta">276/368 files · 8 skipped · 11,705/12,747 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:91.7%"></div></div>
-        <span class="group-pct pct-green">91.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:91.8%"></div></div>
+        <span class="group-pct pct-green">91.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t2">
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35697 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,697 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T23:17:20+00:00" class="gen-time" title="2026-04-09 23:17 UTC">2026-04-09 23:17 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,697</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -4497,14 +4497,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:21.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="81" data-passed="70">
+<tr class="" data-group="t1" data-tests="81" data-passed="81" data-full-pass="1">
   <td class="mono">t1500-rev-parse</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">81</td>
-  <td class="right">70</td>
+  <td class="right">81</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:86.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="39" data-passed="39" data-full-pass="1">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/rev_parse.rs
+++ b/grit-lib/src/rev_parse.rs
@@ -110,6 +110,28 @@ pub fn show_prefix(repo: &Repository, cwd: &Path) -> String {
     out
 }
 
+/// Superproject work tree when `git_dir` lives under `.../<wt>/.git/modules/...` (nested submodule).
+///
+/// Used when the submodule's recorded path in the superproject index does not match the on-disk
+/// layout (e.g. `dir/sub` recorded but git dir is `.../modules/dir/modules/sub`), so
+/// `ls-files`-based superproject detection cannot find a gitlink.
+#[must_use]
+pub fn superproject_work_tree_from_nested_git_modules(git_dir: &Path) -> Option<PathBuf> {
+    let mut p = git_dir.to_path_buf();
+    while let Some(parent) = p.parent() {
+        if p.file_name().is_some_and(|n| n == "modules")
+            && parent.file_name().is_some_and(|n| n == ".git")
+        {
+            return parent.parent().map(PathBuf::from);
+        }
+        if parent == p {
+            break;
+        }
+        p = parent.to_path_buf();
+    }
+    None
+}
+
 /// Resolve a symbolic ref name to its full form.
 ///
 /// For `HEAD`, returns the symbolic target (e.g., `refs/heads/main`).
@@ -2982,4 +3004,25 @@ pub fn list_all_abbrev_matches(repo: &Repository, prefix: &str) -> Result<Vec<Ob
 /// Public: find all object IDs whose hex prefix matches the given string.
 pub fn list_loose_abbrev_matches(repo: &Repository, prefix: &str) -> Result<Vec<ObjectId>> {
     list_all_abbrev_matches(repo, prefix)
+}
+
+#[cfg(test)]
+mod superproject_path_tests {
+    use super::superproject_work_tree_from_nested_git_modules;
+    use std::path::PathBuf;
+
+    #[test]
+    fn nested_modules_yields_superproject_work_tree() {
+        let git_dir = PathBuf::from("/tmp/super/.git/modules/dir/modules/sub");
+        assert_eq!(
+            superproject_work_tree_from_nested_git_modules(&git_dir),
+            Some(PathBuf::from("/tmp/super"))
+        );
+    }
+
+    #[test]
+    fn non_nested_returns_none() {
+        let git_dir = PathBuf::from("/tmp/repo/.git");
+        assert!(superproject_work_tree_from_nested_git_modules(&git_dir).is_none());
+    }
 }

--- a/grit/src/commands/checkout.rs
+++ b/grit/src/commands/checkout.rs
@@ -2032,10 +2032,21 @@ fn force_create_and_switch_branch(
             let head = resolve_head(&repo.git_dir)?;
             match head.oid() {
                 Some(oid) => *oid,
-                None => bail!(
-                    "cannot create branch '{}': HEAD does not point to a commit",
-                    name
-                ),
+                None => match &head {
+                    HeadState::Branch { refname, .. } if refname == &branch_ref => {
+                        checkout_eprintln!("Switched to a new branch '{}'", name);
+                        return Ok(());
+                    }
+                    HeadState::Branch { .. } => {
+                        std::fs::write(repo.git_dir.join("HEAD"), format!("ref: {branch_ref}\n"))?;
+                        checkout_eprintln!("Switched to a new branch '{}'", name);
+                        return Ok(());
+                    }
+                    _ => bail!(
+                        "cannot create branch '{}': HEAD does not point to a commit",
+                        name
+                    ),
+                },
             }
         }
     };

--- a/grit/src/commands/rev_parse.rs
+++ b/grit/src/commands/rev_parse.rs
@@ -1,8 +1,10 @@
 //! `grit rev-parse` - pick out and massage revision parameters.
 
+use crate::grit_exe;
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::error::Error as LibError;
+use grit_lib::git_date::approx::approxidate_careful;
 use grit_lib::merge_base;
 use grit_lib::refs;
 use grit_lib::repo::Repository;
@@ -11,9 +13,12 @@ use grit_lib::rev_parse::{
     is_inside_git_dir, is_inside_work_tree, list_all_abbrev_matches, parse_peel_suffix,
     peel_to_commit_for_merge_base, resolve_revision, resolve_revision_for_range_end,
     resolve_revision_without_index_dwim, show_prefix, split_double_dot_range,
-    split_triple_dot_range, symbolic_full_name, to_relative_path,
+    split_triple_dot_range, superproject_work_tree_from_nested_git_modules, symbolic_full_name,
+    to_relative_path,
 };
 use std::env;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
 /// Arguments for `grit rev-parse`.
 #[derive(Debug, ClapArgs)]
@@ -21,6 +26,158 @@ pub struct Args {
     /// Raw command arguments forwarded by the CLI parser.
     #[arg(value_name = "ARG", num_args = 0.., allow_hyphen_values = true, trailing_var_arg = true)]
     pub args: Vec<String>,
+}
+
+fn realpath_forgiving(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn is_linked_worktree_git_dir(git_dir: &Path) -> bool {
+    git_dir
+        .components()
+        .any(|c| c.as_os_str() == std::ffi::OsStr::new("worktrees"))
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PathDefaultMode {
+    /// Pass through `path` without canonicalization (e.g. literal `.git`).
+    Unmodified,
+    /// Realpath / canonical absolute (default for `--git-dir` inside a work tree).
+    Canonical,
+    /// `relative_path(realpath(path), realpath(cwd))` (Git `DEFAULT_RELATIVE_IF_SHARED`).
+    RelativeToCwd,
+}
+
+fn print_rev_parse_path(
+    path: &Path,
+    cwd: &Path,
+    cli_prefix: Option<&Path>,
+    path_format_absolute: Option<bool>,
+    default_mode: PathDefaultMode,
+) {
+    let path_abs = realpath_forgiving(path);
+    let cwd_abs = realpath_forgiving(cwd);
+    match path_format_absolute {
+        Some(true) => {
+            println!("{}", path_abs.display());
+        }
+        Some(false) => {
+            let base = cli_prefix
+                .map(realpath_forgiving)
+                .unwrap_or_else(|| cwd_abs.clone());
+            println!("{}", to_relative_path(&path_abs, &base));
+        }
+        None => match default_mode {
+            PathDefaultMode::Unmodified => {
+                println!("{}", path.display());
+            }
+            PathDefaultMode::Canonical => {
+                println!("{}", path_abs.display());
+            }
+            PathDefaultMode::RelativeToCwd => {
+                println!("{}", to_relative_path(&path_abs, &cwd_abs));
+            }
+        },
+    }
+}
+
+fn read_extensions_refstorage(git_dir: &Path) -> String {
+    let config_path = git_dir.join("config");
+    let Ok(content) = std::fs::read_to_string(&config_path) else {
+        return "files".to_string();
+    };
+    let mut in_ext = false;
+    let mut found = String::from("files");
+    for line in content.lines() {
+        let t = line.trim();
+        if t.starts_with('[') {
+            in_ext = t.eq_ignore_ascii_case("[extensions]");
+            continue;
+        }
+        if in_ext {
+            if let Some((k, v)) = t.split_once('=') {
+                if k.trim().eq_ignore_ascii_case("refstorage") {
+                    found = v.trim().to_owned();
+                }
+            }
+        }
+    }
+    found
+}
+
+fn ref_storage_format_is_valid(raw: &str) -> bool {
+    let lower = raw.to_ascii_lowercase();
+    let name = lower
+        .split_once(':')
+        .map(|(a, _)| a)
+        .unwrap_or(lower.as_str());
+    matches!(name, "files" | "reftable")
+}
+
+fn path_relative_to_base(base: &Path, target: &Path) -> Option<String> {
+    let base_a = realpath_forgiving(base);
+    let target_a = realpath_forgiving(target);
+    let base_c: Vec<_> = base_a.components().collect();
+    let target_c: Vec<_> = target_a.components().collect();
+    let mut common = 0usize;
+    let max = base_c.len().min(target_c.len());
+    while common < max && base_c[common] == target_c[common] {
+        common += 1;
+    }
+    if common < base_c.len() {
+        return None;
+    }
+    let rest: Vec<_> = target_c
+        .iter()
+        .skip(common)
+        .map(|c| c.as_os_str().to_string_lossy().into_owned())
+        .collect();
+    Some(if rest.is_empty() {
+        ".".to_owned()
+    } else {
+        rest.join("/")
+    })
+}
+
+fn superproject_working_tree_via_ls_files(repo: &Repository, cwd: &Path) -> Option<PathBuf> {
+    let work_tree = repo.work_tree.as_ref()?;
+    let rel_s = path_relative_to_base(work_tree, cwd)?;
+    let spec = if rel_s.is_empty() {
+        "."
+    } else {
+        rel_s.as_str()
+    };
+    let mut cmd = Command::new(grit_exe::grit_executable());
+    grit_exe::strip_trace2_env(&mut cmd);
+    cmd.current_dir(work_tree)
+        .args(["ls-files", "-z", "--stage", "--full-name", "--", spec])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null());
+    let output = cmd.output().ok()?;
+    if output.status.code() == Some(128) || !output.status.success() {
+        return None;
+    }
+    let data = output.stdout;
+    if !data.starts_with(b"160000 ") {
+        return None;
+    }
+    let tab = data.iter().position(|&b| b == b'\t')?;
+    let path_bytes = &data[tab + 1..data.len().saturating_sub(1)];
+    let super_sub = std::str::from_utf8(path_bytes).ok()?.trim_end_matches('\0');
+    let cwd_s = cwd.to_string_lossy();
+    if super_sub.len() > cwd_s.len() {
+        return None;
+    }
+    if !cwd_s.ends_with(super_sub) {
+        return None;
+    }
+    let trim = cwd_s.len() - super_sub.len();
+    let mut super_wt = cwd_s[..trim].to_string();
+    while super_wt.ends_with('/') {
+        super_wt.pop();
+    }
+    Some(PathBuf::from(super_wt))
 }
 
 /// Run `rev-parse` with argv as passed after the subcommand (preserves `--` for path separation).
@@ -55,6 +212,8 @@ pub fn run(args: Args) -> Result<()> {
     let mut no_revs = false;
     let mut no_flags = false;
     let mut sq_output = false;
+    let mut path_format_absolute: Option<bool> = None;
+    let mut cli_prefix_path: Option<PathBuf> = None;
 
     // Collect ordered actions for sequential output
     // Each action captures the flag state at time of parsing
@@ -64,15 +223,19 @@ pub fn run(args: Args) -> Result<()> {
         ShowIsInsideGitDir,
         ShowIsBare,
         ShowIsShallow,
-        ShowToplevel,
+        ShowToplevel(Option<bool>),
         ShowPrefix,
         ShowCdup,
-        ShowGitDir,
-        ShowGitCommonDir,
+        ShowGitDir(Option<bool>),
+        ShowGitCommonDir(Option<bool>),
         ShowAbsoluteGitDir,
+        ShowSuperprojectWorkingTree(Option<bool>),
         ShowRefFormat,
         ShowObjectFormat(String),
-        GitPath(String),
+        GitPath(Option<bool>, String),
+        BisectRefs(bool),
+        MaxAge(String),
+        MinAge(String),
         All,
         Branches(Option<String>),
         Tags(Option<String>),
@@ -126,12 +289,24 @@ pub fn run(args: Args) -> Result<()> {
         }
         if !end_of_options && arg.starts_with('-') {
             if arg == "--path-format=absolute" {
-                // --path-format=absolute: output absolute paths; currently our default
-                // for git-dir etc., so this is a no-op
+                path_format_absolute = Some(true);
                 i += 1;
                 continue;
             } else if arg == "--path-format=relative" {
-                // Relative paths: no-op (we handle per command)
+                path_format_absolute = Some(false);
+                i += 1;
+                continue;
+            } else if arg == "--path-format" {
+                i += 1;
+                let val = args
+                    .args
+                    .get(i)
+                    .ok_or_else(|| anyhow::anyhow!("--path-format requires an argument"))?;
+                match val.as_str() {
+                    "absolute" => path_format_absolute = Some(true),
+                    "relative" => path_format_absolute = Some(false),
+                    other => bail!("unknown argument to --path-format: {other}"),
+                }
                 i += 1;
                 continue;
             } else if arg == "--verify" {
@@ -147,7 +322,9 @@ pub fn run(args: Args) -> Result<()> {
             } else if arg == "--is-bare-repository" {
                 actions.push(Action::ShowIsBare);
             } else if arg == "--show-toplevel" {
-                actions.push(Action::ShowToplevel);
+                actions.push(Action::ShowToplevel(path_format_absolute));
+            } else if arg == "--show-superproject-working-tree" {
+                actions.push(Action::ShowSuperprojectWorkingTree(path_format_absolute));
             } else if arg == "--show-prefix" {
                 actions.push(Action::ShowPrefix);
             } else if arg == "--show-cdup" {
@@ -157,18 +334,28 @@ pub fn run(args: Args) -> Result<()> {
             } else if arg == "--abbrev-ref" {
                 abbrev_ref = true;
             } else if arg == "--git-dir" {
-                actions.push(Action::ShowGitDir);
+                actions.push(Action::ShowGitDir(path_format_absolute));
             } else if arg == "--git-common-dir" {
-                actions.push(Action::ShowGitCommonDir);
+                actions.push(Action::ShowGitCommonDir(path_format_absolute));
             } else if arg == "--absolute-git-dir" {
                 actions.push(Action::ShowAbsoluteGitDir);
+            } else if arg == "--bisect" {
+                actions.push(Action::BisectRefs(show_symbolic_full_name));
+            } else if let Some(date) = arg.strip_prefix("--since=") {
+                actions.push(Action::MaxAge(date.to_owned()));
+            } else if let Some(date) = arg.strip_prefix("--after=") {
+                actions.push(Action::MaxAge(date.to_owned()));
+            } else if let Some(date) = arg.strip_prefix("--before=") {
+                actions.push(Action::MinAge(date.to_owned()));
+            } else if let Some(date) = arg.strip_prefix("--until=") {
+                actions.push(Action::MinAge(date.to_owned()));
             } else if arg == "--git-path" {
                 i += 1;
                 let path_arg = args
                     .args
                     .get(i)
                     .ok_or_else(|| anyhow::anyhow!("--git-path requires an argument"))?;
-                actions.push(Action::GitPath(path_arg.clone()));
+                actions.push(Action::GitPath(path_format_absolute, path_arg.clone()));
             } else if arg == "--prefix" {
                 i += 1;
                 let value = args
@@ -176,8 +363,10 @@ pub fn run(args: Args) -> Result<()> {
                     .get(i)
                     .ok_or_else(|| anyhow::anyhow!("--prefix requires an argument"))?;
                 prefix = Some(value.clone());
+                cli_prefix_path = Some(cwd.join(value));
             } else if let Some(value) = arg.strip_prefix("--prefix=") {
                 prefix = Some(value.to_owned());
+                cli_prefix_path = Some(cwd.join(value));
             } else if let Some(value) = arg.strip_prefix("--short=") {
                 short_len = Some(parse_short_len(value)?);
             } else if arg == "--short" {
@@ -520,14 +709,36 @@ pub fn run(args: Args) -> Result<()> {
                     .unwrap_or(false);
                 println!("{}", if bare { "true" } else { "false" });
             }
-            Action::ShowToplevel => {
+            Action::ShowToplevel(fmt) => {
                 let Some(current) = repo.as_ref() else {
                     bail!("not a git repository (or any of the parent directories)");
                 };
                 let Some(work_tree) = &current.work_tree else {
                     bail!("this operation must be run in a work tree");
                 };
-                println!("{}", work_tree.display());
+                match fmt {
+                    Some(true) => {
+                        println!("{}", realpath_forgiving(work_tree).display());
+                    }
+                    Some(false) => {
+                        let wt_a = realpath_forgiving(work_tree);
+                        let cwd_a = realpath_forgiving(&cwd);
+                        if wt_a == cwd_a {
+                            println!("./");
+                        } else {
+                            print_rev_parse_path(
+                                work_tree,
+                                &cwd,
+                                cli_prefix_path.as_deref(),
+                                Some(false),
+                                PathDefaultMode::Canonical,
+                            );
+                        }
+                    }
+                    None => {
+                        println!("{}", work_tree.display());
+                    }
+                }
             }
             Action::ShowPrefix => {
                 let Some(current) = repo.as_ref() else {
@@ -550,66 +761,134 @@ pub fn run(args: Args) -> Result<()> {
                     println!("{cdup}");
                 }
             }
-            Action::ShowGitDir => {
+            Action::ShowGitDir(fmt) => {
                 let Some(current) = repo.as_ref() else {
                     bail!("not a git repository (or any of the parent directories)");
                 };
-                let git_dir = current.git_dir.as_path();
-                if cwd == git_dir {
-                    println!(".");
-                } else if cwd.starts_with(git_dir) {
-                    // Inside the git directory (e.g. `.git/hooks`): Git prints an absolute path.
-                    println!("{}", git_dir.display());
-                } else if let Ok(rel) = git_dir.strip_prefix(&cwd) {
-                    println!("{}", rel.display());
+                if let Ok(gd) = std::env::var("GIT_DIR") {
+                    let gd_path = PathBuf::from(gd);
+                    print_rev_parse_path(
+                        &gd_path,
+                        &cwd,
+                        cli_prefix_path.as_deref(),
+                        *fmt,
+                        PathDefaultMode::Unmodified,
+                    );
                 } else {
-                    println!("{}", to_relative_path(git_dir, &cwd));
+                    let git_dir = current.git_dir.as_path();
+                    let cwd_a = realpath_forgiving(&cwd);
+                    let git_a = realpath_forgiving(git_dir);
+                    if cwd_a == git_a {
+                        match fmt {
+                            Some(true) => println!("{}", git_a.display()),
+                            Some(false) => println!("."),
+                            None => println!("."),
+                        }
+                    } else if cwd_a.starts_with(&git_a) {
+                        print_rev_parse_path(
+                            git_dir,
+                            &cwd,
+                            cli_prefix_path.as_deref(),
+                            *fmt,
+                            PathDefaultMode::Canonical,
+                        );
+                    } else if current.work_tree.as_ref().is_some_and(|wt| {
+                        cwd_a == realpath_forgiving(wt) && !is_linked_worktree_git_dir(git_dir)
+                    }) {
+                        match fmt {
+                            Some(true) => {
+                                println!("{}", git_a.display());
+                            }
+                            Some(false) => {
+                                print_rev_parse_path(
+                                    Path::new(".git"),
+                                    &cwd,
+                                    cli_prefix_path.as_deref(),
+                                    Some(false),
+                                    PathDefaultMode::Unmodified,
+                                );
+                            }
+                            None => {
+                                println!(".git");
+                            }
+                        }
+                    } else {
+                        print_rev_parse_path(
+                            git_dir,
+                            &cwd,
+                            cli_prefix_path.as_deref(),
+                            *fmt,
+                            PathDefaultMode::Canonical,
+                        );
+                    }
                 }
             }
-            Action::ShowGitCommonDir => {
+            Action::ShowGitCommonDir(fmt) => {
                 let Some(current) = repo.as_ref() else {
                     bail!("not a git repository (or any of the parent directories)");
                 };
                 let common_git_dir =
                     refs::common_dir(&current.git_dir).unwrap_or_else(|| current.git_dir.clone());
-                let common_c = common_git_dir
-                    .canonicalize()
-                    .unwrap_or_else(|_| common_git_dir.clone());
-                println!("{}", common_c.display());
+                print_rev_parse_path(
+                    &common_git_dir,
+                    &cwd,
+                    cli_prefix_path.as_deref(),
+                    *fmt,
+                    PathDefaultMode::RelativeToCwd,
+                );
             }
             Action::ShowAbsoluteGitDir => {
                 let Some(current) = repo.as_ref() else {
                     bail!("not a git repository (or any of the parent directories)");
                 };
-                println!("{}", current.git_dir.display());
+                let gd_path = if let Ok(gd) = std::env::var("GIT_DIR") {
+                    let p = PathBuf::from(gd);
+                    if p.is_relative() {
+                        cwd.join(p)
+                    } else {
+                        p
+                    }
+                } else {
+                    current.git_dir.clone()
+                };
+                println!("{}", realpath_forgiving(&gd_path).display());
+            }
+            Action::ShowSuperprojectWorkingTree(fmt) => {
+                let Some(current) = repo.as_ref() else {
+                    bail!("not a git repository (or any of the parent directories)");
+                };
+                if !is_inside_work_tree(current, &cwd) {
+                    continue;
+                }
+                let super_wt = superproject_working_tree_via_ls_files(current, &cwd)
+                    .or_else(|| superproject_work_tree_from_nested_git_modules(&current.git_dir));
+                if let Some(super_wt) = super_wt {
+                    print_rev_parse_path(
+                        &super_wt,
+                        &cwd,
+                        cli_prefix_path.as_deref(),
+                        *fmt,
+                        PathDefaultMode::Unmodified,
+                    );
+                }
             }
             Action::ShowRefFormat => {
                 let Some(current) = repo.as_ref() else {
                     bail!("not a git repository (or any of the parent directories)");
                 };
-                let config_path = current.git_dir.join("config");
-                let format = if let Ok(content) = std::fs::read_to_string(&config_path) {
-                    let mut in_ext = false;
-                    let mut found = String::from("files");
-                    for line in content.lines() {
-                        let t = line.trim();
-                        if t.starts_with('[') {
-                            in_ext = t.eq_ignore_ascii_case("[extensions]");
-                            continue;
-                        }
-                        if in_ext {
-                            if let Some((k, v)) = t.split_once('=') {
-                                if k.trim().eq_ignore_ascii_case("refstorage") {
-                                    found = v.trim().to_lowercase();
-                                }
-                            }
-                        }
-                    }
-                    found
-                } else {
-                    "files".to_string()
-                };
-                println!("{format}");
+                let raw = read_extensions_refstorage(&current.git_dir);
+                if !ref_storage_format_is_valid(&raw) {
+                    bail!(
+                        "error: invalid value for 'extensions.refstorage': '{}'",
+                        raw
+                    );
+                }
+                let format = raw.to_ascii_lowercase();
+                let name = format
+                    .split_once(':')
+                    .map(|(a, _)| a.to_string())
+                    .unwrap_or(format);
+                println!("{name}");
             }
             Action::ShowObjectFormat(mode) => {
                 let Some(current) = repo.as_ref() else {
@@ -630,7 +909,52 @@ pub fn run(args: Args) -> Result<()> {
                     }
                 }
             }
-            Action::GitPath(path_arg) => {
+            Action::BisectRefs(_) => {
+                let Some(current) = repo.as_ref() else {
+                    bail!("not a git repository (or any of the parent directories)");
+                };
+                let all = grit_lib::refs::list_refs(&current.git_dir, "refs/bisect/")
+                    .context("failed to list bisect refs")?;
+                let mut bad: Vec<String> = all
+                    .iter()
+                    .filter(|(r, _)| {
+                        r.starts_with("refs/bisect/bad")
+                            && r.as_bytes()
+                                .get("refs/bisect/bad".len())
+                                .is_none_or(|b| *b == b'-')
+                    })
+                    .map(|(r, _)| r.clone())
+                    .collect();
+                bad.sort();
+                for r in &bad {
+                    println!("{r}");
+                }
+                let mut good: Vec<String> = all
+                    .iter()
+                    .filter(|(r, _)| {
+                        r.starts_with("refs/bisect/good")
+                            && r.as_bytes()
+                                .get("refs/bisect/good".len())
+                                .is_none_or(|b| *b == b'-')
+                    })
+                    .map(|(r, _)| r.clone())
+                    .collect();
+                good.sort();
+                for r in &good {
+                    println!("^{r}");
+                }
+            }
+            Action::MaxAge(date) => {
+                let mut err = 0;
+                let ts = approxidate_careful(&date, Some(&mut err));
+                println!("--max-age={ts}");
+            }
+            Action::MinAge(date) => {
+                let mut err = 0;
+                let ts = approxidate_careful(&date, Some(&mut err));
+                println!("--min-age={ts}");
+            }
+            Action::GitPath(fmt, path_arg) => {
                 if let Some(current) = repo.as_ref() {
                     // Use original path_arg for output, normalized for matching
                     let path_arg_for_match = {
@@ -755,49 +1079,13 @@ pub fn run(args: Args) -> Result<()> {
                             current.git_dir.join(path_arg)
                         }
                     };
-                    // Output relative path when possible (relative to cwd)
-                    // Use original path_arg_out to preserve double slashes etc.
-                    let cwd = std::env::current_dir().unwrap_or_default();
-                    let git_dir_rel = if let Ok(rel) = current.git_dir.strip_prefix(&cwd) {
-                        rel.display().to_string()
-                    } else {
-                        // Compute relative path from cwd to git_dir
-                        let git_abs = current
-                            .git_dir
-                            .canonicalize()
-                            .unwrap_or_else(|_| current.git_dir.clone());
-                        let cwd_abs = cwd.canonicalize().unwrap_or(cwd.clone());
-                        let git_comps: Vec<_> = git_abs.components().collect();
-                        let cwd_comps: Vec<_> = cwd_abs.components().collect();
-                        let common = git_comps
-                            .iter()
-                            .zip(cwd_comps.iter())
-                            .take_while(|(a, b)| a == b)
-                            .count();
-                        let up = cwd_comps.len() - common;
-                        let mut result = std::path::PathBuf::new();
-                        for _ in 0..up {
-                            result.push("..");
-                        }
-                        for comp in &git_comps[common..] {
-                            result.push(comp.as_os_str());
-                        }
-                        result.display().to_string()
-                    };
-                    // If the resolved path is under git_dir, use git_dir_rel + path_arg_out.
-                    // When cwd is the bare repo root, `git_dir_rel` is empty; avoid a leading `/`.
-                    let output = if resolved.starts_with(&current.git_dir) {
-                        if git_dir_rel.is_empty() {
-                            path_arg_out.clone()
-                        } else {
-                            format!("{git_dir_rel}/{path_arg_out}")
-                        }
-                    } else if let Ok(rel) = resolved.strip_prefix(&cwd) {
-                        rel.display().to_string()
-                    } else {
-                        resolved.display().to_string()
-                    };
-                    println!("{output}");
+                    print_rev_parse_path(
+                        &resolved,
+                        &cwd,
+                        cli_prefix_path.as_deref(),
+                        *fmt,
+                        PathDefaultMode::RelativeToCwd,
+                    );
                 } else {
                     bail!("not a git repository");
                 }

--- a/grit/src/commands/worktree.rs
+++ b/grit/src/commands/worktree.rs
@@ -463,6 +463,19 @@ fn cmd_add(args: AddArgs) -> Result<()> {
         // Existing local branch: check out attached.
         if let Ok(oid) = refs::resolve_ref(&common, &format!("refs/heads/{spec}")) {
             (Some(spec.clone()), Some(oid), false)
+        } else if matches!(
+            resolve_head(&common)?,
+            HeadState::Branch {
+                refname,
+                oid: None,
+                ..
+            } if refname == format!("refs/heads/{spec}")
+        ) {
+            // HEAD is unborn but already points at refs/heads/<spec> (no ref file yet). Git still
+            // allows `worktree add <path> <branch>` once there are commits (t1500 setup).
+            let oid =
+                head_oid.ok_or_else(|| anyhow::anyhow!("fatal: invalid reference: '{spec}'"))?;
+            (Some(spec.clone()), Some(oid), false)
         } else {
             // Existing non-branch commit-ish (e.g. tag): check out detached.
             match resolve_commitish(&repo, spec) {

--- a/logs/2026-04-09_t1500-rev-parse.md
+++ b/logs/2026-04-09_t1500-rev-parse.md
@@ -1,0 +1,18 @@
+# t1500-rev-parse
+
+## Summary
+
+Made `tests/t1500-rev-parse.sh` pass (81/81).
+
+## Changes
+
+- **checkout `-B`**: When HEAD is unborn, match Git: switch HEAD to the new branch without requiring a commit (unless detached/invalid HEAD).
+- **worktree add**: If `refs/heads/<branch>` is missing but HEAD already points at that unborn branch, use the current HEAD commit OID (t1500 setup).
+- **rev-parse**: Per-action `--path-format` (absolute/relative), Git-like `--git-dir` / `--git-common-dir` / `--git-path` / `--show-toplevel`, `--since`/`--after` → `--max-age`, `--before`/`--until` → `--min-age`, `--bisect` with symbolic ref names, `--show-ref-format` validation for `extensions.refstorage`, `--show-superproject-working-tree` via `ls-files` plus fallback for nested `.git/modules/.../modules/...` layout from submodule add.
+- **grit-lib**: `superproject_work_tree_from_nested_git_modules` + unit tests.
+
+## Validation
+
+- `cargo fmt`, `cargo clippy --fix --allow-dirty` (pre-existing workspace warnings remain)
+- `cargo test -p grit-lib --lib`
+- `./scripts/run-tests.sh t1500-rev-parse.sh` → 81/81


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`tests/t1500-rev-parse.sh` now passes **81/81**.

## What changed

- **`checkout -B`**: When HEAD is unborn, match Git by moving HEAD to the new branch without requiring an existing commit (unless HEAD is detached/invalid).
- **`worktree add`**: If `refs/heads/<branch>` does not exist yet but HEAD already points at that unborn branch, use the current resolved HEAD OID so `git worktree add … <branch>` works after the first commit (t1500 setup).
- **`rev-parse`**: Git-compatible path handling (`--path-format` applies per emitted line), `--git-dir` / `--git-common-dir` / `--git-path` / `--show-toplevel`, `--since`/`--after` → `--max-age`, `--before`/`--until` → `--min-age`, `--bisect` with symbolic ref output, validation of `extensions.refstorage` for `--show-ref-format`, and `--show-superproject-working-tree` (parent `ls-files` gitlink check plus fallback for nested `.git/modules/.../modules/...` layouts).
- **`grit-lib`**: Added `superproject_work_tree_from_nested_git_modules` with small unit tests.

## Validation

- `cargo fmt`, `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t1500-rev-parse.sh` → 81/81 (CSV + dashboards updated)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91ee3465-fa71-4e14-8033-120df9954499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91ee3465-fa71-4e14-8033-120df9954499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

