### PR TITLE
fix(test-tool): raw SHA for pack trailers (t5321)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -889,7 +889,8 @@ t5318-commit-graph	t5	skip	85	0	0	false	ok	0
 t5318-pack-objects-revs-exclude	t5	yes	9	6	3	false	ok	0
 t5319-multi-pack-index	t5	yes	98	20	78	false	ok	0
 t5320-delta-islands	t5	yes	15	2	13	false	ok	0
-t5321-pack-large-objects	t5	yes	2	0	2	false	ok	0
+t5321-pack-large-objects	t5	yes	2	2	0	true	ok	0
+t5321-repro-inner	t5	yes	0	0	0	false		0
 t5322-pack-objects-sparse	t5	yes	11	5	6	false	ok	0
 t5323-pack-redundant	t5	yes	18	18	0	true	ok	0
 t5324-split-commit-graph	t5	yes	42	9	33	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,688 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,688 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T01:14:05+00:00" class="gen-time" title="2026-04-10 01:14 UTC">2026-04-10 01:14 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,688</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
-    <span>1,405 test files (in scope)</span>
+    <span>1,406 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">34/168 files · 17 skipped · 1,568/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.9%"></div></div>
+        <span class="group-pct pct-red">37.9%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35688 of 45142 tests passing across 1406 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,688 / 45,142 tests · 1,406 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T01:14:05+00:00" class="gen-time" title="2026-04-10 01:14 UTC">2026-04-10 01:14 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
-  <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
+  <div class="card"><div class="n" id="sum-files">1,406</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,688</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -9047,13 +9047,23 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:13.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="2" data-passed="0">
+<tr class="" data-group="t5" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t5321-pack-large-objects</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">2</td>
-  <td class="right">0</td>
+  <td class="right">2</td>
   <td class="right">ok</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
+  <td class="right small">0</td>
+</tr>
+<tr class="" data-group="t5" data-tests="0" data-passed="0">
+  <td class="mono">t5321-repro-inner</td>
+  <td>t5</td>
+  <td></td>
+  <td class="right">0</td>
+  <td class="right">0</td>
+  <td class="right"></td>
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
@@ -10027,14 +10037,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11677,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/logs/2026-04-10_t5321-test-tool-sha1-binary.md
+++ b/logs/2026-04-10_t5321-test-tool-sha1-binary.md
@@ -1,0 +1,18 @@
+# t5321-pack-large-objects — test-tool `sha1 -b`
+
+## Issue
+
+`t5321-pack-large-objects` failed at `index-pack --stdin` with `pack trailing checksum mismatch`.
+
+## Root cause
+
+`lib-pack.sh` appends the pack trailer via `test-tool $(test_oid algo) -b < pack`, which must emit **raw** hash bytes (Git `test-hash` / `cmd_hash_impl`). The grit `tests/test-tool` stub treated `sha1` as `sha1sum | cut`, ignoring `-b`, so the trailer was 40 ASCII hex bytes instead of 20 binary bytes.
+
+## Fix
+
+Implement `test-tool sha1 -b` and `test-tool sha256 -b` using Python’s `hashlib` to stream stdin and write the raw digest (matches upstream behavior for pack trailers).
+
+## Verification
+
+- `bash t5321-pack-large-objects.sh` in `tests/`: 2/2 pass
+- `./scripts/run-tests.sh --timeout 120 t5321-pack-large-objects.sh`: 2/2 pass

--- a/tests/test-tool
+++ b/tests/test-tool
@@ -118,9 +118,39 @@ case "$1" in
     done
     ;;
   sha1)
-    sha1sum | cut -d' ' -f1 ;;
+    shift
+    # Matches git's test-hash `cmd_hash_impl`: optional buffer size in MB (ignored here) or `-b` for
+    # raw digest bytes on stdout (used by lib-pack.sh `pack_trailer` for pack checksums).
+    if [ "$1" = "-b" ]; then
+      shift
+      python3 -c 'import hashlib,sys
+h = hashlib.sha1()
+for chunk in iter(lambda: sys.stdin.buffer.read(65536), b""):
+    h.update(chunk)
+sys.stdout.buffer.write(h.digest())'
+    elif [ -n "$1" ]; then
+      shift
+      sha1sum | cut -d" " -f1
+    else
+      sha1sum | cut -d" " -f1
+    fi
+    ;;
   sha256)
-    sha256sum | cut -d' ' -f1 ;;
+    shift
+    if [ "$1" = "-b" ]; then
+      shift
+      python3 -c 'import hashlib,sys
+h = hashlib.sha256()
+for chunk in iter(lambda: sys.stdin.buffer.read(65536), b""):
+    h.update(chunk)
+sys.stdout.buffer.write(h.digest())'
+    elif [ -n "$1" ]; then
+      shift
+      sha256sum | cut -d" " -f1
+    else
+      sha256sum | cut -d" " -f1
+    fi
+    ;;
   genrandom)
     shift
     exec "$SCRIPT_DIR/grit" test-tool genrandom "$@" ;;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t5321-pack-large-objects` failed because `lib-pack.sh` uses `test-tool sha1 -b` to append the pack trailer. Upstream Git’s `test-hash` writes **raw** digest bytes; our `tests/test-tool` stub ignored `-b` and printed hex ASCII, so the pack checksum was wrong and `index-pack` reported `pack trailing checksum mismatch`.

## Changes

- Implement `test-tool sha1 -b` and `test-tool sha256 -b` (stream stdin, write raw digest via Python `hashlib`), matching Git’s behavior for optional numeric buffer args (still accepted and ignored for compatibility).
- Refreshed harness CSV/dashboards after `./scripts/run-tests.sh t5321-pack-large-objects.sh`.

## Testing

- `./scripts/run-tests.sh --timeout 120 t5321-pack-large-objects.sh` → 2/2 pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27a6df3b-c212-4b68-aaaf-cb293a18dd02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27a6df3b-c212-4b68-aaaf-cb293a18dd02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

