### PR TITLE
fix: partial clone promisor layout and ODB/fetch materialization (t5616 progress)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1011,7 +1011,7 @@ t5612-clone-refspec	t5	yes	13	3	10	false	ok	0
 t5613-info-alternate	t5	yes	13	13	0	true	ok	0
 t5614-clone-submodules-shallow	t5	yes	9	9	0	true	ok	0
 t5615-alternate-env	t5	yes	9	9	0	true	ok	0
-t5616-partial-clone	t5	yes	0	0	0	false	timeout	0
+t5616-partial-clone	t5	yes	47	13	34	false	ok	0
 t5617-clone-submodules-remote	t5	yes	9	2	7	false	ok	0
 t5618-alternate-refs	t5	yes	6	2	4	false	ok	0
 t5619-clone-local-ambiguous-transport	t5	yes	2	1	1	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79% of harness tests passing (35,699 / 45,189).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79% of harness tests passing (35,699 / 45,189).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-09T23:06:19+00:00" class="gen-time" title="2026-04-09 23:06 UTC">2026-04-09 23:06 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,11 +157,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,699</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">45,142</div>
+      <div class="summary-big-val">45,189</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -171,7 +171,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>758 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,7 +241,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,579/4,186 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35699 of 45189 tests passing across 1405 harness files (79% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,699 / 45,189 tests · 1,405 files in scope · 758 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T23:06:19+00:00" class="gen-time" title="2026-04-09 23:06 UTC">2026-04-09 23:06 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n" id="sum-tests">45,189</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,699</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -10267,14 +10267,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="0" data-passed="0">
+<tr class="" data-group="t5" data-tests="47" data-passed="13">
   <td class="mono">t5616-partial-clone</td>
   <td>t5</td>
   <td></td>
-  <td class="right">0</td>
-  <td class="right">0</td>
-  <td class="right">timeout</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
+  <td class="right">47</td>
+  <td class="right">13</td>
+  <td class="right">ok</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:27.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="9" data-passed="2">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/odb.rs
+++ b/grit-lib/src/odb.rs
@@ -56,6 +56,28 @@ fn read_zlib_loose_payload(mut file: fs::File) -> Result<Vec<u8>> {
     }
 }
 
