### PR TITLE
fix: t2070-restore — REUC resolve-undo for restore --merge

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -497,7 +497,7 @@ t2050-checkout	t2	yes	80	80	0	true	ok	0
 t2050-git-dir-relative	t2	yes	4	2	2	false	ok	0
 t2060-switch	t2	yes	16	6	10	false	ok	0
 t2061-switch-orphan	t2	yes	15	9	6	false	ok	0
-t2070-restore	t2	yes	15	13	2	false	ok	0
+t2070-restore	t2	yes	15	15	0	true	ok	0
 t2071-restore-patch	t2	yes	15	6	9	false	ok	0
 t2072-restore-pathspec-file	t2	yes	12	12	0	true	ok	0
 t2080-parallel-checkout-basics	t2	yes	11	4	7	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,688 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,688 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T00:08:56+00:00" class="gen-time" title="2026-04-10 00:08 UTC">2026-04-10 00:08 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,688</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -208,11 +208,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t2</span>
         <span class="group-desc">Basic commands concerning the working tree</span>
-        <span class="group-meta">30/61 files · 9 skipped · 666/872 tests</span>
+        <span class="group-meta">31/61 files · 9 skipped · 668/872 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:76.4%"></div></div>
-        <span class="group-pct pct-blue">76.4%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:76.6%"></div></div>
+        <span class="group-pct pct-blue">76.6%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t3">
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35688 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,688 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T00:08:56+00:00" class="gen-time" title="2026-04-10 00:08 UTC">2026-04-10 00:08 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,688</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -5127,14 +5127,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:60.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t2" data-tests="15" data-passed="13">
+<tr class="" data-group="t2" data-tests="15" data-passed="15" data-full-pass="1">
   <td class="mono">t2070-restore</td>
   <td>t2</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">15</td>
-  <td class="right">13</td>
+  <td class="right">15</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:86.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t2" data-tests="15" data-passed="6">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/index.rs
+++ b/grit-lib/src/index.rs
@@ -15,7 +15,7 @@
 //! See `Documentation/technical/index-format.txt` in the Git source tree for
 //! the authoritative format specification.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::io::{self, Write};
 use std::path::Path;
@@ -45,6 +45,29 @@ pub const MODE_TREE: u32 = 0o040000;
 const INDEX_EXT_SPARSE_DIRECTORIES: u32 = u32::from_be_bytes(*b"sdir");
 /// Git index extension signature `UNTR` (untracked cache).
 const INDEX_EXT_UNTRACKED: u32 = u32::from_be_bytes(*b"UNTR");
+/// Git index extension signature `REUC` (resolve undo — conflict stages before `git add`).
+const INDEX_EXT_RESOLVE_UNDO: u32 = u32::from_be_bytes(*b"REUC");
+
+/// Saved unmerged index state for one path (Git `resolve_undo_info` / `REUC` extension).
+///
+/// `modes[0]`..`modes[2]` are the index modes for merge stages 1..3; zero means that stage
+/// was absent. When `modes[i]` is non-zero, `oids[i]` holds the blob object id for that stage.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolveUndoInfo {
+    /// Entry mode for stages 1, 2, 3 (Git `ce_mode`); `0` means the stage was not present.
+    pub modes: [u32; 3],
+    /// Object ids for stages 1..3; only meaningful when the corresponding `modes[i]` is non-zero.
+    pub oids: [ObjectId; 3],
+}
+
+impl Default for ResolveUndoInfo {
+    fn default() -> Self {
+        Self {
+            modes: [0, 0, 0],
+            oids: [ObjectId::zero(), ObjectId::zero(), ObjectId::zero()],
+        }
+    }
+}
 
 /// A single entry in the Git index.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -186,6 +209,8 @@ pub struct Index {
     pub sparse_directories: bool,
     /// Optional untracked-cache extension (`UNTR`), matching Git's `istate->untracked`.
     pub untracked_cache: Option<untracked_cache::UntrackedCache>,
