### PR TITLE
fix: make t1411-reflog-show pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -412,7 +412,7 @@ t1407-worktree-ref-store	t1	skip	4	1	3	false	ok	0
 t1408-packed-refs	t1	yes	3	3	0	true	ok	0
 t1409-avoid-packing-refs	t1	yes	11	11	0	true	ok	0
 t1410-reflog	t1	yes	41	23	18	false	ok	0
-t1411-reflog-show	t1	yes	17	8	9	false	ok	0
+t1411-reflog-show	t1	yes	17	17	0	true	ok	0
 t1412-reflog-loop	t1	yes	3	3	0	true	ok	0
 t1413-reflog-detach	t1	yes	7	7	0	true	ok	0
 t1414-reflog-walk	t1	yes	12	3	9	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,695 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,695 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T00:28:08+00:00" class="gen-time" title="2026-04-10 00:28 UTC">2026-04-10 00:28 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,695</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -197,11 +197,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">275/368 files · 8 skipped · 11,694/12,747 tests</span>
+        <span class="group-meta">276/368 files · 8 skipped · 11,703/12,747 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:91.7%"></div></div>
-        <span class="group-pct pct-green">91.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:91.8%"></div></div>
+        <span class="group-pct pct-green">91.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t2">
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35695 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,695 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T00:28:08+00:00" class="gen-time" title="2026-04-10 00:28 UTC">2026-04-10 00:28 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,695</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -4277,14 +4277,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.1%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="17" data-passed="8">
+<tr class="" data-group="t1" data-tests="17" data-passed="17" data-full-pass="1">
   <td class="mono">t1411-reflog-show</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">17</td>
-  <td class="right">8</td>
+  <td class="right">17</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:47.1%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="3" data-passed="3" data-full-pass="1">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/reflog.rs
+++ b/grit-lib/src/reflog.rs
@@ -700,7 +700,11 @@ pub fn expire_reflog_git(
     }
 
     if !params.dry_run && pruned > 0 {
-        fs::write(&path, kept.join(""))?;
+        if kept.is_empty() {
+            let _ = fs::remove_file(&path);
+        } else {
+            fs::write(&path, kept.join(""))?;
+        }
     }
     Ok(pruned)
 }