+/// True when `oid` is stored as a loose object or in a **non-promisor** local pack.
+fn exists_materialized_in_objects_dir(objects_dir: &Path, oid: &ObjectId) -> bool {
+    let loose = objects_dir
+        .join(oid.loose_prefix())
+        .join(oid.loose_suffix());
+    if loose.exists() {
+        return true;
+    }
+    let Ok(indexes) = pack::read_local_pack_indexes(objects_dir) else {
+        return false;
+    };
+    for idx in &indexes {
+        if idx.pack_path.with_extension("promisor").is_file() {
+            continue;
+        }
+        if idx.entries.iter().any(|e| e.oid == *oid) {
+            return true;
+        }
+    }
+    false
+}
+
 /// A loose-object database rooted at a given `objects/` directory.
 #[derive(Debug, Clone)]
 pub struct Odb {
@@ -106,6 +128,11 @@ impl Odb {
     /// `GIT_ALTERNATE_OBJECT_DIRECTORIES`. Used for partial-clone bookkeeping where
     /// objects reachable via alternates are still treated as "missing" until copied locally.
     ///
+    /// Objects stored **only** in promisor packs (sibling `.promisor` marker next to the
+    /// `.pack`) are treated as absent: Git considers them fetchable on demand, and
+    /// `rev-list --missing=print` lists them until materialized as loose objects or a
+    /// non-promisor pack.
+    ///
     /// The empty tree object is treated as present without a loose file (matches Git).
     #[must_use]
     pub fn exists_local(&self, oid: &ObjectId) -> bool {
@@ -113,7 +140,7 @@ impl Odb {
         if oid.to_hex() == EMPTY_TREE {
             return true;
         }
-        self.exists_in_dir(&self.objects_dir, oid)
+        exists_materialized_in_objects_dir(&self.objects_dir, oid)
     }
 
     /// Check whether an object exists in the loose store or any pack file.
@@ -128,7 +155,7 @@ impl Odb {
         if hex == EMPTY_TREE_CANON || hex == EMPTY_TREE_LEGACY {
             return true;
         }
-        if self.exists_local(oid) {
+        if self.exists_in_dir(&self.objects_dir, oid) {
             return true;
         }
         // Check alternates from info/alternates file.
@@ -340,6 +367,44 @@ impl Odb {
         fs::create_dir_all(prefix_dir)?;
 
         // Write to a temp file in the same directory, then rename atomically.
+        let tmp_path = prefix_dir.join(format!("tmp_{}", oid.loose_suffix()));
+        {
+            let tmp_file = fs::File::create(&tmp_path)?;
+            let mut encoder = ZlibEncoder::new(tmp_file, Compression::default());
+            encoder
+                .write_all(&store_bytes)
+                .map_err(|e| Error::Zlib(e.to_string()))?;
+            encoder.finish().map_err(|e| Error::Zlib(e.to_string()))?;
+        }
+        fs::rename(&tmp_path, &path)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = fs::set_permissions(&path, fs::Permissions::from_mode(0o444));
+        }
+
+        Ok(oid)
+    }
+
+    /// Write a loose object file when it is missing, even if [`Self::exists`] is true because
+    /// the object lives only in a pack.
+    ///
+    /// Used when materializing a partial-clone layout: objects must be duplicated as loose files
+    /// before local packs are removed.
+    pub fn write_loose_materialize(&self, kind: ObjectKind, data: &[u8]) -> Result<ObjectId> {
+        let store_bytes = build_store_bytes(kind, data);
+        let oid = hash_bytes(&store_bytes);
+        let path = self.object_path(&oid);
+        if path.exists() {
+            let _ = self.freshen_object(&oid);
+            return Ok(oid);
+        }
+
+        let prefix_dir = path
+            .parent()
+            .ok_or_else(|| Error::PathError("object path has no parent".to_owned()))?;
+        fs::create_dir_all(prefix_dir)?;
+
         let tmp_path = prefix_dir.join(format!("tmp_{}", oid.loose_suffix()));
         {
             let tmp_file = fs::File::create(&tmp_path)?;

--- a/grit/src/commands/checkout.rs
+++ b/grit/src/commands/checkout.rs
@@ -2441,6 +2441,23 @@ fn switch_to_tree(
         None => return Ok(()),
     };
 
+    let cfg = grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+    if grit_lib::promisor::repo_treats_promisor_packs(&repo.git_dir, &cfg)
+        && !crate::commands::promisor_hydrate::git_no_lazy_fetch_env_disables_lazy()?
+    {
+        if let Some(p) =
+            crate::commands::promisor_hydrate::find_promisor_source(&cfg, &repo.git_dir)?
+        {
+            crate::commands::promisor_hydrate::hydrate_tree_blobs_from_promisor(
+                repo,
+                &p,
+                *target_tree_oid,
+            )
+            .context("hydrating checkout tree from promisor remote")?;
+            let _ = crate::commands::promisor_hydrate::trim_promisor_marker_to_missing_local(repo);
+        }
+    }
+
     let index_path = repo.index_path();
     let old_index = repo.load_index_at(&index_path).context("loading index")?;
 

--- a/grit/src/commands/clone.rs
+++ b/grit/src/commands/clone.rs
@@ -1117,6 +1117,8 @@ pub fn run(mut args: Args) -> Result<()> {
         let filter_spec = args.filter.as_deref().unwrap_or("blob:none");
         materialize_blob_none_partial_layout(&dest)
             .context("materializing partial-clone object layout")?;
+        repack_partial_clone_skeleton_into_promisor_pack(&dest, &remote_name)
+            .context("repacking partial-clone skeleton into promisor pack")?;
         initialize_partial_clone_state(&source, &dest, &remote_name, filter_spec)
             .context("initializing partial-clone promisor state")?;
     }
@@ -2028,6 +2030,8 @@ fn run_http_clone(args: Args) -> Result<()> {
     if partial_blob_none_http {
         materialize_blob_none_partial_layout(&dest)
             .context("materializing partial-clone object layout")?;
+        repack_partial_clone_skeleton_into_promisor_pack(&dest, &remote_name)
+            .context("repacking partial-clone skeleton into promisor pack")?;
         initialize_partial_clone_state_http(&dest, &remote_name, "blob:none")?;
     }
 
@@ -2189,6 +2193,8 @@ fn initialize_partial_clone_state_http(
         &format!("remote.{remote_name}.partialclonefilter"),
         filter_spec,
     )?;
+    config.set("core.repositoryformatversion", "1")?;
+    config.set("extensions.partialclone", remote_name)?;
     config.write().context("writing config")?;
     Ok(())
 }
@@ -2706,6 +2712,8 @@ fn run_ssh_clone(args: Args) -> Result<()> {
     if partial_blob_none {
         materialize_blob_none_partial_layout(&dest)
             .context("materializing partial-clone object layout")?;
+        repack_partial_clone_skeleton_into_promisor_pack(&dest, &remote_name)
+            .context("repacking partial-clone skeleton into promisor pack")?;
         initialize_partial_clone_state(&source, &dest, &remote_name, "blob:none")
             .context("initializing partial-clone promisor state")?;
     }
@@ -4026,7 +4034,7 @@ fn materialize_blob_none_partial_layout(dest: &Repository) -> Result<()> {
             Ok(o) => o,
             Err(_) => continue,
         };
-        let _ = dest.odb.write(obj.kind, &obj.data)?;
+        let _ = dest.odb.write_loose_materialize(obj.kind, &obj.data)?;
     }
 
     let pack_dir = dest.git_dir.join("objects/pack");
@@ -4123,6 +4131,111 @@ fn collect_reachable_skeleton_and_blobs(
     Ok((skeleton, blobs))
 }
 
+/// After [`materialize_blob_none_partial_layout`], loose commits/trees remain. Pack them into a
+/// single promisor pack (plus `.idx` and `.promisor`) so the layout matches Git partial clones
+/// (`t5616-partial-clone`).
+fn repack_partial_clone_skeleton_into_promisor_pack(
+    dest: &Repository,
+    remote_name: &str,
+) -> Result<()> {
+    let (skeleton, _) = collect_reachable_skeleton_and_blobs(dest)?;
+    if skeleton.is_empty() {
+        return Ok(());
+    }
+
+    let pack_dir = dest.git_dir.join("objects/pack");
+    let oids: Vec<ObjectId> = skeleton.iter().copied().collect();
+    crate::commands::pack_objects::write_partial_clone_promisor_pack(dest, &pack_dir, &oids)
+        .context("writing promisor pack for partial clone")?;
+
+    let mut written_pack: Option<PathBuf> = None;
+    for entry in fs::read_dir(&pack_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().is_some_and(|e| e == "pack")
+            && path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with("pack-") && n.ends_with(".pack"))
+        {
+            written_pack = Some(path);
+            break;
+        }
+    }
+    let Some(pack_path) = written_pack else {
+        bail!("partial clone promisor pack was not written");
+    };
+    let stem = pack_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .ok_or_else(|| anyhow::anyhow!("invalid promisor pack name"))?;
+    let promisor_path = pack_dir.join(format!("{stem}.promisor"));
+    let promisor_body = partial_clone_promisor_file_contents(&dest.git_dir, remote_name)?;
+    fs::write(&promisor_path, promisor_body).context("write .promisor file")?;
+
+    for oid in &skeleton {
+        let hex = oid.to_hex();
+        if hex.len() < 3 {
+            continue;
+        }
+        let loose = dest.git_dir.join("objects").join(&hex[..2]).join(&hex[2..]);
+        let _ = fs::remove_file(loose);
+    }
+
+    Ok(())
+}
+
+/// Build `.promisor` file body: `oid refname` lines for refs the initial fetch advertised,
+/// matching `fetch-pack` / `write_promisor_file`.
+fn partial_clone_promisor_file_contents(git_dir: &Path, remote_name: &str) -> Result<String> {
+    let head_oid = match refs::resolve_ref(git_dir, "HEAD") {
+        Ok(o) => o.to_hex(),
+        Err(_) => return Ok(String::new()),
+    };
+
+    let mut lines: Vec<String> = vec![format!("{head_oid} HEAD")];
+
+    let head_path = git_dir.join("HEAD");
+    if let Ok(content) = fs::read_to_string(&head_path) {
+        let content = content.trim_end_matches('\n');
+        if let Some(target) = content.strip_prefix("ref: ") {
+            let target = target.trim();
+            if target.starts_with("refs/heads/") {
+                lines.push(format!("{head_oid} {target}"));
+                return Ok(format!("{}\n", lines.join("\n")));
+            }
+        }
+    }
+
+    if let Ok(main_oid) = refs::resolve_ref(git_dir, "refs/heads/main") {
+        if main_oid.to_hex() == head_oid {
+            lines.push(format!("{head_oid} refs/heads/main"));
+            return Ok(format!("{}\n", lines.join("\n")));
+        }
+    }
+
+    let remote_main = format!("refs/remotes/{remote_name}/main");
+    if let Ok(oid) = refs::resolve_ref(git_dir, &remote_main) {
+        if oid.to_hex() == head_oid {
+            lines.push(format!("{head_oid} refs/heads/main"));
+            return Ok(format!("{}\n", lines.join("\n")));
+        }
+    }
+
+    let heads = refs::list_refs(git_dir, "refs/heads/").map_err(|e| anyhow::anyhow!("{e}"))?;
+    let mut matching: Vec<&str> = heads
+        .iter()
+        .filter(|(_, oid)| oid.to_hex() == head_oid)
+        .map(|(name, _)| name.as_str())
+        .collect();
+    matching.sort();
+    if let Some(name) = matching.first() {
+        lines.push(format!("{head_oid} {name}"));
+    }
+
+    Ok(format!("{}\n", lines.join("\n")))
+}
+
 /// Initialize internal promisor metadata for `--filter=blob:none` clones.
 ///
 /// This records reachable blob OIDs in a marker file so commands can emulate
@@ -4156,6 +4269,8 @@ fn initialize_partial_clone_state(
         &format!("remote.{remote_name}.partialclonefilter"),
         filter_spec,
     )?;
+    config.set("core.repositoryformatversion", "1")?;
+    config.set("extensions.partialclone", remote_name)?;
     config.write().context("writing config")?;
 
     Ok(())

--- a/grit/src/commands/fetch.rs
+++ b/grit/src/commands/fetch.rs
@@ -77,6 +77,10 @@ pub struct Args {
     #[arg(long = "filter", value_name = "FILTER-SPEC")]
     pub filter: Option<String>,
 
+    /// Do not apply a list-objects filter (overrides `--filter` and inherited partial-clone filter).
+    #[arg(long = "no-filter")]
+    pub no_filter: bool,
+
     /// Deepen history of a shallow clone back to a date.
     #[arg(long, value_name = "DATE")]
     pub shallow_since: Option<String>,
@@ -240,6 +244,11 @@ pub fn run(mut args: Args) -> Result<()> {
 
     if result.is_ok() && should_recurse_fetch_submodules(&config, &args) {
         super::submodule::recursive_fetch_submodules(true)?;
+    }
+    if result.is_ok() && args.no_filter {
+        if let Ok(repo) = Repository::open(&git_dir, None) {
+            let _ = crate::commands::promisor_hydrate::trim_promisor_marker_to_missing_local(&repo);
+        }
     }
     result
 }
@@ -1614,7 +1623,14 @@ fn fetch_remote(
         fs::write(&fetch_head_path, content).context("writing FETCH_HEAD")?;
     }
 
-    if args.filter.as_deref() == Some("blob:none") {
+    let inherited_blob_none = !args.no_filter
+        && args.filter.is_none()
+        && config
+            .get(&format!("remote.{tracking_remote_name}.partialclonefilter"))
+            .as_deref()
+            == Some("blob:none")
+        && grit_lib::promisor::repo_treats_promisor_packs(git_dir, &config);
+    if !args.no_filter && (args.filter.as_deref() == Some("blob:none") || inherited_blob_none) {
         apply_blob_none_filter(git_dir, remote_repo.as_ref(), &remote_heads)
             .context("applying blob:none filter")?;
     }
@@ -1756,6 +1772,7 @@ fn collect_blob_sets_for_tree(
             )?;
             continue;
         }
+        all_blobs.insert(entry.oid);
         let blob_obj = match odb.read(&entry.oid) {
             Ok(obj) => obj,
             Err(_) => continue,
@@ -1763,7 +1780,6 @@ fn collect_blob_sets_for_tree(
         if blob_obj.kind != ObjectKind::Blob {
             continue;
         }
-        all_blobs.insert(entry.oid);
         if sparse_path_is_included(patterns, &rel_path) {
             keep_blobs.insert(entry.oid);
         }
@@ -2114,9 +2130,9 @@ pub(crate) fn copy_reachable_objects(
         let obj = src_odb.read(&oid).with_context(|| {
             format!("missing object {} while copying from remote", oid.to_hex())
         })?;
-        if !dst_odb.exists(&oid) {
+        if !dst_odb.exists_local(&oid) {
             dst_odb
-                .write(obj.kind, &obj.data)
+                .write_loose_materialize(obj.kind, &obj.data)
                 .with_context(|| format!("write object {}", oid.to_hex()))?;
         }
         match obj.kind {

--- a/grit/src/commands/pack_objects.rs
+++ b/grit/src/commands/pack_objects.rs
@@ -1598,3 +1598,37 @@ static CRC32_TABLE: [u32; 256] = {
     }
     table
 };
+
+/// Write `pack-<hash>.pack` and `pack-<hash>.idx` under `pack_dir` containing exactly `oids`
+/// (full objects, no deltas). Used by partial clone to materialize a promisor pack without
+/// spawning a subprocess.
+pub(crate) fn write_partial_clone_promisor_pack(
+    repo: &Repository,
+    pack_dir: &Path,
+    oids: &[ObjectId],
+) -> Result<()> {
+    std::fs::create_dir_all(pack_dir)?;
+    let mut sorted: Vec<ObjectId> = oids.to_vec();
+    sorted.sort_by_key(|o| o.to_hex());
+    sorted.dedup();
+
+    let mut write_entries: Vec<PackWriteEntry> = Vec::with_capacity(sorted.len());
+    for oid in &sorted {
+        let obj = read_object_from_repo(repo, oid)?;
+        write_entries.push(PackWriteEntry::Full(PackEntry {
+            oid: *oid,
+            kind: obj.kind,
+            data: obj.data,
+        }));
+    }
+
+    let pack_bytes = build_pack(&write_entries)?;
+    let pack_hash = hex::encode(&pack_bytes[pack_bytes.len() - 20..]);
+    let pack_path = pack_dir.join(format!("pack-{pack_hash}.pack"));
+    let idx_path = pack_dir.join(format!("pack-{pack_hash}.idx"));
+
+    std::fs::write(&pack_path, &pack_bytes)?;
+    let idx_bytes = build_idx_for_pack(&pack_bytes, &write_entries)?;
+    std::fs::write(&idx_path, &idx_bytes)?;
+    Ok(())
+}

--- a/grit/src/commands/promisor_hydrate.rs
+++ b/grit/src/commands/promisor_hydrate.rs
@@ -296,6 +296,25 @@ pub(crate) fn hydrate_sparse_tip_blobs_from_promisor(
     flush_promisor_blob_batches(dest, promisor, &mut need, 50_000)
 }
 
+/// Copy every blob under `tree_oid` that is not yet present in the local ODB (loose or pack).
+pub(crate) fn hydrate_tree_blobs_from_promisor(
+    dest: &Repository,
+    promisor: &PromisorSource,
+    tree_oid: ObjectId,
+) -> Result<()> {
+    let mut need = Vec::new();
+    let mut seen_trees = HashSet::new();
+    let mut seen_blobs = HashSet::new();
+    collect_all_missing_blobs_from_tree(
+        dest,
+        tree_oid,
+        &mut seen_trees,
+        &mut seen_blobs,
+        &mut need,
+    )?;
+    flush_promisor_blob_batches(dest, promisor, &mut need, 50_000)
+}
+
 /// Copy every blob reachable from `HEAD`'s tree from the promisor remote.
 pub(crate) fn hydrate_head_tree_blobs_from_promisor(
     dest: &Repository,

--- a/grit/src/commands/pull.rs
+++ b/grit/src/commands/pull.rs
@@ -265,6 +265,7 @@ pub fn run(args: Args) -> Result<()> {
         remote: Some(remote_name.to_owned()),
         refspecs: args.refspecs.clone(),
         filter: None,
+        no_filter: false,
         all: false,
         multiple: false,
         tags: false,

--- a/logs/2026-04-10_t5616-partial-clone-progress.md
+++ b/logs/2026-04-10_t5616-partial-clone-progress.md
@@ -1,0 +1,18 @@
+# t5616-partial-clone progress
+
+## Changes
+
+- **Partial clone layout (`clone.rs`)**: After `materialize_blob_none_partial_layout`, repack skeleton objects into a `pack-*.pack` + `.idx` + `.promisor` (via `pack_objects::write_partial_clone_promisor_pack`), set `core.repositoryformatversion=1` and `extensions.partialclone=<remote>`. Fixed materialization to use `Odb::write_loose_materialize` so objects are duplicated loose before packs are removed.
+- **`Odb` (`odb.rs`)**: `exists_local` ignores objects only in promisor packs; `exists()` still finds them for reads. Added `write_loose_materialize`.
+- **`pack_objects.rs`**: `write_partial_clone_promisor_pack` for in-process promisor pack write.
+- **Checkout**: Hydrate target tree blobs from promisor before populating worktree (`promisor_hydrate::hydrate_tree_blobs_from_promisor`).
+- **Fetch**: `--no-filter` flag; `copy_reachable_objects` uses `exists_local` + `write_loose_materialize` so fetches materialize blobs not only in promisor packs; inherited `blob:none` post-filter when promisor + `remote.*.partialclonefilter`; fixed `collect_blob_sets_for_tree` to count missing blob OIDs; trim marker after `--no-filter`.
+- **`pull.rs`**: `no_filter: false` in fetch args struct.
+
+## Harness
+
+`./scripts/run-tests.sh t5616-partial-clone.sh`: early tests (1–7, 9, 11) pass; many later cases still fail (upload-pack filter protocol, refetch, HTTP, index-pack traces).
+
+## Reason not complete
+
+`blocked` on remaining upload-pack / filter / HTTP / maintenance semantics for the rest of t5616.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves Grit’s partial-clone behavior to align with Git’s promisor layout and missing-object accounting:

- **Clone (`blob:none`)**: After stripping blobs, duplicate commit/tree objects as loose (`write_loose_materialize`), repack skeleton into `pack-*.pack` + `.idx` + `.promisor`, set `core.repositoryformatversion=1` and `extensions.partialclone=<remote>`.
- **Odb**: `exists_local` treats objects only in **promisor** packs as absent (so `rev-list --missing=print` + marker stay consistent); `exists()` still resolves them for reads. Added `write_loose_materialize`.
- **Fetch**: `copy_reachable_objects` uses `exists_local` + `write_loose_materialize` so blobs aren’t skipped when present only in a promisor pack. Added `--no-filter`, optional inherited `blob:none` post-filter when promisor + `remote.*.partialclonefilter`, fixed blob enumeration for missing trees, trim promisor marker after `--no-filter`.
- **Checkout**: Hydrate all blobs under the target tree from the promisor remote before writing the worktree.

## Testing

- `cargo test -p grit-lib --lib` — pass
- `./scripts/run-tests.sh t5616-partial-clone.sh` — **not** fully passing; early cases (e.g. 1–7, 9, 11) pass; many later tests still need upload-pack filter protocol, refetch, HTTP, etc.

## Log

See `logs/2026-04-10_t5616-partial-clone-progress.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d834b195-3e12-41ae-9dd8-9fdf29c8687e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d834b195-3e12-41ae-9dd8-9fdf29c8687e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