+    /// Resolve-undo data (`REUC`): blob/mode for merge stages before a conflict was resolved.
+    pub resolve_undo: BTreeMap<Vec<u8>, ResolveUndoInfo>,
 }
 
 /// Options for loading an index from disk.
@@ -247,6 +272,7 @@ impl Index {
             entries: Vec::new(),
             sparse_directories: false,
             untracked_cache: None,
+            resolve_undo: BTreeMap::new(),
         }
     }
 
@@ -264,6 +290,7 @@ impl Index {
                 entries: Vec::new(),
                 sparse_directories: false,
                 untracked_cache: None,
+                resolve_undo: BTreeMap::new(),
             };
         }
 
@@ -293,6 +320,7 @@ impl Index {
             entries: Vec::new(),
             sparse_directories: false,
             untracked_cache: None,
+            resolve_undo: BTreeMap::new(),
         }
     }
 
@@ -308,6 +336,7 @@ impl Index {
                 entries: Vec::new(),
                 sparse_directories: false,
                 untracked_cache: None,
+                resolve_undo: BTreeMap::new(),
             };
         }
 
@@ -340,6 +369,7 @@ impl Index {
             entries: Vec::new(),
             sparse_directories: false,
             untracked_cache: None,
+            resolve_undo: BTreeMap::new(),
         }
     }
 
@@ -586,6 +616,7 @@ impl Index {
 
         let mut sparse_directories = false;
         let mut untracked_cache = None;
+        let mut resolve_undo = BTreeMap::new();
         while pos + 8 <= body.len() {
             let sig = u32::from_be_bytes(
                 body[pos..pos + 4]
@@ -608,6 +639,9 @@ impl Index {
             } else if sig == INDEX_EXT_UNTRACKED {
                 let ext_data = &body[pos..pos + ext_sz];
                 untracked_cache = untracked_cache::parse_untracked_extension(ext_data);
+            } else if sig == INDEX_EXT_RESOLVE_UNDO {
+                let ext_data = &body[pos..pos + ext_sz];
+                resolve_undo = parse_resolve_undo_extension(ext_data)?;
             }
             pos += ext_sz;
         }
@@ -620,6 +654,7 @@ impl Index {
             entries,
             sparse_directories,
             untracked_cache,
+            resolve_undo,
         })
     }
 
@@ -742,6 +777,12 @@ impl Index {
             out.extend_from_slice(&(payload.len() as u32).to_be_bytes());
             out.extend_from_slice(&payload);
         }
+        if !self.resolve_undo.is_empty() {
+            let payload = write_resolve_undo_extension(&self.resolve_undo);
+            out.extend_from_slice(&INDEX_EXT_RESOLVE_UNDO.to_be_bytes());
+            out.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+            out.extend_from_slice(&payload);
+        }
         Ok(())
     }
 
