### PR TITLE
fix: git-p4 harness (GIT_EXEC_PATH, PYTHON) for t9832-unshelve

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,686 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,686 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T00:43:12+00:00" class="gen-time" title="2026-04-10 00:43 UTC">2026-04-10 00:43 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,686</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>758 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35686 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,686 / 45,142 tests · 1,405 files in scope · 758 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T00:43:12+00:00" class="gen-time" title="2026-04-10 00:43 UTC">2026-04-10 00:43 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,686</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit/src/alias.rs
+++ b/grit/src/alias.rs
@@ -349,11 +349,7 @@ pub(crate) fn find_git_external_helper(cmd: &str, exec_path: Option<&Path>) -> O
 
 fn try_exec_dashed(cmd: &str, rest: &[String], opts: &GlobalOpts) -> Result<bool> {
     let ext_cmd = format!("git-{cmd}");
-    let exec_path = opts.exec_path.clone().or_else(|| {
-        std::env::current_exe()
-            .ok()
-            .and_then(|e| e.parent().map(|p| p.to_path_buf()))
-    });
+    let exec_path = crate::git_exec_path_for_helpers(opts.exec_path.as_deref());
     if let Some(ext_path) = find_git_external_helper(cmd, exec_path.as_deref()) {
         let status = std::process::Command::new(&ext_path)
             .args(rest.iter())

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -2242,6 +2242,22 @@ pub(crate) struct GlobalOpts {
     exec_path: Option<PathBuf>,
 }
 
+/// Directory used to resolve `git-<cmd>` helpers, matching upstream Git order:
+/// `GIT_EXEC_PATH` (when non-empty), then `--exec-path`, then the directory of the running binary.
+#[must_use]
+pub(crate) fn git_exec_path_for_helpers(cli_exec_path: Option<&Path>) -> Option<PathBuf> {
+    if let Ok(ep) = std::env::var("GIT_EXEC_PATH") {
+        if !ep.is_empty() {
+            return Some(PathBuf::from(ep));
+        }
+    }
+    cli_exec_path.map(Path::to_path_buf).or_else(|| {
+        std::env::current_exe()
+            .ok()
+            .and_then(|e| e.parent().map(|p| p.to_path_buf()))
+    })
+}
+
 /// Extract global options and return (globals, subcommand_name, remaining_args).
 ///
 /// We scan argv[1..] for global flags that appear before the subcommand.
@@ -2279,11 +2295,9 @@ pub(crate) fn extract_globals(
             continue;
         }
         if arg == "--exec-path" {
-            // Print exec-path and exit
-            if let Ok(exe) = std::env::current_exe() {
-                if let Some(dir) = exe.parent() {
-                    println!("{}", dir.display());
-                }
+            // Print exec-path and exit (honour GIT_EXEC_PATH like upstream Git).
+            if let Some(dir) = git_exec_path_for_helpers(opts.exec_path.as_deref()) {
+                println!("{}", dir.display());
             }
             std::process::exit(0);
         }
@@ -3796,11 +3810,7 @@ fn handle_unknown_git_command(subcmd: &str, rest: &[String], opts: &GlobalOpts) 
                 .map(|r| r.git_dir)
         });
     let config = grit_lib::config::ConfigSet::load(git_dir.as_deref(), true).unwrap_or_default();
-    let exec_path = opts.exec_path.clone().or_else(|| {
-        std::env::current_exe()
-            .ok()
-            .and_then(|e| e.parent().map(|p| p.to_path_buf()))
-    });
+    let exec_path = git_exec_path_for_helpers(opts.exec_path.as_deref());
 
     let mut names: HashSet<String> = KNOWN_COMMANDS.iter().map(|s| (*s).to_string()).collect();
     for a in collect_alias_command_names(&config) {

--- a/logs/2026-04-10-t9832-unshelve-harness.md
+++ b/logs/2026-04-10-t9832-unshelve-harness.md
@@ -1,0 +1,18 @@
+# t9832-unshelve / git-p4 harness
+
+## Problem
+
+- `lib-git-p4.sh` required `PYTHON` prereq but `tests/test-lib.sh` never set it, so all git-p4 tests skipped as "python not available".
+- Grit resolved `git-<cmd>` helpers only from `--exec-path` or the grit binary directory, ignoring `GIT_EXEC_PATH`, so vendored `git/git-p4.py` could not be used the way upstream Git does.
+
+## Changes
+
+- **`tests/test-lib.sh`**: Export `PYTHON_PATH` early; set `PYTHON` prereq when `NO_PYTHON` is unset; in `setup_trash`, set `GIT_EXEC_PATH` to a per-test dir containing a `git-p4` wrapper that runs `PYTHON_PATH GIT_SOURCE_DIR/git-p4.py`.
+- **`grit/src/main.rs`**: Add `git_exec_path_for_helpers()` (GIT_EXEC_PATH, then CLI `--exec-path`, then binary dir); use it for `git-<cmd>` lookup in unknown-command help and for `git --exec-path` output.
+- **`grit/src/alias.rs`**: Use `git_exec_path_for_helpers` in `try_exec_dashed`.
+
+## Verification
+
+- Manual: `GIT_EXEC_PATH` dir with stub `git-p4` — `grit p4` runs stub; `grit --exec-path` prints `GIT_EXEC_PATH` when set.
+- `cargo check -p grit-rs`, `cargo test -p grit-lib --lib` pass.
+- Full t9832 run in this image skips at `p4`/`p4d` missing (expected without Helix CLI); harness reports 0 tests when skip_all.

--- a/tests/test-lib.sh
+++ b/tests/test-lib.sh
@@ -133,6 +133,10 @@ else
 	RED='' GREEN='' YELLOW='' RESET=''
 fi
 
+# Used by lib-git-p4 (git-p4 wrapper) and other tests; must exist before `setup_trash`.
+PYTHON_PATH=${PYTHON_PATH:-$(command -v python3 2>/dev/null || command -v python 2>/dev/null || echo /usr/bin/python3)}
+export PYTHON_PATH
+
 # Set up a fresh trash directory for this test script.
 setup_trash () {
 	if test -d "$TRASH_DIRECTORY"; then
@@ -172,6 +176,20 @@ EOF
 exec "$GUST_BIN" scalar "\$@"
 EOF
 	chmod +x "$BIN_DIRECTORY/scalar"
+	# GIT_EXEC_PATH: upstream git-p4 lives beside the git binary; grit delegates to
+	# git-p4.py from the vendored Git tree so `git p4` and `$(git --exec-path)/git-p4` work.
+	_GIT_EXEC_HELPER_DIR="$BIN_DIRECTORY/git-exec"
+	mkdir -p "$_GIT_EXEC_HELPER_DIR"
+	if test -f "$GIT_SOURCE_DIR/git-p4.py"
+	then
+		cat >"$_GIT_EXEC_HELPER_DIR/git-p4" <<EOF
+#!/bin/sh
+exec "$PYTHON_PATH" "$GIT_SOURCE_DIR/git-p4.py" "\$@"
+EOF
+		chmod +x "$_GIT_EXEC_HELPER_DIR/git-p4"
+	fi
+	GIT_EXEC_PATH="$_GIT_EXEC_HELPER_DIR"
+	export GIT_EXEC_PATH
 	# Save PATH before grit/git wrappers so test_done can restore the caller's environment.
 	TEST_LIB_ORIG_PATH=$PATH
 	export TEST_LIB_ORIG_PATH
@@ -957,6 +975,12 @@ test_set_prereq () {
 
 # Grit implements the traditional loose-ref + packed-refs layout (not reftable).
 test_set_prereq REFFILES
+
+# Python prerequisite (matches upstream git/t test-lib NO_PYTHON).
+if test -z "${NO_PYTHON-}"
+then
+	test_set_prereq PYTHON
+fi
 
 # Lazy prerequisites (git/t0000 nested-lazy): script runs in a temp dir under trash.
 lazily_testable_prereq=


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Enables the ported `git p4` shell tests to run the real upstream `git/git-p4.py` through grit when Perforce CLI (`p4`/`p4d`) is available.

## Changes

- **Grit**: Resolve `git-<cmd>` helpers using **`GIT_EXEC_PATH`** first (then `--exec-path`, then the grit binary directory), matching upstream Git. `git --exec-path` with no argument prints the same directory.
- **tests/test-lib.sh**: Export **`PYTHON_PATH`** early; set the **`PYTHON`** prerequisite when `NO_PYTHON` is unset; in `setup_trash`, set **`GIT_EXEC_PATH`** to a per-test directory containing a **`git-p4`** wrapper that runs `python3` on `GIT_SOURCE_DIR/git-p4.py`.

## Verification

- `cargo check -p grit-rs`, `cargo test -p grit-lib --lib`
- Manual check: stub `git-p4` under `GIT_EXEC_PATH` is invoked by `grit p4`.

## Note

In environments without `p4`/`p4d`, `lib-git-p4.sh` still skips the whole file (0 tests); with Helix tools installed, t9832 exercises unshelve against the vendored script.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8aa1ca53-a13c-4d02-a1f9-fae55f548e68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8aa1ca53-a13c-4d02-a1f9-fae55f548e68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

