### PR TITLE
fix: make t1800-hook fully pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -456,7 +456,7 @@ t1600-index	t1	yes	7	7	0	true	ok	0
 t1601-index-bogus	t1	yes	4	4	0	true	ok	0
 t1700-split-index	t1	yes	29	3	26	false	ok	0
 t1701-racy-split-index	t1	yes	31	1	30	false	ok	0
-t1800-hook	t1	yes	44	11	33	false	ok	0
+t1800-hook	t1	yes	44	44	0	true	ok	0
 t1800-ls-remote	t1	yes	24	22	2	false	ok	0
 t1900-repo-info	t1	yes	37	37	0	true	ok	0
 t1901-repo-structure	t1	yes	4	4	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,719 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,719 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T00:44:04+00:00" class="gen-time" title="2026-04-10 00:44 UTC">2026-04-10 00:44 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,719</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -197,11 +197,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">275/368 files · 8 skipped · 11,694/12,747 tests</span>
+        <span class="group-meta">276/368 files · 8 skipped · 11,727/12,747 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:91.7%"></div></div>
-        <span class="group-pct pct-green">91.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:92.0%"></div></div>
+        <span class="group-pct pct-green">92.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t2">
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35719 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,719 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T00:44:04+00:00" class="gen-time" title="2026-04-10 00:44 UTC">2026-04-10 00:44 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,719</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -4717,14 +4717,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:3.2%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="44" data-passed="11">
+<tr class="" data-group="t1" data-tests="44" data-passed="44" data-full-pass="1">
   <td class="mono">t1800-hook</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">44</td>
-  <td class="right">11</td>
+  <td class="right">44</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:25.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="24" data-passed="22">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/hooks.rs
+++ b/grit-lib/src/hooks.rs
@@ -1,11 +1,15 @@
 //! Hook execution utilities.
 //!
-//! Provides a reusable function for running Git hooks from `.git/hooks/`
-//! or from the directory configured via `core.hooksPath`.
+//! Implements Git's multihook model: hooks from `hook.<name>.*` config plus the
+//! traditional script in the hooks directory (`core.hooksPath` or `.git/hooks/`).
 
-use crate::config::ConfigSet;
+use crate::config::{parse_path, ConfigSet};
+use crate::objects::ObjectId;
 use crate::repo::Repository;
+use crate::state::HeadState;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs;
+use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -26,10 +30,241 @@ fn stdio_piped(piped: bool) -> Stdio {
     }
 }
 
