### PR TITLE
fix: stash improvements for t3903 (reflog, apply, show, list)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -664,7 +664,7 @@ t3900-i18n-commit	t3	yes	38	16	22	false	ok	0
 t3901-i18n-patch	t3	yes	20	8	12	false	ok	0
 t3902-quoted	t3	yes	13	12	1	false	ok	0
 t3902-quoted-ls-tree	t3	yes	8	8	0	true	ok	0
-t3903-stash	t3	yes	142	86	56	false	ok	0
+t3903-stash	t3	yes	142	101	41	false	ok	0
 t3904-stash-patch	t3	yes	10	10	0	true	ok	0
 t3905-stash-include-untracked	t3	yes	34	13	21	false	ok	0
 t3906-stash-submodule	t3	yes	8	5	3	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,701 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,701 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T00:29:53+00:00" class="gen-time" title="2026-04-10 00:29 UTC">2026-04-10 00:29 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,701</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>758 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -219,11 +219,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">56/141 files · 2 skipped · 4,052/5,398 tests</span>
+        <span class="group-meta">56/141 files · 2 skipped · 4,067/5,398 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:75.1%"></div></div>
-        <span class="group-pct pct-blue">75.1%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:75.3%"></div></div>
+        <span class="group-pct pct-blue">75.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35701 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,701 / 45,142 tests · 1,405 files in scope · 758 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T00:29:53+00:00" class="gen-time" title="2026-04-10 00:29 UTC">2026-04-10 00:29 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,701</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -6797,14 +6797,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="142" data-passed="86">
+<tr class="" data-group="t3" data-tests="142" data-passed="101">
   <td class="mono">t3903-stash</td>
   <td>t3</td>
   <td></td>
   <td class="right">142</td>
-  <td class="right">86</td>
+  <td class="right">101</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:60.6%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:71.1%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="10" data-passed="10" data-full-pass="1">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/index.rs
+++ b/grit-lib/src/index.rs
@@ -1278,6 +1278,14 @@ fn write_lock_pid_file(pid_path: &Path) -> io::Result<()> {
     Ok(())
 }
 
