### PR TITLE
fix: make t5611-clone-config pass (clone -c / global -c)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -621,7 +621,7 @@ commit → check it off → move on.
 - [ ] `t5530-upload-pack-error` ███░░░░░░░░░░░░░░░░░ 2/11 (9 left) — errors in upload-pack
 - [ ] `t5150-request-pull` ██░░░░░░░░░░░░░░░░░░ 1/10 (9 left) — Test workflows involving pull request.
 - [x] `t5320-delta-islands` ████████████████████ 15/15 (0 left) — exercise delta islands
-- [ ] `t5611-clone-config` ████░░░░░░░░░░░░░░░░ 3/13 (10 left) — tests for git clone -c key=value
+- [x] `t5611-clone-config` — tests for git clone -c key=value (13/13 harness; 1 MINGW skip)
 - [ ] `t5335-compact-multi-pack-index` ░░░░░░░░░░░░░░░░░░░░ 0/10 (10 left) — multi-pack-index compaction
 - [ ] `t5003-archive-zip` █████████████████░░░ 71/82 (11 left) — git archive --format=zip test
 - [x] `t5334-incremental-multi-pack-index` — incremental multi-pack-index (16/16)

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1006,7 +1006,7 @@ t5607-clone-bundle	t5	yes	16	5	11	false	ok	0
 t5608-clone-2gb	t5	yes	0	0	0	false	ok	0
 t5609-clone-branch	t5	yes	7	7	0	true	ok	0
 t5610-clone-detached	t5	skip	13	2	11	false	ok	1
-t5611-clone-config	t5	yes	13	9	4	false	ok	0
+t5611-clone-config	t5	yes	13	13	0	true	ok	0
 t5612-clone-refspec	t5	yes	13	3	10	false	ok	0
 t5613-info-alternate	t5	yes	13	13	0	true	ok	0
 t5614-clone-submodules-shallow	t5	yes	9	9	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,690 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,690 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T00:40:16+00:00" class="gen-time" title="2026-04-10 00:40 UTC">2026-04-10 00:40 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,690</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">34/167 files · 17 skipped · 1,570/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.9%"></div></div>
+        <span class="group-pct pct-red">37.9%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35690 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,690 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T00:40:16+00:00" class="gen-time" title="2026-04-10 00:40 UTC">2026-04-10 00:40 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,690</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -10217,14 +10217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t5" data-tests="13" data-passed="9">
+<tr class="" data-group="t5" data-tests="13" data-passed="13" data-full-pass="1">
   <td class="mono">t5611-clone-config</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">13</td>
-  <td class="right">9</td>
+  <td class="right">13</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:69.2%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="13" data-passed="3">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/config.rs
+++ b/grit-lib/src/config.rs
@@ -1363,6 +1363,11 @@ impl ConfigSet {
         self.entries.extend(file.entries.iter().cloned());
     }
 
