### PR TITLE
fix: honor pack/core compression for pack-objects (t5315)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -611,7 +611,7 @@ commit → check it off → move on.
 - [ ] `t5545-push-options` ███████░░░░░░░░░░░░░ 5/13 (8 left) — pushing to a repository using push options
 - [ ] `t5322-pack-objects-sparse` █████░░░░░░░░░░░░░░░ 3/11 (8 left) — pack-objects object selection using sparse algorithm
 - [x] `t5620-backfill` — git backfill on partial clones (10/10 harness)
-- [ ] `t5315-pack-objects-compression` ██░░░░░░░░░░░░░░░░░░ 1/9 (8 left) — pack-object compression configuration
+- [x] `t5315-pack-objects-compression` ████████████████████ 9/9 — pack-object compression configuration
 - [ ] `t5506-remote-groups` ██░░░░░░░░░░░░░░░░░░ 1/9 (8 left) — git remote group handling
 - [x] `t5900-repo-selection` — selecting remote repo in ambiguous cases (8/8)
 - [ ] `t5582-fetch-negative-refspec` ████████░░░░░░░░░░░░ 7/16 (9 left) — 

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -882,7 +882,7 @@ t5311-pack-bitmaps-shallow	t5	yes	6	6	0	true	ok	0
 t5312-prune-corruption	t5	yes	11	4	7	false	ok	0
 t5313-pack-bounds-checks	t5	yes	9	2	7	false	ok	0
 t5314-pack-cycle-detection	t5	yes	2	1	1	false	ok	0
-t5315-pack-objects-compression	t5	yes	9	1	8	false	ok	0
+t5315-pack-objects-compression	t5	yes	9	9	0	true	ok	0
 t5316-pack-delta-depth	t5	yes	5	3	2	false	ok	0
 t5317-pack-objects-filter-objects	t5	yes	33	19	14	false	ok	0
 t5318-commit-graph	t5	skip	85	0	0	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,694 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,694 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T00:43:21+00:00" class="gen-time" title="2026-04-10 00:43 UTC">2026-04-10 00:43 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,694</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">34/167 files · 17 skipped · 1,574/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:38.0%"></div></div>
+        <span class="group-pct pct-red">38.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35694 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,694 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T00:43:21+00:00" class="gen-time" title="2026-04-10 00:43 UTC">2026-04-10 00:43 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,694</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -8977,14 +8977,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="9" data-passed="1">
+<tr class="" data-group="t5" data-tests="9" data-passed="9" data-full-pass="1">
   <td class="mono">t5315-pack-objects-compression</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">9</td>
-  <td class="right">1</td>
+  <td class="right">9</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:11.1%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="5" data-passed="3">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/config.rs
+++ b/grit-lib/src/config.rs
@@ -1463,6 +1463,61 @@ impl ConfigSet {
         self.get(key).map(|v| parse_i64(&v))
     }
 
+    /// Zlib deflate level for `git pack-objects` (Git's `pack_compression_level`).
+    ///
+    /// Entries are applied in [`Self::entries`] order. `core.compression` sets the pack level
+    /// until a `pack.compression` appears (Git `pack_compression_seen`). `core.loosecompression`
+    /// is ignored here — it only affects loose-object zlib, not packs.
+    ///
+    /// `-1` means zlib default (level 6). Valid values are `-1` or `0..=9`.
+    pub fn pack_objects_zlib_level(&self) -> Result<i32> {
+        const Z_DEFAULT_COMPRESSION: i32 = 6;
+        const Z_BEST_COMPRESSION: i32 = 9;
+
+        let parse_compression = |raw: &str| -> Result<i32> {
+            let v = parse_git_config_int_strict(raw.trim()).map_err(|_| {
+                Error::ConfigError(format!("bad numeric config value '{raw}' for compression"))
+            })?;
+            if v == -1 {
+                return Ok(Z_DEFAULT_COMPRESSION);
+            }
+            if v < 0 || v > i64::from(Z_BEST_COMPRESSION) {
+                return Err(Error::ConfigError(format!(
+                    "bad zlib compression level {v}"
+                )));
+            }
+            Ok(v as i32)
+        };
+
+        // `core.loosecompression` affects loose objects only (Git `zlib_compression_level`), not pack.
+        let mut pack_level = Z_DEFAULT_COMPRESSION;
+        let mut pack_compression_seen = false;
+
+        for e in self.entries() {
+            match e.key.as_str() {
+                "core.compression" => {
+                    let Some(val) = e.value.as_deref() else {
+                        continue;
+                    };
+                    let level = parse_compression(val)?;
+                    if !pack_compression_seen {
+                        pack_level = level;
+                    }
+                }
+                "pack.compression" => {
+                    let Some(val) = e.value.as_deref() else {
+                        continue;
+                    };
+                    pack_level = parse_compression(val)?;
+                    pack_compression_seen = true;
+                }
+                _ => {}
+            }
+        }
+
+        Ok(pack_level)
+    }
+
     /// Get all entries matching a key pattern (regex).
     ///
     /// Used by `git config --get-regexp`. Returns an error if the pattern
