### PR TITLE
fix: diff-index honors assume-unchanged (t4039)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -717,7 +717,7 @@ t4035-diff-quiet	t4	yes	23	23	0	true	ok	0
 t4036-format-patch-signer-mime	t4	yes	5	5	0	true	ok	0
 t4037-diff-r-t-dirs	t4	yes	2	2	0	true	ok	0
 t4038-diff-combined	t4	yes	25	6	19	false	ok	1
-t4039-diff-assume-unchanged	t4	yes	4	3	1	false	ok	0
+t4039-diff-assume-unchanged	t4	yes	4	4	0	true	ok	0
 t4040-whitespace-status	t4	yes	11	9	2	false	ok	0
 t4041-diff-submodule-option	t4	yes	47	17	30	false	ok	0
 t4042-diff-textconv-caching	t4	yes	8	7	1	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,687 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,687 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T00:50:25+00:00" class="gen-time" title="2026-04-10 00:50 UTC">2026-04-10 00:50 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,687</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -230,7 +230,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">73/178 files · 2 skipped · 2,862/4,438 tests</span>
+        <span class="group-meta">74/178 files · 2 skipped · 2,863/4,438 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.5%"></div></div>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35687 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,687 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T00:50:25+00:00" class="gen-time" title="2026-04-10 00:50 UTC">2026-04-10 00:50 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,687</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -7327,14 +7327,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:24.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t4" data-tests="4" data-passed="3">
+<tr class="" data-group="t4" data-tests="4" data-passed="4" data-full-pass="1">
   <td class="mono">t4039-diff-assume-unchanged</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">4</td>
