### PR TITLE
fix(rebase): t3438 author-script validation and rebased-patches preflight

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -294,7 +294,7 @@ commit → check it off → move on.
 - [ ] `t3505-cherry-pick-empty` ██████████░░░░░░░░░░ 9/17 (8 left) — test cherry-picking an empty commit
 - [ ] `t3902-quoted` ███████░░░░░░░░░░░░░ 5/13 (8 left) — quoted output
 - [ ] `t3306-notes-prune` ██████░░░░░░░░░░░░░░ 4/12 (8 left) — Test git notes prune
-- [ ] `t3438-rebase-broken-files` ██░░░░░░░░░░░░░░░░░░ 1/9 (8 left) — rebase behavior when on-disk files are broken
+- [x] `t3438-rebase-broken-files` ████████████████████ 9/9 (0 left) — rebase behavior when on-disk files are broken
 - [x] `t3201-branch-contains` ████████████████████ 24/24 (done) — branch --contains <commit>, --no-contains <commit> --merged, and --no-merged
 - [ ] `t3104-ls-tree-format` ██████████░░░░░░░░░░ 10/19 (9 left) — ls-tree --format
 - [ ] `t3204-branch-name-interpretation` ████████░░░░░░░░░░░░ 7/16 (9 left) — interpreting exotic branch name arguments

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -625,7 +625,7 @@ t3434-rebase-i18n	t3	yes	6	3	3	false	ok	0
 t3435-rebase-gpg-sign	t3	skip	11	0	0	false	ok	0
 t3436-rebase-more-options	t3	yes	19	2	17	false	ok	0
 t3437-rebase-fixup-options	t3	yes	13	1	12	false	ok	0
-t3438-rebase-broken-files	t3	yes	9	1	8	false	ok	0
+t3438-rebase-broken-files	t3	yes	9	9	0	true	ok	0
 t3440-rebase-trailer	t3	yes	10	1	9	false	ok	0
 t3441-rebase-exec	t3	yes	3	3	0	true	ok	0
 t3442-rebase-onto-upstream	t3	yes	3	3	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,694 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,694 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T00:10:17+00:00" class="gen-time" title="2026-04-10 00:10 UTC">2026-04-10 00:10 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,694</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -219,11 +219,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">56/141 files · 2 skipped · 4,052/5,398 tests</span>
+        <span class="group-meta">57/141 files · 2 skipped · 4,060/5,398 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:75.1%"></div></div>
-        <span class="group-pct pct-blue">75.1%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:75.2%"></div></div>
+        <span class="group-pct pct-blue">75.2%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35694 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,694 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T00:10:17+00:00" class="gen-time" title="2026-04-10 00:10 UTC">2026-04-10 00:10 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,694</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -6407,14 +6407,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:7.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="9" data-passed="1">
+<tr class="" data-group="t3" data-tests="9" data-passed="9" data-full-pass="1">
   <td class="mono">t3438-rebase-broken-files</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">9</td>
-  <td class="right">1</td>
+  <td class="right">9</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:11.1%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="10" data-passed="1">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit/src/commands/rebase.rs
+++ b/grit/src/commands/rebase.rs
@@ -15,7 +15,7 @@ use clap::Args as ClapArgs;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::fs::OpenOptions;
-use std::io::Write;
+use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
 
 use grit_lib::config::ConfigSet;
@@ -2153,6 +2153,9 @@ fn do_rebase(args: Args, pre_rebase_hook_second: Option<String>) -> Result<()> {
     }
 
     let backend = choose_rebase_backend(&args);
+    if matches!(backend, RebaseBackend::Apply) {
+        prepare_rebased_patches_writable(git_dir)?;
+    }
     // Remove any stale rebase state from either backend so `active_rebase_dir` cannot pick the
     // wrong directory (merge is checked before apply).
     cleanup_rebase_state(git_dir);
@@ -3276,6 +3279,9 @@ fn cherry_pick_for_rebase(
         } else {
             fs::write(git_dir.join("MERGE_MSG"), &commit.message)?;
         }
+        if rb_dir == rebase_merge_dir(git_dir) {
+            write_rebase_author_script_for_commit(git_dir, &commit)?;
+        }
         bail!("conflicts during cherry-pick of {}", commit_oid.to_hex());
     }
 