+    /// Merge another [`ConfigSet`] into this set (entries appended in order).
+    pub fn merge_set(&mut self, other: &ConfigSet) {
+        self.entries.extend(other.entries.iter().cloned());
+    }
+
     /// Add a command-line override (`-c key=value`).
     pub fn add_command_override(&mut self, key: &str, value: &str) -> Result<()> {
         let canon = canonical_key(key)?;
@@ -2424,7 +2429,7 @@ pub fn parse_path_optional(s: &str) -> Option<String> {
 /// - unquoted `key=value` tokens separated by whitespace
 ///
 /// Backslash escapes are interpreted minimally inside double quotes.
-pub(crate) fn parse_config_parameters(raw: &str) -> Vec<String> {
+pub fn parse_config_parameters(raw: &str) -> Vec<String> {
     let mut out: Vec<String> = Vec::new();
     let mut buf = String::new();
     let mut in_single = false;

--- a/grit/src/commands/clone.rs
+++ b/grit/src/commands/clone.rs
@@ -8,8 +8,11 @@ use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::check_ref_format::{check_refname_format, RefNameOptions};
 use grit_lib::config::{ConfigFile, ConfigScope, ConfigSet};
+use grit_lib::crlf;
 use grit_lib::diff::zero_oid;
+use grit_lib::filter_process;
 use grit_lib::hooks::{run_hook, HookResult};
+use grit_lib::index::MODE_SYMLINK;
 use grit_lib::objects::{parse_commit, parse_tag, parse_tree, ObjectId, ObjectKind};
 use grit_lib::promisor::{read_promisor_missing_oids, repo_treats_promisor_packs};
 use grit_lib::refs;
@@ -27,6 +30,7 @@ use std::process::Command;
 use crate::commands::checkout::{
     checkout_parallel_worker_spawns, trace2_emit_checkout_parallel_workers,
 };
+use crate::commands::fetch::{collect_refspecs, default_fetch_refspecs, map_ref_through_refspecs};
 use crate::commands::submodule::set_submodule_core_worktree_after_separate_clone;
 
 /// Arguments for `grit clone`.
@@ -307,6 +311,88 @@ fn resolve_remote_name(args: &Args) -> Result<String> {
     Ok("origin".to_owned())
 }
 
+/// Effective configuration for clone operations before the destination `.git/config` exists.
+///
+/// Merges the usual cascade (system/global/`GIT_CONFIG_PARAMETERS` from `git -c …`) with
+/// `clone -c` entries so keys like `core.autocrlf` and `remote.<name>.fetch` apply during ref copy
+/// and checkout (`t5611-clone-config`).
+fn clone_effective_config_pre_local(dest_git_dir: &Path, clone_c_entries: &[String]) -> ConfigSet {
+    let mut set = ConfigSet::load(None, true).unwrap_or_default();
+    let local_path = dest_git_dir.join("config");
+    if let Ok(Some(f)) = ConfigFile::from_path(&local_path, ConfigScope::Local) {
+        set.merge(&f);
+    }
+    for entry in clone_c_entries {
+        if let Some((key, value)) = entry.split_once('=') {
+            let _ = set.add_command_override(key.trim(), value.trim());
+        } else {
+            let _ = set.add_command_override(entry.trim(), "true");
+        }
+    }
+    set
+}
+
+/// Fetch refspecs used while mapping source refs during a local clone, matching Git: configured
+/// `remote.<name>.fetch` lines plus the default `refs/heads/*` mapping when no positive refspec is
+/// set.
+fn clone_context_fetch_refspecs(
+    dest_git_dir: &Path,
+    remote_name: &str,
+    clone_c_entries: &[String],
+) -> Vec<String> {
+    let key = format!("remote.{remote_name}.fetch");
+    let cfg = clone_effective_config_pre_local(dest_git_dir, clone_c_entries);
+    let specs = collect_refspecs(&cfg, &key);
+    let has_positive = specs.iter().any(|s| !s.negative);
+    let mut out: Vec<String> = Vec::new();
+    if has_positive {
+        for s in specs {
+            if s.negative {
+                continue;
+            }
+            let mut line = String::new();
+            if s.force {
+                line.push('+');
+            }
+            line.push_str(&s.src);
+            line.push(':');
+            line.push_str(&s.dst);
+            out.push(line);
+        }
+    }
+    let default = default_fetch_refspecs(remote_name);
+    for s in default {
+        if s.negative {
+            continue;
+        }
+        let mut line = String::new();
+        if s.force {
+            line.push('+');
+        }
+        line.push_str(&s.src);
+        line.push(':');
+        line.push_str(&s.dst);
+        out.push(line);
+    }
+    out
+}
+
+/// Append the default `remote.<name>.fetch` line after `clone -c` entries are written (Git ordering).
+fn append_remote_default_fetch_line(
+    git_dir: &Path,
+    remote_name: &str,
+    default_refspec: &str,
+) -> Result<()> {
+    let config_path = git_dir.join("config");
+    let mut config = match ConfigFile::from_path(&config_path, ConfigScope::Local)? {
+        Some(c) => c,
+        None => ConfigFile::parse(&config_path, "", ConfigScope::Local)?,
+    };
+    config.add_value(&format!("remote.{remote_name}.fetch"), default_refspec)?;
+    config.write().context("writing config")?;
+    Ok(())
+}
+
 fn effective_reject_shallow(args: &Args) -> bool {
     if args.no_reject_shallow {
         return false;
@@ -421,7 +507,7 @@ fn checkout_head_allow_unborn(repo: &Repository) -> Result<()> {
 
     let obj = repo.odb.read(&oid).context("reading HEAD commit")?;
     let commit = parse_commit(&obj.data).context("parsing HEAD commit")?;
-    checkout_tree(repo, &commit.tree, work_tree, "")?;
+    checkout_tree(repo, &commit.tree, work_tree, "", true)?;
     write_index_from_tree(repo, &commit.tree)?;
     Ok(())
 }
@@ -841,17 +927,10 @@ pub fn run(mut args: Args) -> Result<()> {
                         &remote_tags,
                         args.no_tags,
                     )?;
-                    let refspec = if args.single_branch {
-                        let branch = head_branch.as_deref().unwrap_or(initial_fallback.as_str());
-                        format!("+refs/heads/{branch}:refs/remotes/{remote_name}/{branch}")
-                    } else {
-                        format!("+refs/heads/*:refs/remotes/{remote_name}/*")
-                    };
-                    setup_origin_remote_url(
+                    setup_origin_remote_bare_url(
                         &dest.git_dir,
                         remote_url_for_config.as_str(),
                         &remote_name,
-                        &refspec,
                     )
                     .context("setting up origin remote")?;
 
@@ -1032,17 +1111,16 @@ pub fn run(mut args: Args) -> Result<()> {
             }
         } else {
             // Non-bare clone: copy refs as remote-tracking refs
-            copy_refs_as_remote(&source.git_dir, &dest.git_dir, &remote_name, args.no_tags)
-                .context("copying refs")?;
+            copy_refs_as_remote(
+                &source.git_dir,
+                &dest.git_dir,
+                &remote_name,
+                args.no_tags,
+                &args.config,
+            )
+            .context("copying refs")?;
 
-            // Set up remote "origin" in config
-            let refspec = if args.single_branch {
-                let branch = head_branch.as_deref().unwrap_or(initial_fallback.as_str());
-                format!("+refs/heads/{branch}:refs/remotes/{remote_name}/{branch}")
-            } else {
-                format!("+refs/heads/*:refs/remotes/{remote_name}/*")
-            };
-            setup_origin_remote(&dest.git_dir, &source_path, &remote_name, &refspec)
+            setup_origin_remote_bare(&dest.git_dir, &source_path, &remote_name)
                 .context("setting up origin remote")?;
 
             setup_remote_tracking_head(
@@ -1096,6 +1174,16 @@ pub fn run(mut args: Args) -> Result<()> {
     // Apply -c config values
     if !args.config.is_empty() {
         apply_clone_config(&dest.git_dir, &args.config).context("applying -c config")?;
+    }
+
+    if !args.bare {
+        let default_refspec = if args.single_branch {
+            let branch = head_branch.as_deref().unwrap_or(initial_fallback.as_str());
+            format!("+refs/heads/{branch}:refs/remotes/{remote_name}/{branch}")
+        } else {
+            format!("+refs/heads/*:refs/remotes/{remote_name}/*")
+        };
+        append_remote_default_fetch_line(&dest.git_dir, &remote_name, &default_refspec)?;
     }
 
     apply_submodule_reference_config_for_recursive_clone(&dest.git_dir, &args)?;
@@ -1395,13 +1483,7 @@ fn run_git_clone(args: Args) -> Result<()> {
                     &remote_tags,
                     args.no_tags,
                 )?;
-                let refspec = if args.single_branch {
-                    let branch = head_branch.as_deref().unwrap_or(initial_fallback.as_str());
-                    format!("+refs/heads/{branch}:refs/remotes/{remote_name}/{branch}")
-                } else {
-                    format!("+refs/heads/*:refs/remotes/{remote_name}/*")
-                };
-                setup_origin_remote_url(&dest.git_dir, url.as_str(), &remote_name, &refspec)
+                setup_origin_remote_bare_url(&dest.git_dir, url.as_str(), &remote_name)
                     .context("setting up origin remote")?;
 
                 setup_remote_tracking_head_from_advertisement(
@@ -1458,6 +1540,16 @@ fn run_git_clone(args: Args) -> Result<()> {
 
     if !args.config.is_empty() {
         apply_clone_config(&dest.git_dir, &args.config).context("applying -c config")?;
+    }
+
+    if !args.bare {
+        let default_refspec = if args.single_branch {
+            let branch = head_branch.as_deref().unwrap_or(initial_fallback.as_str());
+            format!("+refs/heads/{branch}:refs/remotes/{remote_name}/{branch}")
+        } else {
+            format!("+refs/heads/*:refs/remotes/{remote_name}/*")
+        };
+        append_remote_default_fetch_line(&dest.git_dir, &remote_name, &default_refspec)?;
     }
 
     apply_submodule_reference_config_for_recursive_clone(&dest.git_dir, &args)?;
@@ -1657,13 +1749,7 @@ fn run_ext_clone(args: Args) -> Result<()> {
                     &remote_tags,
                     args.no_tags,
                 )?;
-                let refspec = if args.single_branch {
-                    let branch = head_branch.as_deref().unwrap_or(initial_fallback.as_str());
-                    format!("+refs/heads/{branch}:refs/remotes/{remote_name}/{branch}")
-                } else {
-                    format!("+refs/heads/*:refs/remotes/{remote_name}/*")
-                };
-                setup_origin_remote_url(&dest.git_dir, url.as_str(), &remote_name, &refspec)
+                setup_origin_remote_bare_url(&dest.git_dir, url.as_str(), &remote_name)
                     .context("setting up origin remote")?;
 
                 setup_remote_tracking_head_from_advertisement(
@@ -1720,6 +1806,16 @@ fn run_ext_clone(args: Args) -> Result<()> {
 
     if !args.config.is_empty() {
         apply_clone_config(&dest.git_dir, &args.config).context("applying -c config")?;
+    }
+
+    if !args.bare {
+        let default_refspec = if args.single_branch {
+            let branch = head_branch.as_deref().unwrap_or(initial_fallback.as_str());
+            format!("+refs/heads/{branch}:refs/remotes/{remote_name}/{branch}")
+        } else {
+            format!("+refs/heads/*:refs/remotes/{remote_name}/*")
+        };
+        append_remote_default_fetch_line(&dest.git_dir, &remote_name, &default_refspec)?;
     }
 
     apply_submodule_reference_config_for_recursive_clone(&dest.git_dir, &args)?;
@@ -1946,13 +2042,7 @@ fn run_http_clone(args: Args) -> Result<()> {
             }
         }
 
-        let refspec = if args.single_branch {
-            let branch = args.branch.as_deref().unwrap_or(initial_fallback.as_str());
-            format!("+refs/heads/{branch}:refs/remotes/{remote_name}/{branch}")
-        } else {
-            format!("+refs/heads/*:refs/remotes/{remote_name}/*")
-        };
-        setup_origin_remote_url(&dest.git_dir, &repo_url, &remote_name, &refspec)?;
+        setup_origin_remote_bare_url(&dest.git_dir, &repo_url, &remote_name)?;
 
         let default_branch = args
             .branch
@@ -2010,6 +2100,16 @@ fn run_http_clone(args: Args) -> Result<()> {
 
     if !args.config.is_empty() {
         apply_clone_config(&dest.git_dir, &args.config).context("applying -c config")?;
+    }
+
+    if !args.bare {
+        let default_refspec = if args.single_branch {
+            let branch = args.branch.as_deref().unwrap_or(initial_fallback.as_str());
+            format!("+refs/heads/{branch}:refs/remotes/{remote_name}/{branch}")
+        } else {
+            format!("+refs/heads/*:refs/remotes/{remote_name}/*")
+        };
+        append_remote_default_fetch_line(&dest.git_dir, &remote_name, &default_refspec)?;
     }
 
     apply_sticky_recursive_clone(&dest.git_dir, args.recurse_submodules)?;
@@ -2468,17 +2568,10 @@ fn run_ssh_clone(args: Args) -> Result<()> {
                         &remote_tags,
                         args.no_tags,
                     )?;
-                    let refspec = if args.single_branch {
-                        let branch = head_branch.as_deref().unwrap_or(initial_fallback.as_str());
-                        format!("+refs/heads/{branch}:refs/remotes/{remote_name}/{branch}")
-                    } else {
-                        format!("+refs/heads/*:refs/remotes/{remote_name}/*")
-                    };
-                    setup_origin_remote_url(
+                    setup_origin_remote_bare_url(
                         &dest.git_dir,
                         remote_url_for_config.as_str(),
                         &remote_name,
-                        &refspec,
                     )
                     .context("setting up origin remote")?;
 
@@ -2634,15 +2727,15 @@ fn run_ssh_clone(args: Args) -> Result<()> {
                 }
             }
         } else {
-            copy_refs_as_remote(&source.git_dir, &dest.git_dir, &remote_name, args.no_tags)
-                .context("copying refs")?;
-            let refspec = if args.single_branch {
-                let branch = head_branch.as_deref().unwrap_or(initial_fallback.as_str());
-                format!("+refs/heads/{branch}:refs/remotes/{remote_name}/{branch}")
-            } else {
-                format!("+refs/heads/*:refs/remotes/{remote_name}/*")
-            };
-            setup_origin_remote_url(&dest.git_dir, remote_url, &remote_name, &refspec)
+            copy_refs_as_remote(
+                &source.git_dir,
+                &dest.git_dir,
+                &remote_name,
+                args.no_tags,
+                &args.config,
+            )
+            .context("copying refs")?;
+            setup_origin_remote_bare_url(&dest.git_dir, remote_url, &remote_name)
                 .context("setting up origin remote")?;
 
             setup_remote_tracking_head(
@@ -2687,6 +2780,16 @@ fn run_ssh_clone(args: Args) -> Result<()> {
 
     if !args.config.is_empty() {
         apply_clone_config(&dest.git_dir, &args.config).context("applying -c config")?;
+    }
+
+    if !args.bare {
+        let default_refspec = if args.single_branch {
+            let branch = head_branch.as_deref().unwrap_or(initial_fallback.as_str());
+            format!("+refs/heads/{branch}:refs/remotes/{remote_name}/{branch}")
+        } else {
+            format!("+refs/heads/*:refs/remotes/{remote_name}/*")
+        };
+        append_remote_default_fetch_line(&dest.git_dir, &remote_name, &default_refspec)?;
     }
 
     apply_submodule_reference_config_for_recursive_clone(&dest.git_dir, &args)?;
@@ -3774,50 +3877,36 @@ fn copy_refs_as_remote(
     dst_git_dir: &Path,
     remote_name: &str,
     no_tags: bool,
+    clone_c_entries: &[String],
 ) -> Result<()> {
-    // Use the library ref-listing API which handles both files and reftable
-    let heads = grit_lib::refs::list_refs(src_git_dir, "refs/heads/")
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
-    for (refname, oid) in &heads {
-        let branch = refname.strip_prefix("refs/heads/").unwrap_or(refname);
-        let dst_name = format!("refs/remotes/{remote_name}/{branch}");
-        clone_write_direct_ref(dst_git_dir, &dst_name, &oid.to_hex())?;
+    let fetch_cli: Vec<String> =
+        clone_context_fetch_refspecs(dst_git_dir, remote_name, clone_c_entries)
+            .into_iter()
+            .map(|s| s.trim().to_owned())
+            .filter(|s| !s.is_empty())
+            .collect();
+    let fetch_key = format!("remote.{remote_name}.fetch");
+    let mut tmp_cfg = ConfigSet::new();
+    for line in &fetch_cli {
+        let _ = tmp_cfg.add_command_override(&fetch_key, line);
+    }
+    let mut fetch_specs = collect_refspecs(&tmp_cfg, &fetch_key);
+    if fetch_specs.is_empty() {
+        fetch_specs = default_fetch_refspecs(remote_name);
     }
 
-    if !no_tags {
-        let tags = grit_lib::refs::list_refs(src_git_dir, "refs/tags/")
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
-        for (refname, oid) in &tags {
-            clone_write_direct_ref(dst_git_dir, refname, &oid.to_hex())?;
+    // Map every source ref through configured fetch refspecs (plus the default heads mapping).
+    // Custom refspecs may pull in namespaces outside `refs/heads/` (e.g. `refs/grab/*`, `t5611`).
+    let all_refs =
+        grit_lib::refs::list_refs(src_git_dir, "refs/").map_err(|e| anyhow::anyhow!("{e}"))?;
+    for (refname, oid) in &all_refs {
+        if no_tags && refname.starts_with("refs/tags/") {
+            continue;
         }
-    }
-
-    // Also handle packed-refs if present (files backend only)
-    if !grit_lib::reftable::is_reftable_repo(src_git_dir) {
-        let packed_refs = src_git_dir.join("packed-refs");
-        if packed_refs.is_file() {
-            let content = fs::read_to_string(&packed_refs)?;
-            for line in content.lines() {
-                if line.is_empty() || line.starts_with('#') || line.starts_with('^') {
-                    continue;
-                }
-                let mut parts = line.split_whitespace();
-                let Some(oid) = parts.next() else { continue };
-                let Some(refname) = parts.next() else {
-                    continue;
-                };
-
-                if let Some(branch) = refname.strip_prefix("refs/heads/") {
-                    let dst_name = format!("refs/remotes/{remote_name}/{branch}");
-                    if !clone_ref_file_exists(dst_git_dir, &dst_name) {
-                        clone_write_direct_ref(dst_git_dir, &dst_name, oid)?;
-                    }
-                } else if !no_tags && refname.starts_with("refs/tags/") {
-                    if !clone_ref_file_exists(dst_git_dir, refname) {
-                        clone_write_direct_ref(dst_git_dir, refname, oid)?;
-                    }
-                }
-            }
+        if let Some(dst_name) = map_ref_through_refspecs(refname, &fetch_specs) {
+            clone_write_direct_ref(dst_git_dir, &dst_name, &oid.to_hex())?;
+        } else if refname.starts_with("refs/tags/") {
+            clone_write_direct_ref(dst_git_dir, refname, &oid.to_hex())?;
         }
     }
 
@@ -4495,7 +4584,7 @@ fn checkout_head(repo: &Repository) -> Result<()> {
     let commit = parse_commit(&obj.data).context("parsing HEAD commit")?;
 
     // Checkout the tree recursively
-    let work_units = checkout_tree(repo, &commit.tree, work_tree, "")?;
+    let work_units = checkout_tree(repo, &commit.tree, work_tree, "", true)?;
     trace2_emit_checkout_parallel_workers(checkout_parallel_worker_spawns(repo, work_units));
 
     // Write the index
@@ -4512,7 +4601,9 @@ fn checkout_tree(
     tree_oid: &ObjectId,
     work_tree: &Path,
     prefix: &str,
+    smudge_worktree: bool,
 ) -> Result<usize> {
+    use grit_lib::index::Index;
     use grit_lib::objects::parse_tree;
 
     let odb = &repo.odb;
@@ -4543,7 +4634,7 @@ fn checkout_tree(
             continue;
         } else if is_tree {
             fs::create_dir_all(&full_path)?;
-            work_units += checkout_tree(repo, &entry.oid, work_tree, &path)?;
+            work_units += checkout_tree(repo, &entry.oid, work_tree, &path, smudge_worktree)?;
         } else {
             // Regular file or symlink
             if let Some(parent) = full_path.parent() {
@@ -4561,7 +4652,6 @@ fn checkout_tree(
                 .read(&entry.oid)
                 .with_context(|| format!("reading blob for {path}"))?;
 
-            use grit_lib::index::MODE_SYMLINK;
             if entry.mode == MODE_SYMLINK {
                 #[cfg(unix)]
                 {
@@ -4582,7 +4672,28 @@ fn checkout_tree(
                     fs::write(&full_path, &blob.data)?;
                 }
             } else {
-                fs::write(&full_path, &blob.data)?;
+                let bytes = if smudge_worktree {
+                    let config = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+                    let conv = crlf::ConversionConfig::from_config(&config);
+                    let idx = Index::new();
+                    let attrs =
+                        crlf::load_gitattributes_for_checkout(work_tree, path.as_str(), &idx, odb);
+                    let file_attrs = crlf::get_file_attrs(&attrs, path.as_str(), false, &config);
+                    let oid_hex = entry.oid.to_hex();
+                    let smudge_meta = filter_process::smudge_meta_blob_only(&oid_hex);
+                    crlf::convert_to_worktree(
+                        &blob.data,
+                        path.as_str(),
+                        &conv,
+                        &file_attrs,
+                        Some(&oid_hex),
+                        Some(&smudge_meta),
+                    )
+                    .map_err(|e| anyhow::anyhow!("{e}"))?
+                } else {
+                    blob.data.clone()
+                };
+                fs::write(&full_path, &bytes)?;
                 // Set executable bit if mode is 100755
                 #[cfg(unix)]
                 if entry.mode == 0o100755 {

--- a/logs/2026-04-10_t5611-clone-config.md
+++ b/logs/2026-04-10_t5611-clone-config.md
@@ -1,0 +1,17 @@
+# t5611-clone-config
+
+## Goal
+
+Make `tests/t5611-clone-config.sh` pass under grit (non-MINGW cases).
+
+## Changes
+
+- **Local clone ref copy** (`copy_refs_as_remote`): build effective fetch refspec list from `GIT_CONFIG_PARAMETERS` + `clone -c` + default `refs/heads/*:refs/remotes/<remote>/*`; list all `refs/*` from source and map through refspecs so namespaces like `refs/grab/*` are copied.
+- **Remote config ordering**: write `remote.<name>.url` only during clone setup; apply `clone -c` to config; append default `remote.<name>.fetch` last (matches Git). Same pattern for git://, ext::, HTTP, and SSH-local clone paths that used `setup_origin_remote_url`.
+- **Checkout**: apply CRLF/filter smudge when writing files during clone `checkout_tree` so `clone -c core.autocrlf` affects working tree.
+- **grit-lib**: `ConfigSet::merge_set`, `parse_config_parameters` made public for reuse.
+
+## Verification
+
+- `./scripts/run-tests.sh t5611-clone-config.sh` → 13/13 pass (1 MINGW skip).
+- `cargo test -p grit-lib --lib` → pass.

--- a/progress.md
+++ b/progress.md
@@ -1,20 +1,21 @@
 # Progress — Grit Test Coverage
 
-**Updated:** 2026-04-09
+**Updated:** 2026-04-10
 
 ## Counts (derived from plan.md)
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   325 |
+| Completed   |   326 |
 | In progress |     5 |
-| Remaining   |   441 |
+| Remaining   |   440 |
 | **Total**   |   771 |
 
-Task lines in `PLAN.md`: 325 completed (`[x]`), 5 in progress (`[~]`), 441 remaining (`[ ]`).
+Task lines in `PLAN.md`: 326 completed (`[x]`), 5 in progress (`[~]`), 440 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t5611-clone-config` — 13/13 harness tests pass (`clone -c` / `git -c` effective during local ref copy + checkout: merged config with `GIT_CONFIG_PARAMETERS`; custom `remote.*.fetch` + default refspec ordering in `.git/config`; CRLF smudge on clone checkout; `ConfigSet::merge_set` + public `parse_config_parameters`)
 - `t3309-notes-merge-auto-resolve` — 31/31 tests pass (`notes merge`: `union` / `cat_sort_uniq` blob combine like Git; successful merge commits use two parents; `notes.mergeStrategy` config errors match upstream expectations)
 - `t4063-diff-blobs` — 18/18 tests pass (`diff`: blob↔blob and `rev:path` pairs without treating blobs as trees; `HEAD:one..HEAD:two` range split; `rev:path` vs worktree file uses tree path + modes + `write_patch_with_prefix`; raw blob OID vs existing file uses filename as old path; `rev_parse::resolve_treeish_blob_at_path` for tree walks)
 - `t5524-pull-msg` — 3/3 tests pass (`git pull --no-rebase --log` merge message preserves `$` in subject lines; `--log=1` limits shortlog; harness CSV/dashboards refreshed; `PLAN.md` marked complete)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes `t5611-clone-config` pass under the harness (13/13 runnable tests; MINGW-only case still skipped as before).

## What changed

- **Effective config during local clone**: When copying refs, merge the normal config cascade (including `GIT_CONFIG_PARAMETERS` from `git -c …`) with `clone -c` entries so `remote.<name>.fetch` and other keys apply before `.git/config` is fully written.
- **Ref copy**: List all `refs/*` from the source and map each through the combined fetch refspec list (custom patterns like `refs/grab/*` are no longer ignored).
- **`.git/config` ordering**: Match Git by writing `remote.<name>.url` first, applying `clone -c`, then appending the default `remote.<name>.fetch` line. Applied consistently across local, `git://`, `ext::`, HTTP, and SSH-resolved-local clone paths that previously set fetch in one shot.
- **Checkout**: Apply CRLF / filter smudge when materializing the working tree during clone so `clone -c core.autocrlf` affects checked-out files.
- **Library**: `ConfigSet::merge_set` and public `parse_config_parameters` for layered config assembly.

## Verification

- `./scripts/run-tests.sh t5611-clone-config.sh`
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08f1aaa1-b0de-425c-a2d4-d24f85e02893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08f1aaa1-b0de-425c-a2d4-d24f85e02893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

