### PR TITLE
fix: make t2016-checkout-patch fully pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -475,7 +475,7 @@ t2012-checkout-last	t2	yes	22	22	0	true	ok	0
 t2013-checkout-submodule	t2	yes	68	19	49	false	ok	0
 t2014-checkout-switch	t2	yes	4	4	0	true	ok	0
 t2015-checkout-unborn	t2	yes	6	4	2	false	ok	0
-t2016-checkout-patch	t2	yes	19	7	12	false	ok	0
+t2016-checkout-patch	t2	yes	19	19	0	true	ok	0
 t2017-checkout-orphan	t2	yes	13	12	1	false	ok	0
 t2018-checkout-branch	t2	yes	25	25	0	true	ok	0
 t2019-checkout-ambiguous-ref	t2	yes	9	9	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,698 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,698 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T01:00:30+00:00" class="gen-time" title="2026-04-10 01:00 UTC">2026-04-10 01:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,698</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -208,11 +208,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t2</span>
         <span class="group-desc">Basic commands concerning the working tree</span>
-        <span class="group-meta">30/61 files · 9 skipped · 666/872 tests</span>
+        <span class="group-meta">31/61 files · 9 skipped · 678/872 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:76.4%"></div></div>
-        <span class="group-pct pct-blue">76.4%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:77.8%"></div></div>
+        <span class="group-pct pct-blue">77.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t3">
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35698 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,698 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T01:00:30+00:00" class="gen-time" title="2026-04-10 01:00 UTC">2026-04-10 01:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,698</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -4907,14 +4907,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:66.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t2" data-tests="19" data-passed="7">
+<tr class="" data-group="t2" data-tests="19" data-passed="19" data-full-pass="1">
   <td class="mono">t2016-checkout-patch</td>
   <td>t2</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">19</td>
-  <td class="right">7</td>
+  <td class="right">19</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:36.8%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t2" data-tests="13" data-passed="12">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit/src/commands/checkout.rs
+++ b/grit/src/commands/checkout.rs
@@ -11,8 +11,9 @@ use crate::grit_exe;
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use std::collections::{HashMap, HashSet};
+use std::io::{BufRead, Write};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use grit_lib::check_ref_format::{check_refname_format, RefNameOptions};
 use grit_lib::config::ConfigSet;
@@ -21,7 +22,9 @@ use grit_lib::diff::read_submodule_head_oid;
 use grit_lib::diff::{diff_index_to_worktree, zero_oid};
 use grit_lib::filter_process;
 use grit_lib::hooks::{run_hook, HookResult};