@@ -2876,5 +2931,77 @@ mod get_regexp_tests {
         let set = set_from_snippet("[user]\n\tname = x\n");
         let err = set.get_regexp("(").expect_err("unclosed group");
         assert!(err.contains("invalid key pattern"), "got: {err}");
+    }
+}
+
+#[cfg(test)]
+mod pack_compression_tests {
+    use super::{ConfigFile, ConfigScope, ConfigSet};
+    use std::path::Path;
+
+    fn set_from_snippet(text: &str) -> ConfigSet {
+        let path = Path::new(".git/config");
+        let file = ConfigFile::parse(path, text, ConfigScope::Local).expect("parse config snippet");
+        let mut set = ConfigSet::new();
+        set.merge(&file);
+        set
+    }
+
+    #[test]
+    fn pack_objects_zlib_level_defaults_to_six() {
+        let set = ConfigSet::new();
+        assert_eq!(set.pack_objects_zlib_level().unwrap(), 6);
+    }
+
+    #[test]
+    fn pack_objects_zlib_level_core_compression() {
+        let set = set_from_snippet("[core]\n\tcompression = 0\n");
+        assert_eq!(set.pack_objects_zlib_level().unwrap(), 0);
+        let set = set_from_snippet("[core]\n\tcompression = 9\n");
+        assert_eq!(set.pack_objects_zlib_level().unwrap(), 9);
+    }
+
+    #[test]
+    fn pack_objects_zlib_level_pack_overrides_core() {
+        let set = set_from_snippet("[core]\n\tcompression = 9\n[pack]\n\tcompression = 0\n");
+        assert_eq!(set.pack_objects_zlib_level().unwrap(), 0);
+        let set = set_from_snippet("[core]\n\tcompression = 0\n[pack]\n\tcompression = 9\n");
+        assert_eq!(set.pack_objects_zlib_level().unwrap(), 9);
+    }
+
+    #[test]
+    fn pack_objects_zlib_level_later_core_does_not_override_earlier_pack() {
+        let mut set = ConfigSet::new();
+        set.merge(
+            &ConfigFile::parse(
+                Path::new("a"),
+                "[pack]\n\tcompression = 9\n",
+                ConfigScope::Local,
+            )
+            .unwrap(),
+        );
+        set.merge(
+            &ConfigFile::parse(
+                Path::new("b"),
+                "[core]\n\tcompression = 0\n",
+                ConfigScope::Local,
+            )
+            .unwrap(),
+        );
+        assert_eq!(set.pack_objects_zlib_level().unwrap(), 9);
+    }
+
+    #[test]
+    fn pack_objects_zlib_level_loosecompression_does_not_block_core_pack_level() {
+        let set = set_from_snippet("[core]\n\tloosecompression = 1\n\tcompression = 0\n");
+        assert_eq!(set.pack_objects_zlib_level().unwrap(), 0);
+    }
+
+    #[test]
+    fn pack_objects_zlib_level_pack_wins_after_loose_and_core() {
+        let set = set_from_snippet(
+            "[core]\n\tloosecompression = 1\n\tcompression = 0\n[pack]\n\tcompression = 9\n",
+        );
+        assert_eq!(set.pack_objects_zlib_level().unwrap(), 9);
     }
 }

--- a/grit/src/commands/pack_objects.rs
+++ b/grit/src/commands/pack_objects.rs
@@ -399,8 +399,14 @@ pub fn run(args: Args) -> Result<()> {
         &pack_list.thin_blob_deltas,
     )?;
 
+    let config = ConfigSet::load(Some(&repo.git_dir), true).context("read repository config")?;
+    let pack_zlib_level = config
+        .pack_objects_zlib_level()
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    let zlib_compression = Compression::new(pack_zlib_level as u32);
+
     // Build pack bytes.
