### PR TITLE
fix: make t4120-apply-popt pass (apply -p, diff quotepath)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -790,7 +790,7 @@ t4116-apply-reverse	t4	yes	7	6	1	false	ok	0
 t4117-apply-reject	t4	yes	8	5	3	false	ok	0
 t4118-apply-empty-context	t4	yes	3	3	0	true	ok	0
 t4119-apply-config	t4	yes	11	3	8	false	ok	0
-t4120-apply-popt	t4	yes	12	5	7	false	ok	0
+t4120-apply-popt	t4	yes	12	12	0	true	ok	0
 t4121-apply-diffs	t4	yes	2	2	0	true	ok	0
 t4122-apply-symlink-inside	t4	yes	7	3	4	false	ok	0
 t4123-apply-shrink	t4	yes	2	2	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,693 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,693 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T23:45:47+00:00" class="gen-time" title="2026-04-09 23:45 UTC">2026-04-09 23:45 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,693</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -230,22 +230,22 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">73/178 files · 2 skipped · 2,862/4,438 tests</span>
+        <span class="group-meta">74/178 files · 2 skipped · 2,869/4,438 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.5%"></div></div>
-        <span class="group-pct pct-blue">64.5%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.6%"></div></div>
+        <span class="group-pct pct-blue">64.6%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35693 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,693 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T23:45:47+00:00" class="gen-time" title="2026-04-09 23:45 UTC">2026-04-09 23:45 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,693</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -8057,14 +8057,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:27.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="12" data-passed="5">
+<tr class="" data-group="t4" data-tests="12" data-passed="12" data-full-pass="1">
   <td class="mono">t4120-apply-popt</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">12</td>
-  <td class="right">5</td>
+  <td class="right">12</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:41.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="2" data-passed="2" data-full-pass="1">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/diff.rs
+++ b/grit-lib/src/diff.rs
@@ -1869,6 +1869,7 @@ pub fn unified_diff(
         0,
         "a/",
         "b/",
+        true,
     )
 }
 
