### PR TITLE
fix: make t1301-shared-repo fully pass

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -129,7 +129,7 @@ commit → check it off → move on.
 - [ ] `t0602-reffiles-fsck` ██░░░░░░░░░░░░░░░░░░ 3/23 (20 left) — Test reffiles backend consistency check
 - [ ] `t1002-read-tree-m-u-2way` █░░░░░░░░░░░░░░░░░░░ 2/22 (20 left) — Two way merge with read-tree -m -u $H $M
 
-- [ ] `t1301-shared-repo` █░░░░░░░░░░░░░░░░░░░ 2/22 (20 left) — Test shared repository initialization
+- [x] `t1301-shared-repo` ████████████████████ 22/22 (0 left) — Test shared repository initialization
 - [ ] `t1011-read-tree-sparse-checkout` ░░░░░░░░░░░░░░░░░░░░ 1/23 (22 left) — sparse checkout tests
 
 - [ ] `t0600-reffiles-backend` █████░░░░░░░░░░░░░░░ 9/33 (24 left) — Test reffiles backend

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -352,7 +352,7 @@ t12980-tag-force-replace	t1	yes	33	33	0	true	ok	0
 t12990-commit-reuse-message	t1	yes	32	32	0	true	ok	0
 t1300-config	t1	yes	497	276	221	false	ok	0
 t13000-add-bulk-paths	t1	yes	31	31	0	true	ok	0
-t1301-shared-repo	t1	yes	22	2	20	false	ok	0
+t1301-shared-repo	t1	yes	22	22	0	true	ok	0
 t13010-rm-ignore-unmatch	t1	yes	30	30	0	true	ok	0
 t1302-repo-version	t1	yes	18	14	4	false	ok	0
 t13020-mv-force-overwrite	t1	yes	30	29	1	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,706 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,706 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T01:15:24+00:00" class="gen-time" title="2026-04-10 01:15 UTC">2026-04-10 01:15 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,706</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -197,11 +197,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">275/368 files · 8 skipped · 11,694/12,747 tests</span>
+        <span class="group-meta">276/368 files · 8 skipped · 11,714/12,747 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:91.7%"></div></div>
-        <span class="group-pct pct-green">91.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:91.9%"></div></div>
+        <span class="group-pct pct-green">91.9%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t2">
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35706 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,706 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T01:15:24+00:00" class="gen-time" title="2026-04-10 01:15 UTC">2026-04-10 01:15 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,706</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -3677,14 +3677,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="22" data-passed="2">
+<tr class="" data-group="t1" data-tests="22" data-passed="22" data-full-pass="1">
   <td class="mono">t1301-shared-repo</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">22</td>
-  <td class="right">2</td>
+  <td class="right">22</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:9.1%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="30" data-passed="30" data-full-pass="1">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/config.rs
+++ b/grit-lib/src/config.rs
@@ -656,6 +656,17 @@ fatal: bad config variable 'fetch.negotiationalgorithm' in file '{file_disp}' at
         })
     }
 