@@ -778,6 +819,11 @@ impl Index {
     /// conflicted file during merge/cherry-pick resolution.
     pub fn stage_file(&mut self, entry: IndexEntry) {
         let path = entry.path.clone();
+        for e in self.entries.iter() {
+            if e.path == path && e.stage() != 0 {
+                record_resolve_undo_for_entry(&mut self.resolve_undo, e);
+            }
+        }
         // Remove conflict stages first
         self.entries.retain(|e| e.path != path || e.stage() == 0);
         // Then add/replace stage-0 entry
@@ -788,6 +834,11 @@ impl Index {
     ///
     /// Returns `true` if at least one entry was removed.
     pub fn remove(&mut self, path: &[u8]) -> bool {
+        for e in self.entries.iter() {
+            if e.path == path && e.stage() != 0 {
+                record_resolve_undo_for_entry(&mut self.resolve_undo, e);
+            }
+        }
         let before = self.entries.len();
         self.entries.retain(|e| e.path != path);
         let removed = self.entries.len() < before;
@@ -821,6 +872,12 @@ impl Index {
             let ep = e.path.as_slice();
             ep.len() > plen && ep.starts_with(prefix) && ep[plen] == b'/'
         });
+        for e in self.entries.iter() {
+            let ep = e.path.as_slice();
+            if ep.len() > plen && ep.starts_with(prefix) && ep[plen] == b'/' && e.stage() != 0 {
+                record_resolve_undo_for_entry(&mut self.resolve_undo, e);
+            }
+        }
         self.entries.retain(|e| {
             let ep = e.path.as_slice();
             if ep.len() <= plen {
@@ -1642,6 +1699,125 @@ pub fn normalize_mode(raw_mode: u32) -> u32 {
     MODE_REGULAR
 }
 
+fn record_resolve_undo_for_entry(map: &mut BTreeMap<Vec<u8>, ResolveUndoInfo>, entry: &IndexEntry) {
+    let stage = entry.stage();
+    if stage == 0 || stage > 3 {
+        return;
+    }
+    let ui = map.entry(entry.path.clone()).or_default();
+    let i = (stage - 1) as usize;
+    ui.modes[i] = entry.mode;
+    ui.oids[i] = entry.oid;
+}
+
+fn parse_resolve_undo_extension(data: &[u8]) -> Result<BTreeMap<Vec<u8>, ResolveUndoInfo>> {
+    let mut out = BTreeMap::new();
+    let mut pos = 0usize;
+    while pos < data.len() {
+        let path_end = data[pos..]
+            .iter()
+            .position(|&b| b == 0)
+            .ok_or_else(|| Error::IndexError("truncated REUC path".to_owned()))?;
+        let path = data[pos..pos + path_end].to_vec();
+        pos += path_end + 1;
+
+        let mut modes = [0u32; 3];
+        for m in &mut modes {
+            let mode_end = data[pos..]
+                .iter()
+                .position(|&b| b == 0)
+                .ok_or_else(|| Error::IndexError("truncated REUC mode".to_owned()))?;
+            let mode_s = std::str::from_utf8(&data[pos..pos + mode_end])
+                .map_err(|_| Error::IndexError("REUC mode is not valid UTF-8".to_owned()))?;
+            *m = u32::from_str_radix(mode_s, 8)
+                .map_err(|_| Error::IndexError(format!("invalid REUC mode octal: {mode_s}")))?;
+            pos += mode_end + 1;
+        }
+
+        let mut oids = [ObjectId::zero(); 3];
+        for i in 0..3 {
+            if modes[i] != 0 {
+                if pos + 20 > data.len() {
+                    return Err(Error::IndexError("truncated REUC object id".to_owned()));
+                }
+                oids[i] = ObjectId::from_bytes(&data[pos..pos + 20])?;
+                pos += 20;
+            }
+        }
+        out.insert(path, ResolveUndoInfo { modes, oids });
+    }
+    Ok(out)
+}
+
+fn write_resolve_undo_extension(map: &BTreeMap<Vec<u8>, ResolveUndoInfo>) -> Vec<u8> {
+    let mut buf = Vec::new();
+    for (path, ui) in map.iter() {
+        buf.extend_from_slice(path);
+        buf.push(0);
+        for m in ui.modes {
+            buf.extend_from_slice(format!("{m:o}").as_bytes());
+            buf.push(0);
+        }
+        for i in 0..3 {
+            if ui.modes[i] != 0 {
+                buf.extend_from_slice(ui.oids[i].as_bytes());
+            }
+        }
+    }
+    buf
+}
+
+impl Index {
+    /// Re-create unmerged index entries for `path` from resolve-undo (`REUC`), matching Git's
+    /// `unmerge_index_entry` used by `git restore --merge` after a mistaken resolution.
+    ///
+    /// Returns `true` if resolve-undo had data for this path (the map entry is always consumed).
+    /// When the path is already unmerged, the index is left unchanged.
+    pub fn unmerge_from_resolve_undo(&mut self, path: &[u8]) -> bool {
+        let Some(ru) = self.resolve_undo.remove(path) else {
+            return false;
+        };
+        let has_conflict_stage = self
+            .entries
+            .iter()
+            .any(|e| e.path == path && e.stage() != 0);
+        if has_conflict_stage {
+            return true;
+        }
+        self.entries.retain(|e| !(e.path == path && e.stage() == 0));
+        for stage in 1u8..=3u8 {
+            let i = (stage - 1) as usize;
+            if ru.modes[i] == 0 {
+                continue;
+            }
+            let path_len = path.len().min(0xFFF) as u16;
+            let flags = path_len | ((stage as u16) << 12);
+            let entry = IndexEntry {
+                ctime_sec: 0,
+                ctime_nsec: 0,
+                mtime_sec: 0,
+                mtime_nsec: 0,
+                dev: 0,
+                ino: 0,
+                mode: ru.modes[i],
+                uid: 0,
+                gid: 0,
+                size: 0,
+                oid: ru.oids[i],
+                flags,
+                flags_extended: None,
+                path: path.to_vec(),
+            };
+            self.add_or_replace(entry);
+        }
+        self.sort();
+        if let Ok(p) = std::str::from_utf8(path) {
+            self.invalidate_untracked_cache_for_path(p);
+        }
+        true
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::expect_used, clippy::unwrap_used)]
@@ -1698,6 +1874,40 @@ mod tests {
         assert_eq!(loaded.entries.len(), 2);
         assert_eq!(loaded.entries[0].path, b"bar/baz.txt");
         assert_eq!(loaded.entries[1].path, b"foo.txt");
+    }
+
+    #[test]
+    fn resolve_undo_reuc_round_trip_and_unmerge() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("index");
+
+        let oid_a = ObjectId::from_bytes(&[1u8; 20]).unwrap();
+        let oid_b = ObjectId::from_bytes(&[2u8; 20]).unwrap();
+        let oid_c = ObjectId::from_bytes(&[3u8; 20]).unwrap();
+
+        let mut idx = Index::new();
+        idx.add_or_replace(make_entry("tracked.txt"));
+        let p = b"conflict.txt".to_vec();
+        for (stage, oid) in [(1u8, oid_a), (2u8, oid_b), (3u8, oid_c)] {
+            let mut e = make_entry("conflict.txt");
+            e.oid = oid;
+            e.mode = MODE_REGULAR;
+            e.flags = (p.len().min(0xFFF) as u16) | ((stage as u16) << 12);
+            idx.add_or_replace(e);
+        }
+        idx.sort();
+        idx.stage_file(make_entry("conflict.txt"));
+        idx.write(&path).unwrap();
+
+        let loaded = Index::load(&path).unwrap();
+        assert!(loaded.resolve_undo.contains_key(p.as_slice()));
+        assert!(loaded.get(p.as_slice(), 0).is_some());
+
+        let mut idx2 = loaded;
+        assert!(idx2.unmerge_from_resolve_undo(p.as_slice()));
+        assert_eq!(idx2.get(p.as_slice(), 1).map(|e| e.oid), Some(oid_a));
+        assert_eq!(idx2.get(p.as_slice(), 2).map(|e| e.oid), Some(oid_b));
+        assert_eq!(idx2.get(p.as_slice(), 3).map(|e| e.oid), Some(oid_c));
     }
 
     #[test]

--- a/grit/src/commands/restore.rs
+++ b/grit/src/commands/restore.rs
@@ -170,6 +170,9 @@ pub fn run(args: Args) -> Result<()> {
         let path_bytes = rel_path.as_bytes();
 
         if args.merge && restore_worktree {
+            if index.unmerge_from_resolve_undo(path_bytes) {
+                index_modified = true;
+            }
             do_restore_worktree_merge(
                 &repo,
                 &index,
@@ -376,8 +379,6 @@ fn do_restore_worktree_merge(
     let ((ours_oid, ours_mode), (theirs_oid, _theirs_mode)) =
         if let (Some(ours), Some(theirs)) = (staged_ours, staged_theirs) {
             (ours, theirs)
-        } else if let Some(saved) = read_saved_merge_state(repo, rel_path)? {
-            ((saved.0, saved.1), (saved.2, saved.3))
         } else {
             bail!("path '{}' is not unmerged", rel_path);
         };
@@ -439,45 +440,6 @@ fn ensure_trailing_newline(mut text: String) -> String {
         text.push('\n');
     }
     text
-}
-
-fn read_saved_merge_state(
-    repo: &Repository,
-    rel_path: &str,
-) -> Result<Option<(ObjectId, u32, ObjectId, u32)>> {
-    let state_path = repo.git_dir.join("grit-restore-merge-state");
-    let content = match std::fs::read_to_string(&state_path) {
-        Ok(c) => c,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(e) => return Err(e.into()),
-    };
-
-    for line in content.lines() {
-        let mut parts = line.splitn(5, '\t');
-        let Some(path) = parts.next() else { continue };
-        if path != rel_path {
-            continue;
-        }
-        let Some(ours_oid_s) = parts.next() else {
-            continue;
-        };
-        let Some(ours_mode_s) = parts.next() else {
-            continue;
-        };
-        let Some(theirs_oid_s) = parts.next() else {
-            continue;
-        };
-        let Some(theirs_mode_s) = parts.next() else {
-            continue;
-        };
-        let ours_oid = ours_oid_s.parse::<ObjectId>()?;
-        let ours_mode = u32::from_str_radix(ours_mode_s, 8).unwrap_or(0o100644);
-        let theirs_oid = theirs_oid_s.parse::<ObjectId>()?;
-        let theirs_mode = u32::from_str_radix(theirs_mode_s, 8).unwrap_or(0o100644);
-        return Ok(Some((ours_oid, ours_mode, theirs_oid, theirs_mode)));
-    }
-
-    Ok(None)
 }
 
 /// Write blob data to the working tree at `rel_path` under `work_tree`.

--- a/logs/2026-04-09-t2070-restore-resolve-undo.md
+++ b/logs/2026-04-09-t2070-restore-resolve-undo.md
@@ -1,0 +1,18 @@
+# t2070-restore — resolve undo (REUC)
+
+## Problem
+
+`git restore --worktree --merge` after resolving a conflict with `git add` or removing the path with `git rm` failed: the index no longer had stages 2/3, so Grit could not rebuild conflict markers.
+
+## Fix
+
+- Implemented Git’s `REUC` index extension: parse/write and in-memory `resolve_undo` map on [`Index`](grit-lib/src/index.rs).
+- Record merge stages when they are dropped via [`stage_file`](grit-lib/src/index.rs), [`remove`](grit-lib/src/index.rs), and [`remove_descendants_under_path`](grit-lib/src/index.rs) (mirrors Git `record_resolve_undo` on removal).
+- [`restore --merge`](grit/src/commands/restore.rs): call `unmerge_from_resolve_undo` before writing conflict markers; persist index when undo was consumed.
+- Removed unused `grit-restore-merge-state` fallback.
+- Unit test `resolve_undo_reuc_round_trip_and_unmerge` in `grit-lib`.
+
+## Verification
+
+- `./scripts/run-tests.sh t2070-restore.sh` — 15/15 pass
+- `cargo test -p grit-lib --lib`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`git restore --worktree --merge` must rebuild conflict markers even after a mistaken resolution (`git add` or `git rm` removed unmerged stages). Git stores the former stages in the index **REUC** (resolve-undo) extension and replays them via `unmerge_index` before checkout.

## Changes

- **grit-lib**: Parse/write `REUC`, keep `Index.resolve_undo`, record stages when conflict entries are removed (`stage_file`, `remove`, `remove_descendants_under_path`), and `unmerge_from_resolve_undo` to restore stages 1–3.
- **grit restore**: Before `--merge`, apply resolve-undo for the path and write the index when consumed; drop the unused `grit-restore-merge-state` file fallback.
- **Tests**: `resolve_undo_reuc_round_trip_and_unmerge` unit test; harness `t2070-restore.sh` now **15/15**.

## Verification

- `cargo test -p grit-lib --lib`
- `cargo clippy -p grit-lib -p grit-rs`
- `./scripts/run-tests.sh t2070-restore.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c1822f5-1c4e-443c-b4b9-d889f2b86592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c1822f5-1c4e-443c-b4b9-d889f2b86592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