@@ -1886,6 +1887,7 @@ pub fn unified_diff_with_prefix(
     inter_hunk_context: usize,
     src_prefix: &str,
     dst_prefix: &str,
+    quote_path_fully: bool,
 ) -> String {
     unified_diff_with_prefix_and_funcname(
         old_content,
@@ -1897,6 +1899,7 @@ pub fn unified_diff_with_prefix(
         src_prefix,
         dst_prefix,
         None,
+        quote_path_fully,
     )
 }
 
@@ -1913,6 +1916,7 @@ pub fn unified_diff_with_prefix_and_funcname(
     src_prefix: &str,
     dst_prefix: &str,
     funcname_matcher: Option<&FuncnameMatcher>,
+    quote_path_fully: bool,
 ) -> String {
     unified_diff_with_prefix_and_funcname_and_algorithm(
         old_content,
@@ -1925,6 +1929,7 @@ pub fn unified_diff_with_prefix_and_funcname(
         dst_prefix,
         funcname_matcher,
         similar::Algorithm::Myers,
+        quote_path_fully,
     )
 }
 
@@ -1942,7 +1947,9 @@ pub fn unified_diff_with_prefix_and_funcname_and_algorithm(
     dst_prefix: &str,
     funcname_matcher: Option<&FuncnameMatcher>,
     algorithm: similar::Algorithm,
+    quote_path_fully: bool,
 ) -> String {
+    use crate::quote_path::format_diff_path_with_prefix;
     use similar::{group_diff_ops, udiff::UnifiedDiffHunk, TextDiff};
 
     let diff = TextDiff::configure()
@@ -1952,13 +1959,31 @@ pub fn unified_diff_with_prefix_and_funcname_and_algorithm(
     let mut output = String::new();
     if old_path == "/dev/null" {
         output.push_str("--- /dev/null\n");
+    } else if src_prefix.is_empty() {
+        // Callers (e.g. `diff-tree`, `diff-index`) may pass a fully formatted token
+        // (already includes `a/` and any C-style quoting).
+        output.push_str(&format!("--- {old_path}\n"));
     } else {
-        output.push_str(&format!("--- {src_prefix}{old_path}\n"));
+        output.push_str("--- ");
+        output.push_str(&format_diff_path_with_prefix(
+            src_prefix,
+            old_path,
+            quote_path_fully,
+        ));
+        output.push('\n');
     }
     if new_path == "/dev/null" {
         output.push_str("+++ /dev/null\n");
+    } else if dst_prefix.is_empty() {
+        output.push_str(&format!("+++ {new_path}\n"));
     } else {
-        output.push_str(&format!("+++ {dst_prefix}{new_path}\n"));
+        output.push_str("+++ ");
+        output.push_str(&format_diff_path_with_prefix(
+            dst_prefix,
+            new_path,
+            quote_path_fully,
+        ));
+        output.push('\n');
     }
 
     let old_lines: Vec<&str> = old_content.lines().collect();
@@ -2021,7 +2046,9 @@ pub fn anchored_unified_diff(
     context_lines: usize,
     anchors: &[String],
     algorithm: similar::Algorithm,
+    quote_path_fully: bool,
 ) -> String {
+    use crate::quote_path::format_diff_path_with_prefix;
     use similar::TextDiff;
 
     let old_lines: Vec<&str> = old_content.lines().collect();
@@ -2068,6 +2095,7 @@ pub fn anchored_unified_diff(
             "b/",
             None,
             algorithm,
+            quote_path_fully,
         );
     }
 
@@ -2184,12 +2212,24 @@ pub fn anchored_unified_diff(
     if old_path == "/dev/null" {
         output.push_str("--- /dev/null\n");
     } else {
-        output.push_str(&format!("--- a/{old_path}\n"));
+        output.push_str("--- ");
+        output.push_str(&format_diff_path_with_prefix(
+            "a/",
+            old_path,
+            quote_path_fully,
+        ));
+        output.push('\n');
     }
     if new_path == "/dev/null" {
         output.push_str("+++ /dev/null\n");
     } else {
-        output.push_str(&format!("+++ b/{new_path}\n"));
+        output.push_str("+++ ");
+        output.push_str(&format_diff_path_with_prefix(
+            "b/",
+            new_path,
+            quote_path_fully,
+        ));
+        output.push('\n');
     }
 
     // Group ops into hunks with context

--- a/grit/src/commands/apply.rs
+++ b/grit/src/commands/apply.rs
@@ -75,7 +75,12 @@ pub struct Args {
     pub allow_empty: bool,
 
     /// Strip N leading path components from diff paths (default: 1).
-    #[arg(short = 'p', default_value = "1")]
+    #[arg(
+        short = 'p',
+        default_value = "1",
+        allow_hyphen_values = true,
+        value_parser = parse_apply_p_value
+    )]
     pub strip: usize,
 
     /// Prepend directory to all file paths in the patch.
@@ -775,11 +780,34 @@ fn find_name_common_bounded(
     Some(slice.to_vec())
 }
 
+/// Path bytes from a traditional `---`/`+++` nameline that starts with `"` (GNU `diff -u`):
+/// `"a/"sub/file1` is `a/` (quoted) immediately followed by `sub/file1` → `a/sub/file1`.
+fn traditional_quoted_nameline_path_bytes(line: &[u8]) -> Option<Vec<u8>> {
+    let s = std::str::from_utf8(line).ok()?;
+    let mut remaining = s;
+    let mut out = Vec::new();
+    if !remaining.starts_with('"') {
+        return None;
+    }
+    let (decoded, rest) = unquote_c_style_diff_prefix(remaining)?;
+    out.extend_from_slice(&decoded);
+    remaining = rest;
+    if !remaining.is_empty() && !remaining.starts_with('"') {
+        let end = remaining
+            .as_bytes()
+            .iter()
+            .position(|&b| b == b'\t' || b == b'\n' || b == b'\r')
+            .unwrap_or(remaining.len());
+        out.extend_from_slice(&remaining.as_bytes()[..end]);
+    }
+    Some(out)
+}
+
 /// Git `find_name_traditional` on the line after `--- ` / `+++ ` (no prefix).
 fn find_name_traditional(line: &[u8], def: Option<&[u8]>, p_value: usize) -> Option<Vec<u8>> {
     if line.first() == Some(&b'"') {
-        let (decoded, _) = unquote_c_style_diff_prefix(std::str::from_utf8(line).ok()?)?;
-        let skip = skip_tree_prefix_bytes(&decoded, p_value)?;
+        let full = traditional_quoted_nameline_path_bytes(line)?;
+        let skip = skip_tree_prefix_bytes(&full, p_value)?;
         return Some(skip.to_vec());
     }
     let ts = diff_timestamp_len(line);
@@ -968,8 +996,17 @@ fn parse_traditional_patch_pair(
 /// Default filename from `diff --git` when both sides agree (Git `git_header_name`).
 fn git_header_def_name(line: &str, p_value: usize) -> Option<String> {
     let rest = line.strip_prefix("diff --git ").unwrap_or(line);
-    let rest_b = rest.as_bytes();
 
+    if let Some((a_token, b_token)) = split_diff_git_paths(rest) {
+        let ra = skip_tree_prefix_bytes(a_token.as_bytes(), p_value)?;
+        let rb = skip_tree_prefix_bytes(b_token.as_bytes(), p_value)?;
+        if ra != rb {
+            return None;
+        }
+        return bytes_to_path_string(ra).ok();
+    }
+
+    let rest_b = rest.as_bytes();
     if rest_b.first() == Some(&b'"') {
         let (first_decoded, second_raw) = unquote_c_style_diff_prefix(rest)?;
         let rel_first = skip_tree_prefix_bytes(&first_decoded, p_value)?;
@@ -985,57 +1022,13 @@ fn git_header_def_name(line: &str, p_value: usize) -> Option<String> {
             }
         } else {
             let rel2 = skip_tree_prefix_bytes(second.as_bytes(), p_value)?;
-            if rel2.len() != rel_first.len() || rel2 != rel_first {
+            if rel2 != rel_first {
                 return None;
             }
         }
         return bytes_to_path_string(rel_first).ok();
     }
 
-    let name = skip_tree_prefix_bytes(rest_b, p_value)?;
-    let name_start = name.as_ptr() as usize - rest_b.as_ptr() as usize;
-
-    for offset in 0..name.len() {
-        if name[offset] != b'"' {
-            continue;
-        }
-        let second_slice = &rest_b[name_start + offset..];
-        let (decoded, _) = unquote_c_style_diff_prefix(std::str::from_utf8(second_slice).ok()?)?;
-        let np = skip_tree_prefix_bytes(&decoded, p_value)?;
-        let plen = np.len();
-        if plen < offset
-            && name.len() > plen
-            && &name[..plen] == np
-            && name[plen].is_ascii_whitespace()
-        {
-            return bytes_to_path_string(np).ok();
-        }
-        return None;
-    }
-
-    let line_len = rest.len().saturating_sub(name_start);
-    let mut len = 0usize;
-    while len < line_len {
-        match rest_b[name_start + len] {
-            b'\n' => return None,
-            b'\t' | b' ' => {
-                let after = name_start + len + 1;
-                if after > name_start + line_len {
-                    return None;
-                }
-                let second =
-                    skip_tree_prefix_bytes(&rest_b[after..name_start + line_len], p_value)?;
-                let names_match =
-                    name.len() >= len && second.len() >= len && name[..len] == second[..len];
-                let boundary_ok = second.get(len) == Some(&b'\n') || second.len() == len;
-                if names_match && boundary_ok {
-                    return bytes_to_path_string(&name[..len]).ok();
-                }
-            }
-            _ => {}
-        }
-        len += 1;
-    }
     None
 }
 
@@ -1180,8 +1173,12 @@ fn parse_patch(input: &str, strip: usize) -> Result<Vec<FilePatch>> {
             if let Some((a, b)) = split_diff_git_paths(rest) {
                 fp.diff_old_path = Some(a.clone());
                 fp.diff_new_path = Some(b.clone());
-                fp.old_path = Some(a);
-                fp.new_path = Some(b);
+                let old_raw = skip_tree_prefix_bytes(a.as_bytes(), p_strip)
+                    .ok_or_else(|| anyhow::anyhow!("unable to strip path prefix"))?;
+                let new_raw = skip_tree_prefix_bytes(b.as_bytes(), p_strip)
+                    .ok_or_else(|| anyhow::anyhow!("unable to strip path prefix"))?;
+                fp.old_path = Some(bytes_to_path_string(old_raw)?);
+                fp.new_path = Some(bytes_to_path_string(new_raw)?);
             }
             i += 1;
 
@@ -1688,6 +1685,54 @@ fn parse_range(s: &str) -> Result<(usize, usize)> {
 // ---------------------------------------------------------------------------
 // Strip / directory adjustment
 // ---------------------------------------------------------------------------
+
+/// Parse `-p` like Git: a non-negative integer, with Git's error text on failure.
+fn parse_apply_p_value(raw: &str) -> Result<usize, String> {
+    let s = raw.trim();
+    if s.is_empty() {
+        return Err(format!(
+            "option -p expects a non-negative integer, got '{raw}'"
+        ));
+    }
+    if s.starts_with('-') {
+        return Err(format!(
+            "option -p expects a non-negative integer, got '{raw}'"
+        ));
+    }
+    if !s.chars().all(|c| c.is_ascii_digit()) {
+        return Err(format!(
+            "option -p expects a non-negative integer, got '{raw}'"
+        ));
+    }
+    s.parse::<usize>()
+        .map_err(|_| format!("option -p expects a non-negative integer, got '{raw}'"))
+}
+
+/// Reject `-p` counts that strip past every path component in a `diff --git` header (Git error).
+fn ensure_diff_git_headers_strip_ok(lines: &[&str], strip: usize) -> Result<()> {
+    if strip == 0 {
+        return Ok(());
+    }
+    for (idx, line) in lines.iter().enumerate() {
+        if !line.starts_with("diff --git ") {
+            continue;
+        }
+        let rest = line.trim_end_matches(['\r', '\n']);
+        let rest = &rest["diff --git ".len()..];
+        let Some((a, b)) = split_diff_git_paths(rest) else {
+            continue;
+        };
+        if skip_tree_prefix_bytes(a.as_bytes(), strip).is_none()
+            || skip_tree_prefix_bytes(b.as_bytes(), strip).is_none()
+        {
+            bail!(
+                "git diff header lacks filename information when removing {strip} leading pathname components (line {})",
+                idx + 1
+            );
+        }
+    }
+    Ok(())
+}
 
 /// Strip `n` leading path components.
 fn strip_components(path: &str, n: usize) -> String {
@@ -3796,6 +3841,9 @@ pub fn run(mut args: Args) -> Result<()> {
         }
         buf
     };
+
+    let diff_git_lines: Vec<&str> = input.lines().collect();
+    ensure_diff_git_headers_strip_ok(&diff_git_lines, args.strip)?;
 
     let mut patches = parse_patch(&input, args.strip)?;
     normalize_mismatched_diff_git_paths(&mut patches, args.strip);

--- a/grit/src/commands/diff.rs
+++ b/grit/src/commands/diff.rs
@@ -25,7 +25,7 @@ use grit_lib::diff::{
     anchored_unified_diff, count_changes, count_changes_with_algorithm, count_git_lines,
     detect_renames, diff_index_to_tree, diff_index_to_worktree, diff_tree_to_worktree, diff_trees,
     diffcore_count_changes, empty_blob_oid, rewrite_dissimilarity_index_percent,
-    should_break_rewrite_for_stat, unified_diff,
+    should_break_rewrite_for_stat, unified_diff_with_prefix,
     unified_diff_with_prefix_and_funcname_and_algorithm, zero_oid, DiffEntry, DiffStatus,
 };
 use grit_lib::diffstat::{terminal_columns, write_diffstat_block, DiffstatOptions, FileStatInput};
@@ -37,6 +37,7 @@ use grit_lib::merge_diff::{
 };
 use grit_lib::objects::{parse_commit, ObjectId, ObjectKind};
 use grit_lib::odb::Odb;
+use grit_lib::quote_path::{format_diff_path_with_prefix, quote_c_style};
 use grit_lib::repo::Repository;
 use grit_lib::rev_list::{rev_list, RevListOptions};
 use grit_lib::rev_parse::{
@@ -416,6 +417,7 @@ fn no_index_unified_patch_body(
     context_lines: usize,
     mode: &WhitespaceMode,
     algorithm: similar::Algorithm,
+    quote_path_fully: bool,
 ) -> String {
     let old_slots = no_index_build_line_slots(old_bytes, mode);
     let new_slots = no_index_build_line_slots(new_bytes, mode);
@@ -444,12 +446,18 @@ fn no_index_unified_patch_body(
     let old_label = if old_path == "/dev/null" {
         "--- /dev/null\n".to_string()
     } else {
-        format!("--- a/{old_path}\n")
+        format!(
+            "--- {}\n",
+            format_diff_path_with_prefix("a/", old_path, quote_path_fully)
+        )
     };
     let new_label = if new_path == "/dev/null" {
         "+++ /dev/null\n".to_string()
     } else {
-        format!("+++ b/{new_path}\n")
+        format!(
+            "+++ {}\n",
+            format_diff_path_with_prefix("b/", new_path, quote_path_fully)
+        )
     };
 
     let line_body_for_patch = |line: &[u8]| -> String {
@@ -962,8 +970,15 @@ struct DirstatFile {
 }
 
 /// Write the `diff --git` line for `git diff --no-index`.
-fn write_no_index_diff_git_line(out: &mut String, path_a: &str, path_b: &str) {
-    let _ = writeln!(out, "diff --git a/{path_a} b/{path_b}");
+fn write_no_index_diff_git_line(
+    out: &mut String,
+    path_a: &str,
+    path_b: &str,
+    quote_path_fully: bool,
+) {
+    let a = format_diff_path_with_prefix("a/", path_a, quote_path_fully);
+    let b = format_diff_path_with_prefix("b/", path_b, quote_path_fully);
+    let _ = writeln!(out, "diff --git {a} {b}");
 }
 
 fn abbrev_oid_hex(data: &[u8], abbrev_len: usize) -> String {
@@ -2169,6 +2184,7 @@ pub fn run(mut args: Args) -> Result<()> {
                     !args.no_textconv,
                     &src_prefix,
                     &dst_prefix,
+                    quote_path_fully,
                     args.submodule.as_deref(),
                     submodule_ignore_flags_from_diff_arg(ignore_sm),
                     line_ignore,
@@ -2384,6 +2400,7 @@ fn run_diff_blob_vs_file(
             !args.no_textconv,
             src_prefix,
             dst_prefix,
+            quote_path_fully,
             args.submodule.as_deref(),
             submodule_ignore_flags_from_diff_arg(
                 args.ignore_submodules.as_deref().unwrap_or("none"),
@@ -2483,14 +2500,18 @@ fn run_diff_two_paths(
             .unwrap_or(3)
     };
 
-    let old_label = format!("{src_prefix}{path_in_repo}");
-    let new_label = format!("{dst_prefix}{path_other}");
-    let patch = unified_diff(
+    let diff_cfg = grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+    let quote_path_fully = diff_cfg.quote_path_fully();
+    let patch = unified_diff_with_prefix(
         text_a.as_ref(),
         text_b.as_ref(),
-        &old_label,
-        &new_label,
+        path_in_repo,
+        path_other,
         context_lines,
+        0,
+        src_prefix,
+        dst_prefix,
+        quote_path_fully,
     );
 
     let mut out = io::stdout().lock();
@@ -2611,6 +2632,7 @@ fn run_no_index(args: Args) -> Result<()> {
                 .unwrap_or_else(|_| grit_lib::config::ConfigSet::new())
         })
         .unwrap_or_default();
+    let quote_path_fully = diff_config.quote_path_fully();
     let ignore_case_attrs = diff_config
         .get("core.ignorecase")
         .is_some_and(|v| matches!(v.to_ascii_lowercase().as_str(), "true" | "yes" | "1"));
@@ -2773,6 +2795,7 @@ fn run_no_index(args: Args) -> Result<()> {
             context_lines,
             &args.anchored,
             line_algo_anchored,
+            quote_path_fully,
         )
     } else {
         no_index_unified_patch_body(
@@ -2783,6 +2806,7 @@ fn run_no_index(args: Args) -> Result<()> {
             context_lines,
             &ws_mode,
             algo_no_index,
+            quote_path_fully,
         )
     };
 
@@ -2809,8 +2833,10 @@ fn run_no_index(args: Args) -> Result<()> {
         Some(_) => false,
     };
 
+    let git_a = format_diff_path_with_prefix("a/", paths[0].as_str(), quote_path_fully);
+    let git_b = format_diff_path_with_prefix("b/", paths[1].as_str(), quote_path_fully);
     if use_color {
-        writeln!(out, "{BOLD}diff --git a/{} b/{}{RESET}", paths[0], paths[1])?;
+        writeln!(out, "{BOLD}diff --git {git_a} {git_b}{RESET}")?;
         writeln!(
             out,
             "{BOLD}index {old_abbrev}..{new_abbrev} {mode_str}{RESET}"
@@ -2832,7 +2858,7 @@ fn run_no_index(args: Args) -> Result<()> {
             }
         }
     } else {
-        writeln!(out, "diff --git a/{} b/{}", paths[0], paths[1])?;
+        writeln!(out, "diff --git {git_a} {git_b}")?;
         writeln!(out, "index {old_abbrev}..{new_abbrev} {mode_str}")?;
         write!(out, "{diff_body}")?;
     }
@@ -2909,6 +2935,7 @@ fn run_no_index_dirs(args: Args, dir_a: &Path, dir_b: &Path) -> Result<()> {
                 .unwrap_or_else(|_| grit_lib::config::ConfigSet::new())
         })
         .unwrap_or_default();
+    let quote_path_fully = diff_config.quote_path_fully();
     let ignore_case_attrs = diff_config
         .get("core.ignorecase")
         .is_some_and(|v| matches!(v.to_ascii_lowercase().as_str(), "true" | "yes" | "1"));
@@ -2991,7 +3018,9 @@ fn run_no_index_dirs(args: Args, dir_a: &Path, dir_b: &Path) -> Result<()> {
         } else {
             rel.as_str()
         };
-        writeln!(out, "diff --git a/{rel} b/{rel}")?;
+        let git_old = format_diff_path_with_prefix("a/", rel.as_str(), quote_path_fully);
+        let git_new = format_diff_path_with_prefix("b/", rel.as_str(), quote_path_fully);
+        writeln!(out, "diff --git {git_old} {git_new}")?;
         let mode_a = fa
             .symlink_metadata()
             .ok()
@@ -3038,6 +3067,7 @@ fn run_no_index_dirs(args: Args, dir_a: &Path, dir_b: &Path) -> Result<()> {
             "b/",
             func_matcher.as_ref(),
             algo,
+            quote_path_fully,
         );
         write!(out, "{patch}")?;
     }
@@ -4224,7 +4254,7 @@ fn find_func_context(header: &str, old_lines: &[&str]) -> Option<String> {
 
 #[allow(dead_code)]
 fn write_diff_header(out: &mut impl Write, entry: &DiffEntry, use_color: bool) -> Result<()> {
-    write_diff_header_with_abbrev(out, entry, use_color, 7)
+    write_diff_header_with_abbrev(out, entry, use_color, 7, true)
 }
 
 #[allow(dead_code)]
@@ -4233,8 +4263,17 @@ fn write_diff_header_with_abbrev(
     entry: &DiffEntry,
     use_color: bool,
     abbrev_len: usize,
+    quote_path_fully: bool,
 ) -> Result<()> {
-    write_diff_header_with_prefix(out, entry, use_color, abbrev_len, "a/", "b/")
+    write_diff_header_with_prefix(
+        out,
+        entry,
+        use_color,
+        abbrev_len,
+        "a/",
+        "b/",
+        quote_path_fully,
+    )
 }
 
 fn write_diff_header_with_prefix(
@@ -4244,6 +4283,7 @@ fn write_diff_header_with_prefix(
     abbrev_len: usize,
     src_prefix: &str,
     dst_prefix: &str,
+    quote_path_fully: bool,
 ) -> Result<()> {
     let old_path = entry
         .old_path
@@ -4255,10 +4295,21 @@ fn write_diff_header_with_prefix(
         .unwrap_or(entry.old_path.as_deref().unwrap_or(""));
 
     let (b, r) = if use_color { (BOLD, RESET) } else { ("", "") };
-    writeln!(
-        out,
-        "{b}diff --git {src_prefix}{old_path} {dst_prefix}{new_path}{r}"
-    )?;
+    let old_git = if old_path.is_empty() {
+        format!("{src_prefix}")
+    } else if old_path == "/dev/null" {
+        "/dev/null".to_string()
+    } else {
+        format_diff_path_with_prefix(src_prefix, old_path, quote_path_fully)
+    };
+    let new_git = if new_path.is_empty() {
+        format!("{dst_prefix}")
+    } else if new_path == "/dev/null" {
+        "/dev/null".to_string()
+    } else {
+        format_diff_path_with_prefix(dst_prefix, new_path, quote_path_fully)
+    };
+    writeln!(out, "{b}diff --git {old_git} {new_git}{r}")?;
 
     let abbr = |oid: &ObjectId| -> String {
         let hex = oid.to_hex();
@@ -4323,8 +4374,16 @@ fn write_diff_header_with_prefix(
         DiffStatus::Renamed => {
             let sim = entry.score.unwrap_or(100);
             writeln!(out, "{b}similarity index {sim}%{r}")?;
-            writeln!(out, "{b}rename from {old_path}{r}")?;
-            writeln!(out, "{b}rename to {new_path}{r}")?;
+            writeln!(
+                out,
+                "{b}rename from {}{r}",
+                quote_c_style(old_path, quote_path_fully)
+            )?;
+            writeln!(
+                out,
+                "{b}rename to {}{r}",
+                quote_c_style(new_path, quote_path_fully)
+            )?;
             if entry.old_oid != entry.new_oid {
                 writeln!(
                     out,
@@ -4337,8 +4396,16 @@ fn write_diff_header_with_prefix(
         DiffStatus::Copied => {
             let sim = entry.score.unwrap_or(100);
             writeln!(out, "{b}similarity index {sim}%{r}")?;
-            writeln!(out, "{b}copy from {old_path}{r}")?;
-            writeln!(out, "{b}copy to {new_path}{r}")?;
+            writeln!(
+                out,
+                "{b}copy from {}{r}",
+                quote_c_style(old_path, quote_path_fully)
+            )?;
+            writeln!(
+                out,
+                "{b}copy to {}{r}",
+                quote_c_style(new_path, quote_path_fully)
+            )?;
             if entry.old_oid != entry.new_oid {
                 writeln!(
                     out,
@@ -4445,6 +4512,7 @@ fn write_patch_with_prefix(
     use_textconv: bool,
     src_prefix: &str,
     dst_prefix: &str,
+    quote_path_fully: bool,
     submodule_fmt: Option<&str>,
     submodule_ignore: SubmoduleIgnoreFlags,
     line_ignore: Option<&[Regex]>,
@@ -4521,17 +4589,31 @@ fn write_patch_with_prefix(
             }
         }
 
-        write_diff_header_with_prefix(out, entry, use_color, abbrev_len, src_prefix, dst_prefix)?;
+        write_diff_header_with_prefix(
+            out,
+            entry,
+            use_color,
+            abbrev_len,
+            src_prefix,
+            dst_prefix,
+            quote_path_fully,
+        )?;
 
         // Submodule gitlink (mode 160000): emit `Subproject commit` hunks like Git — the ODB
         // does not store these as blobs in the superproject (`git apply` / t4137 rely on this).
         if entry.old_mode == "160000" || entry.new_mode == "160000" {
             let (old_label, new_label) = match entry.status {
-                DiffStatus::Added => ("/dev/null".to_owned(), format!("{dst_prefix}{new_path}")),
-                DiffStatus::Deleted => (format!("{src_prefix}{old_path}"), "/dev/null".to_owned()),
+                DiffStatus::Added => (
+                    "/dev/null".to_owned(),
+                    format_diff_path_with_prefix(dst_prefix, new_path, quote_path_fully),
+                ),
+                DiffStatus::Deleted => (
+                    format_diff_path_with_prefix(src_prefix, old_path, quote_path_fully),
+                    "/dev/null".to_owned(),
+                ),
                 _ => (
-                    format!("{src_prefix}{old_path}"),
-                    format!("{dst_prefix}{new_path}"),
+                    format_diff_path_with_prefix(src_prefix, old_path, quote_path_fully),
+                    format_diff_path_with_prefix(dst_prefix, new_path, quote_path_fully),
                 ),
             };
             writeln!(out, "--- {old_label}")?;
@@ -4603,11 +4685,9 @@ fn write_patch_with_prefix(
                     new_path,
                 )?;
             } else {
-                writeln!(
-                    out,
-                    "Binary files {}{} and {}{} differ",
-                    src_prefix, old_path, dst_prefix, new_path
-                )?;
+                let bo = format_diff_path_with_prefix(src_prefix, old_path, quote_path_fully);
+                let bn = format_diff_path_with_prefix(dst_prefix, new_path, quote_path_fully);
+                writeln!(out, "Binary files {bo} and {bn} differ")?;
             }
             continue;
         }
@@ -4684,7 +4764,7 @@ fn write_patch_with_prefix(
                 if display_old == "/dev/null" {
                     "/dev/null".to_owned()
                 } else {
-                    format!("{src_prefix}{display_old}")
+                    format_diff_path_with_prefix(src_prefix, display_old, quote_path_fully)
                 }
             )?;
             writeln!(
@@ -4693,7 +4773,7 @@ fn write_patch_with_prefix(
                 if display_new == "/dev/null" {
                     "/dev/null".to_owned()
                 } else {
-                    format!("{dst_prefix}{display_new}")
+                    format_diff_path_with_prefix(dst_prefix, display_new, quote_path_fully)
                 }
             )?;
             writeln!(out, "@@ -?,? +{new_start},{new_lc} @@")?;
@@ -4716,6 +4796,7 @@ fn write_patch_with_prefix(
                 display_old,
                 display_new,
                 context_lines,
+                quote_path_fully,
             );
             let patch = if suppress_blank_empty {
                 strip_blank_context_trailing_space(&patch)
@@ -4748,6 +4829,7 @@ fn write_patch_with_prefix(
                 dst_prefix,
                 func_matcher.as_ref(),
                 algo,
+                quote_path_fully,
             );
             let patch = if suppress_blank_empty {
                 strip_blank_context_trailing_space(&patch)
@@ -4806,12 +4888,25 @@ fn word_diff_output(
     old_path: &str,
     new_path: &str,
     context_lines: usize,
+    quote_path_fully: bool,
 ) -> String {
     use similar::{ChangeTag, TextDiff};
 
     let mut output = String::new();
-    output.push_str(&format!("--- a/{old_path}\n"));
-    output.push_str(&format!("+++ b/{new_path}\n"));
+    output.push_str("--- ");
+    output.push_str(&format_diff_path_with_prefix(
+        "a/",
+        old_path,
+        quote_path_fully,
+    ));
+    output.push('\n');
+    output.push_str("+++ ");
+    output.push_str(&format_diff_path_with_prefix(
+        "b/",
+        new_path,
+        quote_path_fully,
+    ));
+    output.push('\n');
 
     let old_lines: Vec<&str> = old_content.lines().collect();
     let new_lines: Vec<&str> = new_content.lines().collect();

--- a/grit/src/commands/diff_index.rs
+++ b/grit/src/commands/diff_index.rs
@@ -2170,6 +2170,7 @@ pub(crate) fn write_patch_entry_inner(
         0,
         "",
         "",
+        quote_fully,
     );
     write!(out, "{patch}")?;
 

--- a/grit/src/commands/diff_tree.rs
+++ b/grit/src/commands/diff_tree.rs
@@ -1678,6 +1678,7 @@ fn write_patch_entry(
         0,
         "",
         "",
+        quote_fully,
     );
     write!(out, "{patch}")?;
 

--- a/grit/src/commands/log.rs
+++ b/grit/src/commands/log.rs
@@ -6954,6 +6954,7 @@ fn log_write_patch_entry(
         0,
         src_pfx,
         dst_pfx,
+        true,
     );
     let patch = apply_diff_output_indicators(&patch, args);
     write!(out, "{patch}")?;

--- a/grit/src/commands/show.rs
+++ b/grit/src/commands/show.rs
@@ -1267,6 +1267,7 @@ fn show_commit(
                 context,
                 &args.anchored,
                 line_algo,
+                true,
             )
         } else {
             unified_diff(&old_content, &new_content, old_path, new_path, context)

--- a/logs/2026-04-09_t4120-apply-popt.md
+++ b/logs/2026-04-09_t4120-apply-popt.md
@@ -1,12 +1,15 @@
 # t4120-apply-popt
 
-**Date:** 2026-04-09
+## Summary
 
-## Outcome
+Made `tests/t4120-apply-popt.sh` pass (12/12).
 
-`./scripts/run-tests.sh t4120-apply-popt.sh` reports **12/12** passing. No Rust changes were required on this branch; the implementation already satisfied the suite.
+## Changes
 
-## Actions
+- **apply**: Custom `-p` parser matching Git error text; pre-check `diff --git` lines for over-strip; `git_header_def_name` via `split_diff_git_paths`; strip `-p` when setting `old_path`/`new_path` from `diff --git` (fixes mode-only / index apply with `-p2`); GNU traditional `--- "a/"sub/...` nameline parsing.
+- **diff / grit-lib**: `core.quotepath` / `format_diff_path_with_prefix` for `diff --git`, `---`/`+++`, rename/copy headers, binary message, word-diff, `--no-index`; extended `unified_diff_with_prefix*` and `anchored_unified_diff` with `quote_path_fully`; `run_diff_two_paths` uses `unified_diff_with_prefix` with real tree paths (no double `a/` prefix).
 
-- Refreshed `data/test-files.csv` and dashboards via `run-tests.sh`.
-- Marked `t4120-apply-popt` complete in `PLAN.md` and updated `progress.md` counts.
+## Validation
+
+- `cargo test -p grit-lib --lib`
+- `./scripts/run-tests.sh t4120-apply-popt.sh`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This makes `t4120-apply-popt` pass all 12 harness tests.

## apply

- Parse `-p` with Git-compatible validation and error message (`option -p expects a non-negative integer`).
- Reject patches early when `-p` strips past every path component on a `diff --git` line (matches Git’s “removing N leading pathname components” message).
- Derive default names from `split_diff_git_paths` instead of buggy whole-line prefix skipping.
- Apply `-p` stripping when building `old_path`/`new_path` from `diff --git` tokens so mode-only patches with `-p2` resolve to the real worktree path (`file1` not `sub/file1`).
- Parse GNU-style traditional namelines like `--- "a/"sub/file1` (quoted prefix + unquoted suffix).

## diff / grit-lib

- Thread `core.quotepath` through unified diff emission (`format_diff_path_with_prefix`) for `diff --git`, `---`/`+++`, rename/copy extended headers, binary summaries, word-diff, and `--no-index`.
- Extend `unified_diff_with_prefix*` / `anchored_unified_diff` with a `quote_path_fully` parameter; callers that pre-format `---`/`+++` labels pass empty prefixes.
- Fix `git diff <path> <path>` to use tree paths with configurable prefixes (avoid `a/a/...`).

## Validation

- `cargo fmt`, `cargo check`, `cargo clippy --fix --allow-dirty`, `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t4120-apply-popt.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b96ae69d-0cdd-484d-a46a-54c5370bd8fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b96ae69d-0cdd-484d-a46a-54c5370bd8fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