@@ -3944,12 +3950,28 @@ fn do_continue() -> Result<()> {
         let committer = resolve_identity(&config, "COMMITTER")?;
         let raw_msg = commit_message_after_prepare_hook(&repo, git_dir, &message, "message")?;
         let message = apply_commit_msg_cleanup(&raw_msg, rebase_commit_msg_cleanup(&config));
+        let author_script_path = rebase_merge_dir(git_dir).join("author-script");
+        let (author_line, author_raw) = if author_script_path.exists() {
+            match read_rebase_author_script(git_dir) {
+                Ok(line) => (line, Vec::new()),
+                Err(e) => {
+                    eprintln!("error: could not parse author script");
+                    eprintln!("{e:#}");
+                    bail!("could not parse author script");
+                }
+            }
+        } else {
+            (
+                original_commit.author.clone(),
+                original_commit.author_raw.clone(),
+            )
+        };
         let commit_data = CommitData {
             tree: tree_oid,
             parents: vec![head_oid],
-            author: original_commit.author.clone(),
+            author: author_line,
             committer: format_ident(&committer, now),
-            author_raw: original_commit.author_raw.clone(),
+            author_raw,
             committer_raw: original_commit.committer_raw.clone(),
             encoding,
             message,
@@ -4260,6 +4282,220 @@ fn read_rebase_continue_message(
         }),
     };
     Ok(finalize_message_for_commit_encoding(unicode, config))
