### PR TITLE
fix: pass t5328 commit-graph 64-bit generation overflow

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -896,7 +896,7 @@ t5324-split-commit-graph	t5	yes	42	9	33	false	ok	0
 t5325-reverse-index	t5	yes	16	2	14	false	ok	0
 t5326-multi-pack-bitmaps	t5	yes	357	17	340	false	ok	0
 t5327-multi-pack-bitmaps-rev	t5	yes	314	16	298	false	ok	0
-t5328-commit-graph-64bit-time	t5	yes	0	0	0	false	ok	0
+t5328-commit-graph-64bit-time	t5	yes	6	6	0	true	ok	0
 t5329-pack-objects-cruft	t5	yes	25	1	24	false	ok	0
 t5330-no-lazy-fetch-with-commit-graph	t5	yes	4	3	1	false	ok	0
 t5331-pack-objects-stdin	t5	yes	16	1	15	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,692 / 45,148).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,692 / 45,148).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,30 +148,30 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T23:48:24+00:00" class="gen-time" title="2026-04-09 23:48 UTC">2026-04-09 23:48 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,692</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">45,142</div>
+      <div class="summary-big-val">45,148</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">34/167 files · 17 skipped · 1,572/4,145 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.9%"></div></div>
+        <span class="group-pct pct-red">37.9%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35692 of 45148 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,692 / 45,148 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T23:48:24+00:00" class="gen-time" title="2026-04-09 23:48 UTC">2026-04-09 23:48 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card"><div class="n" id="sum-tests">45,148</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,692</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -9117,14 +9117,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.1%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="0" data-passed="0">
+<tr class="" data-group="t5" data-tests="6" data-passed="6" data-full-pass="1">
   <td class="mono">t5328-commit-graph-64bit-time</td>
   <td>t5</td>
-  <td></td>
-  <td class="right">0</td>
-  <td class="right">0</td>
+  <td><span class="badge ok">full pass</span></td>
+  <td class="right">6</td>
+  <td class="right">6</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="25" data-passed="1">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/commit_graph_file.rs
+++ b/grit-lib/src/commit_graph_file.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, Mutex};
 use crate::bloom::{
     bloom_filter_contains, bloom_keyvec_for_path, BloomBuildOutcome, BloomFilterSettings,
 };
+use crate::error::Error;
 use crate::objects::ObjectId;
 use crate::odb::Odb;
 
@@ -18,11 +19,15 @@ const CHUNK_OID_FANOUT: u32 = 0x4f49_4446; // OIDF
 const CHUNK_OID_LOOKUP: u32 = 0x4f49_444c; // OIDL
 const CHUNK_COMMIT_DATA: u32 = 0x4344_4154; // CDAT
 const CHUNK_GENERATION_DATA: u32 = 0x4744_4132; // GDA2
+const CHUNK_GENERATION_DATA_OVERFLOW: u32 = 0x4744_4f32; // GDO2
 const CHUNK_EXTRA_EDGES: u32 = 0x4544_4745; // EDGE
 const CHUNK_BLOOM_INDEXES: u32 = 0x4249_4458; // BIDX
 const CHUNK_BLOOM_DATA: u32 = 0x4244_4154; // BDAT
 
 const BLOOM_HEADER: usize = crate::bloom::BLOOMDATA_HEADER_LEN;
