### PR TITLE
fix: make t4027-diff-submodule fully pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -705,7 +705,7 @@ t4023-diff-rename-typechange	t4	yes	4	0	4	false	ok	0
 t4024-diff-optimize-common	t4	yes	2	2	0	true	ok	0
 t4025-hunk-header	t4	yes	2	1	1	false	ok	0
 t4026-color	t4	yes	34	34	0	true	ok	0
-t4027-diff-submodule	t4	yes	20	6	14	false	ok	0
+t4027-diff-submodule	t4	yes	20	20	0	true	ok	0
 t4028-format-patch-mime-headers	t4	yes	3	3	0	true	ok	0
 t4029-diff-trailing-space	t4	yes	1	1	0	true	ok	0
 t4030-diff-textconv	t4	yes	19	10	9	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,700 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,700 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T23:20:28+00:00" class="gen-time" title="2026-04-09 23:20 UTC">2026-04-09 23:20 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,700</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -230,22 +230,22 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">73/178 files · 2 skipped · 2,862/4,438 tests</span>
+        <span class="group-meta">74/178 files · 2 skipped · 2,876/4,438 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.5%"></div></div>
-        <span class="group-pct pct-blue">64.5%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.8%"></div></div>
+        <span class="group-pct pct-blue">64.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35700 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,700 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T23:20:28+00:00" class="gen-time" title="2026-04-09 23:20 UTC">2026-04-09 23:20 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,700</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -7207,14 +7207,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="20" data-passed="6">
+<tr class="" data-group="t4" data-tests="20" data-passed="20" data-full-pass="1">
   <td class="mono">t4027-diff-submodule</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">20</td>