+}
+
+/// Ensure `.git/rebased-patches` can be created/truncated for the apply backend, matching Git's
+/// `run_am` behavior (see t3438 `unwritable rebased-patches does not leak`).
+fn prepare_rebased_patches_writable(git_dir: &Path) -> Result<()> {
+    let path = git_dir.join("rebased-patches");
+    match OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(&path)
+    {
+        Ok(_) => {
+            let _ = fs::remove_file(&path);
+            Ok(())
+        }
+        Err(e) if e.kind() == ErrorKind::PermissionDenied => {
+            bail!("could not open '{}' for writing: {}", path.display(), e)
+        }
+        Err(e) => Err(e).with_context(|| format!("open {}", path.display())),
+    }
+}
+
+/// Single-quote a string for `rebase-merge/author-script`, matching Git's `sq_quote_buf`.
+fn shell_single_quote_author_script(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('\'');
+    for ch in value.chars() {
+        if ch == '\'' {
+            out.push_str("'\\'");
+            out.push(ch);
+            out.push('\'');
+        } else if ch == '!' {
+            out.push_str("'\\!");
+            out.push('\'');
+        } else {
+            out.push(ch);
+        }
+    }
+    out.push('\'');
+    out
+}
+
+/// Write `rebase-merge/author-script` from the picked commit's author line (Git `write_author_script`).
+fn write_rebase_author_script_for_commit(git_dir: &Path, commit: &CommitData) -> Result<()> {
+    let rb_merge = rebase_merge_dir(git_dir);
+    if !rb_merge.exists() {
+        return Ok(());
+    }
+    let author = commit.author.trim_end_matches(['\r', '\n']);
+    let Some(lt) = author.find('<') else {
+        let _ = fs::remove_file(rb_merge.join("author-script"));
+        return Ok(());
+    };
+    let Some(gt) = author.rfind('>') else {
+        let _ = fs::remove_file(rb_merge.join("author-script"));
+        return Ok(());
+    };
+    if gt <= lt {
+        let _ = fs::remove_file(rb_merge.join("author-script"));
+        return Ok(());
+    }
+    let name = author[..lt].trim_end();
+    let email = author[lt + 1..gt].trim();
+    let after_gt = author[gt + 1..].trim_start();
+    if name.is_empty() || email.is_empty() {
+        let _ = fs::remove_file(rb_merge.join("author-script"));
+        return Ok(());
+    }
+    let mut script = String::new();
+    script.push_str("GIT_AUTHOR_NAME=");
+    script.push_str(&shell_single_quote_author_script(name));
+    script.push_str("\nGIT_AUTHOR_EMAIL=");
+    script.push_str(&shell_single_quote_author_script(email));
+    script.push_str("\nGIT_AUTHOR_DATE=");
+    script.push('\'');
+    if after_gt.is_empty() {
+        script.push('\'');
+    } else {
+        for ch in after_gt.chars() {
+            if ch == '\'' {
+                script.push_str("'\\'");
+                script.push(ch);
+                script.push('\'');
+            } else if ch == '!' {
+                script.push_str("'\\!");
+                script.push('\'');
+            } else {
+                script.push(ch);
+            }
+        }
+        script.push('\'');
+    }
+    script.push('\n');
+    fs::write(rb_merge.join("author-script"), script)?;
+    Ok(())
+}
+
+/// Dequote one Git shell single-quoted value (see `sq_dequote` in Git's `quote.c`).
+fn git_sq_dequote_single_quoted(value: &str) -> Result<String> {
+    let b = value.trim_start().as_bytes();
+    if b.first() != Some(&b'\'') {
+        bail!("unable to dequote value");
+    }
+    let mut i = 1usize;
+    let mut out = Vec::new();
+    loop {
+        let c = *b
+            .get(i)
+            .ok_or_else(|| anyhow::anyhow!("unable to dequote value"))?;
+        i += 1;
+        if c != b'\'' {
+            out.push(c);
+            continue;
+        }
+        match b.get(i).copied() {
+            None => {
+                return String::from_utf8(out)
+                    .map_err(|_| anyhow::anyhow!("unable to dequote value"));
+            }
+            Some(b'\\') => {
+                i += 1;
+                let esc = *b
+                    .get(i)
+                    .ok_or_else(|| anyhow::anyhow!("unable to dequote value"))?;
+                let close = *b
+                    .get(i + 1)
+                    .ok_or_else(|| anyhow::anyhow!("unable to dequote value"))?;
+                if (esc == b'\'' || esc == b'!') && close == b'\'' {
+                    out.push(esc);
+                    i += 2;
+                    continue;
+                }
+                bail!("unable to dequote value");
+            }
+            Some(_) => bail!("unable to dequote value"),
+        }
+    }
+}
+
+/// Parse `rebase-merge/author-script` into a single Git author identity line (`name <email> date`).
+fn read_rebase_author_script(git_dir: &Path) -> Result<String> {
+    let path = rebase_merge_dir(git_dir).join("author-script");
+    let raw = fs::read_to_string(&path)
+        .with_context(|| format!("could not open '{}' for reading", path.display()))?;
+
+    let mut name: Option<String> = None;
+    let mut email: Option<String> = None;
+    let mut date: Option<String> = None;
+    let mut unknown_err: Option<anyhow::Error> = None;
+
+    for line in raw.lines() {
+        let line = line.trim_end_matches('\r');
+        if line.is_empty() {
+            continue;
+        }
+        let Some((key, value_raw)) = line.split_once('=') else {
+            bail!("no key present in '{}'", line);
+        };
+        let key = key.trim();
+        let value_raw = value_raw.trim_start();
+        let decoded = git_sq_dequote_single_quoted(value_raw)
+            .with_context(|| format!("unable to dequote value of '{key}'"))?;
+
+        match key {
+            "GIT_AUTHOR_NAME" => {
+                if name.is_some() {
+                    bail!("'GIT_AUTHOR_NAME' already given");
+                }
+                name = Some(decoded);
+            }
+            "GIT_AUTHOR_EMAIL" => {
+                if email.is_some() {
+                    bail!("'GIT_AUTHOR_EMAIL' already given");
+                }
+                email = Some(decoded);
+            }
+            "GIT_AUTHOR_DATE" => {
+                if date.is_some() {
+                    bail!("'GIT_AUTHOR_DATE' already given");
+                }
+                date = Some(decoded);
+            }
+            other => {
+                unknown_err = Some(anyhow::anyhow!("unknown variable '{other}'"));
+            }
+        }
+    }
+
+    let mut missing = false;
+    if name.is_none() {
+        eprintln!("error: missing 'GIT_AUTHOR_NAME'");
+        missing = true;
+    }
+    if email.is_none() {
+        eprintln!("error: missing 'GIT_AUTHOR_EMAIL'");
+        missing = true;
+    }
+    if date.is_none() {
+        eprintln!("error: missing 'GIT_AUTHOR_DATE'");
+        missing = true;
+    }
+
+    if missing || unknown_err.is_some() {
+        if let Some(e) = unknown_err {
+            return Err(e);
+        }
+        bail!("invalid author script");
+    }
+
+    let name = name.expect("checked");
+    let email = email.expect("checked");
+    let date = date.expect("checked");
+    Ok(format!("{name} <{email}> {date}"))
 }
 
 // ── Helpers (mirrored from revert.rs) ───────────────────────────────