+
+/// `CORRECTED_COMMIT_DATE_OFFSET_OVERFLOW` — high bit marks GDA2 entries that index GDO2.
+const CORRECTED_COMMIT_DATE_OFFSET_OVERFLOW: u32 = 1u32 << 31;
 
 fn warn_path_for_graph_file(path: &Path) -> String {
     let s = path.to_string_lossy();
@@ -51,50 +56,74 @@ pub struct CommitGraphLayer {
 }
 
 impl CommitGraphLayer {
-    fn parse(path: PathBuf, raw: Vec<u8>) -> Option<Self> {
+    /// Parse a commit-graph layer; fails if generation overflow chunk is inconsistent with GDA2.
+    pub fn try_parse(path: PathBuf, raw: Vec<u8>) -> Result<Self, Error> {
         if raw.len() < 28 {
-            return None;
+            return Err(Error::CorruptObject(
+                "commit-graph file too small".to_owned(),
+            ));
         }
         let body = raw[..raw.len() - HASH_LEN].to_vec();
         if body.len() < 8 || &body[0..4] != SIGNATURE {
-            return None;
+            return Err(Error::CorruptObject(
+                "commit-graph has bad signature".to_owned(),
+            ));
         }
         if body[4] != GRAPH_VERSION || body[5] != HASH_VERSION_SHA1 {
-            return None;
+            return Err(Error::CorruptObject(format!(
+                "commit-graph version/hash not supported (version {} hash {})",
+                body[4], body[5]
+            )));
         }
         let num_chunks = body[6] as usize;
         let toc_start = 8;
         let toc_end = toc_start + (num_chunks + 1) * 12;
         if body.len() < toc_end {
-            return None;
+            return Err(Error::CorruptObject(
+                "commit-graph truncated at chunk table".to_owned(),
+            ));
         }
 
         let mut fanout_off = None;
         let mut oid_lookup_off = None;
         let mut commit_data_off = None;
         let mut generation_off = None;
+        let mut generation_overflow_off = None;
         let mut bloom_idx_off = None;
         let mut bloom_data_range = None;
         let mut chunk_offsets: Vec<usize> = Vec::new();
+        let mut toc_entries: Vec<(u32, usize)> = Vec::with_capacity(num_chunks);
 
         for i in 0..num_chunks {
             let e = toc_start + i * 12;
-            let id = u32::from_be_bytes(body[e..e + 4].try_into().ok()?);
-            let off = u64::from_be_bytes(body[e + 4..e + 12].try_into().ok()?) as usize;
+            let id = u32::from_be_bytes(
+                body[e..e + 4]
+                    .try_into()
+                    .map_err(|_| Error::CorruptObject("commit-graph bad TOC".to_owned()))?,
+            );
+            let off = u64::from_be_bytes(
+                body[e + 4..e + 12]
+                    .try_into()
+                    .map_err(|_| Error::CorruptObject("commit-graph bad TOC".to_owned()))?,
+            ) as usize;
+            toc_entries.push((id, off));
             chunk_offsets.push(off);
             match id {
                 CHUNK_OID_FANOUT => fanout_off = Some(off),
                 CHUNK_OID_LOOKUP => oid_lookup_off = Some(off),
                 CHUNK_COMMIT_DATA => commit_data_off = Some(off),
                 CHUNK_GENERATION_DATA => generation_off = Some(off),
+                CHUNK_GENERATION_DATA_OVERFLOW => generation_overflow_off = Some(off),
                 CHUNK_BLOOM_INDEXES => bloom_idx_off = Some(off),
                 CHUNK_BLOOM_DATA => {
                     let end = if i + 1 < num_chunks {
                         let e2 = toc_start + (i + 1) * 12;
-                        u64::from_be_bytes(body[e2 + 4..e2 + 12].try_into().ok()?) as usize
+                        u64::from_be_bytes(body[e2 + 4..e2 + 12].try_into().unwrap_or([0u8; 8]))
+                            as usize
                     } else {
                         let term = toc_start + num_chunks * 12;
-                        u64::from_be_bytes(body[term + 4..term + 12].try_into().ok()?) as usize
+                        u64::from_be_bytes(body[term + 4..term + 12].try_into().unwrap_or([0u8; 8]))
+                            as usize
                     };
                     bloom_data_range = Some((off, end.saturating_sub(off)));
                 }
@@ -104,11 +133,80 @@ impl CommitGraphLayer {
         let file_end = u64::from_be_bytes(
             body[toc_start + num_chunks * 12 + 4..toc_start + num_chunks * 12 + 12]
                 .try_into()
-                .ok()?,
+                .map_err(|_| Error::CorruptObject("commit-graph bad file end".to_owned()))?,
         ) as usize;
         chunk_offsets.push(file_end);
         chunk_offsets.sort_unstable();
         chunk_offsets.dedup();
+
+        fn chunk_byte_range(
+            start: usize,
+            toc_entries: &[(u32, usize)],
+            file_end: usize,
+        ) -> Result<usize, Error> {
+            let mut ends: Vec<usize> = toc_entries
+                .iter()
+                .map(|&(_, o)| o)
+                .filter(|&o| o > start)
+                .collect();
+            ends.sort_unstable();
+            let end = ends.first().copied().unwrap_or(file_end);
+            if end < start {
+                return Err(Error::CorruptObject(
+                    "commit-graph chunk layout invalid".to_owned(),
+                ));
+            }
+            Ok(end)
+        }
+
+        if let Some(gda) = generation_off {
+            let gda_end = chunk_byte_range(gda, &toc_entries, file_end)?;
+            let gda_len = gda_end.saturating_sub(gda);
+            let num_commits = fanout_off
+                .and_then(|fo| {
+                    let slice = body.get(fo + 255 * 4..fo + 256 * 4)?;
+                    Some(u32::from_be_bytes(slice.try_into().ok()?))
+                })
+                .ok_or_else(|| Error::CorruptObject("commit-graph missing fanout".to_owned()))?;
+            let expected = num_commits as usize * 4;
+            if gda_len < expected {
+                return Err(Error::CorruptObject(
+                    "commit-graph generation data chunk is too small".to_owned(),
+                ));
+            }
+            let gda_slice = body.get(gda..gda + expected).ok_or_else(|| {
+                Error::CorruptObject("commit-graph generation data OOB".to_owned())
+            })?;
+            let mut max_overflow_idx: Option<u32> = None;
+            for w in 0..num_commits as usize {
+                let v =
+                    u32::from_be_bytes(gda_slice[w * 4..w * 4 + 4].try_into().map_err(|_| {
+                        Error::CorruptObject("commit-graph GDA2 corrupt".to_owned())
+                    })?);
+                if v & CORRECTED_COMMIT_DATE_OFFSET_OVERFLOW != 0 {
+                    let pos = v ^ CORRECTED_COMMIT_DATE_OFFSET_OVERFLOW;
+                    max_overflow_idx = Some(match max_overflow_idx {
+                        None => pos,
+                        Some(m) => m.max(pos),
+                    });
+                }
+            }
+            if let Some(pos) = max_overflow_idx {
+                let Some(gdo_start) = generation_overflow_off else {
+                    return Err(Error::CorruptObject(
+                        "commit-graph requires overflow generation data but has none".to_owned(),
+                    ));
+                };
+                let gdo_end = chunk_byte_range(gdo_start, &toc_entries, file_end)?;
+                let overflow_bytes = gdo_end.saturating_sub(gdo_start);
+                let n_slots = overflow_bytes / 8;
+                if n_slots <= pos as usize {
+                    return Err(Error::CorruptObject(
+                        "commit-graph overflow generation data is too small".to_owned(),
+                    ));
+                }
+            }
+        }
         let bidx_len = bloom_idx_off.and_then(|b| {
             chunk_offsets
                 .iter()
@@ -116,23 +214,35 @@ impl CommitGraphLayer {
                 .map(|&next| next.saturating_sub(b))
         });
 
-        let fanout_off = fanout_off?;
-        let oid_lookup_off = oid_lookup_off?;
-        let commit_data_off = commit_data_off?;
+        let fanout_off = fanout_off.ok_or_else(|| {
+            Error::CorruptObject("commit-graph missing OID fanout chunk".to_owned())
+        })?;
+        let oid_lookup_off = oid_lookup_off.ok_or_else(|| {
+            Error::CorruptObject("commit-graph missing OID lookup chunk".to_owned())
+        })?;
+        let commit_data_off = commit_data_off.ok_or_else(|| {
+            Error::CorruptObject("commit-graph missing commit data chunk".to_owned())
+        })?;
         if fanout_off + 256 * 4 > body.len() || oid_lookup_off + 4 > body.len() {
-            return None;
+            return Err(Error::CorruptObject(
+                "commit-graph chunk extends past end of file".to_owned(),
+            ));
         }
         let num_commits = u32::from_be_bytes(
             body[fanout_off + 255 * 4..fanout_off + 256 * 4]
                 .try_into()
-                .ok()?,
+                .map_err(|_| Error::CorruptObject("commit-graph fanout corrupt".to_owned()))?,
         );
         if oid_lookup_off + num_commits as usize * HASH_LEN > body.len() {
-            return None;
+            return Err(Error::CorruptObject(
+                "commit-graph OID lookup extends past end of file".to_owned(),
+            ));
         }
         let graph_data_width = HASH_LEN + 16;
         if commit_data_off + num_commits as usize * graph_data_width > body.len() {
-            return None;
+            return Err(Error::CorruptObject(
+                "commit-graph commit data extends past end of file".to_owned(),
+            ));
         }
 
         let read_generation_data = generation_off.is_some();
@@ -146,10 +256,19 @@ impl CommitGraphLayer {
                 );
             } else if bdat_off + bdat_len <= body.len() {
                 let hdr = &body[bdat_off..bdat_off + BLOOM_HEADER];
+                let hash_version: [u8; 4] = hdr[0..4]
+                    .try_into()
+                    .map_err(|_| Error::CorruptObject("Bloom header corrupt".to_owned()))?;
+                let num_hashes: [u8; 4] = hdr[4..8]
+                    .try_into()
+                    .map_err(|_| Error::CorruptObject("Bloom header corrupt".to_owned()))?;
+                let bits_per_entry: [u8; 4] = hdr[8..12]
+                    .try_into()
+                    .map_err(|_| Error::CorruptObject("Bloom header corrupt".to_owned()))?;
                 bloom_settings = Some(BloomFilterSettings {
-                    hash_version: u32::from_be_bytes(hdr[0..4].try_into().ok()?),
-                    num_hashes: u32::from_be_bytes(hdr[4..8].try_into().ok()?),
-                    bits_per_entry: u32::from_be_bytes(hdr[8..12].try_into().ok()?),
+                    hash_version: u32::from_be_bytes(hash_version),
+                    num_hashes: u32::from_be_bytes(num_hashes),
+                    bits_per_entry: u32::from_be_bytes(bits_per_entry),
                     max_changed_paths: 512,
                 });
                 chunk_bloom_data = Some((bdat_off, bdat_len));
@@ -185,7 +304,7 @@ impl CommitGraphLayer {
             None
         };
 
-        Some(Self {
+        Ok(Self {
             path,
             body,
             num_commits,
@@ -198,6 +317,10 @@ impl CommitGraphLayer {
             bloom_settings,
             bloom_disabled: false,
         })
+    }
+
+    fn parse(path: PathBuf, raw: Vec<u8>) -> Option<Self> {
+        Self::try_parse(path, raw).ok()
     }
 
     fn oid_at_lex(&self, lex_index: u32) -> Option<ObjectId> {
@@ -370,11 +493,14 @@ impl CommitGraphChain {
     }
 
     /// Load from `objects/info/commit-graph` or `objects/info/commit-graphs/commit-graph-chain`.
-    pub fn load(objects_dir: &Path) -> Option<Self> {
+    ///
+    /// Returns `Ok(None)` when no commit-graph exists. Corrupt graphs (including invalid GDO2)
+    /// return [`Err`].
+    pub fn try_load(objects_dir: &Path) -> Result<Option<Self>, Error> {
         let info = objects_dir.join("info");
         let chain_path = info.join("commit-graphs").join("commit-graph-chain");
         if chain_path.is_file() {
-            let content = std::fs::read_to_string(&chain_path).ok()?;
+            let content = std::fs::read_to_string(&chain_path).map_err(Error::from)?;
             let mut layers = Vec::new();
             for line in content.lines() {
                 let h = line.trim();
@@ -382,28 +508,33 @@ impl CommitGraphChain {
                     continue;
                 }
                 let graph_path = info.join("commit-graphs").join(format!("graph-{h}.graph"));
-                let raw = std::fs::read(&graph_path).ok()?;
-                let layer = CommitGraphLayer::parse(graph_path, raw)?;
+                let raw = std::fs::read(&graph_path).map_err(Error::from)?;
+                let layer = CommitGraphLayer::try_parse(graph_path, raw)?;
                 layers.push(layer);
             }
             if layers.is_empty() {
-                return None;
+                return Ok(None);
             }
             let mut chain = Self { layers };
             chain.validate_bloom_compatibility();
-            return Some(chain);
+            return Ok(Some(chain));
         }
         let single = info.join("commit-graph");
         if single.is_file() {
-            let raw = std::fs::read(&single).ok()?;
-            let layer = CommitGraphLayer::parse(single.clone(), raw)?;
+            let raw = std::fs::read(&single).map_err(Error::from)?;
+            let layer = CommitGraphLayer::try_parse(single.clone(), raw)?;
             let mut chain = Self {
                 layers: vec![layer],
             };
             chain.validate_bloom_compatibility();
-            return Some(chain);
+            return Ok(Some(chain));
         }
-        None
+        Ok(None)
+    }
+
+    /// Like [`Self::try_load`] but ignores parse errors (returns `None`).
+    pub fn load(objects_dir: &Path) -> Option<Self> {
+        Self::try_load(objects_dir).ok().flatten()
     }
 
     fn validate_bloom_compatibility(&mut self) {
@@ -618,6 +749,7 @@ pub fn parse_graph_file(path: &Path) -> Option<ParsedGraphDump> {
             CHUNK_OID_LOOKUP => "oid_lookup",
             CHUNK_COMMIT_DATA => "commit_metadata",
             CHUNK_GENERATION_DATA => "generation_data",
+            CHUNK_GENERATION_DATA_OVERFLOW => "generation_data_overflow",
             CHUNK_EXTRA_EDGES => "extra_edges",
             CHUNK_BLOOM_INDEXES => "bloom_indexes",
             CHUNK_BLOOM_DATA => "bloom_data",

--- a/grit-lib/src/commit_graph_write.rs
+++ b/grit-lib/src/commit_graph_write.rs
@@ -19,6 +19,7 @@ const CHUNK_OID_FANOUT: u32 = 0x4f49_4446;
 const CHUNK_OID_LOOKUP: u32 = 0x4f49_444c;
 const CHUNK_COMMIT_DATA: u32 = 0x4344_4154;
 const CHUNK_GENERATION_DATA: u32 = 0x4744_4132;
+const CHUNK_GENERATION_DATA_OVERFLOW: u32 = 0x4744_4f32; // GDO2
 const CHUNK_EXTRA_EDGES: u32 = 0x4544_4745;
 const CHUNK_BLOOM_INDEXES: u32 = 0x4249_4458;
 const CHUNK_BLOOM_DATA: u32 = 0x4244_4154;
@@ -28,12 +29,18 @@ const PARENT_NONE: u32 = 0x7000_0000;
 const GRAPH_EXTRA_EDGES_NEEDED: u32 = 0x8000_0000;
 const GRAPH_LAST_EDGE: u32 = 0x8000_0000;
 
+/// `GENERATION_NUMBER_V2_OFFSET_MAX` from Git `commit.h`.
+const GENERATION_NUMBER_V2_OFFSET_MAX: u64 = (1u64 << 31) - 1;
+/// `CORRECTED_COMMIT_DATE_OFFSET_OVERFLOW` from Git `commit-graph.c`.
+const CORRECTED_COMMIT_DATE_OFFSET_OVERFLOW: u32 = 1u32 << 31;
+
 /// Per-commit data needed to write CDAT / Bloom.
 #[derive(Debug, Clone)]
 pub struct CommitGraphCommitInfo {
     pub tree: ObjectId,
     pub parents: Vec<ObjectId>,
-    pub commit_time: u32,
+    /// Committer Unix timestamp (Git `timestamp_t`; may exceed `u32`).
+    pub commit_time: u64,
 }
 
 fn sha1_file_body(body: &[u8]) -> [u8; 20] {
@@ -42,10 +49,10 @@ fn sha1_file_body(body: &[u8]) -> [u8; 20] {
     h.finalize().into()
 }
 
-fn parse_commit_time(committer: &str) -> u32 {
+fn parse_commit_time(committer: &str) -> u64 {
     let parts: Vec<&str> = committer.rsplitn(3, ' ').collect();
     if parts.len() >= 2 {
-        parts[1].parse::<u32>().unwrap_or(0)
+        parts[1].parse::<u64>().unwrap_or(0)
     } else {
         0
     }
@@ -152,7 +159,7 @@ fn compute_corrected_generations(
             }
             let oid = sorted_oids[idx];
             let info = &infos[&oid];
-            let cdate = info.commit_time as u64;
+            let cdate = info.commit_time;
             if parents_done {
                 let mut max_g = cdate;
                 for p in &info.parents {
@@ -254,12 +261,20 @@ pub fn build_commit_graph_bytes(
     let gen_date = compute_corrected_generations(sorted_oids, infos, &oid_to_idx, &topo);
 
     let mut gda2: Vec<u8> = Vec::with_capacity(sorted_oids.len() * 4);
+    let mut generation_overflow: Vec<u8> = Vec::new();
+    let mut overflow_count: u32 = 0;
     for (i, oid) in sorted_oids.iter().enumerate() {
         let info = &infos[oid];
-        let offset = gen_date[i]
-            .saturating_sub(info.commit_time as u64)
-            .min(u64::from(u32::MAX));
-        gda2.extend_from_slice(&(offset as u32).to_be_bytes());
+        let offset_raw = gen_date[i].saturating_sub(info.commit_time);
+        if offset_raw > GENERATION_NUMBER_V2_OFFSET_MAX {
+            let marker = CORRECTED_COMMIT_DATE_OFFSET_OVERFLOW | overflow_count;
+            overflow_count = overflow_count.wrapping_add(1);
+            gda2.extend_from_slice(&marker.to_be_bytes());
+            generation_overflow.extend_from_slice(&((offset_raw >> 32) as u32).to_be_bytes());
+            generation_overflow.extend_from_slice(&((offset_raw as u32).to_be_bytes()));
+        } else {
+            gda2.extend_from_slice(&(offset_raw as u32).to_be_bytes());
+        }
     }
 
     let mut extra_edges: Vec<u8> = Vec::new();
@@ -294,10 +309,10 @@ pub fn build_commit_graph_bytes(
         cdat.extend_from_slice(&p2.to_be_bytes());
 
         let topo = topo[i];
-        let time_low2 = info.commit_time & 0x3;
-        let packed = (topo << 2) | time_low2;
+        let date = info.commit_time;
+        let packed = (topo << 2) | (((date >> 32) & 0x3) as u32);
         cdat.extend_from_slice(&packed.to_be_bytes());
-        cdat.extend_from_slice(&info.commit_time.to_be_bytes());
+        cdat.extend_from_slice(&((date & 0xFFFF_FFFF) as u32).to_be_bytes());
     }
 
     let mut fanout = vec![0u8; 256 * 4];
@@ -370,6 +385,9 @@ pub fn build_commit_graph_bytes(
     chunks.push((CHUNK_OID_LOOKUP, oid_lookup));
     chunks.push((CHUNK_COMMIT_DATA, cdat));
     chunks.push((CHUNK_GENERATION_DATA, gda2));
+    if !generation_overflow.is_empty() {
+        chunks.push((CHUNK_GENERATION_DATA_OVERFLOW, generation_overflow));
+    }
     if !extra_edges.is_empty() {
         chunks.push((CHUNK_EXTRA_EDGES, extra_edges));
     }

--- a/grit-lib/src/git_date/mod.rs
+++ b/grit-lib/src/git_date/mod.rs
@@ -7,7 +7,7 @@ pub mod tm;
 
 use show::{parse_date_format, DateMode, DateModeType};
 use std::mem::size_of;
-use tm::{atoi_bytes, parse_timestamp_prefix};
+use tm::{atoi_bytes, parse_timestamp_prefix, Timestamp};
 
 /// Result of `test-tool date` — either lines for stdout or a process exit code (no output).
 pub enum TestToolDateResult {
@@ -37,7 +37,8 @@ pub fn test_tool_date(args: &[String]) -> Result<TestToolDateResult, String> {
 
     match sub {
         "is64bit" => {
-            let code = if size_of::<u64>() == 8 { 0 } else { 1 };
+            // Match Git's `test-tool date is64bit` (`test-date.c`): `sizeof(timestamp_t) == 8`.
+            let code = if size_of::<Timestamp>() == 8 { 0 } else { 1 };
             Ok(TestToolDateResult::Exit(code))
         }
         "time_t-is64bit" => {

--- a/grit-lib/src/rev_list.rs
+++ b/grit-lib/src/rev_list.rs
@@ -651,6 +651,9 @@ pub fn rev_list(
             && options.use_commit_graph_bloom
             && crate::pathspec::pathspecs_allow_bloom(paths);
         let read_changed = read_paths && options.commit_graph_read_changed_paths;
+        if core_cg {
+            CommitGraphChain::try_load(&repo.git_dir.join("objects"))?;
+        }
         let bloom_chain = if use_bloom {
             CommitGraphChain::load(&repo.git_dir.join("objects"))
         } else {

--- a/grit/src/commands/log.rs
+++ b/grit/src/commands/log.rs
@@ -2878,6 +2878,10 @@ pub fn run(mut args: Args) -> Result<()> {
         && !args.walk_reflogs;
     let bloom_read_changed_paths = cg_read_paths;
     let bloom_changed_paths_version = cg_changed_ver;
+    if core_commit_graph {
+        CommitGraphChain::try_load(&repo.git_dir.join("objects"))
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+    }
     let bloom_chain = if use_bloom {
         CommitGraphChain::load(&repo.git_dir.join("objects"))
     } else {

--- a/logs/2026-04-09_t5328-commit-graph-64bit-time.md
+++ b/logs/2026-04-09_t5328-commit-graph-64bit-time.md
@@ -1,0 +1,19 @@
+# t5328-commit-graph-64bit-time
+
+## Problem
+
+- Harness skipped t5328: `TIME_IS_64BIT` / `TIME_T_IS_64BIT` lazy prereqs were missing from `tests/test-lib.sh`.
+- `test_commit` override dropped `--date`, so commits never used `GIT_AUTHOR_DATE` / `GIT_COMMITTER_DATE` and generation overflow was not exercised.
+- `commit_graph_write` truncated committer time to `u32`, saturated large generation offsets, and never wrote the GDO2 overflow chunk.
+- Corrupt/truncated GDO2 did not fail `git log` (Git expects `commit-graph overflow generation data is too small`).
+
+## Fix
+
+- Added lazy prereqs and `--date` handling in `test_commit`.
+- `test-tool date is64bit`: match Git (`timestamp_t` = `git_date::tm::Timestamp` / u64 size).
+- Write GDA2 overflow markers + GDO2 chunk; store 64-bit committer dates in CDAT (high bits in packed word).
+- `CommitGraphLayer::try_parse` validates GDA2 vs GDO2; `CommitGraphChain::try_load`; validate when `core.commitgraph` is on in `rev_list` and `log`.
+
+## Verify
+
+`./scripts/run-tests.sh t5328-commit-graph-64bit-time.sh` → 6/6 pass.

--- a/tests/test-lib.sh
+++ b/tests/test-lib.sh
@@ -1047,6 +1047,10 @@ test_lazy_prereq ICONV '
 	iconv -f utf8 -t utf8 </dev/null
 '
 
+# Match git/t/test-lib.sh: far-future dates and 64-bit commit-graph generation overflow.
+test_lazy_prereq TIME_IS_64BIT 'test-tool date is64bit'
+test_lazy_prereq TIME_T_IS_64BIT 'test-tool date time_t-is64bit'
+
 # Filesystem aliases NFC and NFD UTF-8 path spellings (macOS / HFS+). Matches git/t/test-lib.sh.
 # Set GIT_TEST_UTF8_NFD_TO_NFC=true to force on CI where the FS is not normalization-sensitive.
 test_lazy_prereq UTF8_NFD_TO_NFC '
@@ -1197,6 +1201,12 @@ test_commit () {
 		--no-tag) tag=none; shift ;;
 		--annotate) tag=annotate; shift ;;
 		--author) author="$2"; shift 2 ;;
+		--date)
+			notick=yes
+			GIT_COMMITTER_DATE="$2"
+			GIT_AUTHOR_DATE="$2"
+			shift 2
+			;;
 		-C) indir="$2"; shift 2 ;;
 		--append) append=yes; shift ;;
 		--printf) echo=printf; shift ;;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes `t5328-commit-graph-64bit-time` pass (6/6) by aligning the harness with upstream prereqs, fixing `test_commit --date`, implementing Git-compatible generation overflow (GDA2 + GDO2) when writing commit-graphs, and validating overflow chunk bounds when reading so `git log` fails with Git’s message on corruption.

## Key changes

- **Harness:** `TIME_IS_64BIT` / `TIME_T_IS_64BIT` lazy prereqs; `test_commit` accepts `--date` again (sets author/committer date env).
- **`test-tool date is64bit`:** Uses `git_date::tm::Timestamp` (u64) width like Git’s `timestamp_t`.
- **Writer:** `u64` commit times; CDAT high date bits in packed word; GDO2 chunk when corrected-date offset exceeds `2^31-1`.
- **Reader:** `CommitGraphLayer::try_parse` / `CommitGraphChain::try_load`; `rev_list` and `log` call `try_load` when `core.commitgraph` is enabled so truncated GDO2 surfaces as `commit-graph overflow generation data is too small`.

## Testing

- `./scripts/run-tests.sh t5328-commit-graph-64bit-time.sh` → 6/6
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e029b12-e8b3-420e-a65f-dceeaf766492"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e029b12-e8b3-420e-a65f-dceeaf766492"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

