### PR TITLE
fix: make t5325-reverse-index pass (pack .rev RIDX)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -630,7 +630,7 @@ commit → check it off → move on.
 - [x] `t5403-post-checkout-hook` ████████████████████ 14/14 (0 left) — Test the post-checkout hook.
 - [ ] `t5610-clone-detached` ███░░░░░░░░░░░░░░░░░ 2/13 (11 left) — test cloning a repository with detached HEAD
 - [x] `t5605-clone-local` ████████████████████ 23/23 (0 left) — test local clone
-- [ ] `t5325-reverse-index` █████░░░░░░░░░░░░░░░ 4/16 (12 left) — on-disk reverse index
+- [x] `t5325-reverse-index` — on-disk reverse index (16/16)
 - [ ] `t5560-http-backend-noserver` ██░░░░░░░░░░░░░░░░░░ 2/14 (12 left) — test git-http-backend-noserver
 - [ ] `t5612-clone-refspec` █░░░░░░░░░░░░░░░░░░░ 1/13 (12 left) — test refspec written by clone-command
 - [ ] `t5537-fetch-shallow` ███░░░░░░░░░░░░░░░░░ 3/16 (13 left) — fetch/clone from a shallow clone

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -893,7 +893,7 @@ t5321-pack-large-objects	t5	yes	2	0	2	false	ok	0
 t5322-pack-objects-sparse	t5	yes	11	5	6	false	ok	0
 t5323-pack-redundant	t5	yes	18	18	0	true	ok	0
 t5324-split-commit-graph	t5	yes	42	9	33	false	ok	0
-t5325-reverse-index	t5	yes	16	2	14	false	ok	0
+t5325-reverse-index	t5	yes	16	16	0	true	ok	0
 t5326-multi-pack-bitmaps	t5	yes	357	17	340	false	ok	0
 t5327-multi-pack-bitmaps-rev	t5	yes	314	16	298	false	ok	0
 t5328-commit-graph-64bit-time	t5	yes	0	0	0	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,700 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,700 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T01:10:49+00:00" class="gen-time" title="2026-04-10 01:10 UTC">2026-04-10 01:10 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,700</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">34/167 files · 17 skipped · 1,580/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:38.2%"></div></div>
+        <span class="group-pct pct-red">38.2%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35700 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,700 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T01:10:49+00:00" class="gen-time" title="2026-04-10 01:10 UTC">2026-04-10 01:10 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,700</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -9087,14 +9087,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:21.4%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="16" data-passed="2">
+<tr class="" data-group="t5" data-tests="16" data-passed="16" data-full-pass="1">
   <td class="mono">t5325-reverse-index</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">16</td>
-  <td class="right">2</td>
+  <td class="right">16</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:12.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="357" data-passed="17">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/config.rs
+++ b/grit-lib/src/config.rs
@@ -1439,6 +1439,36 @@ impl ConfigSet {
             .unwrap_or(true)
     }
 
+    /// Default for `pack.writeReverseIndex` / `pack.writereverseindex` (Git default: true).
+    ///
+    /// Tests set `GIT_TEST_NO_WRITE_REV_INDEX` to force no `.rev` output.
+    #[must_use]
+    pub fn pack_write_reverse_index_default(&self) -> bool {
+        if std::env::var("GIT_TEST_NO_WRITE_REV_INDEX")
+            .ok()
+            .as_deref()
+            .is_some_and(|v| {
+                let s = v.trim().to_ascii_lowercase();
+                matches!(s.as_str(), "1" | "true" | "yes" | "on")
+            })
+        {
+            return false;
+        }
+        self.get_bool("pack.writereverseindex")
+            .or_else(|| self.get_bool("pack.writeReverseIndex"))
+            .and_then(|r| r.ok())
+            .unwrap_or(true)
+    }
+
+    /// Default for `pack.readReverseIndex` / `pack.readreverseindex` (Git default: true).
+    #[must_use]
+    pub fn pack_read_reverse_index_default(&self) -> bool {
+        self.get_bool("pack.readreverseindex")
+            .or_else(|| self.get_bool("pack.readReverseIndex"))
+            .and_then(|r| r.ok())
+            .unwrap_or(true)
+    }
+
     /// Resolved `core.logAllRefUpdates` using this merged set (includes `git -c` / env), then Git's
     /// bare-repo default when the key is unset everywhere.
     #[must_use]

--- a/grit-lib/src/lib.rs
+++ b/grit-lib/src/lib.rs
@@ -63,6 +63,7 @@ pub mod odb;
 pub mod pack;
 pub mod pack_geometry;
 pub mod pack_name_hash;