-    let pack_bytes = build_pack(&write_entries)?;
+    let pack_bytes = build_pack(&write_entries, zlib_compression)?;
 
     if args.stdout {
         let stdout = io::stdout();
@@ -1431,7 +1437,7 @@ fn encode_pack_object_header(buf: &mut Vec<u8>, type_code: u8, payload_len: usiz
 }
 
 /// Build a PACK v2 byte stream (full objects and optional `REF_DELTA` blobs).
-fn build_pack(entries: &[PackWriteEntry]) -> Result<Vec<u8>> {
+fn build_pack(entries: &[PackWriteEntry], zlib: Compression) -> Result<Vec<u8>> {
     let mut buf = Vec::new();
     buf.extend_from_slice(b"PACK");
     buf.extend_from_slice(&2u32.to_be_bytes());
@@ -1447,7 +1453,7 @@ fn build_pack(entries: &[PackWriteEntry]) -> Result<Vec<u8>> {
                     ObjectKind::Tag => 4,
                 };
                 encode_pack_object_header(&mut buf, type_code, pe.data.len());
-                let mut enc = ZlibEncoder::new(Vec::new(), Compression::default());
+                let mut enc = ZlibEncoder::new(Vec::new(), zlib);
                 enc.write_all(&pe.data)?;
                 let compressed = enc.finish()?;
                 buf.extend_from_slice(&compressed);
@@ -1457,7 +1463,7 @@ fn build_pack(entries: &[PackWriteEntry]) -> Result<Vec<u8>> {
             } => {
                 encode_pack_object_header(&mut buf, 7, delta.len());
                 buf.extend_from_slice(base_oid.as_bytes());
-                let mut enc = ZlibEncoder::new(Vec::new(), Compression::default());
+                let mut enc = ZlibEncoder::new(Vec::new(), zlib);
                 enc.write_all(delta)?;
                 let compressed = enc.finish()?;
                 buf.extend_from_slice(&compressed);

--- a/logs/2026-04-10_t5315-pack-objects-compression.md
+++ b/logs/2026-04-10_t5315-pack-objects-compression.md
@@ -1,0 +1,15 @@
+# t5315-pack-objects-compression
+
+## Problem
+
+Harness showed 5/9: `pack-objects` always used `flate2::Compression::default()` for packed object zlib streams, ignoring `core.compression` and `pack.compression`.
+
+## Fix
+
+- Added `ConfigSet::pack_objects_zlib_level()` in `grit-lib/src/config.rs`: walks merged config entries in order, applies `core.compression` until `pack.compression` appears (Git `pack_compression_seen` semantics). `-1` maps to level 6. Validates with `parse_git_config_int_strict`.
+- `grit pack-objects` loads repo config once per run and passes `Compression::new(level)` into `build_pack` for full objects and REF_DELTA payloads.
+
+## Verification
+
+- `cargo test -p grit-lib --lib`
+- `./scripts/run-tests.sh t5315-pack-objects-compression.sh` → 9/9

--- a/progress.md
+++ b/progress.md
@@ -1,20 +1,21 @@
 # Progress — Grit Test Coverage
 
-**Updated:** 2026-04-09
+**Updated:** 2026-04-10
 
 ## Counts (derived from plan.md)
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   325 |
+| Completed   |   326 |
 | In progress |     5 |
-| Remaining   |   441 |
+| Remaining   |   440 |
 | **Total**   |   771 |
 
-Task lines in `PLAN.md`: 325 completed (`[x]`), 5 in progress (`[~]`), 441 remaining (`[ ]`).
+Task lines in `PLAN.md`: 326 completed (`[x]`), 5 in progress (`[~]`), 440 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t5315-pack-objects-compression` — 9/9 tests pass (`pack-objects` honors `core.compression` / `pack.compression` for zlib deflate level via `ConfigSet::pack_objects_zlib_level`; harness CSV/dashboards refreshed)
 - `t3309-notes-merge-auto-resolve` — 31/31 tests pass (`notes merge`: `union` / `cat_sort_uniq` blob combine like Git; successful merge commits use two parents; `notes.mergeStrategy` config errors match upstream expectations)
 - `t4063-diff-blobs` — 18/18 tests pass (`diff`: blob↔blob and `rev:path` pairs without treating blobs as trees; `HEAD:one..HEAD:two` range split; `rev:path` vs worktree file uses tree path + modes + `write_patch_with_prefix`; raw blob OID vs existing file uses filename as old path; `rev_parse::resolve_treeish_blob_at_path` for tree walks)
 - `t5524-pull-msg` — 3/3 tests pass (`git pull --no-rebase --log` merge message preserves `$` in subject lines; `--log=1` limits shortlog; harness CSV/dashboards refreshed; `PLAN.md` marked complete)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`pack-objects` always zlib-compressed pack entries with `flate2::Compression::default()`, so `core.compression` and `pack.compression` had no effect. The upstream test `t5315-pack-objects-compression` checks pack file size for a 2MB blob of spaces at levels 0 vs 9.

## Changes

- **`grit-lib`**: `ConfigSet::pack_objects_zlib_level()` walks merged config in load order: `core.compression` applies until `pack.compression` is seen (Git `pack_compression_seen` semantics). `-1` maps to zlib default (6). Unit tests added.
- **`grit`**: Load repo config in `pack-objects`, pass the resolved level into `build_pack` for full objects and REF_DELTA payloads.

## Verification

- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t5315-pack-objects-compression.sh` → 9/9

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f7b114b-2500-430f-8e06-0e4c1249791f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f7b114b-2500-430f-8e06-0e4c1249791f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