--- a/grit/src/commands/log.rs
+++ b/grit/src/commands/log.rs
@@ -3572,24 +3572,56 @@ fn reflog_entry_tz(entry: &grit_lib::reflog::ReflogEntry) -> &str {
 fn format_reflog_selector_date(
     display_name: &str,
     entry: &grit_lib::reflog::ReflogEntry,
+    date_mode: Option<&str>,
 ) -> String {
     if let Some(ts) = reflog_entry_unix_ts(entry) {
         let tz = reflog_entry_tz(entry);
         // `format_date_with_mode` parses Git signature tails via `parse_signature_tail`, which
         // requires the `Name <email>` prefix before `<unix> <tz>` (see grit-lib `ident.rs`).
         let pseudo = format!("x <x@x> {ts} {tz}");
-        let date = format_date_with_mode(&pseudo, None);
+        let date = format_date_with_mode(&pseudo, date_mode);
         format!("{display_name}@{{{date}}}")
     } else {
         format!("{display_name}@{{0}}")
     }
 }
 
+#[derive(Clone, Copy)]
+enum ReflogWalkSuffixKind {
+    Index,
+    Date,
+}
+
+/// `%gd` for `log -g`: indexed `@{n}` wins over `--date` when the user gave `@{n}`; date-based
+/// suffixes and explicit `--date` use the reflog entry timestamp (t1411).
+fn reflog_walk_percent_gd(
+    display_name: &str,
+    entry: &grit_lib::reflog::ReflogEntry,
+    nr: usize,
+    j: usize,
+    had_reflog_suffix: bool,
+    last_suffix: ReflogWalkSuffixKind,
+    cli_date: Option<&str>,
+) -> String {
+    if had_reflog_suffix && matches!(last_suffix, ReflogWalkSuffixKind::Index) {
+        let idx_from_tip = nr - 1 - j;
+        return format!("{display_name}@{{{idx_from_tip}}}");
+    }
+    if had_reflog_suffix && matches!(last_suffix, ReflogWalkSuffixKind::Date) {
+        return format_reflog_selector_date(display_name, entry, cli_date);
+    }
+    if let Some(dm) = cli_date {
+        return format_reflog_selector_date(display_name, entry, Some(dm));
+    }
+    let idx_from_tip = nr - 1 - j;
+    format!("{display_name}@{{{idx_from_tip}}}")
+}
+
 /// Run the reflog walk mode (`log -g` / `log --walk-reflogs`).
 fn run_reflog_walk(
     repo: &Repository,
     args: &Args,
-    _patch_context: usize,
+    patch_context: usize,
     author_res: &[Regex],
     committer_res: &[Regex],
     grep_res: &[Regex],
@@ -3640,13 +3672,23 @@ fn run_reflog_walk(
         .cloned()
         .unwrap_or_else(|| "HEAD".to_string());
     let orig_r = orig_r_owned.as_str();
-    let display_name = if orig_r.starts_with("refs/") {
-        orig_r
+    // User-facing reflog selector name: `HEAD@{now}` must stay `HEAD`, not the resolved
+    // branch (`main@{...}`), matching Git (t1411).
+    let display_name: std::borrow::Cow<'_, str> = if let Some(pos) = orig_r.find("@{") {
+        let p = orig_r[..pos].trim();
+        if p.is_empty() {
+            std::borrow::Cow::Borrowed("HEAD")
+        } else {
+            std::borrow::Cow::Borrowed(p)
+        }
+    } else if orig_r.starts_with("refs/") {
+        std::borrow::Cow::Borrowed(orig_r)
     } else if refname.starts_with("refs/heads/") {
-        refname.strip_prefix("refs/heads/").unwrap_or(&refname)
+        std::borrow::Cow::Borrowed(refname.strip_prefix("refs/heads/").unwrap_or(&refname))
     } else {
-        &refname
+        std::borrow::Cow::Borrowed(&refname)
     };
+    let display_name = display_name.as_ref();
 
     let entries = read_reflog(&repo.git_dir, &refname).map_err(|e| anyhow::anyhow!("{e}"))?;
 
@@ -3663,7 +3705,8 @@ fn run_reflog_walk(
 
     let nr = entries.len();
     let mut start_j: Option<usize> = None;
-    let mut use_date_selector = false;
+    let mut had_reflog_suffix = false;
+    let mut last_reflog_suffix = ReflogWalkSuffixKind::Index;
 
     let mut pos = 0usize;
     while let Some(at) = next_reflog_at_open_for_suffix(orig_r, pos) {
@@ -3677,10 +3720,11 @@ fn run_reflog_walk(
             pos = close + 1;
             continue;
         }
+        had_reflog_suffix = true;
         if let Ok(n) = inner.parse::<usize>() {
             let idx = nr.checked_sub(1 + n);
             start_j = Some(idx.unwrap_or(0));
-            use_date_selector = false;
+            last_reflog_suffix = ReflogWalkSuffixKind::Index;
         } else if let Some(target_ts) = grit_lib::rev_parse::reflog_date_selector_timestamp(inner) {
             let mut picked = 0usize;
             for (j, e) in entries.iter().enumerate() {
@@ -3691,21 +3735,29 @@ fn run_reflog_walk(
                 }
             }
             start_j = Some(picked);
-            use_date_selector = true;
+            last_reflog_suffix = ReflogWalkSuffixKind::Date;
         } else {
             start_j = Some(nr.saturating_sub(1));
-            use_date_selector = false;
+            last_reflog_suffix = ReflogWalkSuffixKind::Index;
         }
         pos = close + 1;
     }
 
     let start_j = start_j.unwrap_or(nr.saturating_sub(1));
 
+    let cli_date_for_reflog = args.date.as_deref().filter(|s| !s.is_empty());
+    // Git: `log.date` does not affect reflog selector display; only an explicit `--date` on the
+    // command line does (when no numeric `@{n}` suffix). Date-based suffixes like `@{now}` always
+    // use the reflog entry timestamp in the selector (t1411).
+    let use_reflog_timestamp_in_selector = (cli_date_for_reflog.is_some() && !had_reflog_suffix)
+        || (had_reflog_suffix && matches!(last_reflog_suffix, ReflogWalkSuffixKind::Date));
+
     let max = args.max_count.unwrap_or(usize::MAX);
     let skip = args.skip.unwrap_or(0);
 
     let stdout = io::stdout();
     let mut out = stdout.lock();
+    let mut notes_cache = NotesMapCache::new(repo);
 
     // Detect format
     let is_format_separator = args
@@ -3778,12 +3830,22 @@ fn run_reflog_walk(
             continue;
         }
 
-        let selector = if use_date_selector {
-            format_reflog_selector_date(display_name, entry)
+        let selector = if use_reflog_timestamp_in_selector {
+            format_reflog_selector_date(display_name, entry, cli_date_for_reflog)
         } else {
             let idx_from_tip = nr - 1 - j;
             format!("{display_name}@{{{idx_from_tip}}}")
         };
+
+        let percent_gd = reflog_walk_percent_gd(
+            display_name,
+            entry,
+            nr,
+            j,
+            had_reflog_suffix,
+            last_reflog_suffix,
+            cli_date_for_reflog,
+        );
 
         // NUL separator between entries for multi-line formats
         let is_oneline_fmt = args.format.as_deref() == Some("oneline") || args.oneline;
@@ -3803,14 +3865,26 @@ fn run_reflog_walk(
                     }
                 }
                 "short" => {
-                    writeln!(out, "commit {}", entry.new_oid.to_hex())?;
-                    let author_name = extract_name(&commit_data.author);
-                    writeln!(out, "Author: {author_name}")?;
+                    let abbrev_len = parse_abbrev(&args.abbrev);
+                    let full_hex = entry.new_oid.to_hex();
+                    let abbrev = &full_hex[..abbrev_len.min(full_hex.len())];
+                    writeln!(out, "commit {}", abbrev)?;
+                    let ident_display = if let Some(email_end) = entry.identity.rfind('>') {
+                        &entry.identity[..email_end + 1]
+                    } else {
+                        &entry.identity
+                    };
+                    writeln!(out, "Reflog: {} ({})", selector, ident_display)?;
+                    writeln!(out, "Reflog message: {}", entry.message)?;
+                    writeln!(
+                        out,
+                        "Author: {}",
+                        format_ident_for_header(&commit_data.author)
+                    )?;
                     writeln!(out)?;
                     for line in commit_data.message.lines().take(1) {
                         writeln!(out, "    {line}")?;
                     }
-                    writeln!(out)?;
                 }
                 "medium" => {
                     writeln!(out, "commit {}", entry.new_oid.to_hex())?;
@@ -3921,7 +3995,7 @@ fn run_reflog_walk(
                         fmt_str,
                         &entry.new_oid,
                         &commit_data,
-                        &selector,
+                        &percent_gd,
                         &entry.message,
                         &entry.identity,
                     );
@@ -3965,6 +4039,44 @@ fn run_reflog_walk(
                 writeln!(out, "    {}", line)?;
             }
         }
+
+        let info = CommitInfo {
+            tree: commit_data.tree,
+            parents: commit_data.parents.clone(),
+            author: commit_data.author.clone(),
+            committer: commit_data.committer.clone(),
+            message: commit_data.message.clone(),
+        };
+        let show_diff = args.patch
+            || args.patch_u
+            || !args.stat.is_empty()
+            || args.name_only
+            || args.name_status
+            || args.raw
+            || args.cc
+            || args.merge_diff_c
+            || args.remerge_diff
+            || args.patch_with_stat;
+        if show_diff {
+            write_commit_diff(
+                &mut out,
+                repo,
+                &entry.new_oid,
+                &info,
+                args,
+                &args.pathspecs,
+                None,
+                None,
+                false,
+                &mut notes_cache,
+                patch_context,
+            )?;
+            // Match `git log -p`: blank line after each patch before the next entry (t1411).
+            if j > 0 {
+                writeln!(out)?;
+            }
+        }
+
         shown += 1;
     }
 
@@ -3977,7 +4089,7 @@ fn apply_reflog_format_string(
     fmt: &str,
     oid: &ObjectId,
     commit: &grit_lib::objects::CommitData,
-    selector: &str,
+    percent_gd: &str,
     reflog_msg: &str,
     reflog_identity: &str,
 ) -> String {
@@ -4030,7 +4142,7 @@ fn apply_reflog_format_string(
                     match chars.peek() {
                         Some('d') => {
                             chars.next();
-                            result.push_str(selector);
+                            result.push_str(percent_gd);
                         }
                         Some('s') => {
                             chars.next();

--- a/grit/src/commands/reflog.rs
+++ b/grit/src/commands/reflog.rs
@@ -436,6 +436,10 @@ fn parse_reflog_expire_cli(raw: &str, now: i64) -> Result<i64> {
     if s.eq_ignore_ascii_case("never") || s.eq_ignore_ascii_case("false") {
         return Ok(0);
     }
+    // Git: `--expire=all` removes every reflog entry by age (matches t1411 empty reflog).
+    if s.eq_ignore_ascii_case("all") {
+        return Ok(i64::MAX);
+    }
     if s.eq_ignore_ascii_case("now") || s == "0" {
         return Ok(now);
     }

--- a/logs/2026-04-10-t1411-reflog-show.md
+++ b/logs/2026-04-10-t1411-reflog-show.md
@@ -1,0 +1,14 @@
+# t1411-reflog-show
+
+## Changes
+
+- `reflog expire --expire=all`: parse `all` as prune-all-by-age; remove empty reflog files after expiry (`grit-lib` + CLI parser).
+- `log -g` / reflog walk: `--date` affects `%gd` / `Reflog:` selector only when appropriate; `@{n}` overrides; `HEAD@{now}` keeps `HEAD` as display prefix; `%gd` uses dedicated formatting vs full multiline selector.
+- `reflog --format=short`: Git-style block with reflog lines, full author line, subject only, no extra trailing blank line.
+- `log -g -p`: emit patches via `write_commit_diff` with blank line between entries (t1411).
+
+## Validation
+
+- `./scripts/run-tests.sh t1411-reflog-show.sh` → 17/17
+- `cargo test -p grit-lib --lib`
+- `cargo clippy -p grit-rs -p grit-lib -- -D warnings`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This brings `tests/t1411-reflog-show.sh` to **17/17** by aligning reflog display, `log -g` date/`%gd` behavior, `reflog expire --expire=all`, and `log -g -p` patch output with Git.

## Key changes

- **`reflog expire --expire=all`**: CLI accepts `all` as “expire everything by age”; when the last entry is pruned, the reflog file is removed so `log -g` on an empty branch prints nothing.
- **`log -g` selector display**: Preserve the user prefix before `@{` (e.g. `HEAD@{now}` stays `HEAD` in output). Honor `--date` for `%gd` / multiline `Reflog:` lines without letting `log.date` config imitate `--date`; numeric `@{n}` still wins over `--date` for `%gd`.
- **`git reflog --format=short`**: Emit the Git-style short block including `Reflog:` / `Reflog message:` lines and match the exact trailing newline after the subject line (t1411).
- **`log -g -p`**: Run normal commit diff machinery after each reflog entry and insert the blank line between patches that the test expects.

## Validation

- `./scripts/run-tests.sh t1411-reflog-show.sh`
- `cargo test -p grit-lib --lib`
- `cargo clippy -p grit-rs -p grit-lib -- -D warnings`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0652d8f-5071-4721-883e-a0754dfdfefb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0652d8f-5071-4721-883e-a0754dfdfefb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