-  <td class="right">3</td>
+  <td class="right">4</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:75.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="11" data-passed="9">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit/src/commands/diff_index.rs
+++ b/grit/src/commands/diff_index.rs
@@ -48,6 +48,12 @@ pub fn run(mut args: Args) -> Result<()> {
 
     let index_path = effective_index_path(&repo)?;
     let index = repo.load_index_at(&index_path).context("loading index")?;
+    let assume_unchanged_paths: BTreeSet<Vec<u8>> = index
+        .entries
+        .iter()
+        .filter(|e| e.stage() == 0 && e.assume_unchanged())
+        .map(|e| e.path.clone())
+        .collect();
     let mut index_map = BTreeMap::new();
     for entry in &index.entries {
         if entry.stage() != 0 {
@@ -317,6 +323,7 @@ pub fn run(mut args: Args) -> Result<()> {
                         &repo,
                         options.abbrev,
                         !options.cached,
+                        &assume_unchanged_paths,
                     )?;
                 } else {
                     let line = render_raw_diff_entry(
@@ -325,6 +332,7 @@ pub fn run(mut args: Args) -> Result<()> {
                         options.abbrev,
                         !options.cached,
                         quote_fully,
+                        &assume_unchanged_paths,
                     )?;
                     writeln!(out, "{line}")?;
                 }
@@ -967,6 +975,12 @@ fn diff_tree_vs_worktree(
             continue;
         }
         let path = change.path.as_str();
+        if let Some(ie) = index_entries.get(path.as_bytes()) {
+            // `CE_VALID`: do not use the work tree to refresh the new side; keep the index blob.
+            if ie.assume_unchanged() {
+                continue;
+            }
+        }
         if worktree_matches_index_snapshot(repo, work_tree, path, index_snapshot, &index_entries)? {
             continue;
         }
@@ -1005,9 +1019,10 @@ fn diff_tree_vs_worktree(
 
         let abs = work_tree.join(path);
 
-        // Git `diff-lib.c:do_oneway_diff`: do not examine the work tree for skip-worktree entries.
+        // Git `diff-lib.c:do_oneway_diff`: do not examine the work tree for skip-worktree or
+        // assume-unchanged entries.
         if let Some(ie) = index_entries.get(path.as_bytes()) {
-            if ie.skip_worktree() {
+            if ie.skip_worktree() || ie.assume_unchanged() {
                 continue;
             }
         }
@@ -1285,30 +1300,39 @@ fn write_raw_diff_entry_z(
     repo: &Repository,
     abbrev: Option<usize>,
     diff_index_uncached: bool,
+    assume_unchanged_paths: &BTreeSet<Vec<u8>>,
 ) -> Result<()> {
     let width = abbrev.unwrap_or(40).clamp(4, 40);
 
-    let (old_oid_disp, new_oid_disp) = if diff_index_uncached && entry.status == DiffStatus::Added {
-        ("0".repeat(width), "0".repeat(width))
-    } else {
-        let old_oid = if entry.old_oid == zero_oid() {
-            "0".repeat(width)
+    let use_index_oid_for_added = diff_index_uncached
+        && entry.status == DiffStatus::Added
+        && entry
+            .new_path
+            .as_ref()
+            .is_some_and(|p| assume_unchanged_paths.contains(p.as_bytes()));
+
+    let (old_oid_disp, new_oid_disp) =
+        if diff_index_uncached && entry.status == DiffStatus::Added && !use_index_oid_for_added {
+            ("0".repeat(width), "0".repeat(width))
         } else {
-            match abbrev {
-                Some(min_len) => abbreviate_object_id(repo, entry.old_oid, min_len)?,
-                None => entry.old_oid.to_hex(),
-            }
+            let old_oid = if entry.old_oid == zero_oid() {
+                "0".repeat(width)
+            } else {
+                match abbrev {
+                    Some(min_len) => abbreviate_object_id(repo, entry.old_oid, min_len)?,
+                    None => entry.old_oid.to_hex(),
+                }
+            };
+            let new_oid = if entry.new_oid == zero_oid() {
+                "0".repeat(width)
+            } else {
+                match abbrev {
+                    Some(min_len) => abbreviate_object_id(repo, entry.new_oid, min_len)?,
+                    None => entry.new_oid.to_hex(),
+                }
+            };
+            (old_oid, new_oid)
         };
-        let new_oid = if entry.new_oid == zero_oid() {
-            "0".repeat(width)
-        } else {
-            match abbrev {
-                Some(min_len) => abbreviate_object_id(repo, entry.new_oid, min_len)?,
-                None => entry.new_oid.to_hex(),
-            }
-        };
-        (old_oid, new_oid)
-    };
 
     let status_str = match (entry.status, entry.score) {
         (DiffStatus::Renamed, Some(s)) => format!("R{s:03}"),
@@ -1345,32 +1369,41 @@ fn render_raw_diff_entry(
     abbrev: Option<usize>,
     diff_index_uncached: bool,
     quote_fully: bool,
+    assume_unchanged_paths: &BTreeSet<Vec<u8>>,
 ) -> Result<String> {
     let width = abbrev.unwrap_or(40).clamp(4, 40);
 
+    let use_index_oid_for_added = diff_index_uncached
+        && entry.status == DiffStatus::Added
+        && entry
+            .new_path
+            .as_ref()
+            .is_some_and(|p| assume_unchanged_paths.contains(p.as_bytes()));
+
     // `diff-index` uncached raw lines for newly added paths use all-zero object ids on both sides
     // (t1501-work-tree; matches the harness expectations for tree vs index additions).
-    let (old_oid_disp, new_oid_disp) = if diff_index_uncached && entry.status == DiffStatus::Added {
-        ("0".repeat(width), "0".repeat(width))
-    } else {
-        let old_oid = if entry.old_oid == zero_oid() {
-            "0".repeat(width)
+    let (old_oid_disp, new_oid_disp) =
+        if diff_index_uncached && entry.status == DiffStatus::Added && !use_index_oid_for_added {
+            ("0".repeat(width), "0".repeat(width))
         } else {
-            match abbrev {
-                Some(min_len) => abbreviate_object_id(repo, entry.old_oid, min_len)?,
-                None => entry.old_oid.to_hex(),
-            }
+            let old_oid = if entry.old_oid == zero_oid() {
+                "0".repeat(width)
+            } else {
+                match abbrev {
+                    Some(min_len) => abbreviate_object_id(repo, entry.old_oid, min_len)?,
+                    None => entry.old_oid.to_hex(),
+                }
+            };
+            let new_oid = if entry.new_oid == zero_oid() {
+                "0".repeat(width)
+            } else {
+                match abbrev {
+                    Some(min_len) => abbreviate_object_id(repo, entry.new_oid, min_len)?,
+                    None => entry.new_oid.to_hex(),
+                }
+            };
+            (old_oid, new_oid)
         };
-        let new_oid = if entry.new_oid == zero_oid() {
-            "0".repeat(width)
-        } else {
-            match abbrev {
-                Some(min_len) => abbreviate_object_id(repo, entry.new_oid, min_len)?,
-                None => entry.new_oid.to_hex(),
-            }
-        };
-        (old_oid, new_oid)
-    };
 
     let status_str = match (entry.status, entry.score) {
         (DiffStatus::Renamed, Some(s)) => format!("R{:03}", s),

--- a/logs/2026-04-10_t4039-diff-assume-unchanged.md
+++ b/logs/2026-04-10_t4039-diff-assume-unchanged.md
@@ -1,0 +1,15 @@
+# t4039-diff-assume-unchanged
+
+## Failure
+
+`git diff-index HEAD^ -- one` grepped for the index blob of `one` after `update-index --assume-unchanged` and worktree corruption. Grit reported `A` with all-zero new oid in raw output and/or refreshed from the work tree.
+
+## Fix (`grit/src/commands/diff_index.rs`)
+
+1. **`diff_tree_vs_worktree`**: Skip refreshing the tree↔index “new” side from the work tree and skip index↔worktree follow-up when the index entry has `assume_unchanged` (same idea as `skip_worktree` / Git `CE_VALID`).
+2. **Raw `diff-index` output**: For uncached `Added` lines, Git still prints all-zero placeholders in the usual case (t1501). When the path has assume-unchanged set, print the real index blob oid on the new side so scripts can match the staged content without reading the work tree (t4039).
+
+## Validation
+
+- `./scripts/run-tests.sh t4039-diff-assume-unchanged.sh` — 4/4
+- `cargo test -p grit-lib --lib`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes `t4039-diff-assume-unchanged` pass (4/4).

## Changes

- **`diff_tree_vs_worktree`**: Do not refresh the recorded snapshot from the work tree for index entries with `assume-unchanged` (`CE_VALID`), matching Git’s behavior for skip-worktree.
- **Raw `diff-index` output**: For uncached `Added` lines, keep the all-zero OID placeholder for normal paths (preserves expectations like t1501). When the path has assume-unchanged set, emit the real index blob OID on the new side so scripts can `grep` the staged hash without reading the work tree (t4039).

## Validation

- `./scripts/run-tests.sh t4039-diff-assume-unchanged.sh`
- `cargo test -p grit-lib --lib`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e52912a-993d-4ae6-b578-85f774d4095c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e52912a-993d-4ae6-b578-85f774d4095c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