+/// Detail lines Git prints when the index lock file already exists (used by stash and similar).
+pub fn format_index_lock_blocked_detail(index_path: &Path) -> String {
+    let lock_path = index_path.with_extension("lock");
+    let pid_path = pid_path_for_lock(&lock_path);
+    let err = io::Error::new(io::ErrorKind::AlreadyExists, "File exists");
+    build_lock_exists_message(&lock_path, &pid_path, &err)
+}
+
 fn build_lock_exists_message(lock_path: &Path, pid_path: &Path, err: &io::Error) -> String {
     let mut msg = format!("Unable to create '{}': {}.\n\n", lock_path.display(), err);
 

--- a/grit-lib/src/reflog.rs
+++ b/grit-lib/src/reflog.rs
@@ -266,10 +266,14 @@ pub fn expire_reflog_unreachable(
 
 /// Format a reflog entry back into the on-disk line format.
 fn format_reflog_entry(entry: &ReflogEntry) -> String {
-    format!(
-        "{} {} {}\t{}\n",
-        entry.old_oid, entry.new_oid, entry.identity, entry.message
-    )
+    if entry.message.is_empty() {
+        format!("{} {} {}\n", entry.old_oid, entry.new_oid, entry.identity)
+    } else {
+        format!(
+            "{} {} {}\t{}\n",
+            entry.old_oid, entry.new_oid, entry.identity, entry.message
+        )
+    }
 }
 
 /// Extract the Unix timestamp from an identity string.

--- a/grit-lib/src/rev_parse.rs
+++ b/grit-lib/src/rev_parse.rs
@@ -1906,6 +1906,10 @@ fn dwim_refname(repo: &Repository, raw: &str) -> String {
     if raw.is_empty() || raw == "HEAD" || raw.starts_with("refs/") {
         return raw.to_owned();
     }
+    // Bare `stash` is `refs/stash` (not `refs/heads/stash`); reflog lives at `logs/refs/stash`.
+    if raw == "stash" && refs::resolve_ref(&repo.git_dir, "refs/stash").is_ok() {
+        return "refs/stash".to_owned();
+    }
     let candidate = format!("refs/heads/{raw}");
     if refs::resolve_ref(&repo.git_dir, &candidate).is_ok() {
         candidate

--- a/grit/src/commands/stash.rs
+++ b/grit/src/commands/stash.rs
@@ -11,18 +11,24 @@
 //! Subcommands: push, save, list, show, pop, apply, drop, clear, branch, create, store.
 
 use anyhow::{bail, Context, Result};
-use clap::{Args as ClapArgs, Subcommand};
+use clap::{Args as ClapArgs, Parser, Subcommand};
+
+use crate::explicit_exit::{ExplicitExit, SilentNonZeroExit};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::io::{self, BufRead, Write as IoWrite};
 use std::path::Path;
 
 use grit_lib::config::ConfigSet;
-use grit_lib::diff::{diff_index_to_tree, diff_index_to_worktree, unified_diff};
+use grit_lib::diff::{
+    diff_index_to_tree, diff_index_to_worktree, unified_diff,
+    unified_diff_with_prefix_and_funcname_and_algorithm,
+};
 use grit_lib::error::Error;
 use grit_lib::index::{
     entry_from_stat, Index, IndexEntry, MODE_EXECUTABLE, MODE_GITLINK, MODE_REGULAR, MODE_SYMLINK,
 };
+use grit_lib::merge_diff::{combined_diff_paths, format_combined_textconv_patch};
 use grit_lib::objects::{
     parse_commit, parse_tree, serialize_commit, serialize_tree, CommitData, ObjectId, ObjectKind,
     TreeEntry,
@@ -420,81 +426,116 @@ fn tokens_after_stash_argv() -> Vec<String> {
     argv[idx + 1..].to_vec()
 }
 
-fn assume_push_or_error(args: &Args) -> Result<()> {
-    let mut t = tokens_after_stash_argv();
-    loop {
-        let Some(first) = t.first().cloned() else {
+/// Stash verbs that cannot follow bare `stash` global flags without an explicit `push`/`save`
+/// subcommand (matches Git's `stash -q drop` error). `push` and `save` are excluded because they
+/// are valid after flags (`git stash -q push`).
+const STASH_VERB_AFTER_PUSH_FLAGS: &[&str] = &[
+    "drop", "pop", "apply", "branch", "show", "list", "clear", "create", "store", "export",
+    "import",
+];
+
+/// Skip tokens that belong to the implicit `stash push` form (global flags on `git stash`).
+///
+/// Returns `(index of first non-skipped token, whether any push-style flag was consumed)`.
+fn skip_implicit_stash_push_prefix(rest: &[String]) -> (usize, bool) {
+    let mut i = 0usize;
+    let mut saw_push_flag = false;
+    while i < rest.len() {
+        let a = rest[i].as_str();
+        if a == "--" {
             break;
-        };
-        if first == "--" {
-            break;
         }
-        if first == "-q" || first == "--quiet" {
-            t.remove(0);
-            continue;
-        }
-        if first == "-k" || first == "--keep-index" {
-            t.remove(0);
-            continue;
-        }
-        if first == "--no-keep-index" {
-            t.remove(0);
-            continue;
-        }
-        if first == "-u" || first == "--include-untracked" {
-            t.remove(0);
-            continue;
-        }
-        if first == "-S" || first == "--staged" {
-            t.remove(0);
-            continue;
-        }
-        if first == "-p" || first == "--patch" {
-            t.remove(0);
-            continue;
-        }
-        if first == "-m" || first == "--message" {
-            t.remove(0);
-            if !t.is_empty() {
-                t.remove(0);
+        match a {
+            "-q"
+            | "--quiet"
+            | "-k"
+            | "--keep-index"
+            | "--no-keep-index"
+            | "-u"
+            | "--include-untracked"
+            | "-S"
+            | "--staged"
+            | "-p"
+            | "--patch" => {
+                saw_push_flag = true;
+                i += 1;
             }
-            continue;
-        }
-        if first.starts_with("-m") && first.len() > 2 {
-            t.remove(0);
-            continue;
-        }
-        if let Some(rest) = first.strip_prefix("--message=") {
-            if !rest.is_empty() {
-                t.remove(0);
-                continue;
+            "-m" | "--message" => {
+                saw_push_flag = true;
+                i += 1;
+                if i < rest.len() {
+                    i += 1;
+                }
             }
+            _ if a.starts_with("-m") && a.len() > 2 => {
+                saw_push_flag = true;
+                i += 1;
+            }
+            _ if a
+                .strip_prefix("--message=")
+                .is_some_and(|rest| !rest.is_empty()) =>
+            {
+                saw_push_flag = true;
+                i += 1;
+            }
+            "--pathspec-file-nul" => {
+                saw_push_flag = true;
+                i += 1;
+            }
+            "--pathspec-from-file" => {
+                saw_push_flag = true;
+                i += 1;
+                if i < rest.len() {
+                    i += 1;
+                }
+            }
+            _ if a.starts_with("--pathspec-from-file=") => {
+                saw_push_flag = true;
+                i += 1;
+            }
+            _ => break,
         }
-        break;
     }
-    if let Some(tok) = t.first() {
+    (i, saw_push_flag)
+}
+
+/// Run before clap parses `stash` so `git stash -q drop` is not mistaken for `git stash drop`.
+pub fn pre_parse_stash_argv_guard(rest: &[String]) -> Result<()> {
+    let (i, saw_push_flag) = skip_implicit_stash_push_prefix(rest);
+    if !saw_push_flag {
+        return Ok(());
+    }
+    let Some(tok) = rest.get(i) else {
+        return Ok(());
+    };
+    if tok == "--" {
+        return Ok(());
+    }
+    if STASH_VERB_AFTER_PUSH_FLAGS.contains(&tok.as_str()) {
+        return Err(anyhow::Error::new(ExplicitExit {
+            code: 128,
+            message: format!(
+                "fatal: subcommand wasn't specified; 'push' can't be assumed due to unexpected token '{tok}'"
+            ),
+        }));
+    }
+    Ok(())
+}
+
+fn assume_push_or_error(args: &Args) -> Result<()> {
+    let t = tokens_after_stash_argv();
+    let (i, _) = skip_implicit_stash_push_prefix(&t);
+    if let Some(tok) = t.get(i) {
         if tok == "--" {
             return Ok(());
         }
-        if matches!(
-            tok.as_str(),
-            "drop"
-                | "pop"
-                | "apply"
-                | "branch"
-                | "show"
-                | "list"
-                | "clear"
-                | "push"
-                | "save"
-                | "create"
-                | "store"
-                | "export"
-                | "import"
-        ) {
-            bail!(
-                "subcommand wasn't specified; 'push' can't be assumed due to unexpected token '{tok}'"
-            );
+        if STASH_VERB_AFTER_PUSH_FLAGS.contains(&tok.as_str()) {
+            return Err(anyhow::Error::new(ExplicitExit {
+                code: 128,
+                message: format!(
+                    "fatal: subcommand wasn't specified; 'push' can't be assumed due to unexpected token '{tok}'"
+                ),
+            }));
         }
     }
     let _ = args;
@@ -607,6 +648,22 @@ fn parse_stash_show_args(raw: &[String]) -> Result<ParsedStashShow> {
 // Push options
 // ---------------------------------------------------------------------------
 
+/// Fail before stash work when `index.lock` exists (matches t3903 / Git's pre-write check).
+fn stash_preflight_index_writable(repo: &Repository) -> Result<()> {
+    let index_path = repo.index_path();
+    let lock_path = index_path.with_extension("lock");
+    if index_path.exists() && lock_path.exists() {
+        eprintln!("error: could not write index");
+        eprintln!();
+        let detail = grit_lib::index::format_index_lock_blocked_detail(&index_path);
+        for line in detail.lines() {
+            eprintln!("error: {line}");
+        }
+        return Err(anyhow::Error::new(SilentNonZeroExit { code: 1 }));
+    }
+    Ok(())
+}
+
 struct PushOpts {
     message: Option<String>,
     keep_index: bool,
@@ -654,6 +711,7 @@ fn stash_is_intent_to_add_only(
 
 fn do_push(opts: PushOpts) -> Result<()> {
     let repo = Repository::discover(None).context("not a git repository")?;
+    stash_preflight_index_writable(&repo)?;
     let work_tree = repo
         .work_tree
         .as_deref()
@@ -791,6 +849,7 @@ fn do_stash_patch_push(
 ) -> Result<()> {
     use similar::{Algorithm, TextDiff};
 
+    stash_preflight_index_writable(repo)?;
     let head_obj = repo.odb.read(&head_oid)?;
     let head_commit = parse_commit(&head_obj.data)?;
     let head_tree_entries = flatten_tree_full(&repo.odb, &head_commit.tree, "")?;
@@ -1302,6 +1361,7 @@ fn do_push_pathspec(
     index: &Index,
     opts: &PushOpts,
 ) -> Result<()> {
+    stash_preflight_index_writable(repo)?;
     let head_obj = repo.odb.read(head_oid)?;
     let head_commit = parse_commit(&head_obj.data)?;
 
@@ -1508,6 +1568,7 @@ fn do_push_staged(
     index: &Index,
     opts: &PushOpts,
 ) -> Result<()> {
+    stash_preflight_index_writable(repo)?;
     let head_obj = repo.odb.read(head_oid)?;
     let head_commit = parse_commit(&head_obj.data)?;
 
@@ -1621,6 +1682,7 @@ fn do_create(message: Option<String>) -> Result<()> {
         .ok_or_else(|| anyhow::anyhow!("cannot stash in a bare repository"))?
         .to_path_buf();
 
+    stash_preflight_index_writable(&repo)?;
     let head = resolve_head(&repo.git_dir)?;
     let head_oid = head
         .oid()
@@ -1841,24 +1903,212 @@ fn do_import(revision: String) -> Result<()> {
 // List
 // ---------------------------------------------------------------------------
 
-fn do_list(extra_args: Vec<String>) -> Result<()> {
-    let repo = Repository::discover(None).context("not a git repository")?;
-    let entries = read_reflog(&repo.git_dir, "refs/stash")?;
+/// `git stash list -3` passes `-3` as a single argv token; clap would reject it for `git log`.
+/// Normalize to `-n 3` (and similar for any `-` + all-digits).
+fn preprocess_stash_list_argv_for_log(args: &[String]) -> Vec<String> {
+    let mut out = Vec::with_capacity(args.len() + 4);
+    for a in args {
+        if a.len() > 1
+            && a.starts_with('-')
+            && !a.starts_with("--")
+            && a[1..].chars().all(|c| c.is_ascii_digit())
+        {
+            out.push("-n".to_owned());
+            out.push(a[1..].to_owned());
+        } else {
+            out.push(a.clone());
+        }
+    }
+    out
+}
 
-    // Check if -p flag was passed
-    let show_patch = extra_args.iter().any(|a| a == "-p" || a == "--patch");
-    let show_cc = extra_args.iter().any(|a| a == "--cc");
+struct ParsedStashList {
+    max_count: Option<usize>,
+    /// `true` when `--format=%gd` (t3903 stash list -p / --cc).
+    format_gd_only: bool,
+    show_patch: bool,
+    show_cc: bool,
+    unknown: Vec<String>,
+}
 
-    // Entries are in file order (oldest first), display newest first
-    for (i, entry) in entries.iter().rev().enumerate() {
-        println!("stash@{{{i}}}: {}", entry.message);
-        if show_patch || show_cc {
-            // Show diff for this stash entry
-            if let Ok(stash_oid) = resolve_stash_ref(&repo, Some(&format!("stash@{{{i}}}"))) {
-                let _ = show_stash_diff(&repo, &stash_oid, true);
+fn parse_stash_list_args(args: &[String]) -> ParsedStashList {
+    let mut max_count: Option<usize> = None;
+    let mut format_gd_only = false;
+    let mut show_patch = false;
+    let mut show_cc = false;
+    let mut unknown: Vec<String> = Vec::new();
+    let mut i = 0usize;
+    while i < args.len() {
+        let a = args[i].as_str();
+        if a.len() > 1
+            && a.starts_with('-')
+            && !a.starts_with("--")
+            && a[1..].chars().all(|c| c.is_ascii_digit())
+        {
+            if let Ok(n) = a[1..].parse::<usize>() {
+                max_count = Some(n);
+            }
+            i += 1;
+            continue;
+        }
+        match a {
+            "-p" | "--patch" => {
+                show_patch = true;
+                i += 1;
+            }
+            "--cc" => {
+                show_cc = true;
+                i += 1;
+            }
+            "-n" | "--max-count" => {
+                if i + 1 < args.len() {
+                    if let Ok(n) = args[i + 1].parse::<usize>() {
+                        max_count = Some(n);
+                    }
+                    i += 2;
+                } else {
+                    unknown.push(args[i].clone());
+                    i += 1;
+                }
+            }
+            _ if a.starts_with("--max-count=") => {
+                if let Ok(n) = a
+                    .strip_prefix("--max-count=")
+                    .unwrap_or("")
+                    .parse::<usize>()
+                {
+                    max_count = Some(n);
+                }
+                i += 1;
+            }
+            "--format" => {
+                if i + 1 < args.len() {
+                    let fmt = &args[i + 1];
+                    format_gd_only = fmt == "%gd";
+                    if !format_gd_only {
+                        unknown.push("--format".to_owned());
+                        unknown.push(fmt.clone());
+                    }
+                    i += 2;
+                } else {
+                    unknown.push(args[i].clone());
+                    i += 1;
+                }
+            }
+            _ if a.starts_with("--format=") => {
+                let fmt = a.strip_prefix("--format=").unwrap_or("");
+                format_gd_only = fmt == "%gd";
+                if !format_gd_only {
+                    unknown.push(args[i].clone());
+                }
+                i += 1;
+            }
+            _ => {
+                unknown.push(args[i].clone());
+                i += 1;
             }
         }
     }
+    ParsedStashList {
+        max_count,
+        format_gd_only,
+        show_patch,
+        show_cc,
+        unknown,
+    }
+}
+
+fn stash_list_print_combined_patch(repo: &Repository, stash_oid: &ObjectId) -> Result<()> {
+    let config = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_else(|_| ConfigSet::new());
+    let obj = repo.odb.read(stash_oid)?;
+    let commit = parse_commit(&obj.data)?;
+    if commit.parents.len() < 2 {
+        return Ok(());
+    }
+    let mut parent_trees = Vec::new();
+    for p in commit.parents.iter().take(2) {
+        let po = repo.odb.read(p)?;
+        let pc = parse_commit(&po.data)?;
+        parent_trees.push(pc.tree);
+    }
+    if parent_trees.len() != 2 {
+        return Ok(());
+    }
+    let paths = combined_diff_paths(&repo.odb, &commit.tree, &commit.parents);
+    let abbrev_len = 7usize;
+    let context = 3usize;
+    for path in paths {
+        if let Some(patch) = format_combined_textconv_patch(
+            &repo.git_dir,
+            &config,
+            &repo.odb,
+            &path,
+            &parent_trees,
+            &commit.tree,
+            abbrev_len,
+            context,
+            true,
+            false,
+        ) {
+            print!("{patch}");
+        }
+    }
+    Ok(())
+}
+
+fn do_list(extra_args: Vec<String>) -> Result<()> {
+    let parsed = parse_stash_list_args(&extra_args);
+    if !parsed.unknown.is_empty() {
+        #[derive(Parser)]
+        struct StashListLogCli {
+            #[command(flatten)]
+            log: super::log::Args,
+        }
+
+        let log_argv = preprocess_stash_list_argv_for_log(&extra_args);
+        let mut argv = vec!["git log".to_owned(), "-g".to_owned()];
+        argv.extend(log_argv);
+        argv.push("refs/stash".to_owned());
+        match StashListLogCli::try_parse_from(&argv) {
+            Ok(wrapped) => return super::log::run(wrapped.log),
+            Err(e) => {
+                let mut msg = e.render().to_string();
+                msg = msg.replace("Usage:", "usage:");
+                eprint!("{msg}");
+                std::process::exit(129);
+            }
+        }
+    }
+
+    let repo = Repository::discover(None).context("not a git repository")?;
+    let entries = read_reflog(&repo.git_dir, "refs/stash")?;
+    let n_entries = entries.len();
+    let mut shown = 0usize;
+
+    for (i, entry) in entries.iter().rev().enumerate() {
+        if let Some(limit) = parsed.max_count {
+            if shown >= limit {
+                break;
+            }
+        }
+        if parsed.format_gd_only {
+            println!("stash@{{{i}}}");
+        } else {
+            println!("stash@{{{i}}}: {}", entry.message.trim_end_matches('\n'));
+        }
+        if parsed.show_patch {
+            println!();
+            let stash_oid = entry.new_oid;
+            if parsed.show_cc {
+                stash_list_print_combined_patch(&repo, &stash_oid)?;
+            } else {
+                show_stash_diff(&repo, &stash_oid, true, false)?;
+            }
+        }
+        shown += 1;
+    }
+
+    let _ = n_entries;
     Ok(())
 }
 
@@ -1881,10 +2131,7 @@ fn do_show(stash_ref: Option<String>, mode: ShowMode, patience: bool) -> Result<
 
     match mode {
         ShowMode::Patch => {
-            if patience {
-                // Patience is accepted; diff algorithm not wired — same output as default.
-            }
-            show_stash_diff(&repo, &stash_oid, true)?;
+            show_stash_diff(&repo, &stash_oid, true, patience)?;
         }
         ShowMode::NameStatus => show_stash_name_status(&repo, &stash_oid, true)?,
         ShowMode::NameOnly => show_stash_name_status(&repo, &stash_oid, false)?,
@@ -1902,7 +2149,7 @@ fn show_stash_name_status(
 ) -> Result<()> {
     let obj = repo.odb.read(stash_oid)?;
     let stash_commit = parse_commit(&obj.data)?;
-    let old_tree = stash_index_tree_oid(repo, &stash_commit)?;
+    let old_tree = stash_show_base_tree_oid(repo, &stash_commit)?;
     let old_entries = flatten_tree_full(&repo.odb, &old_tree, "")?;
     let new_entries = flatten_tree_full(&repo.odb, &stash_commit.tree, "")?;
 
@@ -1943,26 +2190,37 @@ fn show_stash_name_status(
     Ok(())
 }
 
-/// Tree for the "old" side of `git stash show`: the index snapshot (`stash^2`), not `stash^1`.
-fn stash_index_tree_oid(repo: &Repository, stash_commit: &CommitData) -> Result<ObjectId> {
-    let idx_parent = stash_commit
+/// Tree for the "old" side of `git stash show` / `stash list -p`: `stash^` (HEAD at stash time),
+/// not the index snapshot (`stash^2`).
+fn stash_show_base_tree_oid(repo: &Repository, stash_commit: &CommitData) -> Result<ObjectId> {
+    let head_parent = stash_commit
         .parents
-        .get(1)
-        .ok_or_else(|| anyhow::anyhow!("corrupt stash commit: expected index parent"))?;
-    let idx_obj = repo.odb.read(idx_parent)?;
-    let idx_commit = parse_commit(&idx_obj.data)?;
-    Ok(idx_commit.tree)
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("corrupt stash commit: expected HEAD parent"))?;
+    let p_obj = repo.odb.read(head_parent)?;
+    let p_commit = parse_commit(&p_obj.data)?;
+    Ok(p_commit.tree)
 }
 
-fn show_stash_diff(repo: &Repository, stash_oid: &ObjectId, _with_hunks: bool) -> Result<()> {
+fn show_stash_diff(
+    repo: &Repository,
+    stash_oid: &ObjectId,
+    _with_hunks: bool,
+    patience: bool,
+) -> Result<()> {
     let obj = repo.odb.read(stash_oid)?;
     let stash_commit = parse_commit(&obj.data)?;
 
-    let old_tree = stash_index_tree_oid(repo, &stash_commit)?;
+    let old_tree = stash_show_base_tree_oid(repo, &stash_commit)?;
     let old_entries = flatten_tree_full(&repo.odb, &old_tree, "")?;
     let new_entries = flatten_tree_full(&repo.odb, &stash_commit.tree, "")?;
 
-    show_tree_diff(&repo.odb, &old_entries, &new_entries)?;
+    let algorithm = if patience {
+        similar::Algorithm::Patience
+    } else {
+        similar::Algorithm::Myers
+    };
+    show_tree_diff(&repo.odb, &old_entries, &new_entries, algorithm)?;
 
     Ok(())
 }
@@ -1971,7 +2229,7 @@ fn show_stash_stat(repo: &Repository, stash_oid: &ObjectId) -> Result<()> {
     let obj = repo.odb.read(stash_oid)?;
     let stash_commit = parse_commit(&obj.data)?;
 
-    let old_tree = stash_index_tree_oid(repo, &stash_commit)?;
+    let old_tree = stash_show_base_tree_oid(repo, &stash_commit)?;
     let old_entries = flatten_tree_full(&repo.odb, &old_tree, "")?;
     let new_entries = flatten_tree_full(&repo.odb, &stash_commit.tree, "")?;
 
@@ -2070,7 +2328,7 @@ fn show_stash_stat(repo: &Repository, stash_oid: &ObjectId) -> Result<()> {
         let bar_del = (s.deletions as f64 * scale).ceil() as usize;
         let bar = format!("{}{}", "+".repeat(bar_ins), "-".repeat(bar_del));
         println!(
-            " {:<width$} | {:>3} {}",
+            " {:<width$} |{:>3} {}",
             s.path,
             changes,
             bar,
@@ -2131,7 +2389,7 @@ fn blob_is_binary(data: &[u8]) -> bool {
 fn show_stash_numstat(repo: &Repository, stash_oid: &ObjectId) -> Result<()> {
     let obj = repo.odb.read(stash_oid)?;
     let stash_commit = parse_commit(&obj.data)?;
-    let old_tree = stash_index_tree_oid(repo, &stash_commit)?;
+    let old_tree = stash_show_base_tree_oid(repo, &stash_commit)?;
     let old_entries = flatten_tree_full(&repo.odb, &old_tree, "")?;
     let new_entries = flatten_tree_full(&repo.odb, &stash_commit.tree, "")?;
 
@@ -2201,6 +2459,7 @@ fn do_pop(stash_ref: Option<String>, index: bool, quiet: bool) -> Result<()> {
         .ok_or_else(|| anyhow::anyhow!("cannot apply stash in a bare repository"))?
         .to_path_buf();
 
+    stash_preflight_index_writable(&repo)?;
     reject_bare_oid_for_stash_stack_op(&repo, stash_ref.as_deref())?;
     let stash_index = parse_stash_index(stash_ref.as_deref())?;
     let stash_oid = resolve_stash_ref(&repo, stash_ref.as_deref())?;
@@ -2238,6 +2497,7 @@ fn do_apply(stash_ref: Option<String>, _drop_after: bool, index: bool, quiet: bo
         .ok_or_else(|| anyhow::anyhow!("cannot apply stash in a bare repository"))?
         .to_path_buf();
 
+    stash_preflight_index_writable(&repo)?;
     let stash_oid = resolve_stash_ref(&repo, stash_ref.as_deref())?;
 
     let had_conflicts = apply_stash_impl(&repo, &work_tree, &stash_oid, index, quiet)?;
@@ -2604,6 +2864,10 @@ fn apply_stash_impl(
     } else {
         // Without --index: index tracks current HEAD for paths the stash touched
         // (worktree gets the stashed changes; index matches HEAD at those paths).
+        //
+        // Exception: paths that exist in the stash index parent but not on **current** HEAD
+        // (e.g. a newly `git add`ed file) must be re-staged from the stash index parent
+        // (t3903 `stash an added file`).
         let mut touched: BTreeSet<String> = BTreeSet::new();
         for p in wt_changes.keys() {
             touched.insert(p.clone());
@@ -2647,7 +2911,47 @@ fn apply_stash_impl(
                     new_index.stage_file(new_entry);
                 }
             } else {
-                new_index.remove(path.as_bytes());
+                let path_bytes = path.as_bytes();
+                let has_unmerged = new_index
+                    .entries
+                    .iter()
+                    .any(|e| e.path == path_bytes && e.stage() > 0);
+                if has_unmerged {
+                    continue;
+                }
+                if let Some(ie) = idx_map.get(path.as_str()) {
+                    let had_staged = match base_map.get(path.as_str()) {
+                        Some(b) => b.oid != ie.oid || b.mode != ie.mode,
+                        None => true,
+                    };
+                    if had_staged {
+                        let size = if ie.mode == MODE_SYMLINK || ie.mode == MODE_GITLINK {
+                            0u32
+                        } else {
+                            repo.odb.read(&ie.oid)?.data.len() as u32
+                        };
+                        new_index.stage_file(IndexEntry {
+                            ctime_sec: 0,
+                            ctime_nsec: 0,
+                            mtime_sec: 0,
+                            mtime_nsec: 0,
+                            dev: 0,
+                            ino: 0,
+                            mode: ie.mode,
+                            uid: 0,
+                            gid: 0,
+                            size,
+                            oid: ie.oid,
+                            flags: path_bytes.len().min(0xFFF) as u16,
+                            flags_extended: None,
+                            path: path_bytes.to_vec(),
+                        });
+                    } else {
+                        new_index.remove(path_bytes);
+                    }
+                } else {
+                    new_index.remove(path_bytes);
+                }
             }
         }
         new_index.sort();
@@ -2789,6 +3093,7 @@ fn do_branch(branch_name: String, stash_ref: Option<String>) -> Result<()> {
         .ok_or_else(|| anyhow::anyhow!("cannot use stash branch in a bare repository"))?
         .to_path_buf();
 
+    stash_preflight_index_writable(&repo)?;
     let stash_index = parse_stash_index(stash_ref.as_deref())?;
     let stash_oid = resolve_stash_ref(&repo, stash_ref.as_deref())?;
 
@@ -2979,7 +3284,10 @@ fn create_stash_commit(
     };
 
     // 3. Create the working-tree state commit
-    let wt_tree_oid = create_worktree_tree(&repo.odb, index, work_tree)?;
+    let head_obj = repo.odb.read(head_oid)?;
+    let head_commit_for_tree = parse_commit(&head_obj.data)?;
+    let wt_tree_oid =
+        create_worktree_tree(&repo.odb, index, work_tree, &head_commit_for_tree.tree)?;
 
     let stash_msg = stash_save_msg(head, message);
 
@@ -3287,8 +3595,22 @@ fn flatten_tree_full(odb: &Odb, tree_oid: &ObjectId, prefix: &str) -> Result<Vec
     Ok(result)
 }
 
+fn git_index_mode_tag(mode: u32) -> String {
+    match mode {
+        MODE_REGULAR => "100644".to_owned(),
+        MODE_EXECUTABLE => "100755".to_owned(),
+        MODE_SYMLINK => "120000".to_owned(),
+        _ => format!("{mode:o}"),
+    }
+}
+
 /// Show diff between two flattened trees.
-fn show_tree_diff(odb: &Odb, old: &[FlatTreeEntry], new: &[FlatTreeEntry]) -> Result<()> {
+fn show_tree_diff(
+    odb: &Odb,
+    old: &[FlatTreeEntry],
+    new: &[FlatTreeEntry],
+    algorithm: similar::Algorithm,
+) -> Result<()> {
     use std::collections::BTreeMap;
 
     let mut old_map: BTreeMap<&str, &FlatTreeEntry> = BTreeMap::new();
@@ -3317,57 +3639,86 @@ fn show_tree_diff(odb: &Odb, old: &[FlatTreeEntry], new: &[FlatTreeEntry]) -> Re
                         println!("old mode {}", format_mode(o.mode));
                         println!("new mode {}", format_mode(n.mode));
                     }
-                    println!("index {}..{}", &o.oid.to_hex()[..7], &n.oid.to_hex()[..7]);
-                    println!("--- a/{path}");
-                    println!("+++ b/{path}");
-                    show_blob_diff(odb, &o.oid, &n.oid)?;
+                    let om = git_index_mode_tag(n.mode);
+                    println!(
+                        "index {}..{} {}",
+                        &o.oid.to_hex()[..7],
+                        &n.oid.to_hex()[..7],
+                        om
+                    );
+                    let old_blob = odb.read(&o.oid)?;
+                    let new_blob = odb.read(&n.oid)?;
+                    let old_text = String::from_utf8_lossy(&old_blob.data);
+                    let new_text = String::from_utf8_lossy(&new_blob.data);
+                    let patch = unified_diff_with_prefix_and_funcname_and_algorithm(
+                        old_text.as_ref(),
+                        new_text.as_ref(),
+                        path,
+                        path,
+                        0,
+                        0,
+                        "a/",
+                        "b/",
+                        None,
+                        algorithm,
+                    );
+                    print!("{patch}");
                 }
             }
             (None, Some(n)) => {
                 println!("diff --git a/{path} b/{path}");
                 println!("new file mode {}", format_mode(n.mode));
-                println!("--- /dev/null");
-                println!("+++ b/{path}");
+                let nm = git_index_mode_tag(n.mode);
+                println!(
+                    "index {}..{} {}",
+                    &ObjectId::zero().to_hex()[..7],
+                    &n.oid.to_hex()[..7],
+                    nm
+                );
                 let blob = odb.read(&n.oid)?;
-                let text = String::from_utf8_lossy(&blob.data);
-                for line in text.lines() {
-                    println!("+{line}");
-                }
+                let new_text = String::from_utf8_lossy(&blob.data);
+                let patch = unified_diff_with_prefix_and_funcname_and_algorithm(
+                    "",
+                    new_text.as_ref(),
+                    "/dev/null",
+                    path,
+                    0,
+                    0,
+                    "a/",
+                    "b/",
+                    None,
+                    algorithm,
+                );
+                print!("{patch}");
             }
             (Some(o), None) => {
                 println!("diff --git a/{path} b/{path}");
                 println!("deleted file mode {}", format_mode(o.mode));
-                println!("--- a/{path}");
-                println!("+++ /dev/null");
+                let om = git_index_mode_tag(o.mode);
+                println!(
+                    "index {}..{} {}",
+                    &o.oid.to_hex()[..7],
+                    &ObjectId::zero().to_hex()[..7],
+                    om
+                );
                 let blob = odb.read(&o.oid)?;
-                let text = String::from_utf8_lossy(&blob.data);
-                for line in text.lines() {
-                    println!("-{line}");
-                }
+                let old_text = String::from_utf8_lossy(&blob.data);
+                let patch = unified_diff_with_prefix_and_funcname_and_algorithm(
+                    old_text.as_ref(),
+                    "",
+                    path,
+                    "/dev/null",
+                    0,
+                    0,
+                    "a/",
+                    "b/",
+                    None,
+                    algorithm,
+                );
+                print!("{patch}");
             }
             (None, None) => unreachable!(),
         }
-    }
-
-    Ok(())
-}
-
-/// Show a simple line diff between two blobs.
-fn show_blob_diff(odb: &Odb, old_oid: &ObjectId, new_oid: &ObjectId) -> Result<()> {
-    let old_blob = odb.read(old_oid)?;
-    let new_blob = odb.read(new_oid)?;
-    let old_text = String::from_utf8_lossy(&old_blob.data);
-    let new_text = String::from_utf8_lossy(&new_blob.data);
-
-    use similar::TextDiff;
-    let diff = TextDiff::from_lines(&old_text as &str, &new_text as &str);
-    for change in diff.iter_all_changes() {
-        let sign = match change.tag() {
-            similar::ChangeTag::Delete => "-",
-            similar::ChangeTag::Insert => "+",
-            similar::ChangeTag::Equal => " ",
-        };
-        print!("{sign}{change}");
     }
 
     Ok(())
@@ -3506,8 +3857,80 @@ fn create_untracked_tree(odb: &Odb, work_tree: &Path, files: &[String]) -> Resul
 }
 
 /// Create a tree representing the working tree state of all tracked files.
-fn create_worktree_tree(odb: &Odb, index: &Index, work_tree: &Path) -> Result<ObjectId> {
+///
+/// `head_tree` is the tree at `HEAD` when the stash is created. Paths that still exist on disk
+/// but are absent from the index (e.g. after `git rm` / staged deletion in Git-compatible form)
+/// must still be captured — Git keeps a stage-0 "deleted" entry in the index; grit `rm` may drop
+/// the path entirely, so we merge in any `HEAD` path missing from the index when the worktree
+/// file is present (`t3903` stash after `rm` + recreate).
+fn create_worktree_tree(
+    odb: &Odb,
+    index: &Index,
+    work_tree: &Path,
+    head_tree: &ObjectId,
+) -> Result<ObjectId> {
     let mut temp_index = index.clone();
+
+    let head_entries = flatten_tree_full(odb, head_tree, "")?;
+    let index_paths: BTreeSet<Vec<u8>> = temp_index
+        .entries
+        .iter()
+        .filter(|e| e.stage() == 0)
+        .map(|e| e.path.clone())
+        .collect();
+    for fe in &head_entries {
+        if index_paths.contains(fe.path.as_bytes()) {
+            continue;
+        }
+        let file_path = work_tree.join(&fe.path);
+        let path_bytes = fe.path.as_bytes();
+        let flags = path_bytes.len().min(0xFFF) as u16;
+        match fs::symlink_metadata(&file_path) {
+            Ok(meta) => {
+                if meta.is_symlink() {
+                    let target = fs::read_link(&file_path)?;
+                    let target_bytes = target.to_string_lossy().into_owned().into_bytes();
+                    let oid = odb.write(ObjectKind::Blob, &target_bytes)?;
+                    temp_index.add_or_replace(IndexEntry {
+                        ctime_sec: 0,
+                        ctime_nsec: 0,
+                        mtime_sec: 0,
+                        mtime_nsec: 0,
+                        dev: 0,
+                        ino: 0,
+                        mode: MODE_SYMLINK,
+                        uid: 0,
+                        gid: 0,
+                        size: 0,
+                        oid,
+                        flags,
+                        flags_extended: None,
+                        path: path_bytes.to_vec(),
+                    });
+                } else if meta.is_file() {
+                    let data = fs::read(&file_path)?;
+                    let oid = odb.write(ObjectKind::Blob, &data)?;
+                    temp_index.add_or_replace(IndexEntry {
+                        ctime_sec: 0,
+                        ctime_nsec: 0,
+                        mtime_sec: 0,
+                        mtime_nsec: 0,
+                        dev: 0,
+                        ino: 0,
+                        mode: mode_from_metadata(&meta),
+                        uid: 0,
+                        gid: 0,
+                        size: 0,
+                        oid,
+                        flags,
+                        flags_extended: None,
+                        path: path_bytes.to_vec(),
+                    });
+                }
+            }
+            Err(_) => {}
+        }
+    }
 
     // Collect directory prefixes that are implied by the index (e.g. if the index
     // has `dir/file`, then `dir` is an implied directory component).
@@ -3775,6 +4198,9 @@ fn reset_worktree_to_index(repo: &Repository, index: &Index, work_tree: &Path) -
             #[cfg(unix)]
             std::os::unix::fs::symlink(&target, &file_path)?;
         } else {
+            if file_path.symlink_metadata().is_ok() {
+                let _ = fs::remove_file(&file_path);
+            }
             fs::write(&file_path, &blob.data)?;
             #[cfg(unix)]
             {
@@ -3791,6 +4217,12 @@ fn reset_worktree_to_index(repo: &Repository, index: &Index, work_tree: &Path) -
 
 /// Reset index and working tree to HEAD.
 fn reset_to_head(repo: &Repository, head_oid: &ObjectId, work_tree: &Path) -> Result<()> {
+    let old_index = match repo.load_index() {
+        Ok(idx) => idx,
+        Err(Error::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => Index::new(),
+        Err(e) => return Err(e.into()),
+    };
+
     let head_obj = repo.odb.read(head_oid)?;
     let head_commit = parse_commit(&head_obj.data)?;
 
@@ -3800,6 +4232,28 @@ fn reset_to_head(repo: &Repository, head_oid: &ObjectId, work_tree: &Path) -> Re
     // First pass: remove worktree files that are not in HEAD tree
     // (handles type changes like file→directory)
     let head_paths: BTreeSet<String> = tree_entries.iter().map(|e| e.path.clone()).collect();
+
+    // Remove paths that were tracked in the pre-reset index but do not exist on HEAD
+    // (e.g. `git add` of a new file then `stash` / `reset --hard` must drop the file from disk).
+    for ie in &old_index.entries {
+        if ie.stage() != 0 {
+            continue;
+        }
+        let path_str = String::from_utf8_lossy(&ie.path).to_string();
+        if head_paths.contains(&path_str) {
+            continue;
+        }
+        let p = work_tree.join(&path_str);
+        if p.is_dir() {
+            let _ = fs::remove_dir_all(&p);
+        } else {
+            let _ = fs::remove_file(&p);
+        }
+        if let Some(parent) = p.parent() {
+            remove_empty_dirs(parent, work_tree);
+        }
+    }
+
     remove_worktree_extras(work_tree, work_tree, &head_paths)?;
 
     for entry in &tree_entries {
@@ -3820,6 +4274,10 @@ fn reset_to_head(repo: &Repository, head_oid: &ObjectId, work_tree: &Path) -> Re
             // If the path is a directory, remove it first (type change: dir→file).
             if file_path.is_dir() {
                 fs::remove_dir_all(&file_path)?;
+            } else if file_path.symlink_metadata().is_ok() {
+                // File→symlink in the worktree: must replace the symlink with the tree blob
+                // (otherwise `fs::write` follows the link; t3903 stash file→symlink).
+                let _ = fs::remove_file(&file_path);
             }
             fs::write(&file_path, &blob.data)?;
             #[cfg(unix)]

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -2571,9 +2571,9 @@ fn print_stash_invalid_option_usage_header() {
         let Some(first) = var.first() else {
             continue;
         };
-        println!("   or: {first}");
+        eprintln!("   or: {first}");
         for cont in var.iter().skip(1) {
-            println!("{pad}{cont}");
+            eprintln!("{pad}{cont}");
         }
     }
 }
@@ -2864,6 +2864,10 @@ fn run() -> Result<()> {
             std::process::exit(1);
         }
     };
+
+    if subcmd == "stash" {
+        commands::stash::pre_parse_stash_argv_guard(&rest)?;
+    }
 
     // t0017-env-helper expects config to be loaded very early when
     // GIT_TEST_ENV_HELPER=true, even before applying -C.

--- a/logs/2026-04-10_t3903-stash-progress.md
+++ b/logs/2026-04-10_t3903-stash-progress.md
@@ -1,0 +1,19 @@
+# t3903-stash progress (2026-04-10)
+
+## Summary
+
+Improved stash/reflog/diff behavior; harness **101/142** passing (was 85/142 at start of session).
+
+## Changes (high level)
+
+- **Reflog**: `stash@{n}` resolves via `logs/refs/stash` (dwim `stash` → `refs/stash`); empty reflog message lines no longer written.
+- **CLI**: Invalid `stash` options print `or:` lines to stderr; `pre_parse_stash_argv_guard` fixes `stash -q drop` vs `stash drop`.
+- **Index lock**: stash create/push/apply/pop/branch preflight matches t3903 messages.
+- **Stash tree**: merge HEAD paths missing from index when disk has content (post-`rm` + recreate); `reset_to_head` removes tracked paths not on HEAD; replace symlinks when writing regular files from HEAD.
+- **Apply**: re-stage paths absent from current HEAD but present in stash index parent.
+- **Show/list**: diff base is `stash^` (HEAD tree); Git-style index line + unified hunks; stat bar spacing; `--cc` list; `-N` list parsing.
+- **Public**: `grit_lib::index::format_index_lock_blocked_detail`.
+
+## Remaining failures (41)
+
+Includes: stash branch with stash-like OID, bare-OID drop/pop errors, numeric stash refs, pathspec stash, export/import, skip-worktree, fsync batch, detached HEAD messages, submodule branch name in message, `stash list` edge cases vs full `git log`, etc.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Progress on `t3903-stash.sh`: harness now reports **101/142** passing (up from 85/142).

## What changed

- **Reflog**: `stash@{n}` resolves using `logs/refs/stash` by mapping bare `stash` to `refs/stash` in reflog DWIM; avoid writing bogus empty reflog message lines.
- **CLI**: Print invalid-option `or: git stash …` lines to **stderr**; add `pre_parse_stash_argv_guard` so `git stash -q drop` is not parsed as `stash drop` (matches Git’s assume-push error).
- **Locked index**: Pre-flight stash create/push/apply/pop/branch when `index.lock` exists; expose `grit_lib::index::format_index_lock_blocked_detail` for Git-style messages.
- **Stash capture**: When building the stash working tree, merge in **HEAD** paths that are missing from the index but still exist on disk (covers `rm` + recreate where grit dropped the index entry).
- **reset_to_head**: Remove tracked paths not on HEAD before reset; remove symlinks before writing regular files from HEAD.
- **stash apply**: Re-stage paths that are not on current HEAD but had staged content in the stash index parent.
- **stash show / stash list**: Diff old side is `stash^` (HEAD tree), not `stash^2`; Git-style `index … 100644` lines and unified hunks; stat bar spacing; `stash list --format=%gd -p` / `--cc` handling; parse `-N` as max-count.

## Remaining

41 tests still fail (branch with stash-like OID, bare OID drop/pop, numeric refs, pathspec stash, export/import, skip-worktree, `core.fsyncmethod=batch`, detached HEAD subject lines, submodule message, fuller `stash list` passthrough to `log`, etc.).

## Validation

- `cargo fmt`, `cargo clippy -p grit-rs -p grit-lib --fix --allow-dirty`
- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t3903-stash.sh --timeout 120`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-953e2587-71fe-465e-b970-86d41f8416c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-953e2587-71fe-465e-b970-86d41f8416c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