+    /// Last value for `key` in this file only (canonical key, case-insensitive section/var like Git).
+    #[must_use]
+    pub fn get(&self, key: &str) -> Option<String> {
+        let canon = canonical_key(key).ok()?;
+        self.entries
+            .iter()
+            .rev()
+            .find(|e| e.key == canon)
+            .map(|e| e.value.clone().unwrap_or_else(|| "true".to_owned()))
+    }
+
     /// Parse like [`Self::parse`] but record a non-disk include origin (blob, stdin, command line).
     pub fn parse_with_origin(
         path: &Path,

--- a/grit-lib/src/lib.rs
+++ b/grit-lib/src/lib.rs
@@ -78,6 +78,7 @@ pub mod repo;
 pub mod rerere;
 pub mod rev_list;
 pub mod rev_parse;
+pub mod shared_repo;
 #[cfg(unix)]
 pub mod simple_ipc;
 pub mod sparse_checkout;

--- a/grit-lib/src/shared_repo.rs
+++ b/grit-lib/src/shared_repo.rs
@@ -1,0 +1,211 @@
+//! Shared-repository permission helpers (`core.sharedRepository`, `--shared`).
+//!
+//! Mirrors Git's `git_config_perm`, `calc_shared_perm`, and `adjust_shared_perm` in `setup.c` /
+//! `path.c`.
+
+use crate::config::{parse_bool, ConfigSet};
+use std::fs;
+use std::path::Path;
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+/// Use the process umask for new files (Git `PERM_UMASK`).
+pub const PERM_UMASK: i32 = 0;
+const OLD_PERM_GROUP: i32 = 1;
+const OLD_PERM_EVERYBODY: i32 = 2;
+/// Group-writable layout (`--shared=group` / `1`).
+pub const PERM_GROUP: i32 = 0o660;
+/// World-readable/writable layout (`--shared=all` / `2`).
+pub const PERM_EVERYBODY: i32 = 0o664;
+
+/// Parse `core.sharedRepository` / `git init --shared=` like Git's `git_config_perm`.
+///
+/// Returns an error when an octal mode is given but the owner lacks read+write (Git `die`).
+pub fn git_config_perm(var: &str, value: &str) -> Result<i32, String> {
+    let value = value.trim();
+    if value.eq_ignore_ascii_case("umask") {
+        return Ok(PERM_UMASK);
+    }
+    if value.eq_ignore_ascii_case("group") {
+        return Ok(PERM_GROUP);
+    }
+    if value.eq_ignore_ascii_case("all")
+        || value.eq_ignore_ascii_case("world")
+        || value.eq_ignore_ascii_case("everybody")
+    {
+        return Ok(PERM_EVERYBODY);
+    }
+
+    // Git: strtol(value, &endptr, 8); if *endptr != 0, fall through to bool.
+    let (octal_prefix, rest) = split_octal_prefix(value);
+    if rest.is_empty() && !octal_prefix.is_empty() {
+        if let Ok(i) = i32::from_str_radix(octal_prefix, 8) {
+            return Ok(match i {
+                PERM_UMASK => PERM_UMASK,
+                OLD_PERM_GROUP => PERM_GROUP,
+                OLD_PERM_EVERYBODY => PERM_EVERYBODY,
+                _ => {
+                    if (i & 0o600) != 0o600 {
+                        return Err(format!(
+                            "problem with core.sharedRepository filemode value (0{i:o}).\n\
+                             The owner of files must always have read and write permissions."
+                        ));
+                    }
+                    -(i & 0o666)
+                }
+            });
+        }
+    }
+
+    match parse_bool(value) {
+        Ok(true) => Ok(PERM_GROUP),
+        Ok(false) => Ok(PERM_UMASK),
+        Err(_) => {
+            eprintln!("warning: bad boolean config value '{value}' for option '{var}'");
+            Ok(PERM_UMASK)
+        }
+    }
+}
+
+fn split_octal_prefix(s: &str) -> (&str, &str) {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() && matches!(bytes[i], b'0'..=b'7') {
+        i += 1;
+    }
+    (&s[..i], &s[i..])
+}
+
+/// Value to persist in `core.sharedRepository` for explicit sharing modes (matches Git `init_db`).
+#[must_use]
+pub fn shared_repository_config_stored_value(perm: i32) -> Option<String> {
+    if perm == 0 {
+        return None;
+    }
+    if perm < 0 {
+        Some(format!("0{:o}", (-perm) as u32))
+    } else if perm == PERM_GROUP {
+        Some(OLD_PERM_GROUP.to_string())
+    } else if perm == PERM_EVERYBODY {
+        // Git stores numeric `2` for world/all modes (`init_db` / t1301-shared-repo).
+        Some(OLD_PERM_EVERYBODY.to_string())
+    } else {
+        None
+    }
+}
+
+/// Git's `calc_shared_perm` (`path.c`).
+#[must_use]
+pub fn calc_shared_perm(shared_repo: i32, mode: u32) -> u32 {
+    let tweak = if shared_repo < 0 {
+        (-shared_repo) as u32
+    } else {
+        shared_repo as u32
+    };
+
+    let mut new_mode = if shared_repo < 0 {
+        (mode & !0o777) | tweak
+    } else {
+        mode | tweak
+    };
+
+    if mode & 0o200 == 0 {
+        new_mode &= !0o222;
+    }
+    if mode & 0o100 != 0 {
+        new_mode |= (new_mode & 0o444) >> 2;
+    }
+
+    new_mode
+}
+
+/// Recursively apply [`adjust_shared_perm_path`] under `git_dir` (Git `adjust_shared_perm` on init).
+#[cfg(unix)]
+pub fn adjust_shared_repo_tree(git_dir: &Path, shared_repo: i32) -> std::io::Result<()> {
+    fn visit(path: &Path, shared_repo: i32) -> std::io::Result<()> {
+        adjust_shared_perm_path(shared_repo, path)?;
+        if path.is_dir() {
+            for entry in fs::read_dir(path)? {
+                let entry = entry?;
+                let name = entry.file_name();
+                if name == "." || name == ".." {
+                    continue;
+                }
+                visit(&entry.path(), shared_repo)?;
+            }
+        }
+        Ok(())
+    }
+    visit(git_dir, shared_repo)
+}
+
+#[cfg(not(unix))]
+pub fn adjust_shared_repo_tree(_git_dir: &Path, _shared_repo: i32) -> std::io::Result<()> {
+    Ok(())
+}
+
+/// Re-run [`adjust_shared_repo_tree`] when `core.sharedRepository` is set (e.g. after commit/repack
+/// created new paths under `.git/`).
+pub fn refresh_repository_shared_tree(git_dir: &Path) -> std::io::Result<()> {
+    let cfg = ConfigSet::load(Some(git_dir), true).unwrap_or_else(|_| ConfigSet::new());
+    let shared =
+        match shared_repository_from_config_value(cfg.get("core.sharedRepository").as_deref()) {
+            Ok(v) => v,
+            Err(_) => return Ok(()),
+        };
+    if shared == 0 {
+        return Ok(());
+    }
+    adjust_shared_repo_tree(git_dir, shared)
+}
+
+/// Git's `adjust_shared_perm` for a single path (`path.c`), using an explicit `shared_repo` value.
+///
+/// When `shared_repo` is zero, this is a no-op. Symlinks are skipped.
+#[cfg(unix)]
+pub fn adjust_shared_perm_path(shared_repo: i32, path: &Path) -> std::io::Result<()> {
+    if shared_repo == 0 {
+        return Ok(());
+    }
+
+    let meta = fs::symlink_metadata(path)?;
+    if meta.file_type().is_symlink() {
+        return Ok(());
+    }
+
+    let old_mode = meta.permissions().mode();
+    let mut new_mode = calc_shared_perm(shared_repo, old_mode);
+    if meta.is_dir() {
+        new_mode |= (new_mode & 0o444) >> 2;
+        // Match Git: setgid on directories is tied to explicit filemode-style sharing
+        // (`shared_repo < 0`), not the legacy positive `PERM_GROUP` / `PERM_EVERYBODY` tweaks.
+        // Default `grit init` uses positive `PERM_GROUP` and should report `775` in `stat -c %a`
+        // (t12660); `git init --shared=0660` uses a negative mask and needs `drwxrw[sx]---` (t1301).
+        if shared_repo < 0 {
+            const S_ISGID: u32 = 0o002000;
+            if (new_mode & 0o060) != 0 {
+                new_mode |= S_ISGID;
+            }
+        }
+    }
+
+    let new_perm = fs::Permissions::from_mode(new_mode & 0o7777);
+    if (old_mode & 0o7777) != (new_mode & 0o7777) {
+        fs::set_permissions(path, new_perm)?;
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+pub fn adjust_shared_perm_path(_shared_repo: i32, _path: &Path) -> std::io::Result<()> {
+    Ok(())
+}
+
+/// Resolve `core.sharedRepository` from config text (merged set's string value).
+pub fn shared_repository_from_config_value(raw: Option<&str>) -> Result<i32, String> {
+    let Some(v) = raw.map(str::trim).filter(|s| !s.is_empty()) else {
+        return Ok(PERM_UMASK);
+    };
+    git_config_perm("core.sharedRepository", v)
+}

--- a/grit/src/commands/commit.rs
+++ b/grit/src/commands/commit.rs
@@ -17,6 +17,7 @@ use grit_lib::objects::{serialize_commit, CommitData, ObjectId, ObjectKind};
 use grit_lib::refs::{append_reflog, list_refs};
 use grit_lib::repo::Repository;
 use grit_lib::rev_parse::resolve_revision;
+use grit_lib::shared_repo::refresh_repository_shared_tree;
 use grit_lib::state::{detect_in_progress, resolve_head, HeadState};
 
 use crate::commands::cherry_pick::try_resume_pick_sequence_after_commit;
@@ -1229,6 +1230,8 @@ pub fn run(mut args: Args) -> Result<()> {
             }
         }
     }
+
+    let _ = refresh_repository_shared_tree(&repo.git_dir);
 
     Ok(())
 }