-use grit_lib::index::{Index, IndexEntry, MODE_EXECUTABLE, MODE_GITLINK, MODE_SYMLINK};
+use grit_lib::index::{
+    entry_from_stat, normalize_mode, Index, IndexEntry, MODE_EXECUTABLE, MODE_GITLINK, MODE_SYMLINK,
+};
 use grit_lib::merge_file::{self, ConflictStyle, MergeFavor, MergeInput};
 use grit_lib::merge_trees::{
     merge_trees_three_way, TheirsConflictLabel, TreeMergeConflictPresentation,
@@ -32,7 +35,8 @@ use grit_lib::odb::Odb;
 use grit_lib::refs::{self, append_reflog};
 use grit_lib::repo::Repository;
 use grit_lib::rev_parse::{
-    abbreviate_object_id, resolve_revision, resolve_upstream_symbolic_name, upstream_suffix_info,
+    abbreviate_object_id, peel_to_tree, resolve_revision, resolve_upstream_symbolic_name,
+    upstream_suffix_info,
 };
 use grit_lib::sparse_checkout::apply_sparse_checkout_skip_worktree;
 use grit_lib::state::{resolve_head, HeadState};
@@ -712,7 +716,34 @@ pub fn run(mut args: Args) -> Result<()> {
     }
 
     if args.patch {
-        return checkout_patch(&repo, target.as_deref(), &paths);
+        let mut patch_target = target.clone();
+        let mut patch_paths = paths.clone();
+        // `checkout -p [<tree-ish>] [<pathspec>...]` — if the first token is not a revision,
+        // Git treats it as a pathspec (no fatal "unknown revision"). If it resolves as both,
+        // require `--` (same as non-patch checkout).
+        if let Some(ref t) = patch_target {
+            if patch_paths.is_empty() && !has_separator {
+                let is_rev = resolve_revision(&repo, t).is_ok()
+                    || refs::resolve_ref(&repo.git_dir, &format!("refs/heads/{t}")).is_ok();
+                let cwd = std::env::current_dir().unwrap_or_default();
+                let wt = repo.work_tree.as_deref();
+                let is_path = wt.is_some_and(|w| {
+                    let rel = resolve_pathspec(t, w, &cwd);
+                    w.join(rel).exists()
+                });
+                if is_rev && is_path {
+                    bail!(
+                        "fatal: ambiguous argument '{}': both revision and filename\nUse '--' to separate paths from revisions, like this:\n'git <command> [<revision>...] -- [<file>...]'",
+                        t
+                    );
+                }
+                if !is_rev && is_path {
+                    patch_paths.push(t.clone());
+                    patch_target = None;
+                }
+            }
+        }
+        return checkout_patch(&repo, patch_target.as_deref(), &patch_paths);
     }
 
     // Case: checkout --orphan <name> [<start_point>]
@@ -3814,9 +3845,108 @@ checking out of the index."
 // Interactive patch mode
 // ---------------------------------------------------------------------------
 
+/// Run `grit apply` with a unified diff on stdin. Returns whether apply/check succeeded.
+fn run_grit_apply_stdin(
+    repo: &Repository,
+    work_tree: &Path,
+    patch: &str,
+    cached: bool,
+    reverse: bool,
+    check: bool,
+) -> Result<bool> {
+    let mut cmd = Command::new(grit_exe::grit_executable());
+    cmd.current_dir(work_tree);
+    cmd.env("GIT_DIR", &repo.git_dir);
+    grit_exe::strip_trace2_env(&mut cmd);
+    cmd.arg("apply");
+    if check {
+        cmd.arg("--check");
+    }
+    if cached {
+        cmd.arg("--cached");
+    }
+    if reverse {
+        cmd.arg("-R");
+    }
+    cmd.stdin(Stdio::piped());
+    cmd.stdout(Stdio::null());
+    cmd.stderr(Stdio::null());
+    let mut child = cmd.spawn().context("spawn grit apply")?;
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(patch.as_bytes())
+            .context("write patch to grit apply stdin")?;
+    }
+    let status = child.wait().context("wait grit apply")?;
+    Ok(status.success())
+}
+
+/// `checkout -p HEAD` / `@`: match Git's `apply_for_checkout` (add-patch.c) — verify with
+/// `apply --check` / `apply --cached --check`, then apply, or prompt when the index rejects
+/// the hunk while the worktree still accepts it.
+fn apply_checkout_head_mode(
+    repo: &Repository,
+    index: &mut Index,
+    index_path: &Path,
+    work_tree: &Path,
+    path: &str,
+    hunk_texts: &[String],
+    accepted: &[bool],
+    reader: &mut dyn BufRead,
+) -> Result<()> {
+    if !accepted.iter().any(|&a| a) {
+        return Ok(());
+    }
+
+    let mut patch = String::new();
+    patch.push_str(&format!("diff --git a/{path} b/{path}\n"));
+    patch.push_str(&format!("--- a/{path}\n+++ b/{path}\n"));
+    for (i, ht) in hunk_texts.iter().enumerate() {
+        if accepted.get(i).copied().unwrap_or(false) {
+            patch.push_str(ht);
+        }
+    }
+
+    const REVERSE: bool = true;
+    let idx_ok = run_grit_apply_stdin(repo, work_tree, &patch, true, REVERSE, true)?;
+    let wt_ok = run_grit_apply_stdin(repo, work_tree, &patch, false, REVERSE, true)?;
+
+    if idx_ok && wt_ok {
+        run_grit_apply_stdin(repo, work_tree, &patch, true, REVERSE, false)?;
+        *index = repo
+            .load_index_at(index_path)
+            .context("reload index after grit apply --cached")?;
+        run_grit_apply_stdin(repo, work_tree, &patch, false, REVERSE, false)?;
+        return Ok(());
+    }
+
+    if !idx_ok {
+        eprintln!("The selected hunks do not apply to the index!");
+        print!("Apply them to the worktree anyway? ");
+        std::io::stdout().flush().ok();
+        let mut line = String::new();
+        if reader.read_line(&mut line).unwrap_or(0) == 0 {
+            return Ok(());
+        }
+        let yes = matches!(
+            line.trim().chars().next().map(|c| c.to_ascii_lowercase()),
+            Some('y')
+        );
+        if yes {
+            let _ = run_grit_apply_stdin(repo, work_tree, &patch, false, REVERSE, false)?;
+        } else {
+            eprintln!("Nothing was applied.");
+        }
+    } else {
+        print!("{patch}");
+    }
+
+    Ok(())
+}
+
 /// Interactive patch-mode checkout (`checkout -p`).
 ///