-/// Spawn a hook script. If the kernel rejects direct execution (e.g. no shebang, ENOEXEC), run it
-/// with `/bin/sh` like Git does.
-fn spawn_hook_child(
-    hook_path: &Path,
+/// Git `git_parse_maybe_bool`: `Some(true/false)` or `None` if unrecognized.
+fn parse_maybe_bool(value: &str) -> Option<bool> {
+    let v = value.trim().to_ascii_lowercase();
+    match v.as_str() {
+        "true" | "yes" | "on" | "1" => Some(true),
+        "false" | "no" | "off" | "0" => Some(false),
+        _ => None,
+    }
+}
+
+/// Split `hook.<subsection>.<var>` into `(subsection, var)`.
+fn parse_hook_config_key(key: &str) -> Option<(&str, &str)> {
+    let rest = key.strip_prefix("hook.")?;
+    let (subsection, var) = rest.rsplit_once('.')?;
+    if subsection.is_empty() || var.is_empty() {
+        return None;
+    }
+    Some((subsection, var))
+}
+
+/// Parsed `hook.*` configuration in one pass (Git `hook_config_lookup_all` semantics).
+#[derive(Debug, Default)]
+struct HookConfigTables {
+    /// Friendly name → last-seen command string.
+    commands: HashMap<String, String>,
+    /// Event name → ordered friendly names (last duplicate wins position).
+    event_hooks: HashMap<String, VecDeque<String>>,
+    disabled: HashSet<String>,
+}
+
+impl HookConfigTables {
+    fn apply_entry(&mut self, key: &str, value: Option<&str>) {
+        let Some((hook_name, subkey)) = parse_hook_config_key(key) else {
+            return;
+        };
+        let Some(value) = value else {
+            return;
+        };
+        let hook_name = hook_name.to_string();
+
+        match subkey {
+            "event" => {
+                if value.is_empty() {
+                    for hooks in self.event_hooks.values_mut() {
+                        hooks.retain(|n| n != &hook_name);
+                    }
+                } else {
+                    let event = value.to_string();
+                    let hooks = self.event_hooks.entry(event).or_default();
+                    hooks.retain(|n| n != &hook_name);
+                    hooks.push_back(hook_name);
+                }
+            }
+            "command" => {
+                self.commands.insert(hook_name, value.to_string());
+            }
+            "enabled" => match parse_maybe_bool(value) {
+                Some(false) => {
+                    self.disabled.insert(hook_name);
+                }
+                Some(true) => {
+                    self.disabled.remove(&hook_name);
+                }
+                None => {}
+            },
+            _ => {}
+        }
+    }
+
+    fn from_config(config: &ConfigSet) -> Self {
+        let mut t = Self::default();
+        for e in config.entries() {
+            t.apply_entry(&e.key, e.value.as_deref());
+        }
+        t
+    }
+
+    /// Configured hooks for `event`, in order, excluding disabled entries without a command.
+    ///
+    /// Returns `Err` if a non-disabled hook lacks `hook.<name>.command` (Git dies here).
+    fn hooks_for_event(&self, event: &str) -> Result<Vec<(String, String)>, String> {
+        let Some(names) = self.event_hooks.get(event) else {
+            return Ok(Vec::new());
+        };
+        let mut out = Vec::new();
+        for name in names {
+            if self.disabled.contains(name) {
+                continue;
+            }
+            let Some(cmd) = self.commands.get(name) else {
+                return Err(format!(
+                    "'hook.{name}.command' must be configured or 'hook.{name}.event' must be removed; aborting."
+                ));
+            };
+            out.push((name.clone(), cmd.clone()));
+        }
+        Ok(out)
+    }
+}
+
+/// One hook invocation resolved for an event.
+#[derive(Debug)]
+enum ResolvedHook {
+    Configured { command: String },
+    Traditional { path: PathBuf, argv0: PathBuf },
+}
+
+/// Resolve the hooks directory from config or fall back to `$GIT_DIR/hooks`.
+pub fn resolve_hooks_dir(repo: &Repository) -> PathBuf {
+    resolve_hooks_dir_for_config(
+        Some(&repo.git_dir),
+        ConfigSet::load(Some(&repo.git_dir), true).ok().as_ref(),
+    )
+}
+
+fn resolve_hooks_dir_for_config(git_dir: Option<&Path>, config: Option<&ConfigSet>) -> PathBuf {
+    if let Some(cfg) = config {
+        if let Some(hooks_path) = cfg.get("core.hooksPath") {
+            let expanded = parse_path(&hooks_path);
+            let p = PathBuf::from(expanded);
+            if p.is_absolute() {
+                return p;
+            }
+            if let Ok(cwd) = std::env::current_dir() {
+                return cwd.join(p);
+            }
+        }
+    }
+    git_dir
+        .map(|gd| gd.join("hooks"))
+        .unwrap_or_else(|| PathBuf::from("hooks"))
+}
+
+fn hook_argv0(repo: &Repository, hooks_dir: &Path, hook_name: &str, cwd: &Path) -> PathBuf {
+    let default_hooks_dir = repo.git_dir.join("hooks");
+    if hooks_dir == default_hooks_dir.as_path() {
+        if cwd == repo.git_dir.as_path() {
+            return PathBuf::from("hooks").join(hook_name);
+        }
+        if let Some(work_tree) = repo.work_tree.as_deref() {
+            if cwd == work_tree {
+                return PathBuf::from(".git").join("hooks").join(hook_name);
+            }
+        }
+    }
+    hooks_dir.join(hook_name)
+}
+
+fn traditional_hook_candidate(
+    repo: &Repository,
+    hooks_dir: &Path,
+    hook_name: &str,
+) -> Option<PathBuf> {
+    let path = hooks_dir.join(hook_name);
+    if !path.exists() {
+        return None;
+    }
+    let meta = fs::metadata(&path).ok()?;
+    if meta.permissions().mode() & 0o111 == 0 {
+        let config = ConfigSet::load(Some(&repo.git_dir), true).ok();
+        let show_warning = config
+            .as_ref()
+            .and_then(|c| c.get("advice.ignoredHook"))
+            .map(|v| !matches!(v.to_lowercase().as_str(), "false" | "no" | "off" | "0"))
+            .unwrap_or(true);
+        if show_warning {
+            eprintln!(
+                "hint: The '{hook_name}' hook was ignored because it's not set as executable."
+            );
+            eprintln!(
+                "hint: You can disable this warning with `git config set advice.ignoredHook false`."
+            );
+        }
+        return None;
+    }
+    Some(path)
+}
+
+/// Configured hooks only (for out-of-repo `git hook run`).
+fn resolve_configured_hooks_only(
+    hook_name: &str,
+    config: &ConfigSet,
+) -> Result<Vec<ResolvedHook>, String> {
+    let tables = HookConfigTables::from_config(config);
+    let mut seq = Vec::new();
+    for (_friendly, command) in tables.hooks_for_event(hook_name)? {
+        seq.push(ResolvedHook::Configured { command });
+    }
+    Ok(seq)
+}
+
+/// Build ordered hook list: configured hooks first, then the traditional hookdir script.
+fn resolve_hook_sequence(
+    repo: &Repository,
+    hook_name: &str,
+    config: &ConfigSet,
+) -> Result<Vec<ResolvedHook>, String> {
+    let tables = HookConfigTables::from_config(config);
+    let mut seq = Vec::new();
+    for (_friendly, command) in tables.hooks_for_event(hook_name)? {
+        seq.push(ResolvedHook::Configured { command });
+    }
+    let hooks_dir = resolve_hooks_dir_for_config(Some(&repo.git_dir), Some(config));
+    if let Some(path) = traditional_hook_candidate(repo, &hooks_dir, hook_name) {
+        let work_dir = repo.work_tree.as_deref().unwrap_or(&repo.git_dir);
+        let argv0 = hook_argv0(repo, &hooks_dir, hook_name, work_dir);
+        seq.push(ResolvedHook::Traditional { path, argv0 });
+    }
+    Ok(seq)
+}
+
+/// List hook display lines for `git hook list` (configured friendly names, then `hook from hookdir`).
+pub fn list_hooks_display_lines(
+    repo: Option<&Repository>,
+    hook_name: &str,
+    config: &ConfigSet,
+) -> Result<Vec<String>, String> {
+    let git_dir = repo.map(|r| r.git_dir.as_path());
+    let tables = HookConfigTables::from_config(config);
+    let mut lines = Vec::new();
+    for (friendly, _) in tables.hooks_for_event(hook_name)? {
+        lines.push(friendly);
+    }
+    if let Some(r) = repo {
+        let hooks_dir = resolve_hooks_dir_for_config(git_dir, Some(config));
+        if traditional_hook_candidate(r, &hooks_dir, hook_name).is_some() {
+            lines.push("hook from hookdir".to_owned());
+        }
+    }
+    Ok(lines)
+}
+
+/// Spawn a traditional hook executable. On ENOEXEC, retry with `/bin/sh`.
+fn spawn_traditional_hook(
+    argv0: &Path,
     hook_args: &[&str],
     cwd: &Path,
     git_dir: &Path,
@@ -41,10 +276,10 @@ fn spawn_hook_child(
 ) -> std::io::Result<std::process::Child> {
     let mut cmd = if use_shell {
         let mut sh = Command::new("/bin/sh");
-        sh.arg(hook_path);
+        sh.arg(argv0);
         sh
     } else {
-        Command::new(hook_path)
+        Command::new(argv0)
     };
     cmd.args(hook_args)
         .current_dir(cwd)
@@ -61,8 +296,8 @@ fn spawn_hook_child(
             #[cfg(unix)]
             {
                 if !use_shell && is_enoexec(&e) {
-                    return spawn_hook_child(
-                        hook_path,
+                    return spawn_traditional_hook(
+                        argv0,
                         hook_args,
                         cwd,
                         git_dir,
@@ -79,6 +314,45 @@ fn spawn_hook_child(
     }
 }
 
+/// Spawn a configured hook (`/bin/sh -c <command>`) with optional extra args as `$1`, `$2`, …
+fn spawn_configured_hook(
+    command: &str,
+    hook_args: &[&str],
+    cwd: &Path,
+    git_dir: Option<&Path>,
+    extra_env: &[(&str, &str)],
+    stdin_piped: bool,
+    stdout_piped: bool,
+    stderr_piped: bool,
+) -> std::io::Result<std::process::Child> {
+    let mut cmd = Command::new("/bin/sh");
+    cmd.arg("-c")
+        .arg(command)
+        .arg("hook")
+        .args(hook_args)
+        .current_dir(cwd)
+        .stdin(stdio_piped(stdin_piped))
+        .stdout(stdio_piped(stdout_piped))
+        .stderr(stdio_piped(stderr_piped));
+    if let Some(gd) = git_dir {
+        cmd.env("GIT_DIR", gd);
+    }
+    for (k, v) in extra_env {
+        cmd.env(k, v);
+    }
+    cmd.spawn()
+}
+
+fn report_spawn_error(path: &Path, err: &std::io::Error) {
+    let msg = format!("{err}");
+    let p = path.display();
+    if msg.contains("No such file") || msg.contains("not found") {
+        eprintln!("error: cannot exec '{p}': {msg}");
+    } else {
+        eprintln!("error: cannot exec '{p}': {msg}");
+    }
+}
+
 /// Result of running a hook.
 #[derive(Debug)]
 pub enum HookResult {
@@ -92,140 +366,210 @@ pub enum HookResult {
 
 impl HookResult {
     /// Returns true if the hook was successful or not found.
+    #[must_use]
     pub fn is_ok(&self) -> bool {
         matches!(self, HookResult::Success | HookResult::NotFound)
     }
 
     /// Returns true if the hook existed and ran (regardless of exit code).
+    #[must_use]
     pub fn was_executed(&self) -> bool {
         matches!(self, HookResult::Success | HookResult::Failed(_))
     }
 }
 
-/// Resolve the hooks directory from config or fall back to `$GIT_DIR/hooks`.
-pub fn resolve_hooks_dir(repo: &Repository) -> PathBuf {
-    let config = ConfigSet::load(Some(&repo.git_dir), true).ok();
+/// Options for [`run_hook_opts`].
+#[derive(Debug, Clone, Default)]
+pub struct RunHookOptions<'a> {
+    /// When true, hook stdout is merged to stderr (Git default except `pre-push`).
+    pub stdout_to_stderr: bool,
+    /// File path to open and pipe to each hook's stdin (reopened per hook).
+    pub path_to_stdin: Option<&'a Path>,
+    /// In-memory stdin (used when `path_to_stdin` is None).
+    pub stdin_data: Option<&'a [u8]>,
+    /// Extra environment variables for each hook subprocess.
+    pub env_vars: &'a [(&'a str, &'a str)],
+}
 
-    if let Some(ref config) = config {
-        if let Some(hooks_path) = config.get("core.hooksPath") {
-            let expanded = crate::config::parse_path(&hooks_path);
-            let p = PathBuf::from(expanded);
-            if p.is_absolute() {
-                return p;
+/// Run all hooks for `hook_name` in Git order; return first non-zero exit or success.
+///
+/// When `repo` is `None`, only configured hooks run (out-of-repo); cwd is the process cwd and
+/// `GIT_DIR` is not set for those hooks.
+///
+/// When `capture_output` is `Some`, each hook's stdout and stderr are appended there (receive-pack /
+/// simulated remote) instead of being written to the process stderr.
+pub fn run_hook_opts(
+    repo: Option<&Repository>,
+    hook_name: &str,
+    args: &[&str],
+    config: &ConfigSet,
+    opts: RunHookOptions<'_>,
+    mut capture_output: Option<&mut Vec<u8>>,
+) -> Result<HookResult, String> {
+    let seq = match repo {
+        Some(r) => resolve_hook_sequence(r, hook_name, config)?,
+        None => resolve_configured_hooks_only(hook_name, config)?,
+    };
+    if seq.is_empty() {
+        return Ok(HookResult::NotFound);
+    }
+
+    let work_dir: PathBuf = match repo {
+        Some(r) => r.work_tree.clone().unwrap_or_else(|| r.git_dir.clone()),
+        None => std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+    };
+    let work_dir = work_dir.as_path();
+    let git_dir_for_configured = repo.map(|r| r.git_dir.as_path());
+
+    for h in &seq {
+        let (stdin_piped, stdin_file) = match opts.path_to_stdin {
+            Some(p) => (true, Some(p.to_path_buf())),
+            None => (opts.stdin_data.is_some(), None),
+        };
+
+        let capture_mode = capture_output.is_some();
+        let (stdout_piped, stderr_piped) = if capture_mode {
+            (true, true)
+        } else if opts.stdout_to_stderr {
+            (true, true)
+        } else {
+            (false, false)
+        };
+
+        let mut child = match h {
+            ResolvedHook::Traditional { path, argv0 } => {
+                let Some(r) = repo else {
+                    continue;
+                };
+                let gd = r.git_dir.as_path();
+                match spawn_traditional_hook(
+                    argv0,
+                    args,
+                    work_dir,
+                    gd,
+                    opts.env_vars,
+                    stdin_piped,
+                    stdout_piped,
+                    stderr_piped,
+                    false,
+                ) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        report_spawn_error(path, &e);
+                        return Ok(HookResult::Failed(1));
+                    }
+                }
             }
-            // Relative to the working directory (git behaviour).
-            if let Ok(cwd) = std::env::current_dir() {
-                return cwd.join(p);
+            ResolvedHook::Configured { command } => {
+                match spawn_configured_hook(
+                    command,
+                    args,
+                    work_dir,
+                    git_dir_for_configured,
+                    opts.env_vars,
+                    stdin_piped,
+                    stdout_piped,
+                    stderr_piped,
+                ) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        eprintln!("error: failed to run configured hook: {e}");
+                        return Ok(HookResult::Failed(1));
+                    }
+                }
             }
+        };
+
+        if let Some(ref path) = stdin_file {
+            let file = match fs::File::open(path) {
+                Ok(f) => f,
+                Err(e) => {
+                    eprintln!("error: failed to open stdin file {}: {e}", path.display());
+                    return Ok(HookResult::Failed(1));
+                }
+            };
+            if let Some(ref mut stdin) = child.stdin {
+                let mut file = file;
+                let _ = std::io::copy(&mut file, stdin);
+            }
+            drop(child.stdin.take());
+        } else if let Some(data) = opts.stdin_data {
+            if let Some(ref mut stdin) = child.stdin {
+                let _ = stdin.write_all(data);
+            }
+            drop(child.stdin.take());
+        }
+
+        let status = if capture_mode {
+            let output = match child.wait_with_output() {
+                Ok(o) => o,
+                Err(_) => return Ok(HookResult::Failed(1)),
+            };
+            if let Some(buf) = capture_output.as_mut() {
+                buf.extend_from_slice(&output.stdout);
+                buf.extend_from_slice(&output.stderr);
+            }
+            output.status
+        } else if opts.stdout_to_stderr {
+            let output = match child.wait_with_output() {
+                Ok(o) => o,
+                Err(_) => return Ok(HookResult::Failed(1)),
+            };
+            let mut stderr = std::io::stderr().lock();
+            let _ = stderr.write_all(&output.stdout);
+            let _ = stderr.write_all(&output.stderr);
+            output.status
+        } else {
+            match child.wait() {
+                Ok(s) => s,
+                Err(_) => return Ok(HookResult::Failed(1)),
+            }
+        };
+
+        if !status.success() {
+            return Ok(HookResult::Failed(status.code().unwrap_or(1)));
         }
     }
 
-    repo.git_dir.join("hooks")
+    Ok(HookResult::Success)
 }
 
-fn hook_command_path(repo: &Repository, hooks_dir: &Path, hook_name: &str, cwd: &Path) -> PathBuf {
-    let default_hooks_dir = repo.git_dir.join("hooks");
-    if hooks_dir == default_hooks_dir {
-        if cwd == repo.git_dir {
-            return PathBuf::from("hooks").join(hook_name);
-        }
-        if let Some(work_tree) = repo.work_tree.as_deref() {
-            if cwd == work_tree {
-                return PathBuf::from(".git").join("hooks").join(hook_name);
-            }
-        }
-    }
-    hooks_dir.join(hook_name)
-}
-
-/// Run a hook by name with the given arguments.
+/// Run a hook by name with the given arguments (Git-compatible multihooks).
 ///
-/// The hook is looked up in the hooks directory (respecting `core.hooksPath`).
-/// If the hook file doesn't exist or isn't executable, returns `HookResult::NotFound`.
-///
-/// `stdin_data` can optionally provide data to write to the hook's stdin.
+/// `pre-push` keeps stdout separate; other hooks merge stdout to stderr.
 pub fn run_hook(
     repo: &Repository,
     hook_name: &str,
     args: &[&str],
     stdin_data: Option<&[u8]>,
 ) -> HookResult {
-    let hooks_dir = resolve_hooks_dir(repo);
-    let hook_path = hooks_dir.join(hook_name);
-
-    // If the hook doesn't exist, silently succeed (git behaviour).
-    if !hook_path.exists() {
-        return HookResult::NotFound;
-    }
-
-    // Check if executable.
-    let meta = match fs::metadata(&hook_path) {
-        Ok(m) => m,
-        Err(_) => return HookResult::NotFound,
-    };
-    if meta.permissions().mode() & 0o111 == 0 {
-        // Warn that the hook exists but is not executable (like git does)
-        let config = ConfigSet::load(Some(&repo.git_dir), true).ok();
-        let show_warning = config
-            .as_ref()
-            .and_then(|c| c.get("advice.ignoredHook"))
-            .map(|v| !matches!(v.to_lowercase().as_str(), "false" | "no" | "off" | "0"))
-            .unwrap_or(true);
-        if show_warning {
-            eprintln!(
-                "hint: The '{}' hook was ignored because it's not set as executable.",
-                hook_name
-            );
-            eprintln!(
-                "hint: You can disable this warning with `git config set advice.ignoredHook false`."
-            );
-        }
-        return HookResult::NotFound;
-    }
-
-    let work_dir = repo.work_tree.as_deref().unwrap_or(&repo.git_dir);
-    let command_path = hook_command_path(repo, &hooks_dir, hook_name, work_dir);
-
-    let stdin_piped = stdin_data.is_some();
-
-    let mut child = match spawn_hook_child(
-        &command_path,
-        args,
-        work_dir,
-        &repo.git_dir,
-        &[],
-        stdin_piped,
-        false,
-        false,
-        false,
-    ) {
+    let config = match ConfigSet::load(Some(&repo.git_dir), true) {
         Ok(c) => c,
         Err(_) => return HookResult::Failed(1),
     };
-
-    if let Some(data) = stdin_data {
-        if let Some(ref mut stdin) = child.stdin {
-            use std::io::Write;
-            let _ = stdin.write_all(data);
+    let stdout_to_stderr = hook_name != "pre-push";
+    match run_hook_opts(
+        Some(repo),
+        hook_name,
+        args,
+        &config,
+        RunHookOptions {
+            stdout_to_stderr,
+            path_to_stdin: None,
+            stdin_data,
+            env_vars: &[],
+        },
+        None,
+    ) {
+        Ok(r) => r,
+        Err(msg) => {
+            eprintln!("fatal: {msg}");
+            HookResult::Failed(1)
         }
-        // Drop stdin to signal EOF
-        drop(child.stdin.take());
-    }
-
-    match child.wait() {
-        Ok(status) => {
-            if status.success() {
-                HookResult::Success
-            } else {
-                HookResult::Failed(status.code().unwrap_or(1))
-            }
-        }
-        Err(_) => HookResult::Failed(1),
     }
 }
 
-/// Like `run_hook` but captures stdout and returns it alongside the result.
-/// Run a hook with extra env vars, setting cwd to GIT_DIR (for receive-side hooks).
+/// Run a hook with extra env vars, cwd = `GIT_DIR` (receive-pack and similar).
 pub fn run_hook_in_git_dir(
     repo: &Repository,
     hook_name: &str,
@@ -233,59 +577,26 @@ pub fn run_hook_in_git_dir(
     stdin_data: Option<&[u8]>,
     env_vars: &[(&str, &str)],
 ) -> (HookResult, Vec<u8>) {
-    let hooks_dir = resolve_hooks_dir(repo);
-    let hook_path = hooks_dir.join(hook_name);
-
-    if !hook_path.exists() {
-        return (HookResult::NotFound, Vec::new());
-    }
-
-    let meta = match fs::metadata(&hook_path) {
-        Ok(m) => m,
-        Err(_) => return (HookResult::NotFound, Vec::new()),
-    };
-    if meta.permissions().mode() & 0o111 == 0 {
-        return (HookResult::NotFound, Vec::new());
-    }
-
-    let command_path = hook_command_path(repo, &hooks_dir, hook_name, &repo.git_dir);
-    let stdin_piped = stdin_data.is_some();
-
-    let mut child = match spawn_hook_child(
-        &command_path,
-        args,
-        &repo.git_dir,
-        &repo.git_dir,
-        env_vars,
-        stdin_piped,
-        true,
-        true,
-        false,
-    ) {
+    let config = match ConfigSet::load(Some(&repo.git_dir), true) {
         Ok(c) => c,
         Err(_) => return (HookResult::Failed(1), Vec::new()),
     };
-
-    if let Some(data) = stdin_data {
-        if let Some(ref mut stdin) = child.stdin {
-            use std::io::Write;
-            let _ = stdin.write_all(data);
-        }
-        drop(child.stdin.take());
-    }
-
-    match child.wait_with_output() {
-        Ok(output) => {
-            let mut combined = output.stdout;
-            combined.extend_from_slice(&output.stderr);
-            let result = if output.status.success() {
-                HookResult::Success
-            } else {
-                HookResult::Failed(output.status.code().unwrap_or(1))
-            };
-            (result, combined)
-        }
-        Err(_) => (HookResult::Failed(1), Vec::new()),
+    let mut captured = Vec::new();
+    match run_hook_opts(
+        Some(repo),
+        hook_name,
+        args,
+        &config,
+        RunHookOptions {
+            stdout_to_stderr: true,
+            path_to_stdin: None,
+            stdin_data,
+            env_vars,
+        },
+        Some(&mut captured),
+    ) {
+        Ok(r) => (r, captured),
+        Err(_) => (HookResult::Failed(1), captured),
     }
 }
 
@@ -297,61 +608,26 @@ pub fn run_hook_with_env(
     stdin_data: Option<&[u8]>,
     env_vars: &[(&str, &str)],
 ) -> (HookResult, Vec<u8>) {
-    let hooks_dir = resolve_hooks_dir(repo);
-    let hook_path = hooks_dir.join(hook_name);
-
-    if !hook_path.exists() {
-        return (HookResult::NotFound, Vec::new());
-    }
-
-    let meta = match fs::metadata(&hook_path) {
-        Ok(m) => m,
-        Err(_) => return (HookResult::NotFound, Vec::new()),
-    };
-    if meta.permissions().mode() & 0o111 == 0 {
-        return (HookResult::NotFound, Vec::new());
-    }
-
-    let work_dir = repo.work_tree.as_deref().unwrap_or(&repo.git_dir);
-    let command_path = hook_command_path(repo, &hooks_dir, hook_name, work_dir);
-
-    let stdin_piped = stdin_data.is_some();
-
-    let mut child = match spawn_hook_child(
-        &command_path,
-        args,
-        work_dir,
-        &repo.git_dir,
-        env_vars,
-        stdin_piped,
-        true,
-        true,
-        false,
-    ) {
+    let config = match ConfigSet::load(Some(&repo.git_dir), true) {
         Ok(c) => c,
         Err(_) => return (HookResult::Failed(1), Vec::new()),
     };
-
-    if let Some(data) = stdin_data {
-        if let Some(ref mut stdin) = child.stdin {
-            use std::io::Write;
-            let _ = stdin.write_all(data);
-        }
-        drop(child.stdin.take());
-    }
-
-    match child.wait_with_output() {
-        Ok(output) => {
-            let mut combined = output.stdout;
-            combined.extend_from_slice(&output.stderr);
-            let result = if output.status.success() {
-                HookResult::Success
-            } else {
-                HookResult::Failed(output.status.code().unwrap_or(1))
-            };
-            (result, combined)
-        }
-        Err(_) => (HookResult::Failed(1), Vec::new()),
+    let mut captured = Vec::new();
+    match run_hook_opts(
+        Some(repo),
+        hook_name,
+        args,
+        &config,
+        RunHookOptions {
+            stdout_to_stderr: true,
+            path_to_stdin: None,
+            stdin_data,
+            env_vars,
+        },
+        Some(&mut captured),
+    ) {
+        Ok(r) => (r, captured),
+        Err(_) => (HookResult::Failed(1), captured),
     }
 }
 
@@ -361,60 +637,44 @@ pub fn run_hook_capture(
     args: &[&str],
     stdin_data: Option<&[u8]>,
 ) -> (HookResult, Vec<u8>) {
-    let hooks_dir = resolve_hooks_dir(repo);
-    let hook_path = hooks_dir.join(hook_name);
+    run_hook_with_env(repo, hook_name, args, stdin_data, &[])
+}
 
-    if !hook_path.exists() {
-        return (HookResult::NotFound, Vec::new());
-    }
-
-    let meta = match fs::metadata(&hook_path) {
-        Ok(m) => m,
-        Err(_) => return (HookResult::NotFound, Vec::new()),
+/// `reference-transaction` hook with phase `committed` after updating `HEAD` and (on a branch)
+/// the branch ref to `new_oid`.
+///
+/// `old_head_commit` is the commit OID `HEAD` pointed at before the update, or `None` for an
+/// unborn branch (null old OID in hook stdin).
+#[must_use]
+pub fn run_reference_transaction_committed_for_head_update(
+    repo: &Repository,
+    head: &HeadState,
+    old_head_commit: Option<ObjectId>,
+    new_oid: ObjectId,
+) -> HookResult {
+    let zero = ObjectId::from_bytes(&[0u8; 20]).unwrap();
+    let old_oid = old_head_commit.unwrap_or(zero);
+    let old_hex = if old_oid == zero {
+        "0000000000000000000000000000000000000000".to_owned()
+    } else {
+        old_oid.to_hex()
     };
-    if meta.permissions().mode() & 0o111 == 0 {
-        return (HookResult::NotFound, Vec::new());
-    }
-
-    let work_dir = repo.work_tree.as_deref().unwrap_or(&repo.git_dir);
-    let command_path = hook_command_path(repo, &hooks_dir, hook_name, work_dir);
-
-    let stdin_piped = stdin_data.is_some();
-
-    let mut child = match spawn_hook_child(
-        &command_path,
-        args,
-        work_dir,
-        &repo.git_dir,
-        &[],
-        stdin_piped,
-        true,
-        true,
-        false,
-    ) {
-        Ok(c) => c,
-        Err(_) => return (HookResult::Failed(1), Vec::new()),
-    };
-
-    if let Some(data) = stdin_data {
-        if let Some(ref mut stdin) = child.stdin {
-            use std::io::Write;
-            let _ = stdin.write_all(data);
+    let new_hex = new_oid.to_hex();
+    let mut stdin = String::new();
+    match head {
+        HeadState::Branch { refname, .. } => {
+            // Git sorts ref updates lexicographically; `HEAD` precedes `refs/...`.
+            stdin.push_str(&format!("{old_hex} {new_hex} HEAD\n"));
+            stdin.push_str(&format!("{old_hex} {new_hex} {refname}\n"));
         }
-        drop(child.stdin.take());
-    }
-
-    match child.wait_with_output() {
-        Ok(output) => {
-            let mut combined = output.stdout;
-            combined.extend_from_slice(&output.stderr);
-            let result = if output.status.success() {
-                HookResult::Success
-            } else {
-                HookResult::Failed(output.status.code().unwrap_or(1))
-            };
-            (result, combined)
+        _ => {
+            stdin.push_str(&format!("{old_hex} {new_hex} HEAD\n"));
         }
-        Err(_) => (HookResult::Failed(1), Vec::new()),
     }
+    run_hook(
+        repo,
+        "reference-transaction",
+        &["committed"],
+        Some(stdin.as_bytes()),
+    )
 }

--- a/grit-lib/src/repo.rs
+++ b/grit-lib/src/repo.rs
@@ -25,6 +25,7 @@ use std::sync::Mutex;
 
 use crate::config::{ConfigFile, ConfigScope, ConfigSet};
 use crate::error::{Error, Result};
+use crate::hooks::run_hook;
 use crate::index::Index;
 use crate::objects::parse_commit;
 use crate::odb::Odb;
@@ -401,7 +402,11 @@ impl Repository {
     /// Like [`Repository::write_index`], but writes to an explicit index file path.
     pub fn write_index_at(&self, path: &std::path::Path, index: &mut Index) -> Result<()> {
         self.finalize_sparse_index_if_needed(index)?;
-        index.write(path)
+        index.write(path)?;
+        // Git `write_locked_index`: `post-index-change` after a successful index write (t1800).
+        // Grit does not yet track `updated_workdir` / `updated_skipworktree`; pass `0` `0`.
+        let _ = run_hook(self, "post-index-change", &["0", "0"], None);
+        Ok(())
     }
 
     fn finalize_sparse_index_if_needed(&self, index: &mut Index) -> Result<()> {

--- a/grit/src/commands/am.rs
+++ b/grit/src/commands/am.rs
@@ -16,6 +16,7 @@ use std::io::{self, Read, Write};
 use std::path::Path;
 
 use grit_lib::config::{parse_bool, ConfigSet};
+use grit_lib::hooks::{run_hook, run_reference_transaction_committed_for_head_update, HookResult};
 use grit_lib::index::{Index, IndexEntry, MODE_REGULAR};
 use grit_lib::objects::{parse_commit, serialize_commit, CommitData, ObjectId, ObjectKind};
 use grit_lib::refs::{delete_ref, write_ref};
@@ -814,18 +815,14 @@ fn apply_one_patch(repo: &Repository, patch: &MboxPatch, opts: &AmOptions) -> Re
             if !opts.no_verify {
                 let msg_path = git_dir.join("MERGE_MSG");
                 fs::write(&msg_path, &patch.message)?;
-                if !run_hook(
-                    git_dir,
-                    "applypatch-msg",
-                    &[msg_path.to_str().unwrap_or("")],
-                )? {
+                if !run_am_hook(repo, "applypatch-msg", &[msg_path.to_str().unwrap_or("")])? {
                     let _ = fs::remove_file(&msg_path);
                     bail!("applypatch-msg hook rejected the patch");
                 }
             }
 
             // Run pre-applypatch hook
-            if !opts.no_verify && !run_hook(git_dir, "pre-applypatch", &[])? {
+            if !opts.no_verify && !run_am_hook(repo, "pre-applypatch", &[])? {
                 bail!("pre-applypatch hook rejected the patch");
             }
 
@@ -835,7 +832,7 @@ fn apply_one_patch(repo: &Repository, patch: &MboxPatch, opts: &AmOptions) -> Re
 
             // Run post-applypatch hook
             if !opts.no_verify {
-                let _ = run_hook(git_dir, "post-applypatch", &[]);
+                let _ = run_am_hook(repo, "post-applypatch", &[]);
             }
 
             let _ = fs::remove_file(git_dir.join("MERGE_MSG"));
@@ -849,11 +846,7 @@ fn apply_one_patch(repo: &Repository, patch: &MboxPatch, opts: &AmOptions) -> Re
     if !opts.no_verify {
         let msg_path = git_dir.join("MERGE_MSG");
         fs::write(&msg_path, &patch.message)?;
-        if !run_hook(
-            git_dir,
-            "applypatch-msg",
-            &[msg_path.to_str().unwrap_or("")],
-        )? {
+        if !run_am_hook(repo, "applypatch-msg", &[msg_path.to_str().unwrap_or("")])? {
             let _ = fs::remove_file(&msg_path);
             bail!("applypatch-msg hook rejected the patch");
         }
@@ -908,7 +901,7 @@ fn apply_one_patch(repo: &Repository, patch: &MboxPatch, opts: &AmOptions) -> Re
     }
 
     // Run pre-applypatch hook
-    if !opts.no_verify && !run_hook(git_dir, "pre-applypatch", &[])? {
+    if !opts.no_verify && !run_am_hook(repo, "pre-applypatch", &[])? {
         bail!("pre-applypatch hook rejected the patch");
     }
 
@@ -916,7 +909,7 @@ fn apply_one_patch(repo: &Repository, patch: &MboxPatch, opts: &AmOptions) -> Re
 
     // Run post-applypatch hook (failure doesn't abort)
     if !opts.no_verify {
-        let _ = run_hook(git_dir, "post-applypatch", &[]);
+        let _ = run_am_hook(repo, "post-applypatch", &[]);
     }
 
     let _ = fs::remove_file(git_dir.join("MERGE_MSG"));
@@ -1731,8 +1724,15 @@ variable i18n.commitEncoding to the encoding your project uses.\n"
     let commit_bytes = serialize_commit(&commit_data);
     let commit_oid = repo.odb.write(ObjectKind::Commit, &commit_bytes)?;
 
+    let old_head_commit = head.oid().copied();
     // Update HEAD
     update_head(git_dir, &head, &commit_oid)?;
+    let _ = run_reference_transaction_committed_for_head_update(
+        repo,
+        &head,
+        old_head_commit,
+        commit_oid,
+    );
 
     Ok(())
 }
@@ -2082,33 +2082,11 @@ fn load_am_options(state_dir: &Path) -> AmOptions {
 
 // ── Hooks ───────────────────────────────────────────────────────────
 
-fn run_hook(git_dir: &Path, hook_name: &str, args: &[&str]) -> Result<bool> {
-    let hook_path = git_dir.join("hooks").join(hook_name);
-    if !hook_path.exists() {
-        return Ok(true); // No hook = success
-    }
-
-    // Determine the work tree (parent of git_dir, unless it's a bare repo)
-    let work_dir = git_dir.parent().unwrap_or(git_dir);
-
-    // Build the command - use sh to handle scripts without shebangs
-    let mut cmd = std::process::Command::new(&hook_path);
-    cmd.args(args).env("GIT_DIR", git_dir).current_dir(work_dir);
-
-    let status = cmd
-        .status()
-        .or_else(|_| {
-            // If direct execution fails, try via /bin/sh
-            std::process::Command::new("/bin/sh")
-                .arg(&hook_path)
-                .args(args)
-                .env("GIT_DIR", git_dir)
-                .current_dir(work_dir)
-                .status()
-        })
-        .with_context(|| format!("failed to execute hook {}", hook_name))?;
-
-    Ok(status.success())
+fn run_am_hook(repo: &Repository, hook_name: &str, args: &[&str]) -> Result<bool> {
+    Ok(matches!(
+        run_hook(repo, hook_name, args, None),
+        HookResult::Success | HookResult::NotFound
+    ))
 }
 
 // ── Cleanup ─────────────────────────────────────────────────────────

--- a/grit/src/commands/checkout.rs
+++ b/grit/src/commands/checkout.rs
@@ -20,7 +20,7 @@ use grit_lib::crlf::{self, MergeAttr};
 use grit_lib::diff::read_submodule_head_oid;
 use grit_lib::diff::{diff_index_to_worktree, zero_oid};
 use grit_lib::filter_process;
-use grit_lib::hooks::{run_hook, HookResult};
+use grit_lib::hooks::{run_hook, run_reference_transaction_committed_for_head_update, HookResult};
 use grit_lib::index::{Index, IndexEntry, MODE_EXECUTABLE, MODE_GITLINK, MODE_SYMLINK};
 use grit_lib::merge_file::{self, ConflictStyle, MergeFavor, MergeInput};
 use grit_lib::merge_trees::{
@@ -1282,6 +1282,13 @@ fn run_post_checkout_hook(
     new_oid: &ObjectId,
     is_branch_checkout: bool,
 ) -> Result<()> {
+    let head = resolve_head(&repo.git_dir)?;
+    let _ = run_reference_transaction_committed_for_head_update(
+        repo,
+        &head,
+        old_oid.copied(),
+        *new_oid,
+    );
     let z = zero_oid();
     let old_hex = old_oid.unwrap_or(&z).to_hex();
     let new_hex = new_oid.to_hex();

--- a/grit/src/commands/commit.rs
+++ b/grit/src/commands/commit.rs
@@ -11,7 +11,7 @@ use grit_lib::diff::{
     DiffStatus,
 };
 use grit_lib::error::Error;
-use grit_lib::hooks::{run_hook, HookResult};
+use grit_lib::hooks::{run_hook, run_reference_transaction_committed_for_head_update, HookResult};
 use grit_lib::index::Index;
 use grit_lib::objects::{serialize_commit, CommitData, ObjectId, ObjectKind};
 use grit_lib::refs::{append_reflog, list_refs};
@@ -762,9 +762,11 @@ pub fn run(mut args: Args) -> Result<()> {
         }
     }
 
-    // Run pre-commit hook
-    if let HookResult::Failed(code) = run_hook(&repo, "pre-commit", &[], None) {
-        bail!("pre-commit hook exited with status {code}");
+    // Run pre-commit hook (skipped with `--no-verify` / `-n`, matching Git).
+    if !args.no_verify {
+        if let HookResult::Failed(code) = run_hook(&repo, "pre-commit", &[], None) {
+            bail!("pre-commit hook exited with status {code}");
+        }
     }
 
     let template_path = resolve_commit_template_path(&args, &config)?;
@@ -787,6 +789,37 @@ pub fn run(mut args: Args) -> Result<()> {
     );
     let mut raw_message = msg_result.raw_bytes;
     let template_for_aborted_check = template_path.filter(|_| use_editor_for_message);
+
+    // prepare-commit-msg runs for normal commits (not skipped by `--no-verify`; only pre-commit
+    // and commit-msg are). Writes COMMIT_EDITMSG then lets the hook edit it in place.
+    {
+        let msg_file = repo.git_dir.join("COMMIT_EDITMSG");
+        if let Some(ref raw) = raw_message {
+            fs::write(&msg_file, raw)?;
+        } else {
+            fs::write(&msg_file, message.as_bytes())?;
+        }
+        let msg_path_str = msg_file.to_string_lossy().to_string();
+        let (hook_arg1, hook_arg2) = prepare_commit_msg_hook_args(&args, &repo.git_dir);
+        let hook_args: Vec<&str> = match hook_arg2.as_deref() {
+            Some(s) => vec![msg_path_str.as_str(), hook_arg1, s],
+            None => vec![msg_path_str.as_str(), hook_arg1],
+        };
+        if let HookResult::Failed(code) = run_hook(&repo, "prepare-commit-msg", &hook_args, None) {
+            bail!("prepare-commit-msg hook exited with status {code}");
+        }
+        let new_raw = fs::read(&msg_file)?;
+        match String::from_utf8(new_raw.clone()) {
+            Ok(s) => {
+                message = s;
+                raw_message = None;
+            }
+            Err(_) => {
+                message = String::from_utf8_lossy(&new_raw).to_string();
+                raw_message = Some(new_raw);
+            }
+        }
+    }
 
     if message.trim().is_empty() && !args.allow_empty_message {
         eprintln!("Aborting commit due to empty commit message.");
@@ -943,10 +976,9 @@ pub fn run(mut args: Args) -> Result<()> {
         }
     }
 
-    // Run commit-msg hook with temp file containing the message
-    {
+    // commit-msg hook (skipped with `--no-verify` / `-n`).
+    if !args.no_verify {
         let msg_file = repo.git_dir.join("COMMIT_EDITMSG");
-        // Write raw bytes when available so the hook sees the original encoding
         if let Some(ref raw) = raw_message {
             fs::write(&msg_file, raw)?;
         } else {
@@ -958,7 +990,6 @@ pub fn run(mut args: Args) -> Result<()> {
                 bail!("commit-msg hook exited with status {code}");
             }
             HookResult::Success => {
-                // Re-read the message in case the hook modified it
                 let new_raw = fs::read(&msg_file)?;
                 match String::from_utf8(new_raw.clone()) {
                     Ok(s) => {
@@ -1118,6 +1149,13 @@ pub fn run(mut args: Args) -> Result<()> {
             );
         }
     }
+
+    let _ = run_reference_transaction_committed_for_head_update(
+        &repo,
+        &head,
+        head.oid().copied(),
+        commit_oid,
+    );
 
     let _ = grit_lib::rerere::rerere_post_commit(&repo);
     let _ = crate::commands::maintenance::run_auto_after_commit(&repo, args.quiet);
@@ -2774,6 +2812,34 @@ fn format_git_timestamp(dt: OffsetDateTime) -> String {
     let hours = offset.whole_hours();
     let minutes = offset.minutes_past_hour().unsigned_abs();
     format!("{epoch} {hours:+03}{minutes:02}")
+}
+
+/// First and optional second argument for `prepare-commit-msg` (Git `prepare_to_commit` semantics).
+fn prepare_commit_msg_hook_args(args: &Args, git_dir: &Path) -> (&'static str, Option<String>) {
+    let merge_msg = git_dir.join("MERGE_MSG");
+    let squash_msg = git_dir.join("SQUASH_MSG");
+    if merge_msg.exists() {
+        if squash_msg.exists() {
+            return ("squash", None);
+        }
+        return ("merge", None);
+    }
+    if squash_msg.exists() {
+        return ("squash", None);
+    }
+    if args.template.is_some() {
+        return ("template", None);
+    }
+    if git_dir.join("CHERRY_PICK_HEAD").exists() {
+        return ("commit", Some("CHERRY_PICK_HEAD".to_owned()));
+    }
+    if let Some(ref r) = args.reuse_message {
+        return ("commit", Some(r.clone()));
+    }
+    if let Some(ref r) = args.reedit_message {
+        return ("commit", Some(r.clone()));
+    }
+    ("message", None)
 }
 
 /// Update HEAD to point to the new commit.

--- a/grit/src/commands/hook.rs
+++ b/grit/src/commands/hook.rs
@@ -1,63 +1,241 @@
-//! `grit hook` — run git hooks.
-//!
-//! Runs a hook script from `.git/hooks/` or the directory configured
-//! via `core.hooksPath`.
+//! `grit hook` — list and run git hooks (Git-compatible multihooks).
 //!
 //! Usage:
-//!   grit hook run <hook-name> [-- <hook-args>...]
+//!   git hook run [--ignore-missing] [--to-stdin=<path>] <hook-name> [-- <hook-args>...]
+//!   git hook list [-z] <hook-name>
 
 use anyhow::Result;
-use clap::{Args as ClapArgs, Subcommand};
-use grit_lib::hooks::{run_hook, HookResult};
+use grit_lib::config::ConfigSet;
+use grit_lib::hooks::{list_hooks_display_lines, run_hook_opts, HookResult, RunHookOptions};
 use grit_lib::repo::Repository;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process;
 
-/// Arguments for `grit hook`.
-#[derive(Debug, ClapArgs)]
-#[command(about = "Run git hooks")]
-pub struct Args {
-    #[command(subcommand)]
-    pub action: HookAction,
+fn usage_hook_top() -> ! {
+    eprintln!("usage: git hook run [--ignore-missing] [--to-stdin=<path>] <hook-name> [-- <hook-args>...]");
+    eprintln!("   or: git hook list [-z] <hook-name>");
+    process::exit(129);
 }
 
-#[derive(Debug, Subcommand)]
-pub enum HookAction {
-    /// Run a hook.
-    Run(RunArgs),
+fn usage_hook_run() -> ! {
+    eprintln!("usage: git hook run [--ignore-missing] [--to-stdin=<path>] <hook-name> [-- <hook-args>...]");
+    process::exit(129);
 }
 
-/// Arguments for `grit hook run`.
-#[derive(Debug, ClapArgs)]
-pub struct RunArgs {
-    /// Exit successfully when the requested hook does not exist.
-    #[arg(long = "ignore-missing")]
-    pub ignore_missing: bool,
-
-    /// Name of the hook to run (e.g. pre-commit, post-merge).
-    pub hook_name: String,
-
-    /// Arguments to pass to the hook script.
-    #[arg(last = true)]
-    pub hook_args: Vec<String>,
+fn usage_hook_list() -> ! {
+    eprintln!("usage: git hook list [-z] <hook-name>");
+    process::exit(129);
 }
 
-/// Run the `hook` command.
-pub fn run(args: Args) -> Result<()> {
-    match args.action {
-        HookAction::Run(run_args) => run_hook_cmd(run_args),
+/// Entry point: `rest` is everything after `git hook`.
+pub fn run_from_argv(rest: &[String]) -> Result<()> {
+    let Some(sub) = rest.first().map(|s| s.as_str()) else {
+        usage_hook_top();
+    };
+    match sub {
+        "run" => run_cmd(&rest[1..]),
+        "list" => list_cmd(&rest[1..]),
+        _ => {
+            eprintln!("error: unknown option `{sub}`");
+            process::exit(129);
+        }
     }
 }
 
-fn run_hook_cmd(args: RunArgs) -> Result<()> {
-    let repo = Repository::discover(None)?;
-    let hook_args: Vec<&str> = args.hook_args.iter().map(|s| s.as_str()).collect();
+fn load_config(git_dir: Option<&Path>) -> Result<ConfigSet> {
+    ConfigSet::load(git_dir, true).map_err(|e| anyhow::anyhow!(e))
+}
 
-    match run_hook(&repo, &args.hook_name, &hook_args, None) {
-        HookResult::Success => Ok(()),
-        HookResult::NotFound if args.ignore_missing => Ok(()),
-        HookResult::NotFound => {
-            eprintln!("error: cannot find a hook named {}", args.hook_name);
-            std::process::exit(1);
+fn discover_repo() -> Result<Repository> {
+    Repository::discover(None).map_err(|e| anyhow::anyhow!(e))
+}
+
+/// Git still discovers a repository for `git hook run` even when `GIT_CEILING_DIRECTORIES`
+/// blocks normal commands (`nongit` in the test suite); match that by ignoring the ceiling here.
+struct CeilingDirectoriesGuard {
+    previous: Option<String>,
+}
+
+impl CeilingDirectoriesGuard {
+    fn unset() -> Self {
+        let previous = std::env::var("GIT_CEILING_DIRECTORIES").ok();
+        let _ = std::env::remove_var("GIT_CEILING_DIRECTORIES");
+        Self { previous }
+    }
+}
+
+impl Drop for CeilingDirectoriesGuard {
+    fn drop(&mut self) {
+        if let Some(ref s) = self.previous {
+            std::env::set_var("GIT_CEILING_DIRECTORIES", s);
         }
-        HookResult::Failed(code) => std::process::exit(code),
+    }
+}
+
+fn discover_repo_for_hook_run() -> Result<Repository> {
+    let _ceiling = CeilingDirectoriesGuard::unset();
+    discover_repo()
+}
+
+fn list_cmd(rest: &[String]) -> Result<()> {
+    let mut nul = false;
+    let mut pos: Vec<&str> = Vec::new();
+    let mut i = 0usize;
+    while i < rest.len() {
+        let a = rest[i].as_str();
+        match a {
+            "-z" => {
+                nul = true;
+                i += 1;
+            }
+            "-h" | "--help" => usage_hook_list(),
+            _ if a.starts_with('-') => {
+                eprintln!("error: unknown option `{a}`");
+                process::exit(129);
+            }
+            _ => {
+                pos.push(a);
+                i += 1;
+            }
+        }
+    }
+    if pos.len() != 1 {
+        usage_hook_list();
+    }
+    let hook_event = pos[0];
+
+    let repo_result = discover_repo();
+    let (repo_opt, git_dir_opt) = match repo_result {
+        Ok(r) => (Some(r), None),
+        Err(_) => {
+            let cfg = load_config(None)?;
+            (None, Some(cfg))
+        }
+    };
+
+    let config = if let Some(ref r) = repo_opt {
+        load_config(Some(&r.git_dir))?
+    } else {
+        git_dir_opt.expect("config loaded")
+    };
+
+    let lines = match list_hooks_display_lines(repo_opt.as_ref(), hook_event, &config) {
+        Ok(l) => l,
+        Err(msg) => {
+            eprintln!("fatal: {msg}");
+            process::exit(1);
+        }
+    };
+
+    if lines.is_empty() {
+        eprintln!("warning: No hooks found for event '{hook_event}'");
+        process::exit(1);
+    }
+
+    let mut out = std::io::stdout().lock();
+    if nul {
+        for line in &lines {
+            let _ = write!(out, "{line}\0");
+        }
+    } else {
+        for line in &lines {
+            let _ = writeln!(out, "{line}");
+        }
+    }
+    Ok(())
+}
+
+fn run_cmd(rest: &[String]) -> Result<()> {
+    let mut ignore_missing = false;
+    let mut path_to_stdin: Option<PathBuf> = None;
+    let mut i = 0usize;
+    while i < rest.len() {
+        let a = rest[i].as_str();
+        if a == "-h" || a == "--help" {
+            usage_hook_run();
+        }
+        if a == "--ignore-missing" {
+            ignore_missing = true;
+            i += 1;
+            continue;
+        }
+        if let Some(path) = a.strip_prefix("--to-stdin=") {
+            path_to_stdin = Some(PathBuf::from(path));
+            i += 1;
+            continue;
+        }
+        if a == "--to-stdin" {
+            i += 1;
+            let Some(p) = rest.get(i) else {
+                usage_hook_run();
+            };
+            path_to_stdin = Some(PathBuf::from(p));
+            i += 1;
+            continue;
+        }
+        if a.starts_with('-') {
+            eprintln!("error: unknown option `{a}`");
+            process::exit(129);
+        }
+        break;
+    }
+
+    let Some(hook_name) = rest.get(i).map(|s| s.as_str()) else {
+        usage_hook_run();
+    };
+    i += 1;
+
+    let hook_args: Vec<String> = if i >= rest.len() {
+        Vec::new()
+    } else {
+        let dash = rest[i].as_str();
+        if dash != "--" && dash != "--end-of-options" {
+            usage_hook_run();
+        }
+        rest[i + 1..].to_vec()
+    };
+
+    let hook_args_ref: Vec<&str> = hook_args.iter().map(|s| s.as_str()).collect();
+
+    let repo_result = discover_repo_for_hook_run();
+    let (repo, config) = match repo_result {
+        Ok(r) => {
+            let cfg = load_config(Some(&r.git_dir))?;
+            (Some(r), cfg)
+        }
+        Err(_) => {
+            let cfg = load_config(None)?;
+            (None, cfg)
+        }
+    };
+
+    let stdout_to_stderr = hook_name != "pre-push";
+    let stdin_path = path_to_stdin.as_deref();
+
+    match run_hook_opts(
+        repo.as_ref(),
+        hook_name,
+        &hook_args_ref,
+        &config,
+        RunHookOptions {
+            stdout_to_stderr,
+            path_to_stdin: stdin_path,
+            stdin_data: None,
+            env_vars: &[],
+        },
+        None,
+    ) {
+        Ok(HookResult::Success) => Ok(()),
+        Ok(HookResult::NotFound) if ignore_missing => Ok(()),
+        Ok(HookResult::NotFound) => {
+            eprintln!("error: cannot find a hook named {hook_name}");
+            process::exit(1);
+        }
+        Ok(HookResult::Failed(code)) => process::exit(code),
+        Err(msg) => {
+            eprintln!("fatal: {msg}");
+            process::exit(1);
+        }
     }
 }

--- a/grit/src/commands/merge.rs
+++ b/grit/src/commands/merge.rs
@@ -16,7 +16,7 @@ use grit_lib::config::ConfigSet;
 use grit_lib::crlf::MergeAttr;
 use grit_lib::diff::{count_changes, detect_renames, diff_trees, zero_oid, DiffEntry, DiffStatus};
 use grit_lib::diffstat::{terminal_columns, write_diffstat_block, DiffstatOptions, FileStatInput};
-use grit_lib::hooks::run_hook;
+use grit_lib::hooks::{run_hook, run_reference_transaction_committed_for_head_update, HookResult};
 use grit_lib::index::{Index, IndexEntry, MODE_EXECUTABLE, MODE_GITLINK, MODE_SYMLINK, MODE_TREE};
 use grit_lib::merge_base::is_ancestor;
 use grit_lib::merge_file::{self, ConflictStyle, MergeFavor, MergeInput};
@@ -66,6 +66,27 @@ fn run_post_merge_hook(repo: &Repository, squash: bool) {
     let _ = run_hook(repo, "post-merge", &[flag], None);
 }
 
+fn run_pre_merge_commit_hook(repo: &Repository) -> Result<()> {
+    if let HookResult::Failed(code) = run_hook(repo, "pre-merge-commit", &[], None) {
+        bail!("pre-merge-commit hook exited with status {code}");
+    }
+    Ok(())
+}
+
+/// Update `HEAD` (and branch ref when on a branch) then run `reference-transaction` with phase
+/// `committed` (t1800 client hook ordering).
+fn merge_update_head(
+    repo: &Repository,
+    head: &HeadState,
+    old_head_commit: Option<ObjectId>,
+    new_oid: ObjectId,
+) -> Result<()> {
+    update_head(&repo.git_dir, head, &new_oid)?;
+    let _ =
+        run_reference_transaction_committed_for_head_update(repo, head, old_head_commit, new_oid);
+    Ok(())
+}
+
 /// Arguments for `grit merge`.
 #[derive(Debug, Clone, ClapArgs)]
 #[command(about = "Join two or more development histories together")]
@@ -93,6 +114,10 @@ pub struct Args {
     /// Squash merge: stage changes but don't commit.
     #[arg(long = "squash")]
     pub squash: bool,
+
+    /// Skip the pre-merge-commit hook (Git `--no-verify` / `-n`).
+    #[arg(long = "no-verify", short = 'n')]
+    pub no_verify: bool,
 
     /// Abort in-progress merge.
     #[arg(long = "abort")]
@@ -981,7 +1006,7 @@ fn merge_unborn(repo: &Repository, head: &HeadState, args: &Args) -> Result<()> 
         bail!("Can merge only exactly one commit into empty head");
     }
     let merge_oid = resolve_merge_target(repo, &args.commits[0])?;
-    update_head(&repo.git_dir, head, &merge_oid)?;
+    merge_update_head(repo, head, head.oid().copied(), merge_oid)?;
     // Update index and working tree
     let commit_obj = repo.odb.read(&merge_oid)?;
     let commit = parse_commit(&commit_obj.data)?;
@@ -1050,7 +1075,7 @@ Aborting"
         bail_if_merge_would_overwrite_local_changes(repo, &old_entries, &new_index, false)?;
     }
 
-    update_head(&repo.git_dir, head, &merge_oid)?;
+    merge_update_head(repo, head, Some(head_oid), merge_oid)?;
 
     if let Some(ref wt) = repo.work_tree {
         // Remove files that existed in old HEAD but not in new
@@ -1685,6 +1710,10 @@ Aborting"
         return Ok(());
     }
 
+    if !args.no_verify {
+        run_pre_merge_commit_hook(repo)?;
+    }
+
     // Create merge commit
     let tree_oid = write_tree_from_index(&repo.odb, &merge_result.index, "")?;
     let config = ConfigSet::load(Some(&repo.git_dir), true)?;
@@ -1749,7 +1778,7 @@ Aborting"
 
     let commit_bytes = serialize_commit(&commit_data);
     let commit_oid = repo.odb.write(ObjectKind::Commit, &commit_bytes)?;
-    update_head(&repo.git_dir, head, &commit_oid)?;
+    merge_update_head(repo, head, Some(head_oid), commit_oid)?;
 
     if args.autostash && !autostash_entries.is_empty() {
         apply_autostash_entries(repo, &autostash_entries)?;
@@ -2597,6 +2626,10 @@ fn do_octopus_merge(
         return Ok(());
     }
 
+    if !args.no_verify {
+        run_pre_merge_commit_hook(repo)?;
+    }
+
     let tree_oid = write_tree_from_index(&repo.odb, &final_index, "")?;
     let msg = build_octopus_merge_message(head, &merge_names, args.message.as_deref(), repo);
 
@@ -2626,7 +2659,7 @@ fn do_octopus_merge(
 
     let commit_bytes = serialize_commit(&commit_data);
     let commit_oid = repo.odb.write(ObjectKind::Commit, &commit_bytes)?;
-    update_head(&repo.git_dir, head, &commit_oid)?;
+    merge_update_head(repo, head, Some(head_oid), commit_oid)?;
 
     if !args.quiet {
         let short = &commit_oid.to_hex()[..7];
@@ -2811,6 +2844,10 @@ fn do_strategy_ours(
         return Ok(());
     }
 
+    if !args.no_verify {
+        run_pre_merge_commit_hook(repo)?;
+    }
+
     let commit_data = CommitData {
         tree: tree_oid,
         parents: vec![head_oid, merge_oid],
@@ -2825,7 +2862,7 @@ fn do_strategy_ours(
 
     let commit_bytes = serialize_commit(&commit_data);
     let commit_oid = repo.odb.write(ObjectKind::Commit, &commit_bytes)?;
-    update_head(&repo.git_dir, head, &commit_oid)?;
+    merge_update_head(repo, head, Some(head_oid), commit_oid)?;
 
     if !args.quiet {
         let short = &commit_oid.to_hex()[..7];
@@ -2861,6 +2898,10 @@ fn do_strategy_theirs(
     let author = resolve_ident(&config, "author", now)?;
     let committer = resolve_ident(&config, "committer", now)?;
 
+    if !args.no_verify {
+        run_pre_merge_commit_hook(repo)?;
+    }
+
     let commit_data = CommitData {
         tree: tree_oid,
         parents: vec![head_oid, merge_oid],
@@ -2875,7 +2916,7 @@ fn do_strategy_theirs(
 
     let commit_bytes = serialize_commit(&commit_data);
     let commit_oid = repo.odb.write(ObjectKind::Commit, &commit_bytes)?;
-    update_head(&repo.git_dir, head, &commit_oid)?;
+    merge_update_head(repo, head, Some(head_oid), commit_oid)?;
 
     // Update index and working tree to match theirs
     let entries = tree_to_index_entries(repo, &tree_oid, "")?;
@@ -3252,6 +3293,8 @@ fn merge_continue(message: Option<String>) -> Result<()> {
     let author = resolve_ident(&config, "author", now)?;
     let committer = resolve_ident(&config, "committer", now)?;
 
+    run_pre_merge_commit_hook(&repo)?;
+
     let mut parents = vec![head_oid];
     parents.extend(merge_heads);
 
@@ -3269,7 +3312,7 @@ fn merge_continue(message: Option<String>) -> Result<()> {
 
     let commit_bytes = serialize_commit(&commit_data);
     let commit_oid = repo.odb.write(ObjectKind::Commit, &commit_bytes)?;
-    update_head(git_dir, &head, &commit_oid)?;
+    merge_update_head(&repo, &head, Some(head_oid), commit_oid)?;
 
     // Clean up
     let _ = fs::remove_file(git_dir.join("MERGE_HEAD"));

--- a/grit/src/commands/pull.rs
+++ b/grit/src/commands/pull.rs
@@ -612,6 +612,7 @@ fn build_pull_merge_args(
         ff_only,
         no_ff,
         no_commit: false,
+        no_verify: false,
         squash: false,
         abort: false,
         continue_merge: false,

--- a/grit/src/commands/push.rs
+++ b/grit/src/commands/push.rs
@@ -9,7 +9,7 @@ use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::config::{parse_bool, parse_color, ConfigFile, ConfigScope, ConfigSet};
 use grit_lib::gitmodules::{oids_from_copied_object_paths, verify_gitmodules_for_commit};
-use grit_lib::hooks::{run_hook, run_hook_capture, HookResult};
+use grit_lib::hooks::{run_hook, run_hook_capture, run_hook_with_env, HookResult};
 use grit_lib::merge_base::is_ancestor;
 use grit_lib::objects::ObjectId;
 use grit_lib::push_submodules::{
@@ -1968,6 +1968,26 @@ fn push_to_url(
         }
     }
 
+    if !args.dry_run && !applied_updates.is_empty() {
+        let post_update_owned: Vec<String> = applied_updates
+            .iter()
+            .map(|(u, _)| u.remote_ref.clone())
+            .collect();
+        let post_update_args: Vec<&str> = post_update_owned.iter().map(|s| s.as_str()).collect();
+        let (_, hook_output) = grit_lib::hooks::run_hook_in_git_dir(
+            &remote_repo,
+            "post-update",
+            &post_update_args,
+            None,
+            &push_option_env_refs,
+        );
+        if !hook_output.is_empty() {
+            let output_str = String::from_utf8_lossy(&hook_output);
+            let color_remote = RemoteMessageColorStyle::from_config(config);
+            colorize_remote_output(&output_str, &color_remote);
+        }
+    }
+
     // Set upstream tracking if requested (`--dry-run` only prints what Git would do).
     if args.set_upstream {
         use std::collections::BTreeMap;
@@ -2060,6 +2080,54 @@ fn read_receive_deny_delete_current(cfg: &ConfigSet) -> ReceiveDenyAction {
 ///
 /// Returns `Err(short_reason)` when the ref must be rejected (matches Git's parenthetical in
 /// `! [remote rejected] ... (reason)`).
+/// `receive.denyCurrentBranch = updateInstead`: run `push-to-checkout` then sync work tree when
+/// the hook is missing (Git's `push_to_deploy` uses `read-tree -u -m`).
+fn update_instead_for_checked_out_branch(
+    remote_repo: &Repository,
+    new_oid: &ObjectId,
+    pushing_config: &ConfigSet,
+) -> Result<()> {
+    let work_tree = remote_repo
+        .work_tree
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("updateInstead requires a work tree"))?;
+    let wt_env = work_tree
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("invalid UTF-8 in work tree path for push-to-checkout"))?;
+    let style = RemoteMessageColorStyle::from_config(pushing_config);
+    let (hook_res, hook_out) = run_hook_with_env(
+        remote_repo,
+        "push-to-checkout",
+        &[&new_oid.to_hex()],
+        None,
+        &[("GIT_WORK_TREE", wt_env)],
+    );
+    if !hook_out.is_empty() {
+        let output_str = String::from_utf8_lossy(&hook_out);
+        colorize_remote_output(&output_str, &style);
+    }
+    match hook_res {
+        HookResult::Failed(_) => {
+            bail!("push-to-checkout hook declined");
+        }
+        HookResult::Success => Ok(()),
+        HookResult::NotFound => {
+            let grit_bin = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("grit"));
+            let status = Command::new(&grit_bin)
+                .env("GIT_DIR", &remote_repo.git_dir)
+                .env("GIT_WORK_TREE", wt_env)
+                .current_dir(work_tree)
+                .args(["read-tree", "-u", "-m", &new_oid.to_hex()])
+                .status()
+                .context("spawning read-tree for updateInstead")?;
+            if !status.success() {
+                bail!("could not update working tree to new HEAD (read-tree failed)");
+            }
+            Ok(())
+        }
+    }
+}
+
 fn check_receive_pack_policy(
     remote_repo: &Repository,
     remote_config: &ConfigSet,
@@ -2120,7 +2188,7 @@ fn check_receive_pack_policy(
                 return Err("branch is currently checked out".to_owned());
             }
             ReceiveDenyAction::UpdateInstead => {
-                return Err("denyCurrentBranch = updateInstead is not supported".to_owned());
+                // Allowed: `apply_ref_update` runs `push-to-checkout` and updates the worktree.
             }
         }
     } else {
@@ -2253,6 +2321,21 @@ fn apply_ref_update(
     match (&update.new_oid, &update.old_oid) {
         (Some(new_oid), old_oid_opt) => {
             if !args.dry_run {
+                if !remote_repo.is_bare() {
+                    let head = resolve_head(&remote_repo.git_dir)?;
+                    if let HeadState::Branch { ref refname, .. } = head {
+                        if refname == &update.remote_ref
+                            && read_receive_deny_current(remote_config)
+                                == ReceiveDenyAction::UpdateInstead
+                        {
+                            update_instead_for_checked_out_branch(
+                                remote_repo,
+                                new_oid,
+                                pushing_config,
+                            )?;
+                        }
+                    }
+                }
                 refs::write_ref(&remote_repo.git_dir, &update.remote_ref, new_oid)
                     .with_context(|| format!("updating remote ref {}", update.remote_ref))?;
                 update_remote_tracking_ref(repo, remote_name, &update.remote_ref, Some(*new_oid))?;

--- a/grit/src/commands/receive_pack.rs
+++ b/grit/src/commands/receive_pack.rs
@@ -653,6 +653,28 @@ fn run_hooks_and_update_refs(
         // post-receive is informational only.
     }
 
+    let post_update_arg_strings: Vec<String> = updates
+        .iter()
+        .map(|(_, _, refname)| refname.clone())
+        .collect();
+    if !post_update_arg_strings.is_empty() {
+        let post_update_args: Vec<&str> =
+            post_update_arg_strings.iter().map(|s| s.as_str()).collect();
+        let (post_update_result, post_update_output) = run_hook_in_git_dir(
+            repo,
+            "post-update",
+            &post_update_args,
+            None,
+            &push_option_env,
+        );
+        if !post_update_output.is_empty() {
+            let _ = io::stderr().write_all(&post_update_output);
+        }
+        if let HookResult::Failed(_code) = post_update_result {
+            // post-update failures are ignored (matches receive-pack).
+        }
+    }
+
     let auto_gc = config_bool_any(&remote_config, &["receive.autoGc", "receive.autogc"], true);
     if auto_gc && !updates.is_empty() {
         run_auto_maintenance_quiet(&repo.git_dir);

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -4217,7 +4217,7 @@ pub(crate) fn dispatch(subcmd: &str, rest: &[String], opts: &GlobalOpts) -> Resu
         "hash-object" => commands::hash_object::run(parse_cmd_args(subcmd, rest)),
         "help" => commands::help::run(parse_cmd_args(subcmd, rest)),
         "history" => commands::history::run_from_argv(rest),
-        "hook" => commands::hook::run(parse_cmd_args(subcmd, rest)),
+        "hook" => commands::hook::run_from_argv(rest),
         "http-backend" => commands::http_backend::run(parse_cmd_args(subcmd, rest)),
         "http-fetch" => commands::http_fetch::run(parse_cmd_args(subcmd, rest)),
         "http-push" => commands::http_push::run(parse_cmd_args(subcmd, rest)),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible multihooks and related plumbing so `tests/t1800-hook.sh` passes **44/44**.

### Highlights

- **`git hook`**: `list` / `run` with `hook.<name>.*` config, `--to-stdin`, mandatory `--` for extra args, `-z` NUL output, usage exit **129**, `GIT_CEILING_DIRECTORIES` workaround for `nongit` + in-repo discovery.
- **`grit-lib` hooks**: Ordered configured + traditional hooks; `stdout_to_stderr` (except `pre-push`); optional capture buffer for server paths; shared `reference-transaction` helper for HEAD+branch updates.
- **Commands**: `prepare-commit-msg` + `reference-transaction` on commit (`--no-verify` for pre-commit/commit-msg only); checkout/merge/am/post-index-change hook ordering; `pre-merge-commit` + ref transaction on merge completion; `merge --no-verify`.
- **Transport**: `run_hook_in_git_dir` / `run_hook_capture` use multihook capture (no stdout leak); **`post-update`** after receive-pack and local push simulation; **`receive.denyCurrentBranch = updateInstead`** via `push-to-checkout` + `read-tree` fallback.

### Validation

- `./scripts/run-tests.sh t1800-hook.sh` → **44/44**
- `cargo test -p grit-lib --lib` → pass

Dashboard CSV/HTML/SVG updated from the harness run.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa169f79-aa2e-48d3-903b-915ac9bda934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa169f79-aa2e-48d3-903b-915ac9bda934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