--- a/grit/src/commands/init.rs
+++ b/grit/src/commands/init.rs
@@ -5,18 +5,12 @@ use clap::Args as ClapArgs;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use grit_lib::config::{parse_bool, ConfigFile, ConfigScope, ConfigSet};
+use grit_lib::config::{ConfigFile, ConfigScope, ConfigSet};
+use grit_lib::shared_repo::{
+    adjust_shared_repo_tree, git_config_perm, shared_repository_config_stored_value, PERM_GROUP,
+    PERM_UMASK,
+};
 use grit_lib::unicode_normalization::probe_filesystem_normalizes_nfd_to_nfc;
-
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
-
-/// `PERM_UMASK` / `PERM_GROUP` / `PERM_EVERYBODY` from git `setup.h` (`sharedrepo` enum).
-const PERM_UMASK: i32 = 0;
-const OLD_PERM_GROUP: i32 = 1;
-const OLD_PERM_EVERYBODY: i32 = 2;
-const PERM_GROUP: i32 = 0o660;
-const PERM_EVERYBODY: i32 = 0o664;
 
 /// `guess_repository_type` from git/builtin/init-db.c (used when `--bare` was not passed).
 fn guess_repository_type(git_dir: &Path, cwd: &Path, raw_git_dir_env: Option<&str>) -> bool {
@@ -219,7 +213,8 @@ pub fn run(args: Args, global_bare: bool) -> Result<()> {
         );
     }
 
-    // Load config to get defaults (system + global + GIT_CONFIG_PARAMETERS)
+    // Load config to get defaults. Fresh init must not read the current repo's local config
+    // (t1301 "remote init does not use config from cwd"); reinit loads this repo only.
     let config = if is_reinit {
         ConfigSet::load(Some(&real_git_dir), true).unwrap_or_else(|_| ConfigSet::new())
     } else {
@@ -321,22 +316,13 @@ pub fn run(args: Args, global_bare: bool) -> Result<()> {
         }
     }
 
-    // Shared-repository mode: matches git's `git_config_perm` / `calc_shared_perm` /
-    // `adjust_shared_perm` (see git/path.c, git/setup.c). Fresh init defaults to
-    // group-writable layout (775 dirs, 664 files under umask 022) without writing
-    // `core.sharedRepository`, matching harness expectations (t12660-init-shared-perm).
-    let (shared_perm, shared_repo_config_value) = resolve_shared_repository_mode(
-        args.shared.as_deref(),
-        config.get("core.sharedRepository").as_deref(),
-        is_reinit,
-    );
-
     let work_tree_abs = work_tree_env.as_ref().map(|wt| {
         let p = PathBuf::from(wt);
         fs::canonicalize(&p).unwrap_or(p)
     });
 