--- a/logs/2026-04-09_t3438-rebase-broken-files.md
+++ b/logs/2026-04-09_t3438-rebase-broken-files.md
@@ -1,0 +1,23 @@
+# t3438-rebase-broken-files
+
+## Summary
+
+Made harness file `tests/t3438-rebase-broken-files.sh` fully pass (9/9).
+
+## Changes
+
+- **`grit/src/commands/rebase.rs`**
+  - On merge-backend conflict with `rebase-merge/`, write `author-script` from the picked commit’s author line (Git `write_author_script` format: `GIT_AUTHOR_NAME` / `GIT_AUTHOR_EMAIL` / `GIT_AUTHOR_DATE` with shell single-quoting).
+  - `rebase --continue` for the normal pick path reads and strictly validates `author-script` (missing keys, duplicates, unknown keys, bad quoting) and builds the replayed commit author from the parsed line; falls back to original commit metadata when the file is absent.
+  - Apply backend: before starting rebase, try create/truncate `.git/rebased-patches` and remove it; on `PermissionDenied`, fail early with Git-style “could not open … for writing” so no `rebase-apply` state leaks (t3438 last test).
+
+## Validation
+
+- `cargo build --release -p grit-rs`
+- `cargo test -p grit-lib --lib`
+- Manual: `bash tests/t3438-rebase-broken-files.sh` (all ok)
+- `./scripts/run-tests.sh t3438-rebase-broken-files.sh`
+
+## Note
+
+Workspace `cargo clippy -- -D warnings` currently reports many pre-existing issues in other crates; scoped check of `rebase.rs` via IDE lints is clean.

--- a/progress.md
+++ b/progress.md
@@ -6,15 +6,16 @@
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   325 |
+| Completed   |   326 |
 | In progress |     5 |
-| Remaining   |   441 |
+| Remaining   |   440 |
 | **Total**   |   771 |
 
-Task lines in `PLAN.md`: 325 completed (`[x]`), 5 in progress (`[~]`), 441 remaining (`[ ]`).
+Task lines in `PLAN.md`: 326 completed (`[x]`), 5 in progress (`[~]`), 440 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t3438-rebase-broken-files` — 9/9 tests pass (`rebase-merge/author-script` written on conflict; strict parse on `rebase --continue`; apply backend preflight for writable `.git/rebased-patches`)
 - `t3309-notes-merge-auto-resolve` — 31/31 tests pass (`notes merge`: `union` / `cat_sort_uniq` blob combine like Git; successful merge commits use two parents; `notes.mergeStrategy` config errors match upstream expectations)
 - `t4063-diff-blobs` — 18/18 tests pass (`diff`: blob↔blob and `rev:path` pairs without treating blobs as trees; `HEAD:one..HEAD:two` range split; `rev:path` vs worktree file uses tree path + modes + `write_patch_with_prefix`; raw blob OID vs existing file uses filename as old path; `rev_parse::resolve_treeish_blob_at_path` for tree walks)
 - `t5524-pull-msg` — 3/3 tests pass (`git pull --no-rebase --log` merge message preserves `$` in subject lines; `--log=1` limits shortlog; harness CSV/dashboards refreshed; `PLAN.md` marked complete)

--- a/test-results.md
+++ b/test-results.md
@@ -1,5 +1,10 @@
 # Test results
 
+**2026-04-09 (t3438 / rebase broken files)**
+
+- `cargo test -p grit-lib --lib`: 160 passed
+- `./scripts/run-tests.sh t3438-rebase-broken-files.sh`: 9/9 passed
+
 **2026-04-09 (t4063 / diff blobs)**
 
 - `cargo test -p grit-lib --lib`: 155 passed


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes harness test `t3438-rebase-broken-files.sh` pass (9/9).

## Changes

- **Merge rebase conflicts:** When a merge-backend pick stops with conflicts under `.git/rebase-merge/`, write `author-script` in Git’s format (`GIT_AUTHOR_NAME` / `GIT_AUTHOR_EMAIL` / `GIT_AUTHOR_DATE`, shell single-quoted values).
- **`rebase --continue`:** Strictly read and validate `author-script` before building the replayed commit (missing keys, duplicates, unknown keys, bad dequoting). If the file is absent, keep using the original commit’s author metadata.
- **Apply backend:** Before starting rebase, try to create/truncate `.git/rebased-patches` and remove it; on permission errors, fail with Git-style “could not open … for writing” so no `rebase-apply` state is left behind.

## Validation

- `cargo build --release -p grit-rs`
- `cargo test -p grit-lib --lib` (160 passed)
- `./scripts/run-tests.sh t3438-rebase-broken-files.sh` (9/9)

## Housekeeping

- `PLAN.md` / `progress.md` / `test-results.md` / `logs/` updated; harness CSV and dashboards refreshed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ced29f8-ee49-4a00-9b52-b992baf807d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ced29f8-ee49-4a00-9b52-b992baf807d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