+pub mod pack_rev;
 pub mod parse_options_test_tool;
 pub mod patch_ids;
 pub mod pathspec;

--- a/grit-lib/src/pack_rev.rs
+++ b/grit-lib/src/pack_rev.rs
@@ -1,0 +1,263 @@
+//! On-disk pack reverse index (`.rev`) — RIDX format matching Git's `pack-write.c`.
+//!
+//! Maps pack-file order (sorted by object offset) to index positions in the `.idx` OID table.
+
+use crate::pack::PackIndex;
+use sha1::{Digest, Sha1};
+use std::path::Path;
+
+/// Magic `RIDX` in big-endian form (same as Git's `RIDX_SIGNATURE`).
+pub const RIDX_SIGNATURE: u32 = 0x5249_4458;
+/// On-disk format version (Git `RIDX_VERSION`).
+pub const RIDX_VERSION: u32 = 1;
+/// Hash id field for SHA-1 packs (`oid_version` in Git).
+pub const RIDX_HASH_ID_SHA1: u32 = 1;
+
+const HEADER_LEN: usize = 12;
+const SHA1_TRAILER: usize = 20;
+
+/// Build `.rev` file bytes for a pack index (RIDX body + trailing SHA-1 of the body).
+#[must_use]
+pub fn build_pack_rev_bytes(index: &PackIndex) -> Vec<u8> {
+    let offsets: Vec<u64> = index.entries.iter().map(|e| e.offset).collect();
+    build_pack_rev_bytes_from_index_order_offsets(&offsets)
+}
+
+/// Build `.rev` bytes from object offsets in **pack index order** (OID-sorted, same row order as `.idx`).
+#[must_use]
+pub fn build_pack_rev_bytes_from_index_order_offsets(offsets: &[u64]) -> Vec<u8> {
+    let n = offsets.len();
+    let mut order: Vec<u32> = (0..n as u32).collect();
+    order.sort_by_key(|&i| offsets[i as usize]);
+
+    let body_len = HEADER_LEN + n * 4;
+    let total_len = body_len + SHA1_TRAILER;
+    let mut out = Vec::with_capacity(total_len);
+
+    out.extend_from_slice(&RIDX_SIGNATURE.to_be_bytes());
+    out.extend_from_slice(&RIDX_VERSION.to_be_bytes());
+    out.extend_from_slice(&RIDX_HASH_ID_SHA1.to_be_bytes());
+    for idx_pos in order {
+        out.extend_from_slice(&idx_pos.to_be_bytes());
+    }
+
+    debug_assert_eq!(out.len(), body_len);
+    let mut h = Sha1::new();
+    h.update(&out);
+    let digest = h.finalize();
+    // Git's hashfile appends the hash of the body; it is unrelated to the pack checksum.
+    out.extend_from_slice(digest.as_slice());
+    debug_assert_eq!(out.len(), total_len);
+
+    out
+}
+
+/// Path for the reverse index alongside a `.idx` file (`other.idx` → `other.rev`).
+#[must_use]
+pub fn rev_path_for_index(idx_path: &Path) -> std::path::PathBuf {
+    let mut p = idx_path.to_path_buf();
+    p.set_extension("rev");
+    p
+}
+
+/// True if `data` is a valid SHA-1 hashfile: last 20 bytes equal SHA-1 of preceding bytes.
+#[must_use]
+pub fn hashfile_checksum_valid_sha1(data: &[u8]) -> bool {
+    if data.len() < SHA1_TRAILER {
+        return false;
+    }
+    let body_len = data.len() - SHA1_TRAILER;
+    let mut h = Sha1::new();
+    h.update(&data[..body_len]);
+    h.finalize().as_slice() == &data[body_len..]
+}
+
+fn read_u32_be(buf: &[u8], pos: &mut usize) -> Option<u32> {
+    if *pos + 4 > buf.len() {
+        return None;
+    }
+    let v = u32::from_be_bytes(buf[*pos..*pos + 4].try_into().ok()?);
+    *pos += 4;
+    Some(v)
+}
+
+/// Verify `.rev` bytes against the given pack index.
+///
+/// `path_for_errors` is embedded in messages (use the file path or a placeholder).
+/// Messages for `git fsck` / load order: header checks first (like `load_revindex_from_disk`), then
+/// checksum and index comparison (like `verify_pack_revindex`). May return multiple strings.
+pub fn pack_rev_fsck_messages(
+    data: &[u8],
+    index: &PackIndex,
+    rev_path_display: &str,
+) -> Vec<String> {
+    let n = index.entries.len();
+    let expected_len = HEADER_LEN + n * 4 + SHA1_TRAILER;
+    if data.len() < ridx_min_size() {
+        return vec![format!(
+            "reverse-index file {rev_path_display} is too small"
+        )];
+    }
+    if data.len() != expected_len {
+        return vec![format!("reverse-index file {rev_path_display} is corrupt")];
+    }
+
+    let mut pos = 0usize;
+    let Some(sig) = read_u32_be(data, &mut pos) else {
+        return vec!["truncated rev-index header".to_owned()];
+    };
+    if sig != RIDX_SIGNATURE {
+        return vec![format!(
+            "reverse-index file {rev_path_display} has unknown signature"
+        )];
+    }
+    let Some(ver) = read_u32_be(data, &mut pos) else {
+        return vec!["truncated rev-index header".to_owned()];
+    };
+    if ver != RIDX_VERSION {
+        return vec![format!(
+            "reverse-index file {rev_path_display} has unsupported version {ver}"
+        )];
+    }
+    let Some(hash_id) = read_u32_be(data, &mut pos) else {
+        return vec!["truncated rev-index header".to_owned()];
+    };
+    if hash_id != RIDX_HASH_ID_SHA1 && hash_id != 2 {
+        return vec![format!(
+            "reverse-index file {rev_path_display} has unsupported hash id {hash_id}"
+        )];
+    }
+
+    let mut msgs = Vec::new();
+    if !hashfile_checksum_valid_sha1(data) {
+        msgs.push("invalid checksum".to_owned());
+    }
+
+    let mut order: Vec<u32> = (0..n as u32).collect();
+    order.sort_by_key(|&i| index.entries[i as usize].offset);
+
+    for i in 0..n {
+        let Some(got) = read_u32_be(data, &mut pos) else {
+            msgs.push("truncated rev-index data".to_owned());
+            break;
+        };
+        let expected = order[i];
+        if got != expected {
+            msgs.push(format!(
+                "invalid rev-index position at {i}: {got} != {expected}"
+            ));
+        }
+    }
+
+    msgs
+}
+
+fn ridx_min_size() -> usize {
+    HEADER_LEN + SHA1_TRAILER
+}
+
+/// Verify a `.rev` file for `index-pack --rev-index --verify` (checksum first, like Git's
+/// `verify_pack_revindex`).
+pub fn verify_pack_rev_file_contents(
+    data: &[u8],
+    index: &PackIndex,
+    path_for_errors: &str,
+) -> std::result::Result<(), String> {
+    if !hashfile_checksum_valid_sha1(data) {
+        return Err(format!("sha1 file '{path_for_errors}': validation error"));
+    }
+    let n = index.entries.len();
+    let expected_len = HEADER_LEN + n * 4 + SHA1_TRAILER;
+    if data.len() != expected_len {
+        return Err(format!("reverse-index file {path_for_errors} is corrupt"));
+    }
+    let mut pos = 0usize;
+    let sig = read_u32_be(data, &mut pos).ok_or_else(|| "truncated rev-index header".to_owned())?;
+    if sig != RIDX_SIGNATURE {
+        return Err(format!(
+            "reverse-index file {path_for_errors} has unknown signature"
+        ));
+    }
+    let ver = read_u32_be(data, &mut pos).ok_or_else(|| "truncated rev-index header".to_owned())?;
+    if ver != RIDX_VERSION {
+        return Err(format!(
+            "reverse-index file {path_for_errors} has unsupported version {ver}"
+        ));
+    }
+    let hash_id =
+        read_u32_be(data, &mut pos).ok_or_else(|| "truncated rev-index header".to_owned())?;
+    if hash_id != RIDX_HASH_ID_SHA1 && hash_id != 2 {
+        return Err(format!(
+            "reverse-index file {path_for_errors} has unsupported hash id {hash_id}"
+        ));
+    }
+    let mut order: Vec<u32> = (0..n as u32).collect();
+    order.sort_by_key(|&i| index.entries[i as usize].offset);
+    for i in 0..n {
+        let got =
+            read_u32_be(data, &mut pos).ok_or_else(|| "truncated rev-index data".to_owned())?;
+        let expected = order[i];
+        if got != expected {
+            return Err(format!(
+                "invalid rev-index position at {i}: {got} != {expected}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Verify on-disk `.rev` against the given pack index.
+///
+/// Returns `Ok(())` when the file is missing (optional sidecar). On parse or mismatch errors,
+/// returns a message suitable for `error: ...` output.
+pub fn verify_pack_rev_file(rev_path: &Path, index: &PackIndex) -> std::result::Result<(), String> {
+    let data = match std::fs::read(rev_path) {
+        Ok(d) => d,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(format!("failed to read {}: {e}", rev_path.display())),
+    };
+    let p = rev_path.display().to_string();
+    verify_pack_rev_file_contents(&data, index, &p)
+}
+
+/// If `data` is a well-formed RIDX for `num_objects`, returns index positions in **pack order**
+/// (object at pack offset rank `i` → OID at index row `result[i]`). Otherwise `None`.
+#[must_use]
+pub fn try_rev_positions_in_pack_order(data: &[u8], num_objects: usize) -> Option<Vec<u32>> {
+    let expected_len = HEADER_LEN + num_objects * 4 + SHA1_TRAILER;
+    if data.len() != expected_len || !hashfile_checksum_valid_sha1(data) {
+        return None;
+    }
+    let mut pos = 0usize;
+    let sig = read_u32_be(data, &mut pos)?;
+    if sig != RIDX_SIGNATURE {
+        return None;
+    }
+    let ver = read_u32_be(data, &mut pos)?;
+    if ver != RIDX_VERSION {
+        return None;
+    }
+    let hash_id = read_u32_be(data, &mut pos)?;
+    if hash_id != RIDX_HASH_ID_SHA1 && hash_id != 2 {
+        return None;
+    }
+    let mut pack_order_idx = vec![0u32; num_objects];
+    for slot in &mut pack_order_idx {
+        *slot = read_u32_be(data, &mut pos)?;
+    }
+    if pos != HEADER_LEN + num_objects * 4 {
+        return None;
+    }
+    if pack_order_idx.len() != num_objects {
+        return None;
+    }
+    let mut seen = vec![false; num_objects];
+    for &p in &pack_order_idx {
+        let pi = p as usize;
+        if pi >= num_objects || seen[pi] {
+            return None;
+        }
+        seen[pi] = true;
+    }
+    Some(pack_order_idx)
+}

--- a/grit/src/commands/cat_file.rs
+++ b/grit/src/commands/cat_file.rs
@@ -8,6 +8,7 @@ use grit_lib::error::Error as LibError;
 use grit_lib::error::Result as LibResult;
 use grit_lib::merge_diff::{convert_blob_to_worktree_for_path, run_textconv_raw};
 use grit_lib::pack;
+use grit_lib::pack_rev::{rev_path_for_index, try_rev_positions_in_pack_order};
 use grit_lib::rev_list::{self, ObjectFilter};
 use std::io::{self, BufRead, Write};
 use std::path::{Path, PathBuf};
@@ -682,7 +683,18 @@ fn collect_loose_disk_entries(objects_dir: &Path, out: &mut Vec<(ObjectId, u64)>
     Ok(())
 }
 
-fn append_packed_disk_entries(objects_dir: &Path, out: &mut Vec<(ObjectId, u64)>) -> Result<()> {
+fn env_git_test_bool(name: &str) -> bool {
+    std::env::var(name).ok().as_deref().is_some_and(|v| {
+        let s = v.trim().to_ascii_lowercase();
+        matches!(s.as_str(), "1" | "true" | "yes" | "on")
+    })
+}
+
+fn append_packed_disk_entries(
+    objects_dir: &Path,
+    read_rev_index: bool,
+    out: &mut Vec<(ObjectId, u64)>,
+) -> Result<()> {
     let indexes = pack::read_local_pack_indexes(objects_dir)?;
     for idx in indexes {
         let pack_size = match std::fs::metadata(&idx.pack_path) {
@@ -694,21 +706,44 @@ fn append_packed_disk_entries(objects_dir: &Path, out: &mut Vec<(ObjectId, u64)>
             .first()
             .map(|e| pack_checksum_trailer_len(&e.oid))
             .unwrap_or(20);
-        let mut offsets: Vec<(u64, ObjectId)> = idx
-            .entries
-            .into_iter()
-            .map(|entry| (entry.offset, entry.oid))
-            .collect();
-        offsets.sort_by_key(|(offset, _)| *offset);
-        for (pos, (offset, oid)) in offsets.iter().enumerate() {
-            let next_offset = offsets
-                .get(pos + 1)
-                .map(|(next, _)| *next)
-                .unwrap_or_else(|| pack_size.saturating_sub(trailer));
-            if next_offset < *offset {
+        let n = idx.entries.len();
+        let rev_path = rev_path_for_index(&idx.idx_path);
+
+        let pack_order_idx: Vec<u32> = if read_rev_index && rev_path.is_file() {
+            if env_git_test_bool("GIT_TEST_REV_INDEX_DIE_ON_DISK") {
+                bail!("dying as requested by 'GIT_TEST_REV_INDEX_DIE_ON_DISK'");
+            }
+            match std::fs::read(&rev_path) {
+                Ok(data) => try_rev_positions_in_pack_order(&data, n).unwrap_or_default(),
+                Err(_) => Vec::new(),
+            }
+        } else {
+            Vec::new()
+        };
+
+        let pack_order_idx = if !pack_order_idx.is_empty() {
+            pack_order_idx
+        } else {
+            if env_git_test_bool("GIT_TEST_REV_INDEX_DIE_IN_MEMORY") {
+                bail!("dying as requested by 'GIT_TEST_REV_INDEX_DIE_IN_MEMORY'");
+            }
+            let mut order: Vec<u32> = (0..n as u32).collect();
+            order.sort_by_key(|&i| idx.entries[i as usize].offset);
+            order
+        };
+
+        for i in 0..n {
+            let oid = idx.entries[pack_order_idx[i] as usize].oid;
+            let offset = idx.entries[pack_order_idx[i] as usize].offset;
+            let next_offset = if i + 1 < n {
+                idx.entries[pack_order_idx[i + 1] as usize].offset
+            } else {
+                pack_size.saturating_sub(trailer)
+            };
+            if next_offset < offset {
                 continue;
             }
-            out.push((*oid, next_offset - *offset));
+            out.push((oid, next_offset - offset));
         }
     }
     Ok(())
@@ -719,8 +754,10 @@ fn collect_all_disk_object_entries(repo: &Repository) -> Result<Vec<(ObjectId, u
     // Match upstream tests (t1006 `%(objectsize:disk)`): only count on-disk copies under this
     // repo's `objects/` tree, not duplicate loose/pack files reachable via `info/alternates`.
     let dir = repo.odb.objects_dir().to_path_buf();
+    let cfg = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+    let read_rev = cfg.pack_read_reverse_index_default();
     collect_loose_disk_entries(&dir, &mut out)?;
-    append_packed_disk_entries(&dir, &mut out)?;
+    append_packed_disk_entries(&dir, read_rev, &mut out)?;
     Ok(out)
 }
 
@@ -1596,10 +1633,11 @@ fn pack_checksum_trailer_len(sample_oid: &ObjectId) -> u64 {
 
 fn append_packed_object_sizes(
     objects_dir: &Path,
+    read_rev_index: bool,
     sizes: &mut HashMap<ObjectId, u64>,
 ) -> Result<()> {
     let mut tmp = Vec::new();
-    append_packed_disk_entries(objects_dir, &mut tmp)?;
+    append_packed_disk_entries(objects_dir, read_rev_index, &mut tmp)?;
     for (oid, sz) in tmp {
         sizes.entry(oid).or_insert(sz);
     }
@@ -1607,9 +1645,11 @@ fn append_packed_object_sizes(
 }
 
 fn collect_packed_object_sizes(repo: &Repository) -> Result<HashMap<ObjectId, u64>> {
+    let cfg = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+    let read_rev = cfg.pack_read_reverse_index_default();
     let mut sizes = HashMap::new();
     for dir in object_storage_dirs_for_repo(repo)? {
-        append_packed_object_sizes(&dir, &mut sizes)?;
+        append_packed_object_sizes(&dir, read_rev, &mut sizes)?;
     }
     Ok(sizes)
 }

--- a/grit/src/commands/fsck.rs
+++ b/grit/src/commands/fsck.rs
@@ -17,6 +17,7 @@ use grit_lib::ident::fsck_commit_idents;
 use grit_lib::objects::{parse_commit, parse_tree, tag_object_line_oid, ObjectId, ObjectKind};
 use grit_lib::odb::Odb;
 use grit_lib::pack::read_local_pack_indexes;
+use grit_lib::pack_rev::rev_path_for_index;
 use grit_lib::promisor::{
     promisor_expanded_object_ids, promisor_pack_object_ids, repo_treats_promisor_packs,
 };
@@ -202,6 +203,8 @@ pub fn run(args: Args) -> Result<()> {
         HashSet::new()
     };
     let packed_ids = collect_packed_ids(&objects_dir)?;
+
+    check_pack_reverse_indexes(&objects_dir, &config, &mut issues)?;
 
     let (reachable, walked_kinds) = walk_reachable(
         &repo,
@@ -1052,4 +1055,47 @@ fn collect_packed_ids(objects_dir: &Path) -> Result<HashSet<ObjectId>> {
         }
     }
     Ok(ids)
+}
+
+fn check_pack_reverse_indexes(
+    objects_dir: &Path,
+    config: &ConfigSet,
+    issues: &mut Vec<Issue>,
+) -> Result<()> {
+    if !config.pack_read_reverse_index_default() {
+        return Ok(());
+    }
+    let indexes = read_local_pack_indexes(objects_dir)?;
+    for idx in indexes {
+        let rev_path = rev_path_for_index(&idx.idx_path);
+        if !rev_path.is_file() {
+            continue;
+        }
+        let data = match fs::read(&rev_path) {
+            Ok(d) => d,
+            Err(e) => {
+                let pack_label = pack_fsck_label(&idx.pack_path);
+                issues.push(Issue::FsckMessage(format!(
+                    "unable to load rev-index for pack '{pack_label}': {e}"
+                )));
+                continue;
+            }
+        };
+        let pack_label = pack_fsck_label(&idx.pack_path);
+        let rev_disp = rev_path.display().to_string();
+        for msg in grit_lib::pack_rev::pack_rev_fsck_messages(&data, &idx, &rev_disp) {
+            issues.push(Issue::FsckMessage(format!(
+                "invalid rev-index for pack '{pack_label}': {msg}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn pack_fsck_label(pack_path: &Path) -> String {
+    pack_path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .map(|n| format!("objects/pack/{n}"))
+        .unwrap_or_else(|| pack_path.display().to_string())
 }

--- a/grit/src/commands/index_pack.rs
+++ b/grit/src/commands/index_pack.rs
@@ -16,7 +16,10 @@ use std::io::{self, Read, Write};
 use std::path::PathBuf;
 
 use grit_lib::odb::Odb;
-use grit_lib::pack::verify_pack_and_collect;
+use grit_lib::pack::{read_pack_index, verify_pack_and_collect};
+use grit_lib::pack_rev::{
+    build_pack_rev_bytes_from_index_order_offsets, rev_path_for_index, verify_pack_rev_file,
+};
 use grit_lib::unpack_objects::{apply_delta, strict_verify_packed_references};
 
 /// Merge `git index-pack --strict RULE` / `--fsck-objects RULE` into `--strict=RULE` so the pack
@@ -100,6 +103,14 @@ pub struct Args {
     /// Thread count (accepted; grit is single-threaded).
     #[arg(long = "threads", value_name = "N")]
     pub threads: Option<u32>,
+
+    /// Write a `.rev` reverse index next to the `.idx` (overrides `pack.writeReverseIndex` when set).
+    #[arg(long = "rev-index")]
+    pub rev_index: bool,
+
+    /// Do not write a `.rev` reverse index (overrides `pack.writeReverseIndex` when set).
+    #[arg(long = "no-rev-index", conflicts_with = "rev_index")]
+    pub no_rev_index: bool,
 }
 
 /// A resolved pack object.
@@ -108,6 +119,16 @@ struct ResolvedObject {
     _kind: ObjectKind,
     offset: u64,
     crc32: u32,
+}
+
+fn effective_write_rev_index(args: &Args, cfg: &ConfigSet) -> bool {
+    if args.no_rev_index {
+        return false;
+    }
+    if args.rev_index {
+        return true;
+    }
+    cfg.pack_write_reverse_index_default()
 }
 
 /// Run `grit index-pack`.
@@ -266,6 +287,22 @@ pub fn run(args: Args) -> Result<()> {
     // Write the .idx file.
     let idx_bytes = build_idx_v2(&resolved, &pack_bytes)?;
     fs::write(&idx_path, &idx_bytes)?;
+
+    let cfg = grit_lib::repo::Repository::discover(None)
+        .ok()
+        .and_then(|r| ConfigSet::load(Some(&r.git_dir), true).ok())
+        .unwrap_or_default();
+    let write_rev = effective_write_rev_index(&args, &cfg);
+    let rev_path = rev_path_for_index(&idx_path);
+    if write_rev {
+        let mut sorted_entries: Vec<&ResolvedObject> = resolved.iter().collect();
+        sorted_entries.sort_by_key(|e| *e.oid.as_bytes());
+        let idx_order_offsets: Vec<u64> = sorted_entries.iter().map(|e| e.offset).collect();
+        let rev_bytes = build_pack_rev_bytes_from_index_order_offsets(&idx_order_offsets);
+        fs::write(&rev_path, rev_bytes)?;
+    } else if rev_path.exists() {
+        let _ = fs::remove_file(&rev_path);
+    }
 
     // Print the pack hash (matches git index-pack output).
     let pack_checksum = &pack_bytes[pack_bytes.len() - 20..];
@@ -941,6 +978,15 @@ fn run_verify(args: &Args) -> Result<()> {
                     bail!("pack checksum in index does not match pack file");
                 }
             }
+        }
+    }
+
+    if args.rev_index && rev_path_for_index(&idx_path).is_file() {
+        let rev_path = rev_path_for_index(&idx_path);
+        let index = read_pack_index(&idx_path)
+            .with_context(|| format!("cannot read index {}", idx_path.display()))?;
+        if let Err(msg) = verify_pack_rev_file(&rev_path, &index) {
+            bail!("{msg}");
         }
     }
 

--- a/grit/src/commands/pack_objects.rs
+++ b/grit/src/commands/pack_objects.rs
@@ -9,6 +9,7 @@ use flate2::write::ZlibEncoder;
 use flate2::Compression;
 use grit_lib::config::ConfigSet;
 use grit_lib::error::Error as LibError;
+use grit_lib::pack_rev::{build_pack_rev_bytes_from_index_order_offsets, rev_path_for_index};
 use grit_lib::rev_list::{rev_list, MissingAction, RevListOptions};
 use sha1::{Digest, Sha1};
 use std::collections::{BTreeSet, HashSet};
@@ -420,9 +421,17 @@ pub fn run(args: Args) -> Result<()> {
 
         std::fs::write(&pack_path, &pack_bytes)?;
 
-        // Build and write idx.
-        let idx_bytes = build_idx_for_pack(&pack_bytes, &write_entries)?;
+        // Build and write idx (and optional `.rev`).
+        let cfg = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+        let (idx_bytes, idx_order_offsets) = build_idx_for_pack(&pack_bytes, &write_entries)?;
         std::fs::write(&idx_path, &idx_bytes)?;
+        let idx_pb = Path::new(&idx_path);
+        if cfg.pack_write_reverse_index_default() {
+            let rev_bytes = build_pack_rev_bytes_from_index_order_offsets(&idx_order_offsets);
+            std::fs::write(rev_path_for_index(idx_pb), rev_bytes)?;
+        } else {
+            let _ = std::fs::remove_file(rev_path_for_index(idx_pb));
+        }
 
         println!("{pack_hash}");
         if !args.quiet {
@@ -1475,7 +1484,12 @@ fn build_pack(entries: &[PackWriteEntry]) -> Result<Vec<u8>> {
 }
 
 /// Build idx v2 for a pack we just wrote.
-fn build_idx_for_pack(pack_bytes: &[u8], entries: &[PackWriteEntry]) -> Result<Vec<u8>> {
+///
+/// The second return value is object offsets in **index row order** (OID-sorted), for `.rev` files.
+fn build_idx_for_pack(
+    pack_bytes: &[u8],
+    entries: &[PackWriteEntry],
+) -> Result<(Vec<u8>, Vec<u64>)> {
     use grit_lib::pack::skip_one_pack_object;
 
     // We need offsets. Reparse the pack to get them.
@@ -1566,7 +1580,12 @@ fn build_idx_for_pack(pack_bytes: &[u8], entries: &[PackWriteEntry]) -> Result<V
     let idx_checksum = h.finalize();
     buf.extend_from_slice(idx_checksum.as_slice());
 
-    Ok(buf)
+    let idx_order_offsets: Vec<u64> = sorted
+        .iter()
+        .map(|(orig_idx, _)| offsets[*orig_idx])
+        .collect();
+
+    Ok((buf, idx_order_offsets))
 }
 
 /// CRC32 IEEE.

--- a/logs/2026-04-10_t5325-reverse-index.md
+++ b/logs/2026-04-10_t5325-reverse-index.md
@@ -1,0 +1,20 @@
+# t5325-reverse-index
+
+## Goal
+
+Make harness file `tests/t5325-reverse-index.sh` fully pass (on-disk pack reverse index / RIDX).
+
+## Changes
+
+- Added `grit-lib/src/pack_rev.rs`: build RIDX `.rev` from index-order offsets, parse/validate for `index-pack --verify`, `pack_rev_fsck_messages` for `fsck` (header-before-checksum ordering to match load path + multiple errors like Git), `try_rev_positions_in_pack_order` for `cat-file`.
+- `ConfigSet`: `pack_write_reverse_index_default` / `pack_read_reverse_index_default` (honor `GIT_TEST_NO_WRITE_REV_INDEX`, camelCase + lowercase keys).
+- `index-pack`: `--rev-index` / `--no-rev-index`, write/remove `.rev` from config + flags, `--rev-index --verify` validates existing `.rev`.
+- `pack-objects`: write `.rev` when `pack.writeReverseIndex` true (default).
+- `cat-file`: packed `%(objectsize:disk)` uses `.rev` when allowed; `GIT_TEST_REV_INDEX_DIE_IN_MEMORY` / `GIT_TEST_REV_INDEX_DIE_ON_DISK`.
+- `fsck`: when `pack.readReverseIndex` true, validate each `.rev` next to `.idx`.
+
+## Validation
+
+- `./scripts/run-tests.sh --timeout 120 t5325-reverse-index.sh` → 16/16
+- `cargo test -p grit-lib --lib`
+- `cargo fmt`, `cargo clippy --fix --allow-dirty`

--- a/progress.md
+++ b/progress.md
@@ -1,20 +1,21 @@
 # Progress — Grit Test Coverage
 
-**Updated:** 2026-04-09
+**Updated:** 2026-04-10
 
 ## Counts (derived from plan.md)
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   325 |
+| Completed   |   326 |
 | In progress |     5 |
-| Remaining   |   441 |
+| Remaining   |   440 |
 | **Total**   |   771 |
 
-Task lines in `PLAN.md`: 325 completed (`[x]`), 5 in progress (`[~]`), 441 remaining (`[ ]`).
+Task lines in `PLAN.md`: 326 completed (`[x]`), 5 in progress (`[~]`), 440 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t5325-reverse-index` — 16/16 tests pass (RIDX `.rev` write/read: `index-pack` `--[no-]rev-index` + `pack.writeReverseIndex`, `-o` sibling `.rev`, `--rev-index --verify` hashfile errors; `pack-objects` reverse index; `cat-file %(objectsize:disk)` uses on-disk rev when `pack.readReverseIndex` true + test env hooks; `fsck` validates `.rev` with Git-ordered diagnostics)
 - `t3309-notes-merge-auto-resolve` — 31/31 tests pass (`notes merge`: `union` / `cat_sort_uniq` blob combine like Git; successful merge commits use two parents; `notes.mergeStrategy` config errors match upstream expectations)
 - `t4063-diff-blobs` — 18/18 tests pass (`diff`: blob↔blob and `rev:path` pairs without treating blobs as trees; `HEAD:one..HEAD:two` range split; `rev:path` vs worktree file uses tree path + modes + `write_patch_with_prefix`; raw blob OID vs existing file uses filename as old path; `rev_parse::resolve_treeish_blob_at_path` for tree walks)
 - `t5524-pull-msg` — 3/3 tests pass (`git pull --no-rebase --log` merge message preserves `$` in subject lines; `--log=1` limits shortlog; harness CSV/dashboards refreshed; `PLAN.md` marked complete)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible on-disk pack reverse indexes (`.rev` / RIDX) so `tests/t5325-reverse-index.sh` passes 16/16.

## What changed

- **Library** (`grit-lib`): new `pack_rev` module to build RIDX bytes from index-order offsets, verify for `index-pack --verify` (checksum first, matching Git’s hashfile verify path), `pack_rev_fsck_messages` for `fsck` (header checks before checksum + multiple errors like Git’s load+verify sequence), and helpers to use `.rev` for pack-order traversal in `cat-file`.
- **Config** (`ConfigSet`): `pack_write_reverse_index_default` / `pack_read_reverse_index_default` with `GIT_TEST_NO_WRITE_REV_INDEX` and camelCase/lowercase key aliases.
- **Commands**: `index-pack` (`--rev-index` / `--no-rev-index`, config-driven write, verify); `pack-objects` writes `.rev` when enabled; `cat-file` uses on-disk rev for `%(objectsize:disk)` when allowed + test env hooks; `fsck` validates `.rev` files when `pack.readReverseIndex` is true.

## Testing

- `./scripts/run-tests.sh --timeout 120 t5325-reverse-index.sh`
- `cargo test -p grit-lib --lib`
- `cargo fmt`, `cargo clippy --fix --allow-dirty`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21006d86-7289-4afc-be8e-39287d46e59d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21006d86-7289-4afc-be8e-39287d46e59d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