-    // Create the git directory structure
+    // Create the git directory structure (shared-repository mode is applied afterward so
+    // templates can supply `core.sharedRepository` and `--shared` can update on reinit; t1301).
     create_git_dir(
         &real_git_dir,
         CreateGitDirOptions {
@@ -345,13 +331,14 @@ pub fn run(args: Args, global_bare: bool) -> Result<()> {
             object_format: &object_format,
             template_dir: template_dir.as_deref(),
             skip_default_templates,
-            shared_perm,
-            shared_repo_config_value: shared_repo_config_value.as_deref(),
             is_reinit,
             ref_format,
             work_tree: work_tree_abs.as_deref(),
         },
     )?;
+
+    let shared_perm =
+        apply_shared_repository_settings(&real_git_dir, args.shared.as_deref(), is_reinit, bare)?;
 
     // Git's probe_utf8_pathname_composition: if the FS aliases NFC/NFD spellings under .git,
     // set core.precomposeunicode (unless already set in higher-priority config).
@@ -396,7 +383,13 @@ pub fn run(args: Args, global_bare: bool) -> Result<()> {
 
     if !args.quiet {
         let prefix = if is_reinit {
-            "Reinitialized existing"
+            if shared_perm != 0 {
+                "Reinitialized existing shared"
+            } else {
+                "Reinitialized existing"
+            }
+        } else if shared_perm != 0 {
+            "Initialized empty shared"
         } else {
             "Initialized empty"
         };
@@ -448,8 +441,6 @@ struct CreateGitDirOptions<'a> {
     object_format: &'a str,
     template_dir: Option<&'a Path>,
     skip_default_templates: bool,
-    shared_perm: i32,
-    shared_repo_config_value: Option<&'a str>,
     is_reinit: bool,
     ref_format: &'a str,
     work_tree: Option<&'a Path>,
@@ -462,8 +453,6 @@ fn create_git_dir(git_dir: &Path, opts: CreateGitDirOptions<'_>) -> Result<()> {
         object_format,
         template_dir,
         skip_default_templates,
-        shared_perm,
-        shared_repo_config_value,
         is_reinit,
         ref_format,
         work_tree,
@@ -523,59 +512,44 @@ fn create_git_dir(git_dir: &Path, opts: CreateGitDirOptions<'_>) -> Result<()> {
         fs::write(&head_path, head_content)?;
     }
 
-    // Write config
+    // Write or merge config (templates may supply `config`; do not clobber it — t1301 #22).
     let config_path = git_dir.join("config");
     if !is_reinit || !config_path.exists() {
         let needs_extensions = object_format != "sha1" || ref_format == "reftable";
         let repo_version = if needs_extensions { 1 } else { 0 };
 
-        let mut config_content = String::from("[core]\n");
-        config_content.push_str(&format!("\trepositoryformatversion = {repo_version}\n"));
-        config_content.push_str("\tfilemode = true\n");
+        let existing = fs::read_to_string(&config_path).unwrap_or_default();
+        let mut cfg = ConfigFile::parse(&config_path, &existing, ConfigScope::Local)?;
+
+        cfg.set("core.repositoryformatversion", &repo_version.to_string())?;
+        cfg.set("core.filemode", "true")?;
         if bare {
-            config_content.push_str("\tbare = true\n");
+            cfg.set("core.bare", "true")?;
         } else {
-            config_content.push_str("\tbare = false\n");
-            config_content.push_str("\tlogallrefupdates = true\n");
+            cfg.set("core.bare", "false")?;
+            cfg.set("core.logallrefupdates", "true")?;
             if let Some(wt) = work_tree {
-                config_content.push_str(&format!(
-                    "\tworktree = {}\n",
-                    wt.display().to_string().replace('\\', "/")
-                ));
+                cfg.set(
+                    "core.worktree",
+                    &wt.display().to_string().replace('\\', "/"),
+                )?;
             }
         }
 
-        // Write extensions if needed
         if needs_extensions {
-            config_content.push_str("[extensions]\n");
             if object_format != "sha1" {
-                config_content.push_str(&format!("\tobjectformat = {}\n", object_format));
+                cfg.set("extensions.objectformat", object_format)?;
             }
             if ref_format == "reftable" {
-                config_content.push_str("\trefStorage = reftable\n");
+                cfg.set("extensions.refStorage", "reftable")?;
             }
         }
 
         if !is_reinit && !initial_branch.is_empty() {
-            config_content.push_str("[init]\n");
-            config_content.push_str(&format!("\tdefaultBranch = {initial_branch}\n"));
+            cfg.set("init.defaultBranch", initial_branch)?;
         }
 
-        // Write shared repository config when `--shared` or `core.sharedRepository` applies.
-        if let Some(stored) = shared_repo_config_value {
-            let insert_before_extensions = if let Some(pos) = config_content.find("[extensions]") {
-                pos
-            } else {
-                config_content.len()
-            };
-            config_content.insert_str(
-                insert_before_extensions,
-                &format!("\tsharedRepository = {stored}\n"),
-            );
-            config_content.push_str("\n[receive]\n\tdenyNonFastforwards = true\n");
-        }
-
-        fs::write(&config_path, config_content)?;
+        cfg.write()?;
     }
 
     // Write description (only on fresh init)
@@ -587,175 +561,82 @@ fn create_git_dir(git_dir: &Path, opts: CreateGitDirOptions<'_>) -> Result<()> {
         )?;
     }
 
-    if shared_perm != 0 {
-        adjust_shared_repo_tree(git_dir, shared_perm)?;
-    }
-
     Ok(())
 }
 
-/// Value to persist in `core.sharedRepository` for explicit sharing modes (matches git `init_db`).
-fn shared_repository_config_stored_value(perm: i32) -> Option<String> {
-    if perm == 0 {
-        return None;
+/// Read local `config` only (ignore global/system `core.sharedRepository`; t12660), resolve sharing,
+/// update `config` / `receive.*`, chmod the git dir.
+fn apply_shared_repository_settings(
+    git_dir: &Path,
+    shared_arg: Option<&str>,
+    is_reinit: bool,
+    bare: bool,
+) -> Result<i32> {
+    let config_path = git_dir.join("config");
+    let from_cfg = fs::read_to_string(&config_path)
+        .ok()
+        .and_then(|c| ConfigFile::parse(&config_path, &c, ConfigScope::Local).ok())
+        .and_then(|f| f.get("core.sharedRepository"));
+    let (shared_perm, stored) =
+        resolve_shared_repository_mode(shared_arg, from_cfg.as_deref(), is_reinit, bare)?;
+
+    let content = fs::read_to_string(&config_path).unwrap_or_default();
+    let mut cfg = ConfigFile::parse(&config_path, &content, ConfigScope::Local)?;
+
+    let shared_from_cli = shared_arg
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .is_some();
+    if let Some(stored_val) = stored.as_deref() {
+        cfg.set("core.sharedRepository", stored_val)?;
+        cfg.set("receive.denyNonFastforwards", "true")?;
+    } else if shared_from_cli && shared_perm == PERM_UMASK {
+        let _ = cfg.unset("core.sharedRepository");
+        let _ = cfg.unset("receive.denyNonFastforwards");
     }
-    if perm < 0 {
-        Some(format!("0{:o}", -perm as u32))
-    } else if perm == PERM_GROUP {
-        Some(OLD_PERM_GROUP.to_string())
-    } else if perm == PERM_EVERYBODY {
-        Some(OLD_PERM_EVERYBODY.to_string())
-    } else {
-        None
+    cfg.write()?;
+
+    if shared_perm != 0 {
+        adjust_shared_repo_tree(git_dir, shared_perm)
+            .context("adjust shared repository permissions")?;
     }
+
+    Ok(shared_perm)
 }
 
-/// Resolve effective shared-repository mode (`git_config_perm` semantics).
-///
-/// On fresh init, when no `--shared` and no `core.sharedRepository` in loaded config, defaults
-/// to [`PERM_GROUP`] so new repositories get group-writable objects/refs (775 under umask 022).
-/// On reinit, unset config means [`PERM_UMASK`] (no permission adjustment).
+/// Resolve chmod vs config persistence separately: Grit defaults fresh non-bare repos to
+/// group-writable `.git` trees (t12660) **without** writing `core.sharedRepository` unless the
+/// mode came from `--shared` or from config (template / prior init; t1301).
 fn resolve_shared_repository_mode(
     shared_arg: Option<&str>,
     shared_config: Option<&str>,
     is_reinit: bool,
-) -> (i32, Option<String>) {
+    bare: bool,
+) -> Result<(i32, Option<String>)> {
     let from_arg = shared_arg.map(str::trim).filter(|s| !s.is_empty());
     let from_cfg = shared_config.map(str::trim).filter(|s| !s.is_empty());
 
-    let perm = match from_arg {
-        Some(v) => git_config_perm("arg", v),
-        None => match from_cfg {
-            Some(v) => git_config_perm("core.sharedRepository", v),
-            None if is_reinit => PERM_UMASK,
-            None => PERM_GROUP,
-        },
-    };
-
-    let stored = if from_arg.is_some() || from_cfg.is_some() {
-        shared_repository_config_stored_value(perm)
-    } else {
-        None
-    };
-
-    (perm, stored)
-}
-
-/// Parse `core.sharedRepository` / `--shared` like git's `git_config_perm`.
-fn git_config_perm(var: &str, value: &str) -> i32 {
-    let value = value.trim();
-    if value.eq_ignore_ascii_case("umask") {
-        return PERM_UMASK;
-    }
-    if value.eq_ignore_ascii_case("group") {
-        return PERM_GROUP;
-    }
-    if value.eq_ignore_ascii_case("all")
-        || value.eq_ignore_ascii_case("world")
-        || value.eq_ignore_ascii_case("everybody")
-    {
-        return PERM_EVERYBODY;
-    }
-
-    // Git: strtol(value, &endptr, 8) on the full string; trailing junk falls through to bool.
-    if !value.is_empty() && value.chars().all(|c| ('0'..='7').contains(&c)) {
-        if let Ok(i) = i32::from_str_radix(value, 8) {
-            return match i {
-                PERM_UMASK => PERM_UMASK,
-                OLD_PERM_GROUP => PERM_GROUP,
-                OLD_PERM_EVERYBODY => PERM_EVERYBODY,
-                _ => {
-                    if (i & 0o600) != 0o600 {
-                        eprintln!(
-                            "warning: problem with core.sharedRepository filemode value (0{i:o})"
-                        );
-                        return PERM_UMASK;
-                    }
-                    -(i & 0o666)
-                }
-            };
+    let perm_explicit: Option<i32> = match (&from_arg, &from_cfg) {
+        (Some(v), _) => Some(git_config_perm("arg", v).map_err(|e| anyhow::anyhow!(e))?),
+        (None, Some(v)) => {
+            Some(git_config_perm("core.sharedRepository", v).map_err(|e| anyhow::anyhow!(e))?)
         }
-    }
+        (None, None) => None,
+    };
 
-    match parse_bool(value) {
-        Ok(true) => PERM_GROUP,
-        Ok(false) => PERM_UMASK,
-        Err(_) => {
-            eprintln!("warning: bad boolean config value '{value}' for option '{var}'");
+    let perm = perm_explicit.unwrap_or_else(|| {
+        if is_reinit {
             PERM_UMASK
+        } else if bare {
+            PERM_UMASK
+        } else {
+            PERM_GROUP
         }
-    }
-}
+    });
 
-/// Apply git's `calc_shared_perm` + directory execute-bit rule (see `adjust_shared_perm` in git/path.c).
-fn calc_shared_perm(shared_repo: i32, mode: u32) -> u32 {
-    let tweak = if shared_repo < 0 {
-        (-shared_repo) as u32
-    } else {
-        shared_repo as u32
-    };
+    let stored = perm_explicit.and_then(shared_repository_config_stored_value);
 
-    let mut new_mode = if shared_repo < 0 {
-        (mode & !0o777) | tweak
-    } else {
-        mode | tweak
-    };
-
-    if mode & 0o200 == 0 {
-        new_mode &= !0o222;
-    }
-    if mode & 0o100 != 0 {
-        new_mode |= (new_mode & 0o444) >> 2;
-    }
-
-    new_mode
-}
-
-#[cfg(unix)]
-fn adjust_shared_repo_tree(git_dir: &Path, shared_repo: i32) -> Result<()> {
-    fn visit(path: &Path, shared_repo: i32) -> Result<()> {
-        let meta =
-            fs::symlink_metadata(path).with_context(|| format!("stat {}", path.display()))?;
-        let ft = meta.file_type();
-        if ft.is_symlink() {
-            return Ok(());
-        }
-
-        let old_mode = meta.permissions().mode();
-        let mut new_mode = calc_shared_perm(shared_repo, old_mode);
-        if ft.is_dir() {
-            new_mode |= (new_mode & 0o444) >> 2;
-        }
-
-        let new_perm = fs::Permissions::from_mode(new_mode & 0o7777);
-        if (old_mode & 0o7777) != (new_mode & 0o7777) {
-            fs::set_permissions(path, new_perm)
-                .with_context(|| format!("chmod {}", path.display()))?;
-        }
-
-        if ft.is_dir() {
-            for entry in
-                fs::read_dir(path).with_context(|| format!("read_dir {}", path.display()))?
-            {
-                let entry = entry?;
-                let p = entry.path();
-                let name = entry.file_name();
-                if name == "." || name == ".." {
-                    continue;
-                }
-                visit(&p, shared_repo)?;
-            }
-        }
-        Ok(())
-    }
-
-    visit(git_dir, shared_repo)?;
-    Ok(())
-}
-
-#[cfg(not(unix))]
-fn adjust_shared_repo_tree(_git_dir: &Path, _shared_repo: i32) -> Result<()> {
-    Ok(())
+    Ok((perm, stored))
 }
 
 /// Expand ~ at the start of a path to $HOME.

--- a/grit/src/commands/repack.rs
+++ b/grit/src/commands/repack.rs
@@ -151,7 +151,11 @@ pub fn run(args: Args) -> Result<()> {
         anyhow::bail!("options '--geometric' and '-a' cannot be used together");
     }
     if geometric > 0 {
-        return run_geometric(&repo, &args, pack_kept_objects, geometric);
+        let r = run_geometric(&repo, &args, pack_kept_objects, geometric);
+        if r.is_ok() {
+            let _ = grit_lib::shared_repo::refresh_repository_shared_tree(&repo.git_dir);
+        }
+        return r;
     }
 
     if args.write_bitmap {
@@ -504,6 +508,8 @@ pub fn run(args: Args) -> Result<()> {
         update_server_info::refresh_objects_info_packs(&repo)?;
     }
 
+    let _ = grit_lib::shared_repo::refresh_repository_shared_tree(&repo.git_dir);
+
     Ok(())
 }
 
@@ -680,6 +686,8 @@ fn run_geometric(
         remove_duplicate_packs_matching_alternates(&objects_dir)?;
         update_server_info::refresh_objects_info_packs(repo)?;
     }
+
+    let _ = grit_lib::shared_repo::refresh_repository_shared_tree(&repo.git_dir);
 
     Ok(())
 }

--- a/grit/src/commands/update_server_info.rs
+++ b/grit/src/commands/update_server_info.rs
@@ -8,12 +8,18 @@
 
 use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
+use grit_lib::config::ConfigSet;
 use grit_lib::objects::ObjectId;
 use grit_lib::repo::Repository;
+use grit_lib::shared_repo::{adjust_shared_perm_path, shared_repository_from_config_value};
 use std::collections::BTreeMap;
 use std::fs;
 use std::io;
+use std::io::Write;
 use std::path::Path;
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 
 /// Arguments for `grit update-server-info`.
 #[derive(Debug, ClapArgs)]
@@ -26,11 +32,14 @@ pub struct Args {
 
 /// Run the `update-server-info` command.
 pub fn run(args: Args) -> Result<()> {
-    let _ = args;
     let repo = Repository::discover(None)?;
+    let cfg = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_else(|_| ConfigSet::new());
+    let shared_repo =
+        shared_repository_from_config_value(cfg.get("core.sharedRepository").as_deref())
+            .map_err(|msg| anyhow::anyhow!(msg))?;
 
-    update_info_refs(&repo, args.force)?;
-    update_info_packs(&repo)?;
+    update_info_refs(&repo, args.force, shared_repo)?;
+    update_info_packs(&repo, shared_repo)?;
 
     Ok(())
 }
@@ -38,7 +47,7 @@ pub fn run(args: Args) -> Result<()> {
 // ── info/refs ────────────────────────────────────────────────────────
 
 /// Write `info/refs` — one line per ref: `<hex-oid>\t<refname>\n`.
-fn update_info_refs(repo: &Repository, force: bool) -> Result<()> {
+fn update_info_refs(repo: &Repository, force: bool, shared_repo: i32) -> Result<()> {
     let info_dir = repo.git_dir.join("info");
     fs::create_dir_all(&info_dir).with_context(|| format!("creating {}", info_dir.display()))?;
 
@@ -48,17 +57,16 @@ fn update_info_refs(repo: &Repository, force: bool) -> Result<()> {
         out.push_str(&format!("{oid}\t{name}\n"));
     }
 
-    // Only write if content changed (preserves mtime when no-op), unless --force
     let refs_path = info_dir.join("refs");
-    if force {
-        fs::write(&refs_path, out).context("writing info/refs")?;
-    } else {
+    if !force {
         let existing = fs::read_to_string(&refs_path).unwrap_or_default();
-        if existing != out {
-            fs::write(&refs_path, out).context("writing info/refs")?;
+        if existing == out {
+            return Ok(());
         }
     }
 
+    write_atomic_with_shared_perm(&refs_path, out.as_bytes(), shared_repo)
+        .context("writing info/refs")?;
     Ok(())
 }
 
@@ -124,10 +132,14 @@ fn collect_loose_refs(
 /// Write `objects/info/packs` — one `P <pack-name>.pack\n` per pack file.
 /// Rewrite `objects/info/packs` from `.pack` files in `objects/pack` (e.g. after repack).
 pub fn refresh_objects_info_packs(repo: &Repository) -> Result<()> {
-    update_info_packs(repo)
+    let cfg = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_else(|_| ConfigSet::new());
+    let shared_repo =
+        shared_repository_from_config_value(cfg.get("core.sharedRepository").as_deref())
+            .map_err(|msg| anyhow::anyhow!(msg))?;
+    update_info_packs(repo, shared_repo)
 }
 
-fn update_info_packs(repo: &Repository) -> Result<()> {
+fn update_info_packs(repo: &Repository, shared_repo: i32) -> Result<()> {
     let objects_dir = repo.odb.objects_dir();
     let info_dir = objects_dir.join("info");
     fs::create_dir_all(&info_dir).with_context(|| format!("creating {}", info_dir.display()))?;
@@ -156,7 +168,30 @@ fn update_info_packs(repo: &Repository) -> Result<()> {
         out.push('\n');
     }
 
-    fs::write(info_dir.join("packs"), out).context("writing objects/info/packs")?;
+    let packs_path = info_dir.join("packs");
+    write_atomic_with_shared_perm(&packs_path, out.as_bytes(), shared_repo)
+        .context("writing objects/info/packs")?;
 
+    Ok(())
+}
+
+/// Write via a temp file in the same directory, then rename into place (matches Git `update_info_file`).
+fn write_atomic_with_shared_perm(path: &Path, content: &[u8], shared_repo: i32) -> io::Result<()> {
+    let parent = path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent)?;
+    let mut builder = tempfile::Builder::new();
+    #[cfg(unix)]
+    {
+        builder.permissions(fs::Permissions::from_mode(0o666));
+    }
+    let mut tmp = builder.tempfile_in(parent)?;
+    tmp.write_all(content)?;
+    tmp.flush()?;
+    tmp.as_file().sync_all()?;
+    adjust_shared_perm_path(shared_repo, tmp.path())?;
+    tmp.persist(path).map_err(|e| e.error)?;
     Ok(())
 }

--- a/logs/2026-04-10_t1301-shared-repo.md
+++ b/logs/2026-04-10_t1301-shared-repo.md
@@ -1,0 +1,20 @@
+# t1301-shared-repo
+
+## Goal
+
+Make `tests/t1301-shared-repo.sh` pass all 22 harness tests (shared repository init + `update-server-info` modes).
+
+## Changes (summary)
+
+- Added `grit-lib::shared_repo`: `git_config_perm` (die on bad owner perms), `calc_shared_perm` / `adjust_shared_perm_path` / `adjust_shared_repo_tree`, `refresh_repository_shared_tree` for post-commit/repack.
+- `init`: merge template `config` via `ConfigFile` instead of overwriting; apply sharing after templates; read `core.sharedRepository` from **local** `config` only (not global); re-init honors `--shared`; fresh bare default umask unless explicit sharing; `shared` / `receive` keys written when sharing is active.
+- `update-server-info`: temp file + rename with `0666` create + `adjust_shared_perm` (matches Git `update_info_file`).
+- `commit` / `repack`: call `refresh_repository_shared_tree` after mutating `.git` so new `logs/`, index, packs get shared modes (t1301 #18).
+- `ConfigFile::get` for single-file lookups.
+
+## Verification
+
+- `./scripts/run-tests.sh t1301-shared-repo.sh` → **22/22**
+- `t12660-init-shared-perm.sh` → **37/37** (clean env)
+- `cargo test -p grit-lib --lib`
+- `cargo clippy -p grit-rs -p grit-lib`

--- a/progress.md
+++ b/progress.md
@@ -1,20 +1,21 @@
 # Progress — Grit Test Coverage
 
-**Updated:** 2026-04-09
+**Updated:** 2026-04-10
 
 ## Counts (derived from plan.md)
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   325 |
+| Completed   |   326 |
 | In progress |     5 |
-| Remaining   |   441 |
+| Remaining   |   440 |
 | **Total**   |   771 |
 
-Task lines in `PLAN.md`: 325 completed (`[x]`), 5 in progress (`[~]`), 441 remaining (`[ ]`).
+Task lines in `PLAN.md`: 326 completed (`[x]`), 5 in progress (`[~]`), 440 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t1301-shared-repo` — 22/22 tests pass (`init`/`re-init`: `--shared` + template `core.sharedRepository`, invalid octal dies like Git, bare init ignores parent cwd config; `update-server-info` atomic writes + `adjust_shared_perm`; `commit`/`repack` refresh shared chmod for new `.git` paths; `ConfigFile::get` for local-only shared reads; harness CSV/dashboards refreshed)
 - `t3309-notes-merge-auto-resolve` — 31/31 tests pass (`notes merge`: `union` / `cat_sort_uniq` blob combine like Git; successful merge commits use two parents; `notes.mergeStrategy` config errors match upstream expectations)
 - `t4063-diff-blobs` — 18/18 tests pass (`diff`: blob↔blob and `rev:path` pairs without treating blobs as trees; `HEAD:one..HEAD:two` range split; `rev:path` vs worktree file uses tree path + modes + `write_patch_with_prefix`; raw blob OID vs existing file uses filename as old path; `rev_parse::resolve_treeish_blob_at_path` for tree walks)
 - `t5524-pull-msg` — 3/3 tests pass (`git pull --no-rebase --log` merge message preserves `$` in subject lines; `--log=1` limits shortlog; harness CSV/dashboards refreshed; `PLAN.md` marked complete)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible shared-repository behavior so `tests/t1301-shared-repo.sh` passes **22/22**.

### Key changes

- **`grit-lib::shared_repo`**: `git_config_perm` (fatal on invalid owner filemode like Git), `calc_shared_perm` / `adjust_shared_perm_path` / `adjust_shared_repo_tree`, and `refresh_repository_shared_tree` for re-applying modes after new files appear under `.git/`.
- **`grit init`**: Merges template `config` instead of overwriting it; resolves and applies `--shared` / local `core.sharedRepository` **after** templates (fixes re-init `--shared=all` and template-injected sharing); fresh bare repos use umask unless sharing is explicit (t1301 #19); reads sharing from **local** `config` only so global `core.sharedRepository` does not affect default inits.
- **`update-server-info`**: Writes via temp file with mode `0666` (umask applies) then `adjust_shared_perm` before rename, matching Git `update_info_file`.
- **`commit` / `repack`**: Calls `refresh_repository_shared_tree` after mutations so new `logs/`, index, packs, etc. get correct shared modes (t1301 #18).
- **`ConfigFile::get`**: Single-file key lookup for local config parsing.

### Verification

- `./scripts/run-tests.sh t1301-shared-repo.sh` → 22/22
- `t12660-init-shared-perm.sh` → 37/37
- `cargo test -p grit-lib --lib`, `cargo clippy -p grit-rs -p grit-lib`

Harness CSV and dashboards updated for `t1301-shared-repo`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a1017dd-6432-4028-bb7b-4799b31212ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a1017dd-6432-4028-bb7b-4799b31212ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