-/// Shows each hunk of difference between the source (index or commit) and the
+/// Shows each hunk of difference between the source tree (or index) and the
 /// working tree, prompting the user to accept (y), reject (n), quit (q),
 /// accept-all-in-file (a), or skip-rest-of-file (d) for each hunk.
 pub(crate) fn checkout_patch(
@@ -3827,6 +3957,16 @@ pub(crate) fn checkout_patch(
     use similar::TextDiff;
     use std::io::{self, BufRead, Write};
 
+    #[derive(Clone, Copy)]
+    enum PatchMode {
+        /// Default: diff index vs worktree; apply to worktree only.
+        IndexWorktree,
+        /// `HEAD` / `@`: diff `HEAD^{tree}` vs worktree+index; apply to both when staged differs.
+        HeadTree,
+        /// Named tree-ish: diff that tree vs worktree+index; apply to both when staged differs.
+        OtherTree,
+    }
+
     let work_tree = repo
         .work_tree
         .as_deref()
@@ -3834,20 +3974,30 @@ pub(crate) fn checkout_patch(
 
     let cwd = std::env::current_dir().context("resolving cwd")?;
     let index_path = repo.index_path();
-    let index = repo.load_index_at(&index_path).context("loading index")?;
+    let mut index = repo.load_index_at(&index_path).context("loading index")?;
 
-    // Determine which files to consider
     let filter_paths: Vec<String> = paths
         .iter()
         .map(|p| resolve_pathspec(p, work_tree, &cwd))
         .collect();
 
-    // Build list of (rel_path, source_content) pairs for modified files
-    let mut file_diffs: Vec<(String, Vec<u8>, Vec<u8>)> = Vec::new(); // (path, source_bytes, worktree_bytes)
+    let (patch_mode, source_tree_oid) = match source {
+        None => (PatchMode::IndexWorktree, None),
+        Some("HEAD" | "@") => {
+            let oid = resolve_treeish_to_tree_oid(repo, "HEAD")?;
+            (PatchMode::HeadTree, Some(oid))
+        }
+        Some(spec) => {
+            let oid = resolve_treeish_to_tree_oid(repo, spec)?;
+            (PatchMode::OtherTree, Some(oid))
+        }
+    };
 
-    match source {
-        None => {
-            // Diff working tree against index
+    let mut file_diffs: Vec<(String, Vec<u8>, Vec<u8>, Vec<u8>, u32)> = Vec::new();
+    // (path, source_bytes, staged_bytes, worktree_bytes, index_mode)
+
+    match patch_mode {
+        PatchMode::IndexWorktree => {
             for ie in &index.entries {
                 if ie.stage() != 0 {
                     continue;
@@ -3864,10 +4014,15 @@ pub(crate) fn checkout_patch(
 
                 let abs_path = work_tree.join(&path_str);
                 if !abs_path.exists() {
-                    // Deleted file — treat as empty worktree content
                     let obj = repo.odb.read(&ie.oid)?;
                     if obj.kind == ObjectKind::Blob {
-                        file_diffs.push((path_str, obj.data.clone(), Vec::new()));
+                        file_diffs.push((
+                            path_str,
+                            obj.data.clone(),
+                            obj.data.clone(),
+                            Vec::new(),
+                            ie.mode,
+                        ));
                     }
                     continue;
                 }
@@ -3880,14 +4035,19 @@ pub(crate) fn checkout_patch(
                 }
 
                 if worktree_data != obj.data {
-                    file_diffs.push((path_str, obj.data.clone(), worktree_data));
+                    file_diffs.push((
+                        path_str,
+                        obj.data.clone(),
+                        obj.data.clone(),
+                        worktree_data,
+                        ie.mode,
+                    ));
                 }
             }
         }
-        Some(source_spec) => {
-            // Diff working tree against a specific commit's tree
-            let source_oid = resolve_to_commit(repo, source_spec)?;
-            let tree_oid = commit_to_tree(repo, &source_oid)?;
+        PatchMode::HeadTree | PatchMode::OtherTree => {
+            let tree_oid = source_tree_oid
+                .ok_or_else(|| anyhow::anyhow!("internal: missing source tree for checkout -p"))?;
             let flat = tree_to_flat_entries(repo, &tree_oid, "")?;
 
             for flat_entry in &flat {
@@ -3912,8 +4072,26 @@ pub(crate) fn checkout_patch(
                     continue;
                 }
 
-                if worktree_data != obj.data {
-                    file_diffs.push((path_str, obj.data.clone(), worktree_data));
+                let staged_data = index
+                    .get(flat_entry.path.as_slice(), 0)
+                    .and_then(|e| {
+                        if e.mode == MODE_SYMLINK {
+                            return None;
+                        }
+                        repo.odb
+                            .read(&e.oid)
+                            .ok()
+                            .and_then(|o| (o.kind == ObjectKind::Blob).then_some(o.data))
+                    })
+                    .unwrap_or_else(Vec::new);
+
+                let tree_blob = obj.data.clone();
+                if worktree_data != tree_blob || staged_data != tree_blob {
+                    let mode = index
+                        .get(flat_entry.path.as_slice(), 0)
+                        .map(|e| e.mode)
+                        .unwrap_or(flat_entry.mode);
+                    file_diffs.push((path_str, tree_blob, staged_data, worktree_data, mode));
                 }
             }
         }
@@ -3923,19 +4101,16 @@ pub(crate) fn checkout_patch(
         return Ok(());
     }
 
-    // Sort for deterministic order
     file_diffs.sort_by(|a, b| a.0.cmp(&b.0));
 
     let stdin = io::stdin();
     let mut reader = stdin.lock();
-    let mut stdout = io::stderr();
+    let mut out = io::stdout();
 
-    for (path, source_data, worktree_data) in &file_diffs {
+    for (path, source_data, staged_data, worktree_data, index_mode) in &file_diffs {
         let source_str = String::from_utf8_lossy(source_data);
         let worktree_str = String::from_utf8_lossy(worktree_data);
 
-        // The diff shows what changed FROM source TO worktree.
-        // "Accepting" a hunk means reverting the worktree back to source.
         let text_diff = TextDiff::from_lines(source_str.as_ref(), worktree_str.as_ref());
         let hunks: Vec<_> = text_diff
             .unified_diff()
@@ -3946,6 +4121,21 @@ pub(crate) fn checkout_patch(
         if hunks.is_empty() {
             continue;
         }
+
+        let hunk_texts: Vec<String> = hunks.iter().map(|h| format!("{h}")).collect();
+
+        let update_index = matches!(patch_mode, PatchMode::HeadTree | PatchMode::OtherTree)
+            && staged_data != source_data;
+
+        // `checkout -p HEAD` / `@` always uses Git's `patch_mode_checkout_head` prompts and
+        // `apply --cached` + `apply` verification, even when the index already matches HEAD.
+        let prompt = match patch_mode {
+            PatchMode::HeadTree => "Discard this hunk from index and worktree [y,n,q,a,d,?]? ",
+            PatchMode::OtherTree if update_index => {
+                "Apply this hunk to index and worktree [y,n,q,a,d,?]? "
+            }
+            _ => "Discard this hunk from worktree [y,n,q,a,d,?]? ",
+        };
 
         let mut accept_all = false;
         let mut skip_file = false;
@@ -3960,16 +4150,14 @@ pub(crate) fn checkout_patch(
                 continue;
             }
 
-            // Display the hunk
-            writeln!(stdout, "diff --git a/{path} b/{path}").ok();
-            write!(stdout, "--- a/{path}\n+++ b/{path}\n").ok();
-            write!(stdout, "{hunk}").ok();
-            write!(stdout, "Discard this hunk from worktree [y,n,q,a,d,?]? ").ok();
-            stdout.flush().ok();
+            writeln!(out, "diff --git a/{path} b/{path}").ok();
+            write!(out, "--- a/{path}\n+++ b/{path}\n").ok();
+            write!(out, "{hunk}").ok();
+            write!(out, "{prompt}").ok();
+            out.flush().ok();
 
             let mut line = String::new();
             if reader.read_line(&mut line).unwrap_or(0) == 0 {
-                // EOF — keep remaining changes
                 break;
             }
             let answer = line.trim();
@@ -3977,7 +4165,7 @@ pub(crate) fn checkout_patch(
                 "y" | "Y" => {
                     accepted_hunks[i] = true;
                 }
-                "n" | "N" => { /* keep this hunk (don't revert) */ }
+                "n" | "N" => {}
                 "a" | "A" => {
                     accepted_hunks[i] = true;
                     accept_all = true;
@@ -3986,32 +4174,66 @@ pub(crate) fn checkout_patch(
                     skip_file = true;
                 }
                 "q" | "Q" => {
-                    // Apply what we've accepted so far, then return
-                    apply_accepted_hunks(
-                        repo,
-                        work_tree,
-                        path,
-                        source_data,
-                        worktree_data,
-                        &accepted_hunks,
-                    )?;
+                    if matches!(patch_mode, PatchMode::HeadTree) {
+                        apply_checkout_head_mode(
+                            repo,
+                            &mut index,
+                            &index_path,
+                            work_tree,
+                            path,
+                            &hunk_texts,
+                            &accepted_hunks,
+                            &mut reader,
+                        )?;
+                    } else {
+                        apply_accepted_hunks(
+                            repo,
+                            &mut index,
+                            work_tree,
+                            path,
+                            source_data,
+                            staged_data,
+                            worktree_data,
+                            *index_mode,
+                            update_index,
+                            &accepted_hunks,
+                        )?;
+                        repo.write_index(&mut index)?;
+                    }
                     return Ok(());
                 }
-                _ => { /* Unrecognized — treat as 'n' */ }
+                _ => {}
             }
         }
 
-        // Apply accepted hunks for this file
-        apply_accepted_hunks(
-            repo,
-            work_tree,
-            path,
-            source_data,
-            worktree_data,
-            &accepted_hunks,
-        )?;
+        if matches!(patch_mode, PatchMode::HeadTree) {
+            apply_checkout_head_mode(
+                repo,
+                &mut index,
+                &index_path,
+                work_tree,
+                path,
+                &hunk_texts,
+                &accepted_hunks,
+                &mut reader,
+            )?;
+        } else {
+            apply_accepted_hunks(
+                repo,
+                &mut index,
+                work_tree,
+                path,
+                source_data,
+                staged_data,
+                worktree_data,
+                *index_mode,
+                update_index,
+                &accepted_hunks,
+            )?;
+        }
     }
 
+    repo.write_index(&mut index)?;
     Ok(())
 }
 
@@ -4191,38 +4413,77 @@ pub(crate) fn blend_line_diff_by_hunk_ranges(
 }
 
 /// Apply per-hunk revert decisions: for each accepted hunk, use `source_data`; otherwise keep
-/// `worktree_data`. Used by `checkout -p` and `stash -p` (same semantics as Git's add--interactive).
+/// `worktree_data`. Used by `checkout -p` (and shared blend helpers for stash).
+///
+/// When `update_index` is true, accepted hunks also update the index blob (from blended staged +
+/// worktree sides); otherwise only the worktree file is written.
 pub(crate) fn apply_accepted_hunks(
-    _repo: &Repository,
+    repo: &Repository,
+    index: &mut Index,
     work_tree: &std::path::Path,
     path: &str,
     source_data: &[u8],
+    staged_data: &[u8],
     worktree_data: &[u8],
+    index_mode: u32,
+    update_index: bool,
     accepted: &[bool],
 ) -> Result<()> {
+    use std::os::unix::fs::MetadataExt;
+
     if !accepted.iter().any(|&a| a) {
         return Ok(());
     }
 
     let abs_path = work_tree.join(path);
+    let path_bytes = path.as_bytes();
 
-    if accepted.iter().all(|&a| a) {
-        if source_data.is_empty() {
-            let _ = std::fs::remove_file(&abs_path);
-        } else {
-            if let Some(parent) = abs_path.parent() {
-                std::fs::create_dir_all(parent)?;
-            }
-            std::fs::write(&abs_path, source_data)?;
+    let wt_out = if accepted.iter().all(|&a| a) {
+        source_data.to_vec()
+    } else {
+        blend_line_diff_by_hunks(source_data, worktree_data, accepted).into_bytes()
+    };
+
+    if wt_out.is_empty() {
+        let _ = std::fs::remove_file(&abs_path);
+    } else {
+        if let Some(parent) = abs_path.parent() {
+            std::fs::create_dir_all(parent)?;
         }
-        return Ok(());
+        std::fs::write(&abs_path, &wt_out)?;
     }
 
-    let output = blend_line_diff_by_hunks(source_data, worktree_data, accepted);
-    if let Some(parent) = abs_path.parent() {
-        std::fs::create_dir_all(parent)?;
+    if update_index {
+        let idx_out = if accepted.iter().all(|&a| a) {
+            source_data.to_vec()
+        } else {
+            blend_line_diff_by_hunks(source_data, staged_data, accepted).into_bytes()
+        };
+
+        if idx_out.is_empty() {
+            index.remove(path_bytes);
+        } else {
+            let oid = repo
+                .odb
+                .write(ObjectKind::Blob, &idx_out)
+                .with_context(|| format!("writing blob for index entry {path}"))?;
+            let meta = std::fs::symlink_metadata(&abs_path)
+                .with_context(|| format!("stat for index update '{path}'"))?;
+            let entry = entry_from_stat(
+                &abs_path,
+                path_bytes,
+                oid,
+                if index_mode == MODE_SYMLINK {
+                    MODE_SYMLINK
+                } else {
+                    normalize_mode(meta.mode())
+                },
+            )
+            .with_context(|| format!("building index entry for '{path}'"))?;
+            index.add_or_replace(entry);
+        }
     }
-    std::fs::write(&abs_path, output.as_bytes())?;
+
     Ok(())
 }
 
@@ -4480,6 +4741,13 @@ fn resolve_to_commit(repo: &Repository, spec: &str) -> Result<ObjectId> {
     let oid =
         resolve_revision(repo, spec).with_context(|| format!("unknown revision: '{spec}'"))?;
     peel_to_commit(repo, oid)
+}
+
+/// Resolve `spec` to a root tree OID (commit → tree, tag → peel, tree → identity).
+fn resolve_treeish_to_tree_oid(repo: &Repository, spec: &str) -> Result<ObjectId> {
+    let oid =
+        resolve_revision(repo, spec).with_context(|| format!("unknown revision: '{spec}'"))?;
+    peel_to_tree(repo, oid).with_context(|| format!("'{spec}' is not a valid tree-ish"))
 }
 
 /// Peel an OID to a commit (follows tag chains).

--- a/logs/2026-04-10-t2016-checkout-patch.md
+++ b/logs/2026-04-10-t2016-checkout-patch.md
@@ -1,0 +1,18 @@
+# t2016-checkout-patch
+
+## Summary
+
+Fixed `grit checkout -p` to match Git’s interactive checkout patch behavior so `tests/t2016-checkout-patch.sh` passes (19/19).
+
+## Changes
+
+- Disambiguate first positional when it is only a path (e.g. `checkout -p dir`), not a revision; keep ambiguous rev+path error when both apply.
+- Default `checkout -p`: diff index vs worktree; `HEAD` / `@`: diff `HEAD^{tree}` vs worktree with correct prompts; other tree-ish: `resolve_revision` + `peel_to_tree` (empty tree, etc.).
+- Write patch UI to stdout so `test_grep "Discard" output` works.
+- For `HEAD`/`@`, apply selected hunks via subprocess `grit apply --check` / `--cached --check` then apply (mirrors Git `apply_for_checkout`), including “does not apply to the index” + worktree-only fallback prompt.
+- Non-`HEAD` tree-ish modes still use line-blending + index update when staged content differs from the source tree.
+
+## Validation
+
+- `./scripts/run-tests.sh t2016-checkout-patch.sh` — all pass
+- `cargo test -p grit-lib --lib`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible `checkout -p` / `checkout --patch` behavior so `t2016-checkout-patch.sh` passes (19/19).

## What changed

- **Argument parsing**: When the first token after `-p` is not a revision but exists as a path, treat it as a pathspec (e.g. `checkout -p dir`). Still error when the token is both a revision and an on-disk path without `--`.
- **Sources**: Default mode diffs **index vs worktree**. Explicit `HEAD` / `@` diffs **`HEAD^{tree}`** vs worktree with the same prompts as Git. Other tree-ish values resolve via **`peel_to_tree`** so bare trees (e.g. empty tree) work.
- **Output**: Patch prompts and diffs go to **stdout** so harness `test_grep "Discard" output` matches Git.
- **`HEAD` / `@` apply path**: Mirrors Git’s `apply_for_checkout` — verify with `grit apply --check` and `grit apply --cached --check`, then apply; if the index rejects the hunk, prompt **Apply them to the worktree anyway?** and match Git’s stderr messages.

## Test / harness

- `./scripts/run-tests.sh t2016-checkout-patch.sh` → 19/19; CSV and dashboards refreshed.

## Note

`AGENTS.md` asks not to use GitButler; the user rule referencing a GitButler MCP tool is not available in this environment, so it was not run.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f08c59ea-f5f6-42e0-9328-30c4c6e0b67f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f08c59ea-f5f6-42e0-9328-30c4c6e0b67f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