-  <td class="right">6</td>
+  <td class="right">20</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:30.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="3" data-passed="3" data-full-pass="1">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/diff.rs
+++ b/grit-lib/src/diff.rs
@@ -965,6 +965,10 @@ pub fn hash_worktree_file(
         // For symlinks, hash the target path
         let target = fs::read_link(path)?;
         target.to_string_lossy().into_owned().into_bytes()
+    } else if meta.is_dir() {
+        // `read()` on a directory fails with EISDIR; unmerged paths may leave an empty
+        // placeholder directory (e.g. t4027 combined submodule conflict).
+        Vec::new()
     } else {
         let raw = fs::read(path)?;
         // Apply clean conversion (CRLF→LF) so hash matches index blob.
@@ -1070,8 +1074,20 @@ pub fn diff_tree_to_worktree(
             if let Some(te) = tree_entry {
                 let sub_dir = work_tree.join(path);
                 let sub_head = read_submodule_head_oid(&sub_dir);
-                if sub_head.as_ref() != Some(&te.oid) {
-                    let new_oid = sub_head.unwrap_or_else(zero_oid);
+                let index_oid = index_entries
+                    .get(path.as_bytes())
+                    .filter(|ie| ie.mode == 0o160000)
+                    .map(|ie| ie.oid);
+                let index_matches_tree = index_oid.is_some_and(|oid| oid == te.oid);
+                let head_differs = sub_head.as_ref() != Some(&te.oid);
+                let dirty_while_aligned = index_matches_tree
+                    && !head_differs
+                    && submodule_has_dirty_worktree_for_super_diff(work_tree, path, &te.oid);
+                if head_differs || dirty_while_aligned {
+                    // Raw `git diff <tree>` lines use a null OID on the worktree side when the
+                    // checked-out submodule HEAD differs from the tree's gitlink; patch output still
+                    // resolves the real commit from the submodule directory.
+                    let new_oid = if head_differs { zero_oid() } else { te.oid };
                     result.push(DiffEntry {
                         status: DiffStatus::Modified,
                         old_path: Some(path.clone()),
@@ -2898,6 +2914,17 @@ pub fn read_submodule_head_oid(sub_dir: &Path) -> Option<ObjectId> {
         // Detached HEAD — direct OID
         ObjectId::from_hex(head_content).ok()
     }
+}
+
+/// True when a checked-out submodule at `rel_path` has modified or untracked content relative to
+/// the gitlink `recorded_oid` stored in the superproject (used for `git diff <tree>` parity).
+fn submodule_has_dirty_worktree_for_super_diff(
+    super_worktree: &Path,
+    rel_path: &str,
+    recorded_oid: &ObjectId,
+) -> bool {
+    let flags = submodule_porcelain_flags(super_worktree, rel_path, *recorded_oid);
+    flags.modified || flags.untracked
 }
 
 /// Submodule dirty bits aligned with Git's `DIRTY_SUBMODULE_*` / porcelain v2 `S???` token.

--- a/grit-lib/src/merge_diff.rs
+++ b/grit-lib/src/merge_diff.rs
@@ -549,6 +549,34 @@ pub fn format_combined_textconv_patch(
     Some(out)
 }
 
+/// Combined `diff --cc` for an unmerged **gitlink** path when stage blobs are absent from the ODB
+/// (e.g. `t4027` synthetic `1ff…` / `2ff…` OIDs). Uses full hex in `Subproject commit` lines like Git.
+#[must_use]
+pub fn format_gitlink_unmerged_conflict_combined(
+    path: &str,
+    stage2_oid: &ObjectId,
+    stage3_oid: &ObjectId,
+    result_subproject_line: &str,
+    abbrev: usize,
+) -> String {
+    let p1a = abbrev_hex(stage2_oid, abbrev);
+    let p2a = abbrev_hex(stage3_oid, abbrev);
+    let z = crate::diff::zero_oid();
+    let za = abbrev_hex(&z, abbrev);
+
+    let t_ours = format!("Subproject commit {}", stage2_oid.to_hex());
+    let t_theirs = format!("Subproject commit {}", stage3_oid.to_hex());
+    let tr = result_subproject_line.trim_end_matches('\n').to_owned();
+
+    let mut out = String::new();
+    out.push_str(&format!("diff --cc {path}\n"));
+    out.push_str(&format!("index {p1a},{p2a}..{za}\n"));
+    out.push_str(&format!("--- a/{path}\n"));
+    out.push_str(&format!("+++ b/{path}\n"));
+    out.push_str(&combined_hunk_two_parents(&t_ours, &t_theirs, &tr));
+    out
+}
+
 /// `git diff` / `git diff --cc` during a conflict: worktree file with markers.
 #[allow(clippy::too_many_arguments)]
 pub fn format_worktree_conflict_combined(

--- a/grit/src/commands/config.rs
+++ b/grit/src/commands/config.rs
@@ -87,7 +87,14 @@ pub struct Args {
     pub list: bool,
 
     /// Add a new line for a multi-valued key (legacy).
-    #[arg(long = "add", value_name = "KEY")]
+    ///
+    /// Supports `git config --add -f path key value` (key may follow `-f` and the file path).
+    #[arg(
+        long = "add",
+        value_name = "KEY",
+        num_args = 0..=1,
+        default_missing_value = ""
+    )]
     pub add_key: Option<String>,
 
     /// Replace all matching values (legacy).
@@ -509,11 +516,19 @@ pub fn run(args: Args) -> Result<()> {
         return cmd_unset(&args, &unset_args, scope, &file_path, value_pattern, false);
     }
 
-    if let Some(ref key) = args.add_key {
-        if args.positional.is_empty() {
-            bail!("missing value for --add");
-        }
-        return cmd_add(&args, key, &args.positional[0], scope, &file_path);
+    if let Some(ref key_raw) = args.add_key {
+        let (key, value) = if key_raw.is_empty() {
+            if args.positional.len() < 2 {
+                bail!("usage: git config --add <key> <value>");
+            }
+            (args.positional[0].clone(), args.positional[1].as_str())
+        } else {
+            if args.positional.is_empty() {
+                bail!("missing value for --add");
+            }
+            (key_raw.clone(), args.positional[0].as_str())
+        };
+        return cmd_add(&args, &key, value, scope, &file_path);
     }
 
     if args.remove_section {

--- a/grit/src/commands/diff.rs
+++ b/grit/src/commands/diff.rs
@@ -30,10 +30,10 @@ use grit_lib::diff::{
 };
 use grit_lib::diffstat::{terminal_columns, write_diffstat_block, DiffstatOptions, FileStatInput};
 use grit_lib::error::Error;
-use grit_lib::index::Index;
+use grit_lib::index::{Index, MODE_GITLINK};
 use grit_lib::merge_diff::{
     blob_text_for_diff_with_oid, combined_diff_paths, diff_textconv_active,
-    format_worktree_conflict_combined, run_textconv,
+    format_gitlink_unmerged_conflict_combined, format_worktree_conflict_combined, run_textconv,
 };
 use grit_lib::objects::{parse_commit, ObjectId, ObjectKind};
 use grit_lib::odb::Odb;
@@ -46,10 +46,12 @@ use grit_lib::rev_parse::{
 use grit_lib::userdiff::matcher_for_path_parsed;
 use regex::Regex;
 use similar::{ChangeTag, TextDiff};
+use std::collections::HashMap;
 use std::fmt::Write as FmtWrite;
 use std::sync::Arc;
 
 use crate::commands::diff_index::{write_patch_entry, SubmoduleIgnoreFlags};
+use grit_lib::config::{canonical_key, ConfigFile, ConfigScope};
 
 /// Shared gitattributes + config for per-path diff algorithm selection (`diff.<driver>.algorithm`).
 #[derive(Clone)]
@@ -152,17 +154,233 @@ fn submodule_ignore_flags_from_diff_arg(ignore_sm: &str) -> SubmoduleIgnoreFlags
     }
 }
 
+/// Submodule HEAD OID for patch output when raw diff used a null new side (`git diff <tree>`).
+fn submodule_head_oid_for_gitlink_patch(entry: &DiffEntry, work_tree: Option<&Path>) -> ObjectId {
+    if entry.old_mode != "160000" || entry.new_mode != "160000" {
+        return entry.new_oid;
+    }
+    if entry.new_oid != zero_oid() {
+        return entry.new_oid;
+    }
+    work_tree
+        .and_then(|wt| grit_lib::diff::read_submodule_head_oid(&wt.join(entry.path())))
+        .unwrap_or_else(zero_oid)
+}
+
+/// Suffix for `+Subproject commit …` when the submodule checkout has local changes.
+fn submodule_path_to_name_map(work_tree: &Path, cfg: &ConfigSet) -> HashMap<String, String> {
+    let mut out: HashMap<String, String> = HashMap::new();
+    let gm = work_tree.join(".gitmodules");
+    if let Ok(text) = fs::read_to_string(&gm) {
+        if let Ok(file) = ConfigFile::parse(&gm, &text, ConfigScope::Local) {
+            for e in &file.entries {
+                let Some(rest) = e.key.strip_prefix("submodule.") else {
+                    continue;
+                };
+                let Some(name) = rest.strip_suffix(".path") else {
+                    continue;
+                };
+                if let Some(p) = e.value.as_deref() {
+                    let key = p.trim().replace('\\', "/");
+                    if !key.is_empty() {
+                        out.insert(key, name.to_string());
+                    }
+                }
+            }
+        }
+    }
+    for e in cfg.entries() {
+        let Some(rest) = e.key.strip_prefix("submodule.") else {
+            continue;
+        };
+        let Some(name) = rest.strip_suffix(".path") else {
+            continue;
+        };
+        if let Some(p) = e.value.as_deref() {
+            let key = p.trim().replace('\\', "/");
+            if !key.is_empty() {
+                out.insert(key, name.to_string());
+            }
+        }
+    }
+    out
+}
+
+/// `submodule.<name>.ignore` from `.gitmodules` (not part of merged [`ConfigSet`]).
+fn gitmodules_submodule_name_to_ignore(work_tree: &Path) -> HashMap<String, String> {
+    let mut out: HashMap<String, String> = HashMap::new();
+    let gm = work_tree.join(".gitmodules");
+    let Ok(text) = fs::read_to_string(&gm) else {
+        return out;
+    };
+    let Ok(file) = ConfigFile::parse(&gm, &text, ConfigScope::Local) else {
+        return out;
+    };
+    for e in &file.entries {
+        let Some(rest) = e.key.strip_prefix("submodule.") else {
+            continue;
+        };
+        let Some(name) = rest.strip_suffix(".ignore") else {
+            continue;
+        };
+        if let Some(v) = e.value.as_deref() {
+            out.insert(name.to_string(), v.trim().to_ascii_lowercase());
+        }
+    }
+    out
+}
+
+fn submodule_named_ignore_from_repo_config(
+    submodule_name: &str,
+    cfg: &ConfigSet,
+) -> Option<String> {
+    let key = format!("submodule.{submodule_name}.ignore");
+    let key_canon = canonical_key(&key).ok()?;
+    cfg.entries()
+        .iter()
+        .rev()
+        .find(|e| e.key == key_canon)
+        .and_then(|e| e.value.as_deref())
+        .map(|s| s.trim().to_ascii_lowercase())
+}
+
+/// Per-path submodule ignore: repo `submodule.<name>.ignore`, then `.gitmodules`, then `diff.ignoreSubmodules`.
+///
+/// When the path is not registered in `.gitmodules` / config (embedded submodule), only
+/// `diff.ignoreSubmodules` applies — matches Git (t4027 `test_config diff.ignoreSubmodules none`).
+fn submodule_effective_ignore_token(
+    path: &str,
+    path_to_name: &HashMap<String, String>,
+    gm_name_ignore: &HashMap<String, String>,
+    cfg: &ConfigSet,
+) -> Option<String> {
+    if let Some(name) = path_to_name.get(path) {
+        if let Some(v) = submodule_named_ignore_from_repo_config(name, cfg)
+            .or_else(|| gm_name_ignore.get(name).cloned())
+        {
+            return Some(v);
+        }
+    }
+    cfg.get("diff.ignoreSubmodules")
+        .map(|s| s.trim().to_ascii_lowercase())
+}
+
+fn ignore_submodules_cli_all(cli: Option<&str>) -> bool {
+    cli.is_some_and(|c| c.eq_ignore_ascii_case("all"))
+}
+
+fn ignore_submodules_cli_dirty(cli: Option<&str>) -> bool {
+    cli.is_some_and(|c| c.eq_ignore_ascii_case("dirty"))
+}
+
+/// Drop gitlink entries entirely (`--ignore-submodules=all` or effective policy `all`).
+fn gitlink_suppressed_ignore_all(
+    entry: &DiffEntry,
+    cli: Option<&str>,
+    path_to_name: &HashMap<String, String>,
+    gm_name_ignore: &HashMap<String, String>,
+    cfg: &ConfigSet,
+) -> bool {
+    if entry.old_mode != "160000" && entry.new_mode != "160000" {
+        return false;
+    }
+    if ignore_submodules_cli_all(cli) {
+        return true;
+    }
+    if cli.is_some() {
+        return false;
+    }
+    submodule_effective_ignore_token(entry.path(), path_to_name, gm_name_ignore, cfg).as_deref()
+        == Some("all")
+}
+
+/// Drop same-OID gitlink noise (dirty worktree and/or policy `dirty`, or default untracked-only).
+fn gitlink_same_oid_suppressed(
+    entry: &DiffEntry,
+    cli: Option<&str>,
+    path_to_name: &HashMap<String, String>,
+    gm_name_ignore: &HashMap<String, String>,
+    cfg: &ConfigSet,
+    work_tree: Option<&Path>,
+) -> bool {
+    if entry.old_mode != "160000" || entry.new_mode != "160000" || entry.old_oid != entry.new_oid {
+        return false;
+    }
+    if ignore_submodules_cli_dirty(cli) {
+        return true;
+    }
+    if cli.is_some() {
+        return false;
+    }
+    let path = entry.path();
+    let token = submodule_effective_ignore_token(path, path_to_name, gm_name_ignore, cfg);
+    if token.as_deref() == Some("none") {
+        return false;
+    }
+    if token.as_deref() == Some("dirty") {
+        return true;
+    }
+    let Some(wt) = work_tree else {
+        return false;
+    };
+    let flags = grit_lib::diff::submodule_porcelain_flags(wt, path, entry.old_oid);
+    if token.as_deref() == Some("untracked") {
+        return !flags.modified && flags.untracked;
+    }
+    !flags.modified && flags.untracked
+}
+
+fn submodule_gitlink_patch_plus_suffix(
+    entry: &DiffEntry,
+    work_tree: Option<&Path>,
+    submodule_ignore: SubmoduleIgnoreFlags,
+    ignore_submodules_cli: Option<&str>,
+    diff_cfg: &grit_lib::config::ConfigSet,
+    path_to_name: &HashMap<String, String>,
+    gm_name_ignore: &HashMap<String, String>,
+) -> String {
+    if entry.old_mode != "160000" || entry.new_mode != "160000" {
+        return String::new();
+    }
+    let Some(wt) = work_tree else {
+        return String::new();
+    };
+    let path = entry.path();
+    let flags = grit_lib::diff::submodule_porcelain_flags(wt, path, entry.old_oid);
+    let eff = submodule_effective_ignore_token(path, path_to_name, gm_name_ignore, diff_cfg);
+    let cli_none = ignore_submodules_cli.is_some_and(|s| s.eq_ignore_ascii_case("none"));
+    let count_untracked =
+        !submodule_ignore.ignore_untracked && (cli_none || eff.as_deref() == Some("none"));
+    let dirty_for_suffix =
+        (flags.modified && !submodule_ignore.ignore_dirty) || (flags.untracked && count_untracked);
+    if dirty_for_suffix {
+        "-dirty".to_owned()
+    } else {
+        String::new()
+    }
+}
+
 fn write_submodule_log_lines(
     out: &mut impl Write,
     repo: &Repository,
     entry: &DiffEntry,
+    work_tree: Option<&Path>,
 ) -> Result<()> {
     let z = zero_oid();
-    if entry.old_oid == z || entry.new_oid == z {
+    if entry.old_oid == z {
+        return Ok(());
+    }
+    let new_oid =
+        if entry.new_oid == z && (entry.old_mode == "160000" || entry.new_mode == "160000") {
+            submodule_head_oid_for_gitlink_patch(entry, work_tree)
+        } else {
+            entry.new_oid
+        };
+    if new_oid == z {
         return Ok(());
     }
     let old_a = abbreviate_object_id(repo, entry.old_oid, 7)?;
-    let new_a = abbreviate_object_id(repo, entry.new_oid, 7)?;
+    let new_a = abbreviate_object_id(repo, new_oid, 7)?;
     writeln!(out, "Submodule {} {}..{}:", entry.path(), old_a, new_a)?;
     let Some(wt) = repo.work_tree.as_deref() else {
         return Ok(());
@@ -175,7 +393,7 @@ fn write_submodule_log_lines(
     opts.first_parent = true;
     let Ok(res) = rev_list(
         &sub_repo,
-        &[entry.new_oid.to_hex()],
+        &[new_oid.to_hex()],
         &[entry.old_oid.to_hex()],
         &opts,
     ) else {
@@ -1684,19 +1902,34 @@ pub fn run(mut args: Args) -> Result<()> {
         entries
     };
 
-    // `--ignore-submodules=all` hides gitlink paths entirely. `dirty` / `untracked` still show
-    // when the superproject records a different submodule commit (tree-to-tree / index gitlink
-    // updates); they only suppress "submodule working tree dirty" noise elsewhere (matches Git;
-    // see `t4137-apply-submodule.sh`).
-    let ignore_sm = args.ignore_submodules.as_deref().unwrap_or("none");
-    let entries = if ignore_sm == "all" {
-        entries
-            .into_iter()
-            .filter(|e| e.old_mode != "160000" && e.new_mode != "160000")
-            .collect()
-    } else {
-        entries
-    };
+    // Submodule ignore: `--ignore-submodules`, `diff.ignoreSubmodules`, and `submodule.*.ignore`
+    // (matches Git combined ordering for t4027).
+    let ignore_sm = args.ignore_submodules.as_deref();
+    let path_to_sm_name = work_tree
+        .map(|wt| submodule_path_to_name_map(wt, &diff_config))
+        .unwrap_or_default();
+    let gm_sub_ignore = work_tree
+        .map(gitmodules_submodule_name_to_ignore)
+        .unwrap_or_default();
+    let entries: Vec<DiffEntry> = entries
+        .into_iter()
+        .filter(|e| {
+            !(gitlink_suppressed_ignore_all(
+                e,
+                ignore_sm,
+                &path_to_sm_name,
+                &gm_sub_ignore,
+                &diff_config,
+            ) || gitlink_same_oid_suppressed(
+                e,
+                ignore_sm,
+                &path_to_sm_name,
+                &gm_sub_ignore,
+                &diff_config,
+                work_tree,
+            ))
+        })
+        .collect();
 
     let entries = if let Some(ref df) = args.diff_filter {
         if df.is_empty() {
@@ -1876,9 +2109,10 @@ pub fn run(mut args: Args) -> Result<()> {
         || (args.summary && !stat_enabled)
         || dirstat_opts.is_some();
 
-    let merge_in_progress = std::fs::metadata(repo.git_dir.join("MERGE_HEAD")).is_ok();
     let mut conflict_combined_patches: Vec<String> = Vec::new();
-    if merge_in_progress && !args.cached && revs.is_empty() && work_tree.is_some() {
+    // Combined `diff --cc` for unmerged paths: required for conflicted index entries even when
+    // `MERGE_HEAD` is absent (e.g. t4027 `update-index --index-info` submodule conflict).
+    if !args.cached && revs.is_empty() && work_tree.is_some() {
         let mut conflict_paths: Vec<String> = entries
             .iter()
             .filter(|e| e.status == DiffStatus::Unmerged)
@@ -1913,18 +2147,48 @@ pub fn run(mut args: Args) -> Result<()> {
                         continue;
                     };
                     let file_path = wt.join(&repo_path);
-                    let wt_bytes = std::fs::read(&file_path).unwrap_or_default();
-                    conflict_combined_patches.push(format_worktree_conflict_combined(
-                        &repo.git_dir,
-                        &config,
-                        &repo.odb,
-                        display_path,
-                        &e1.oid,
-                        &e2.oid,
-                        &e3.oid,
-                        &wt_bytes,
-                        patch_abbrev,
-                    ));
+                    let wt_bytes = match std::fs::symlink_metadata(&file_path) {
+                        Ok(m) if m.is_dir() => Vec::new(),
+                        _ => std::fs::read(&file_path).unwrap_or_default(),
+                    };
+                    let patch = if e1.mode == MODE_GITLINK
+                        && e2.mode == MODE_GITLINK
+                        && e3.mode == MODE_GITLINK
+                    {
+                        let result_line = if wt_bytes.is_empty() {
+                            if file_path.join(".git").exists() {
+                                resolve_revision(&repo, "HEAD")
+                                    .map(|oid| format!("Subproject commit {}", oid.to_hex()))
+                                    .unwrap_or_else(|_| {
+                                        format!("Subproject commit {}", zero_oid().to_hex())
+                                    })
+                            } else {
+                                format!("Subproject commit {}", zero_oid().to_hex())
+                            }
+                        } else {
+                            String::from_utf8_lossy(&wt_bytes).into_owned()
+                        };
+                        format_gitlink_unmerged_conflict_combined(
+                            display_path,
+                            &e2.oid,
+                            &e3.oid,
+                            &result_line,
+                            patch_abbrev,
+                        )
+                    } else {
+                        format_worktree_conflict_combined(
+                            &repo.git_dir,
+                            &config,
+                            &repo.odb,
+                            display_path,
+                            &e1.oid,
+                            &e2.oid,
+                            &e3.oid,
+                            &wt_bytes,
+                            patch_abbrev,
+                        )
+                    };
+                    conflict_combined_patches.push(patch);
                 }
             }
             // Git keeps index↔worktree `U`/`M` lines for `--raw` / `--name-only` during conflicts;
@@ -1932,13 +2196,7 @@ pub fn run(mut args: Args) -> Result<()> {
             let strip_conflict_index_lines =
                 emit_unified_patch && !args.no_patch && !format_besides_unified_patch;
             if strip_conflict_index_lines {
-                entries.retain(|e| {
-                    if conflict_paths.iter().any(|p| p == e.path()) {
-                        e.status != DiffStatus::Unmerged && e.status != DiffStatus::Modified
-                    } else {
-                        true
-                    }
-                });
+                entries.retain(|e| !conflict_paths.iter().any(|p| p == e.path()));
             }
         }
     }
@@ -2170,7 +2428,11 @@ pub fn run(mut args: Args) -> Result<()> {
                     &src_prefix,
                     &dst_prefix,
                     args.submodule.as_deref(),
-                    submodule_ignore_flags_from_diff_arg(ignore_sm),
+                    submodule_ignore_flags_from_diff_arg(ignore_sm.unwrap_or("none")),
+                    ignore_sm,
+                    &diff_config,
+                    &path_to_sm_name,
+                    &gm_sub_ignore,
                     line_ignore,
                     &diff_algo_ctx,
                     diff_algo_cli,
@@ -2364,6 +2626,8 @@ fn run_diff_blob_vs_file(
     let word_diff = args.word_diff.is_some() || args.color_words;
     let show_patch = !args.quiet && !args.no_patch;
     if show_patch {
+        let empty_sm: HashMap<String, String> = HashMap::new();
+        let empty_gm: HashMap<String, String> = HashMap::new();
         write_patch_with_prefix(
             &mut out,
             repo,
@@ -2388,6 +2652,10 @@ fn run_diff_blob_vs_file(
             submodule_ignore_flags_from_diff_arg(
                 args.ignore_submodules.as_deref().unwrap_or("none"),
             ),
+            args.ignore_submodules.as_deref(),
+            &diff_config,
+            &empty_sm,
+            &empty_gm,
             None,
             &diff_algo_ctx,
             diff_algo_cli,
@@ -4038,7 +4306,14 @@ fn read_content_raw_or_worktree(
         // Empty tree / new file side: read from the work tree when available (t1501 tree diffs).
         if let Some(wt) = work_tree {
             if path != "/dev/null" {
-                if let Ok(data) = std::fs::read(wt.join(path)) {
+                let p = wt.join(path);
+                if std::fs::symlink_metadata(&p)
+                    .map(|m| m.is_dir())
+                    .unwrap_or(false)
+                {
+                    return Vec::new();
+                }
+                if let Ok(data) = std::fs::read(p) {
                     return data;
                 }
             }
@@ -4052,7 +4327,14 @@ fn read_content_raw_or_worktree(
     // Fall back to reading from working tree
     if let Some(wt) = work_tree {
         if path != "/dev/null" {
-            if let Ok(data) = std::fs::read(wt.join(path)) {
+            let p = wt.join(path);
+            if std::fs::symlink_metadata(&p)
+                .map(|m| m.is_dir())
+                .unwrap_or(false)
+            {
+                return Vec::new();
+            }
+            if let Ok(data) = std::fs::read(p) {
                 return data;
             }
         }
@@ -4234,7 +4516,7 @@ fn write_diff_header_with_abbrev(
     use_color: bool,
     abbrev_len: usize,
 ) -> Result<()> {
-    write_diff_header_with_prefix(out, entry, use_color, abbrev_len, "a/", "b/")
+    write_diff_header_with_prefix(out, entry, use_color, abbrev_len, "a/", "b/", None)
 }
 
 fn write_diff_header_with_prefix(
@@ -4244,6 +4526,7 @@ fn write_diff_header_with_prefix(
     abbrev_len: usize,
     src_prefix: &str,
     dst_prefix: &str,
+    work_tree: Option<&Path>,
 ) -> Result<()> {
     let old_path = entry
         .old_path
@@ -4266,6 +4549,14 @@ fn write_diff_header_with_prefix(
         hex[..len].to_owned()
     };
 
+    let new_oid_for_index_line = || -> ObjectId {
+        if entry.old_mode == "160000" && entry.new_mode == "160000" && entry.new_oid == zero_oid() {
+            submodule_head_oid_for_gitlink_patch(entry, work_tree)
+        } else {
+            entry.new_oid
+        }
+    };
+
     match entry.status {
         DiffStatus::Added => {
             writeln!(out, "{b}new file mode {}{r}", entry.new_mode)?;
@@ -4273,7 +4564,7 @@ fn write_diff_header_with_prefix(
                 if entry.old_oid == zero_oid() && entry.new_oid == empty_blob_oid() {
                     empty_blob_oid()
                 } else {
-                    entry.new_oid
+                    new_oid_for_index_line()
                 };
             writeln!(
                 out,
@@ -4288,7 +4579,7 @@ fn write_diff_header_with_prefix(
                 out,
                 "{b}index {}..{}{r}",
                 abbr(&entry.old_oid),
-                abbr(&entry.new_oid)
+                abbr(&new_oid_for_index_line())
             )?;
         }
         DiffStatus::Modified => {
@@ -4308,7 +4599,7 @@ fn write_diff_header_with_prefix(
                     out,
                     "{b}index {}..{} {}{r}",
                     abbr(&entry.old_oid),
-                    abbr(&entry.new_oid),
+                    abbr(&new_oid_for_index_line()),
                     entry.old_mode
                 )?;
             } else {
@@ -4316,7 +4607,7 @@ fn write_diff_header_with_prefix(
                     out,
                     "{b}index {}..{}{r}",
                     abbr(&entry.old_oid),
-                    abbr(&entry.new_oid)
+                    abbr(&new_oid_for_index_line())
                 )?;
             }
         }
@@ -4447,6 +4738,10 @@ fn write_patch_with_prefix(
     dst_prefix: &str,
     submodule_fmt: Option<&str>,
     submodule_ignore: SubmoduleIgnoreFlags,
+    ignore_submodules_cli: Option<&str>,
+    diff_cfg: &grit_lib::config::ConfigSet,
+    path_to_sm_name: &HashMap<String, String>,
+    gm_sub_ignore: &HashMap<String, String>,
     line_ignore: Option<&[Regex]>,
     algo_ctx: &DiffAlgoContext,
     algo_cli: Option<similar::Algorithm>,
@@ -4471,7 +4766,7 @@ fn write_patch_with_prefix(
                     )
                     && entry.old_oid != entry.new_oid
                 {
-                    write_submodule_log_lines(out, repo, entry)?;
+                    write_submodule_log_lines(out, repo, entry, work_tree)?;
                     continue;
                 }
                 if fmt == "diff" {
@@ -4521,7 +4816,9 @@ fn write_patch_with_prefix(
             }
         }
 
-        write_diff_header_with_prefix(out, entry, use_color, abbrev_len, src_prefix, dst_prefix)?;
+        write_diff_header_with_prefix(
+            out, entry, use_color, abbrev_len, src_prefix, dst_prefix, work_tree,
+        )?;
 
         // Submodule gitlink (mode 160000): emit `Subproject commit` hunks like Git — the ODB
         // does not store these as blobs in the superproject (`git apply` / t4137 rely on this).
@@ -4549,7 +4846,17 @@ fn write_patch_with_prefix(
                     if entry.old_mode == "160000" && entry.new_mode == "160000" {
                         writeln!(out, "@@ -1 +1 @@")?;
                         writeln!(out, "-Subproject commit {}", entry.old_oid.to_hex())?;
-                        writeln!(out, "+Subproject commit {}", entry.new_oid.to_hex())?;
+                        let plus_oid = submodule_head_oid_for_gitlink_patch(entry, work_tree);
+                        let plus_suffix = submodule_gitlink_patch_plus_suffix(
+                            entry,
+                            work_tree,
+                            submodule_ignore,
+                            ignore_submodules_cli,
+                            diff_cfg,
+                            path_to_sm_name,
+                            gm_sub_ignore,
+                        );
+                        writeln!(out, "+Subproject commit {}{plus_suffix}", plus_oid.to_hex())?;
                     } else if entry.old_mode == "160000" {
                         writeln!(out, "@@ -1 +0,0 @@")?;
                         writeln!(out, "-Subproject commit {}", entry.old_oid.to_hex())?;
@@ -5287,16 +5594,21 @@ fn write_raw(out: &mut impl Write, entries: &[DiffEntry], abbrev_len: usize) -> 
                 writeln!(out, ":{old_mode} {new_mode} {old_oid} {new_oid} {status}{score:03}\t{old_path}\t{new_path}")?;
             }
             DiffStatus::Modified => {
+                let zero_new = (old_mode == "160000"
+                    && new_mode == "160000"
+                    && entry.old_oid == entry.new_oid)
+                    .then(|| "0".repeat(abbrev_len));
+                let rn = zero_new.as_deref().unwrap_or(new_oid);
                 if let Some(pct) = entry.score {
                     writeln!(
                         out,
-                        ":{old_mode} {new_mode} {old_oid} {new_oid} {status}{pct:03}\t{}",
+                        ":{old_mode} {new_mode} {old_oid} {rn} {status}{pct:03}\t{}",
                         entry.path()
                     )?;
                 } else {
                     writeln!(
                         out,
-                        ":{old_mode} {new_mode} {old_oid} {new_oid} {status}\t{}",
+                        ":{old_mode} {new_mode} {old_oid} {rn} {status}\t{}",
                         entry.path()
                     )?;
                 }

--- a/grit/src/commands/diff_files.rs
+++ b/grit/src/commands/diff_files.rs
@@ -7,8 +7,8 @@ use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::diff::{
     count_changes, detect_copies, empty_blob_oid, format_stat_line,
-    rewrite_dissimilarity_index_percent, should_break_rewrite_for_stat, stat_matches, unified_diff,
-    zero_oid, DiffEntry, DiffStatus,
+    rewrite_dissimilarity_index_percent, should_break_rewrite_for_stat, stat_matches,
+    submodule_porcelain_flags, unified_diff, zero_oid, DiffEntry, DiffStatus,
 };
 use grit_lib::index::{
     Index, IndexEntry, MODE_EXECUTABLE, MODE_GITLINK, MODE_REGULAR, MODE_SYMLINK,
@@ -642,7 +642,7 @@ fn collect_changes(
         // Use stat info to skip unchanged files (avoid hashing).
         for (path, (idx_mode, idx_oid, idx_entry)) in &stage0 {
             let abs = work_tree.join(path);
-            match read_worktree_info_fast(repo, &abs, idx_entry)? {
+            match read_worktree_info_fast(repo, work_tree, &abs, idx_entry)? {
                 WorktreeStatus::Unchanged => { /* skip — stat says identical */ }
                 WorktreeStatus::Modified(wt_mode, wt_oid) => {
                     let idx_canonical = canonicalize_mode(*idx_mode);
@@ -1150,6 +1150,7 @@ fn path_component_is_not_directory(err: &std::io::Error) -> bool {
 
 fn read_worktree_info_fast(
     repo: &Repository,
+    super_worktree: &Path,
     abs_path: &Path,
     index_entry: &IndexEntry,
 ) -> Result<WorktreeStatus> {
@@ -1244,6 +1245,14 @@ fn read_worktree_info_fast(
         if dot_git.exists() {
             // Treat as a submodule (mode 160000)
             let sub_oid = read_submodule_head(abs_path).unwrap_or(index_entry.oid);
+            if sub_oid == index_entry.oid {
+                let path_str = std::str::from_utf8(&index_entry.path).unwrap_or("");
+                let flags = submodule_porcelain_flags(super_worktree, path_str, index_entry.oid);
+                if flags.modified || flags.untracked {
+                    return Ok(WorktreeStatus::Modified(0o160000, zero_oid()));
+                }
+                return Ok(WorktreeStatus::Unchanged);
+            }
             return Ok(WorktreeStatus::Modified(0o160000, sub_oid));
         }
         if canonicalize_mode(index_entry.mode) == MODE_GITLINK {

--- a/grit/src/commands/diff_index.rs
+++ b/grit/src/commands/diff_index.rs
@@ -1022,8 +1022,22 @@ fn diff_tree_vs_worktree(
             if sub_head.is_none() {
                 continue;
             }
-            if sub_head.as_ref() != Some(&index_snapshot.oid) {
+            let tree_snap = tree_map.get(path).copied();
+            let tree_matches_index = tree_snap.is_some_and(|t| t == *index_snapshot);
+            let head_differs_from_index = sub_head.as_ref() != Some(&index_snapshot.oid);
+            let dirty = submodule_dirty_flags(
+                work_tree,
+                path,
+                &index_snapshot.oid,
+                submodule_ignore.ignore_untracked,
+                submodule_ignore.ignore_dirty,
+            );
+            let report_dirty_aligned = tree_matches_index
+                && !head_differs_from_index
+                && (dirty.modified || dirty.untracked);
+            if head_differs_from_index || report_dirty_aligned {
                 let old = tree_map.get(path).copied().or(Some(*index_snapshot));
+                let new_oid = zero_oid();
                 merged.insert(
                     path.clone(),
                     RawChange {
@@ -1032,7 +1046,7 @@ fn diff_tree_vs_worktree(
                         old,
                         new: Some(Snapshot {
                             mode: MODE_GITLINK,
-                            oid: sub_head.unwrap_or_else(zero_oid),
+                            oid: new_oid,
                         }),
                     },
                 );

--- a/logs/2026-04-09_t4027-diff-submodule.md
+++ b/logs/2026-04-09_t4027-diff-submodule.md
@@ -1,0 +1,19 @@
+# t4027-diff-submodule
+
+## Summary
+
+Made `t4027-diff-submodule` pass (20/20) by aligning submodule raw diff, ignore rules, combined conflict output, and harness `test_oid` fallback.
+
+## Changes
+
+- **grit-lib `diff`**: Gitlink tree↔worktree uses null new OID when submodule HEAD differs; emit same-OID modified when HEAD matches but worktree dirty; `hash_worktree_file` treats directories as empty bytes (EISDIR).
+- **grit `diff`**: Raw mode for same-OID gitlink; patch headers resolve submodule HEAD when new side is null; `diff.ignoreSubmodules` + `.gitmodules` + CLI `--ignore-submodules` filtering and `-dirty` suffix; unmerged index → `--cc` without `MERGE_HEAD`; `format_gitlink_unmerged_conflict_combined` for synthetic OIDs.
+- **grit `diff-index` / `diff-files`**: Gitlink raw OIDs and dirty-aligned index cases.
+- **grit `config`**: `git config --add -f file key val` when `--add` has no inline key.
+- **tests `test-lib.sh`**: `test_oid` fallback reads `GIT_SOURCE_DIR/t/oid-info/oid` (e.g. `ff_1`).
+- **Harness**: `run-tests.sh` refreshed CSV + dashboards.
+
+## Validation
+
+- `cargo test -p grit-lib --lib`
+- `./scripts/run-tests.sh t4027-diff-submodule.sh` → 20/20

--- a/tests/test-lib.sh
+++ b/tests/test-lib.sh
@@ -653,6 +653,25 @@ test_oid () {
 				return
 			fi
 		fi
+		# Upstream git/t/oid-info (ff_1, deadbeef, …) when the per-test cache was not primed.
+		if test -n "${GIT_SOURCE_DIR-}" && test -f "$GIT_SOURCE_DIR/t/oid-info/oid"
+		then
+			oid=$(awk -v k="$1" -v a="$effective" '
+				$1 == k {
+					for (i = 2; i <= NF; i++) {
+						if ($i ~ "^" a ":") {
+							print substr($i, length(a) + 2)
+							exit
+						}
+					}
+				}
+			' FS='[[:space:]]+' "$GIT_SOURCE_DIR/t/oid-info/oid")
+			if test -n "$oid"
+			then
+				echo "$oid"
+				return
+			fi
+		fi
 		case "$1" in
 		empty_blob)
 			if test "$effective" = sha256


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible submodule diff behavior so `t4027-diff-submodule` passes 20/20.

## Key changes

- **Raw / plumbing**: Gitlink diffs use a null worktree OID when submodule HEAD differs from the recorded tree; `diff-index` and `diff-files` align with Git for dirty submodule cases.
- **`git diff`**: Respects `diff.ignoreSubmodules`, per-path `.gitmodules` / `submodule.*.ignore`, and CLI `--ignore-submodules`; patch output uses `-dirty` and resolves submodule HEAD for index lines when raw uses null OIDs.
- **Combined conflicts**: Emit `diff --cc` for unmerged index entries without requiring `MERGE_HEAD`; special-case unmerged gitlinks with synthetic OIDs via `format_gitlink_unmerged_conflict_combined`.
- **`git config`**: Support `git config --add -f <file> <key> <value>` (key after `-f`).
- **Harness**: `test_oid` falls back to `GIT_SOURCE_DIR/t/oid-info/oid` for keys like `ff_1`.

## Validation

- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t4027-diff-submodule.sh` → 20/20

Work log: `logs/2026-04-09_t4027-diff-submodule.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd4390a7-7aee-4a36-8914-522af7295de4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd4390a7-7aee-4a36-8914-522af7295de4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

