### PR TITLE
fix: make t4008-diff-break-rewrite pass (diff-index -B / rename / copy)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -468,7 +468,7 @@ commit → check it off → move on.
 - [x] `t4035-diff-quiet` — Return value of diffs (23/23)
 - [ ] `t4213-log-tabexpand` ██░░░░░░░░░░░░░░░░░░ 1/9 (8 left) — log/show --expand-tabs
 - [x] `t4058-diff-duplicates` ████████████████████ 16/16 (0 left) — test tree diff when trees have duplicate entries
-- [ ] `t4008-diff-break-rewrite` ███████░░░░░░░░░░░░░ 5/14 (9 left) — Break and then rename
+- [x] `t4008-diff-break-rewrite` ████████████████████ 14/14 (0 left) — Break and then rename (`diff-index -B` break/merge, `-B -M` copy pass, typechange raw `T`, uncached worktree OIDs for rename/copy)
 
 - [x] `t4120-apply-popt` ████████████████████ 12/12 (0 left) — git apply -p handling.
 - [ ] `t4067-diff-partial-clone` ░░░░░░░░░░░░░░░░░░░░ 0/9 (9 left) — behavior of diff when reading objects in a partial clone

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -681,7 +681,7 @@ t4004-diff-rename-symlink	t4	yes	4	2	2	false	ok	0
 t4005-diff-rename-2	t4	yes	4	1	3	false	ok	0
 t4006-diff-mode	t4	yes	7	6	1	false	ok	0
 t4007-rename-3	t4	yes	13	6	7	false	ok	0
-t4008-diff-break-rewrite	t4	yes	14	5	9	false	ok	0
+t4008-diff-break-rewrite	t4	yes	14	14	0	true	ok	0
 t4009-diff-rename-4	t4	yes	7	4	3	false	ok	0
 t4010-diff-pathspec	t4	yes	17	17	0	true	ok	0
 t4011-diff-symlink	t4	yes	8	7	1	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,695 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,695 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T01:41:32+00:00" class="gen-time" title="2026-04-10 01:41 UTC">2026-04-10 01:41 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,695</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -230,22 +230,22 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">73/178 files · 2 skipped · 2,862/4,438 tests</span>
+        <span class="group-meta">74/178 files · 2 skipped · 2,871/4,438 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.5%"></div></div>
-        <span class="group-pct pct-blue">64.5%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.7%"></div></div>
+        <span class="group-pct pct-blue">64.7%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35695 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,695 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T01:41:32+00:00" class="gen-time" title="2026-04-10 01:41 UTC">2026-04-10 01:41 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,695</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -6967,14 +6967,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:46.2%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="14" data-passed="5">
+<tr class="" data-group="t4" data-tests="14" data-passed="14" data-full-pass="1">
   <td class="mono">t4008-diff-break-rewrite</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">14</td>
-  <td class="right">5</td>
+  <td class="right">14</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:35.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="7" data-passed="4">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/diff.rs
+++ b/grit-lib/src/diff.rs
@@ -1248,6 +1248,98 @@ pub fn diff_tree_to_worktree(
 
 // ── Rename detection ────────────────────────────────────────────────
 
+fn read_added_entry_bytes(
+    odb: &Odb,
+    entry: &DiffEntry,
+    work_root: Option<&Path>,
+) -> Option<Vec<u8>> {
+    if entry.new_oid != zero_oid() {
+        return odb.read(&entry.new_oid).ok().map(|obj| obj.data);
+    }
+    let path = entry.new_path.as_deref()?;
+    let root = work_root?;
+    fs::read(root.join(path)).ok()
+}
+
+fn modified_as_copy_from_sources(
+    odb: &Odb,
+    work_root: Option<&Path>,
+    e: &DiffEntry,
+    threshold: u32,
+    sources: &[(String, ObjectId, bool)],
+    source_contents: &[Option<Vec<u8>>],
+    source_tree_entries: &[(String, String, ObjectId)],
+) -> Option<DiffEntry> {
+    fn regular_file_mode(mode: &str) -> bool {
+        mode == "100644" || mode == "100755"
+    }
+
+    if e.status != DiffStatus::Modified || !regular_file_mode(&e.new_mode) {
+        return None;
+    }
+    let new_data = read_added_entry_bytes(odb, e, work_root)?;
+    let new_oid_eff = if e.new_oid != zero_oid() {
+        e.new_oid
+    } else {
+        Odb::hash_object_data(ObjectKind::Blob, &new_data)
+    };
+
+    let mut best: Option<(usize, u32)> = None;
+    for (si, (src_path, src_oid, is_deleted)) in sources.iter().enumerate() {
+        if *is_deleted {
+            continue;
+        }
+        if e.new_path.as_deref() == Some(src_path.as_str()) {
+            continue;
+        }
+        let src_mode_str = source_tree_entries
+            .iter()
+            .find(|(p, _, _)| p == src_path)
+            .map(|(_, m, _)| m.as_str())
+            .unwrap_or("100644");
+        if !regular_file_mode(src_mode_str) {
+            continue;
+        }
+
+        let score = if *src_oid == new_oid_eff {
+            100
+        } else {
+            match (&source_contents[si], Some(new_data.as_slice())) {
+                (Some(old_data), Some(nd)) => compute_similarity(old_data, nd),
+                _ => 0,
+            }
+        };
+        if score >= threshold {
+            let replace = match best {
+                None => true,
+                Some((_, s)) => score > s,
+            };
+            if replace {
+                best = Some((si, score));
+            }
+        }
+    }
+
+    let (si, score) = best?;
+    let (src_path, src_oid, _) = &sources[si];
+    let src_mode = source_tree_entries
+        .iter()
+        .find(|(p, _, _)| p == src_path)
+        .map(|(_, m, _)| m.clone())
+        .unwrap_or_else(|| e.old_mode.clone());
+
+    Some(DiffEntry {
+        status: DiffStatus::Copied,
+        old_path: Some(src_path.clone()),
+        new_path: e.new_path.clone(),
+        old_mode: src_mode,
+        new_mode: e.new_mode.clone(),
+        old_oid: *src_oid,
+        new_oid: e.new_oid,
+        score: Some(score),
+    })
+}
+
 /// Detect renames by pairing Deleted and Added entries with similar content.
 ///
 /// `threshold` is the minimum similarity percentage (0–100) for a pair to
@@ -1255,7 +1347,16 @@ pub fn diff_tree_to_worktree(
 /// content from the ODB to compute a line-level similarity score.
 ///
 /// Exact-OID matches are always 100% similar regardless of content.
-pub fn detect_renames(odb: &Odb, entries: Vec<DiffEntry>, threshold: u32) -> Vec<DiffEntry> {
+///
+/// When `work_root` is set, added entries whose `new_oid` is the zero placeholder (as in
+/// uncached `diff-index` when the work tree diverged from the index) load content from disk
+/// under that root instead of the object database.
+pub fn detect_renames(
+    odb: &Odb,
+    work_root: Option<&Path>,
+    entries: Vec<DiffEntry>,
+    threshold: u32,
+) -> Vec<DiffEntry> {
     // Split entries into deleted, added, and others.
     let mut deleted: Vec<DiffEntry> = Vec::new();
     let mut added: Vec<DiffEntry> = Vec::new();
@@ -1287,18 +1388,28 @@ pub fn detect_renames(odb: &Odb, entries: Vec<DiffEntry>, threshold: u32) -> Vec
     // Read content for all added blobs.
     let added_contents: Vec<Option<Vec<u8>>> = added
         .iter()
-        .map(|a| odb.read(&a.new_oid).ok().map(|obj| obj.data))
+        .map(|a| read_added_entry_bytes(odb, a, work_root))
         .collect();
 
     // Build a matrix of similarity scores and find the best pairings.
     // We use a greedy approach: pick the highest-scoring pair first.
     let mut scores: Vec<(u32, usize, usize)> = Vec::new();
 
+    fn is_regularish_mode(mode: &str) -> bool {
+        mode == "100644" || mode == "100755"
+    }
+
     for (di, del) in deleted.iter().enumerate() {
         for (ai, add) in added.iter().enumerate() {
             // Exact OID match → 100%
             if del.old_oid == add.new_oid {
                 scores.push((100, di, ai));
+                continue;
+            }
+
+            // Do not use line similarity across file types (e.g. regular ↔ symlink); Git keeps these
+            // as separate changes (`t4008-diff-break-rewrite` #7).
+            if !is_regularish_mode(&del.old_mode) || !is_regularish_mode(&add.new_mode) {
                 continue;
             }
 
@@ -1377,6 +1488,7 @@ pub fn detect_renames(odb: &Odb, entries: Vec<DiffEntry>, threshold: u32) -> Vec
 /// used when `find_copies_harder` is true to consider unmodified files as copy sources.
 pub fn detect_copies(
     odb: &Odb,
+    work_root: Option<&Path>,
     entries: Vec<DiffEntry>,
     threshold: u32,
     find_copies_harder: bool,
@@ -1397,13 +1509,6 @@ pub fn detect_copies(
         }
     }
 
-    if added.is_empty() {
-        let mut result = others;
-        result.extend(deleted);
-        result.sort_by(|a, b| a.path().cmp(b.path()));
-        return result;
-    }
-
     // Build source candidates: deleted files, modified files, and optionally tree entries.
     // Track which sources are from deleted files (can become renames).
     let mut sources: Vec<(String, ObjectId, bool)> = Vec::new(); // (path, oid, is_deleted)
@@ -1416,9 +1521,10 @@ pub fn detect_copies(
         }
     }
 
-    // Modified files are always candidates for -C.
+    // Modified and type-changed files are candidates for `-C` (e.g. symlink rewrite leaves the
+    // old blob available as a copy source for another path; see `t4008-diff-break-rewrite`).
     for entry in &others {
-        if entry.status == DiffStatus::Modified {
+        if matches!(entry.status, DiffStatus::Modified | DiffStatus::TypeChanged) {
             if let Some(ref old_path) = entry.old_path {
                 if !sources.iter().any(|(p, _, _)| p == old_path) {
                     sources.push((old_path.clone(), entry.old_oid, false));
@@ -1450,118 +1556,122 @@ pub fn detect_copies(
         .map(|(_, oid, _)| odb.read(oid).ok().map(|obj| obj.data))
         .collect();
 
-    // Read content for added blobs.
-    let added_contents: Vec<Option<Vec<u8>>> = added
-        .iter()
-        .map(|a| odb.read(&a.new_oid).ok().map(|obj| obj.data))
-        .collect();
-
-    // Build score matrix: (score, source_idx, added_idx)
-    let mut scores: Vec<(u32, usize, usize)> = Vec::new();
-    for (si, (src_path, src_oid, _)) in sources.iter().enumerate() {
-        for (ai, add) in added.iter().enumerate() {
-            // Never pair a path with itself as copy source (matches Git; avoids
-            // arbitrary tie-breaking when several sources share the same blob).
-            if add.new_path.as_deref() == Some(src_path.as_str()) {
-                continue;
-            }
-            if *src_oid == add.new_oid {
-                scores.push((100, si, ai));
-                continue;
-            }
-            let score = match (&source_contents[si], &added_contents[ai]) {
-                (Some(old_data), Some(new_data)) => compute_similarity(old_data, new_data),
-                _ => 0,
-            };
-            if score >= threshold {
-                scores.push((score, si, ai));
-            }
-        }
-    }
-
-    // Sort by score descending.
-    scores.sort_by(|a, b| b.0.cmp(&a.0));
-
-    // Build source->added mappings, each added file assigned to best source.
-    let mut used_added = vec![false; added.len()];
-    let mut source_to_added: HashMap<usize, Vec<(usize, u32)>> = HashMap::new();
-    for &(score, si, ai) in &scores {
-        if used_added[ai] {
-            continue;
-        }
-        used_added[ai] = true;
-        source_to_added.entry(si).or_default().push((ai, score));
-    }
-
-    // Determine which become Rename vs Copy.
-    // For each deleted source, at most one assignment becomes a Rename;
-    // the rest become Copies. Pick the last alphabetically as rename target.
-    let mut used_added2 = vec![false; added.len()];
     let mut result_entries: Vec<DiffEntry> = Vec::new();
-
-    // Track which deleted sources got a rename.
     let mut renamed_deleted: HashSet<usize> = HashSet::new();
+    let mut used_added2 = vec![false; added.len()];
 
-    // For each deleted source, pick one assignment as Rename, rest as Copy.
-    for (&si, assignments_for_src) in &source_to_added {
-        let (_, _, is_deleted) = &sources[si];
-        if *is_deleted && !assignments_for_src.is_empty() {
-            // Pick the last one (by path) as the rename target.
-            // Git tends to pick the rename as the last alphabetically.
-            let rename_ai = assignments_for_src
-                .iter()
-                .max_by_key(|(ai, _score)| added[*ai].path().to_string())
-                .map(|(ai, _)| *ai);
+    if !added.is_empty() {
+        // Read content for added blobs.
+        let added_contents: Vec<Option<Vec<u8>>> = added
+            .iter()
+            .map(|a| read_added_entry_bytes(odb, a, work_root))
+            .collect();
 
-            for &(ai, score) in assignments_for_src {
-                let (ref src_path, _, _) = sources[si];
-                let add = &added[ai];
-                let src_mode = source_tree_entries
-                    .iter()
-                    .find(|(p, _, _)| p == src_path)
-                    .map(|(_, m, _)| m.clone())
-                    .unwrap_or_else(|| add.old_mode.clone());
-
-                let is_rename = Some(ai) == rename_ai;
-                result_entries.push(DiffEntry {
-                    status: if is_rename {
-                        DiffStatus::Renamed
-                    } else {
-                        DiffStatus::Copied
-                    },
-                    old_path: Some(src_path.clone()),
-                    new_path: add.new_path.clone(),
-                    old_mode: src_mode,
-                    new_mode: add.new_mode.clone(),
-                    old_oid: sources[si].1,
-                    new_oid: add.new_oid,
-                    score: Some(score),
-                });
-                used_added2[ai] = true;
+        // Build score matrix: (score, source_idx, added_idx)
+        let mut scores: Vec<(u32, usize, usize)> = Vec::new();
+        for (si, (src_path, src_oid, _)) in sources.iter().enumerate() {
+            for (ai, add) in added.iter().enumerate() {
+                // Never pair a path with itself as copy source (matches Git; avoids
+                // arbitrary tie-breaking when several sources share the same blob).
+                if add.new_path.as_deref() == Some(src_path.as_str()) {
+                    continue;
+                }
+                let add_oid = if add.new_oid != zero_oid() {
+                    add.new_oid
+                } else if let Some(ref data) = added_contents[ai] {
+                    Odb::hash_object_data(ObjectKind::Blob, data)
+                } else {
+                    zero_oid()
+                };
+                if *src_oid == add_oid {
+                    scores.push((100, si, ai));
+                    continue;
+                }
+                let score = match (&source_contents[si], &added_contents[ai]) {
+                    (Some(old_data), Some(new_data)) => compute_similarity(old_data, new_data),
+                    _ => 0,
+                };
+                if score >= threshold {
+                    scores.push((score, si, ai));
+                }
             }
-            renamed_deleted.insert(si);
-        } else {
-            // Non-deleted source: all assignments are copies.
-            for &(ai, score) in assignments_for_src {
-                let (ref src_path, _, _) = sources[si];
-                let add = &added[ai];
-                let src_mode = source_tree_entries
-                    .iter()
-                    .find(|(p, _, _)| p == src_path)
-                    .map(|(_, m, _)| m.clone())
-                    .unwrap_or_else(|| add.old_mode.clone());
+        }
 
-                result_entries.push(DiffEntry {
-                    status: DiffStatus::Copied,
-                    old_path: Some(src_path.clone()),
-                    new_path: add.new_path.clone(),
-                    old_mode: src_mode,
-                    new_mode: add.new_mode.clone(),
-                    old_oid: sources[si].1,
-                    new_oid: add.new_oid,
-                    score: Some(score),
-                });
-                used_added2[ai] = true;
+        // Sort by score descending.
+        scores.sort_by(|a, b| b.0.cmp(&a.0));
+
+        // Build source->added mappings, each added file assigned to best source.
+        let mut used_added = vec![false; added.len()];
+        let mut source_to_added: HashMap<usize, Vec<(usize, u32)>> = HashMap::new();
+        for &(score, si, ai) in &scores {
+            if used_added[ai] {
+                continue;
+            }
+            used_added[ai] = true;
+            source_to_added.entry(si).or_default().push((ai, score));
+        }
+
+        // For each deleted source, pick one assignment as Rename, rest as Copy.
+        for (&si, assignments_for_src) in &source_to_added {
+            let (_, _, is_deleted) = &sources[si];
+            if *is_deleted && !assignments_for_src.is_empty() {
+                // Pick the last one (by path) as the rename target.
+                // Git tends to pick the rename as the last alphabetically.
+                let rename_ai = assignments_for_src
+                    .iter()
+                    .max_by_key(|(ai, _score)| added[*ai].path().to_string())
+                    .map(|(ai, _)| *ai);
+
+                for &(ai, score) in assignments_for_src {
+                    let (ref src_path, _, _) = sources[si];
+                    let add = &added[ai];
+                    let src_mode = source_tree_entries
+                        .iter()
+                        .find(|(p, _, _)| p == src_path)
+                        .map(|(_, m, _)| m.clone())
+                        .unwrap_or_else(|| add.old_mode.clone());
+
+                    let is_rename = Some(ai) == rename_ai;
+                    result_entries.push(DiffEntry {
+                        status: if is_rename {
+                            DiffStatus::Renamed
+                        } else {
+                            DiffStatus::Copied
+                        },
+                        old_path: Some(src_path.clone()),
+                        new_path: add.new_path.clone(),
+                        old_mode: src_mode,
+                        new_mode: add.new_mode.clone(),
+                        old_oid: sources[si].1,
+                        new_oid: add.new_oid,
+                        score: Some(score),
+                    });
+                    used_added2[ai] = true;
+                }
+                renamed_deleted.insert(si);
+            } else {
+                // Non-deleted source: all assignments are copies.
+                for &(ai, score) in assignments_for_src {
+                    let (ref src_path, _, _) = sources[si];
+                    let add = &added[ai];
+                    let src_mode = source_tree_entries
+                        .iter()
+                        .find(|(p, _, _)| p == src_path)
+                        .map(|(_, m, _)| m.clone())
+                        .unwrap_or_else(|| add.old_mode.clone());
+
+                    result_entries.push(DiffEntry {
+                        status: DiffStatus::Copied,
+                        old_path: Some(src_path.clone()),
+                        new_path: add.new_path.clone(),
+                        old_mode: src_mode,
+                        new_mode: add.new_mode.clone(),
+                        old_oid: sources[si].1,
+                        new_oid: add.new_oid,
+                        score: Some(score),
+                    });
+                    used_added2[ai] = true;
+                }
             }
         }
     }
@@ -1588,8 +1698,25 @@ pub fn detect_copies(
         }
     }
 
-    result.sort_by(|a, b| a.path().cmp(b.path()));
-    result
+    let mut final_result = Vec::with_capacity(result.len());
+    for e in result {
+        if let Some(c) = modified_as_copy_from_sources(
+            odb,
+            work_root,
+            &e,
+            threshold,
+            &sources,
+            &source_contents,
+            source_tree_entries,
+        ) {
+            final_result.push(c);
+        } else {
+            final_result.push(e);
+        }
+    }
+
+    final_result.sort_by(|a, b| a.path().cmp(b.path()));
+    final_result
 }
 
 /// Apply Git-style rename and optional copy detection for index↔worktree diffs.
@@ -1608,7 +1735,7 @@ pub fn status_apply_rename_copy_detection(
     copies: bool,
     head_tree: Option<&ObjectId>,
 ) -> Result<Vec<DiffEntry>> {
-    let after_renames = detect_renames(odb, unstaged_raw, threshold);
+    let after_renames = detect_renames(odb, None, unstaged_raw, threshold);
     if !copies {
         return Ok(after_renames);
     }
@@ -1621,6 +1748,7 @@ pub fn status_apply_rename_copy_detection(
     };
     Ok(detect_copies(
         odb,
+        None,
         after_renames,
         threshold,
         false,
@@ -2459,9 +2587,16 @@ pub fn count_git_lines(data: &[u8]) -> usize {
     count
 }
 
-const DIFF_MAX_SCORE: u64 = 60_000;
+/// Internal maximum diff score used by Git rename/break heuristics (`MAX_SCORE` in `diffcore.h`).
+pub const GIT_DIFF_MAX_SCORE: u64 = 60_000;
+const DIFF_MAX_SCORE: u64 = GIT_DIFF_MAX_SCORE;
 const DIFF_MINIMUM_BREAK_SIZE: usize = 400;
 const DIFF_DEFAULT_BREAK_SCORE: u64 = 30_000;
+/// Default break threshold (`DEFAULT_BREAK_SCORE` in `diffcore.h`), internal 0–[`GIT_DIFF_MAX_SCORE`] scale.
+pub const GIT_DIFF_DEFAULT_BREAK_SCORE: u64 = DIFF_DEFAULT_BREAK_SCORE;
+/// Default merge threshold after a break (`DEFAULT_MERGE_SCORE` in `diffcore.h`): pairs broken for
+/// rename/copy but not consumed are merged back when deletion-weight is below this (60% by default).
+pub const GIT_DIFF_DEFAULT_MERGE_SCORE_AFTER_BREAK: u64 = 36_000;
 const DIFF_HASHBASE: u32 = 107_927;
 
 #[derive(Clone, Copy, Default)]
@@ -2669,6 +2804,51 @@ pub fn diffcore_count_changes(old: &[u8], new: &[u8]) -> (u64, u64) {
 #[must_use]
 pub fn should_break_rewrite_for_stat(old: &[u8], new: &[u8]) -> bool {
     should_break_rewrite_inner(old, new, DIFF_DEFAULT_BREAK_SCORE)
+}
+
+/// Whether an in-place blob edit should be split into delete+create for rename/copy (`should_break`
+/// in `diffcore-break.c`). `break_score` is on the internal 0–[`GIT_DIFF_MAX_SCORE`] scale (default
+/// [`DIFF_DEFAULT_BREAK_SCORE`]).
+#[must_use]
+pub fn should_break_rewrite_pair(old: &[u8], new: &[u8], break_score: u64) -> bool {
+    should_break_rewrite_inner(old, new, break_score)
+}
+
+/// Parse a single Git `parse_rename_score` token (`50`, `50%`, decimal forms) into internal
+/// 0–[`GIT_DIFF_MAX_SCORE`] units.
+pub fn parse_diff_rename_score_token(arg: &str) -> Option<u64> {
+    let mut num: u64 = 0;
+    let mut scale: u64 = 1;
+    let mut dot = false;
+    let mut saw_digit = false;
+    for ch in arg.chars() {
+        if !dot && ch == '.' {
+            scale = 1;
+            dot = true;
+            continue;
+        }
+        if ch == '%' {
+            scale = if dot { scale.saturating_mul(100) } else { 100 };
+            break;
+        }
+        if ch.is_ascii_digit() {
+            saw_digit = true;
+            if scale < 100_000 {
+                scale = scale.saturating_mul(10);
+                num = num.saturating_mul(10) + u64::from(ch as u8 - b'0');
+            }
+        } else {
+            break;
+        }
+    }
+    if !saw_digit {
+        return None;
+    }
+    Some(if num >= scale {
+        GIT_DIFF_MAX_SCORE
+    } else {
+        GIT_DIFF_MAX_SCORE * num / scale
+    })
 }
 
 /// Git `merge_score` from `diffcore-break.c` when a pair is considered broken: how much of the

--- a/grit-lib/src/line_log.rs
+++ b/grit-lib/src/line_log.rs
@@ -954,7 +954,7 @@ fn diff_tree_pair(
     let old = old_tree.copied();
     let mut entries = diff_trees(odb, old.as_ref(), Some(new_tree), "")?;
     if rename_threshold < 100 {
-        entries = detect_renames(odb, entries, rename_threshold);
+        entries = detect_renames(odb, None, entries, rename_threshold);
     }
     Ok(filter_entries_for_paths(entries, paths))
 }

--- a/grit-lib/src/merge_trees.rs
+++ b/grit-lib/src/merge_trees.rs
@@ -147,7 +147,7 @@ fn rename_pairs_base_to_other(
     other_tree: &ObjectId,
 ) -> crate::error::Result<Vec<(Vec<u8>, Vec<u8>, u32)>> {
     let mut entries = diff_trees(odb, Some(base_tree), Some(other_tree), "")?;
-    entries = detect_renames(odb, entries, 50);
+    entries = detect_renames(odb, None, entries, 50);
     let mut out = Vec::new();
     for e in entries {
         if e.status != DiffStatus::Renamed {

--- a/grit/src/commands/diff.rs
+++ b/grit/src/commands/diff.rs
@@ -1679,7 +1679,7 @@ pub fn run(mut args: Args) -> Result<()> {
         }
     };
     let entries = if let Some(threshold) = rename_threshold {
-        detect_renames(&repo.odb, entries, threshold)
+        detect_renames(&repo.odb, None, entries, threshold)
     } else {
         entries
     };

--- a/grit/src/commands/diff_files.rs
+++ b/grit/src/commands/diff_files.rs
@@ -118,13 +118,14 @@ pub fn run(mut args: Args) -> Result<()> {
             .collect();
         diff_entries = detect_copies(
             &repo.odb,
+            None,
             diff_entries,
             threshold,
             options.find_copies_harder,
             &source_index_entries,
         );
     } else if let Some(threshold) = options.find_renames {
-        diff_entries = grit_lib::diff::detect_renames(&repo.odb, diff_entries, threshold);
+        diff_entries = grit_lib::diff::detect_renames(&repo.odb, None, diff_entries, threshold);
     }
 
     if options.summary {

--- a/grit/src/commands/diff_index.rs
+++ b/grit/src/commands/diff_index.rs
@@ -3,8 +3,10 @@
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::diff::{
-    detect_renames, diff_trees, read_submodule_head_oid, stat_matches, zero_oid, DiffEntry,
-    DiffStatus,
+    detect_renames, diff_trees, empty_blob_oid, parse_diff_rename_score_token,
+    read_submodule_head_oid, rewrite_dissimilarity_index_percent, rewrite_merge_score,
+    should_break_rewrite_pair, stat_matches, zero_oid, DiffEntry, DiffStatus,
+    GIT_DIFF_DEFAULT_MERGE_SCORE_AFTER_BREAK,
 };
 use grit_lib::index::{
     Index, IndexEntry, MODE_EXECUTABLE, MODE_GITLINK, MODE_REGULAR, MODE_SYMLINK, MODE_TREE,
@@ -16,7 +18,7 @@ use grit_lib::quote_path::{format_diff_path_with_prefix, quote_c_style};
 use grit_lib::repo::Repository;
 use grit_lib::rev_list::merge_bases;
 use grit_lib::rev_parse::{abbreviate_object_id, resolve_revision};
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::io::Write;
 use std::os::unix::ffi::OsStrExt;
@@ -146,26 +148,95 @@ pub fn run(mut args: Args) -> Result<()> {
         }
     }
 
-    let diff_entries = if options.find_copies {
+    let rename_work_root = if options.cached {
+        None
+    } else {
+        repo.work_tree.as_deref()
+    };
+
+    let (mut diff_entries, broken_for_merge) = if options.break_rewrites {
+        apply_diffcore_break_rewrites_split(
+            &repo.odb,
+            rename_work_root,
+            options.cached,
+            diff_entries,
+            options.break_score,
+            options.merge_after_break_score,
+        )
+    } else {
+        (diff_entries, HashSet::new())
+    };
+
+    let source_tree_entries: Vec<(String, String, ObjectId)> = tree_map
+        .iter()
+        .map(|(path, snap)| (path.clone(), format!("{:06o}", snap.mode), snap.oid))
+        .collect();
+
+    diff_entries = if options.find_copies {
         let threshold = options.find_renames.unwrap_or(50);
-        // Build source tree entries for copy detection (`path, mode, oid` order matches
-        // `grit_lib::diff::detect_copies`).
-        let source_tree_entries: Vec<(String, String, ObjectId)> = tree_map
-            .iter()
-            .map(|(path, snap)| (path.clone(), format!("{:06o}", snap.mode), snap.oid))
-            .collect();
         grit_lib::diff::detect_copies(
             &repo.odb,
+            rename_work_root,
             diff_entries,
             threshold,
             options.find_copies_harder,
             &source_tree_entries,
         )
     } else if let Some(threshold) = options.find_renames {
-        detect_renames(&repo.odb, diff_entries, threshold)
+        let mut d = detect_renames(&repo.odb, rename_work_root, diff_entries, threshold);
+        // Git runs copy detection after rename when `-B` and `-M` are combined (e.g.
+        // `t4008-diff-break-rewrite` #6): a type-changed path can be the copy source for a modified
+        // sibling even without `-C`.
+        if options.break_rewrites {
+            d = grit_lib::diff::detect_copies(
+                &repo.odb,
+                rename_work_root,
+                d,
+                threshold,
+                false,
+                &source_tree_entries,
+            );
+        }
+        d
     } else {
         diff_entries
     };
+
+    if options.break_rewrites && !broken_for_merge.is_empty() {
+        diff_entries = merge_broken_rewrite_pairs(diff_entries, &broken_for_merge);
+    }
+
+    if options.break_rewrites && options.find_renames.is_some() {
+        diff_entries = drop_break_delete_superseded_by_rename_dest(diff_entries);
+    }
+
+    if options.break_rewrites {
+        for e in &mut diff_entries {
+            if e.status != DiffStatus::TypeChanged {
+                continue;
+            }
+            if e.score.is_some() {
+                continue;
+            }
+            if e.old_oid == zero_oid() || e.new_oid == zero_oid() {
+                continue;
+            }
+            let Ok(old_obj) = repo.odb.read(&e.old_oid) else {
+                continue;
+            };
+            let Ok(new_obj) = repo.odb.read(&e.new_oid) else {
+                continue;
+            };
+            if grit_lib::merge_file::is_binary(&old_obj.data)
+                || grit_lib::merge_file::is_binary(&new_obj.data)
+            {
+                continue;
+            }
+            if let Some(pct) = rewrite_dissimilarity_index_percent(&old_obj.data, &new_obj.data) {
+                e.score = Some(pct);
+            }
+        }
+    }
 
     let diff_entries = if options.ignore_all_space {
         filter_entries_ignore_all_space(&repo, diff_entries)
@@ -492,6 +563,13 @@ struct Options {
     ignore_all_space: bool,
     nul_terminated: bool,
     relative: bool,
+    /// Git `-B` / `--break-rewrites`: split large in-place edits before rename/copy, then merge
+    /// surviving pairs (see `diffcore-break.c`).
+    break_rewrites: bool,
+    /// Internal break threshold (0–[`GIT_DIFF_MAX_SCORE`]); default matches Git `DEFAULT_BREAK_SCORE`.
+    break_score: u64,
+    /// Internal merge-back threshold after break (high 16 bits of Git's `break_opt`).
+    merge_after_break_score: u64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -507,6 +585,18 @@ impl Snapshot {
             oid,
         }
     }
+}
+
+fn blobish_object_kind(mode: u32) -> bool {
+    let t = mode & 0o170_000;
+    // Regular and executable files share the `0o100000` object type; symlinks use `0o120000`.
+    t == 0o100_000 || t == 0o120_000
+}
+
+fn typechange_between_snapshots(old: Snapshot, new_mode: u32) -> bool {
+    blobish_object_kind(old.mode)
+        && blobish_object_kind(new_mode)
+        && (old.mode & 0o170_000) != (new_mode & 0o170_000)
 }
 
 #[derive(Debug, Clone)]
@@ -554,6 +644,9 @@ fn parse_options(argv: &[String]) -> Result<Options> {
     let mut ignore_all_space = false;
     let mut nul_terminated = false;
     let mut relative = false;
+    let mut break_rewrites = false;
+    let mut break_score: u64 = grit_lib::diff::GIT_DIFF_DEFAULT_BREAK_SCORE;
+    let mut merge_after_break_score: u64 = GIT_DIFF_DEFAULT_MERGE_SCORE_AFTER_BREAK;
 
     let mut idx = 0usize;
     while idx < argv.len() {
@@ -585,6 +678,50 @@ fn parse_options(argv: &[String]) -> Result<Options> {
                 }
                 "--numstat" => {
                     numstat = true;
+                }
+                "-B" => {
+                    break_rewrites = true;
+                }
+                "--break-rewrites" => {
+                    break_rewrites = true;
+                }
+                _ if arg.starts_with("--break-rewrites=") => {
+                    break_rewrites = true;
+                    let rest = arg.trim_start_matches("--break-rewrites=");
+                    if !rest.is_empty() {
+                        let (b_part, m_part) = rest
+                            .split_once('/')
+                            .map(|(a, b)| (a, Some(b)))
+                            .unwrap_or((rest, None));
+                        break_score = parse_diff_rename_score_token(b_part)
+                            .with_context(|| format!("invalid --break-rewrites value: `{rest}`"))?;
+                        if let Some(m) = m_part {
+                            if m.is_empty() {
+                                bail!("invalid --break-rewrites value: `{rest}`");
+                            }
+                            merge_after_break_score = parse_diff_rename_score_token(m)
+                                .with_context(|| {
+                                    format!("invalid --break-rewrites value: `{rest}`")
+                                })?;
+                        }
+                    }
+                }
+                _ if arg.starts_with("-B") && arg.len() > 2 => {
+                    break_rewrites = true;
+                    let rest = &arg[2..];
+                    let (b_part, m_part) = rest
+                        .split_once('/')
+                        .map(|(a, b)| (a, Some(b)))
+                        .unwrap_or((rest, None));
+                    break_score = parse_diff_rename_score_token(b_part)
+                        .with_context(|| format!("invalid -B value: `{arg}`"))?;
+                    if let Some(m) = m_part {
+                        if m.is_empty() {
+                            bail!("invalid -B value: `{arg}`");
+                        }
+                        merge_after_break_score = parse_diff_rename_score_token(m)
+                            .with_context(|| format!("invalid -B value: `{arg}`"))?;
+                    }
                 }
                 "-M" | "--find-renames" => {
                     find_renames = Some(50);
@@ -753,6 +890,9 @@ fn parse_options(argv: &[String]) -> Result<Options> {
         ignore_all_space,
         nul_terminated,
         relative,
+        break_rewrites,
+        break_score,
+        merge_after_break_score,
     })
 }
 
@@ -902,12 +1042,22 @@ fn diff_tree_vs_index(
         let new = index_map.get(&path).copied();
         match (old, new) {
             (Some(old), Some(new)) if old == new => {}
-            (Some(old), Some(new)) => changes.push(RawChange {
-                path,
-                status: 'M',
-                old: Some(old),
-                new: Some(new),
-            }),
+            (Some(old), Some(new)) => {
+                let old_type = old.mode & 0o170_000;
+                let new_type = new.mode & 0o170_000;
+                let is_blob_pair = blobish_object_kind(old.mode) && blobish_object_kind(new.mode);
+                let status = if is_blob_pair && old_type != new_type {
+                    'T'
+                } else {
+                    'M'
+                };
+                changes.push(RawChange {
+                    path,
+                    status,
+                    old: Some(old),
+                    new: Some(new),
+                });
+            }
             (Some(old), None) => changes.push(RawChange {
                 path,
                 status: 'D',
@@ -981,6 +1131,11 @@ fn diff_tree_vs_worktree(
         let Some(wt_snapshot) = read_worktree_snapshot_from_meta(repo, &abs, &meta)? else {
             continue;
         };
+        if let Some(tree_side) = change.old {
+            if typechange_between_snapshots(tree_side, wt_snapshot.mode) {
+                change.status = 'T';
+            }
+        }
         change.new = Some(Snapshot {
             mode: wt_snapshot.mode,
             oid: zero_oid(),
@@ -1088,6 +1243,15 @@ fn diff_tree_vs_worktree(
                         );
                     } else {
                         let old = tree_map.get(path).copied().or(Some(*index_snapshot));
+                        let old_tree_side = tree_snap.unwrap_or(*index_snapshot);
+                        let status = if typechange_between_snapshots(
+                            old_tree_side,
+                            worktree_snapshot.mode,
+                        ) {
+                            'T'
+                        } else {
+                            'M'
+                        };
                         // Use zero OID for worktree side — the blob is not
                         // in the object database, matching git's behaviour.
                         let wt_placeholder = Snapshot {
@@ -1098,7 +1262,7 @@ fn diff_tree_vs_worktree(
                             path.clone(),
                             RawChange {
                                 path: path.clone(),
-                                status: 'M',
+                                status,
                                 old,
                                 new: Some(wt_placeholder),
                             },
@@ -1167,6 +1331,204 @@ fn entry_matches_pathspecs(
         .any(|spec| matches_pathspec_with_context(spec, path, ctx))
 }
 
+fn parse_mode_octal(mode: &str) -> Option<u32> {
+    u32::from_str_radix(mode, 8).ok()
+}
+
+fn is_break_eligible_blob_mode(mode: u32) -> bool {
+    mode == MODE_REGULAR || mode == MODE_EXECUTABLE
+}
+
+/// Split in-place edits that qualify for `diffcore-break` into delete+add pairs.
+///
+/// Returns the expanded entry list and the set of paths that were split (for `diffcore_merge_broken`).
+fn apply_diffcore_break_rewrites_split(
+    odb: &Odb,
+    work_root: Option<&Path>,
+    cached: bool,
+    entries: Vec<DiffEntry>,
+    break_score: u64,
+    merge_after_break_score: u64,
+) -> (Vec<DiffEntry>, HashSet<String>) {
+    let mut out = Vec::with_capacity(entries.len() + 8);
+    let mut broken_paths = HashSet::new();
+    for e in entries {
+        if e.status != DiffStatus::Modified {
+            out.push(e);
+            continue;
+        }
+        if e.old_oid == zero_oid() || e.new_oid == zero_oid() {
+            out.push(e);
+            continue;
+        }
+        let Some(old_mode) = parse_mode_octal(&e.old_mode) else {
+            out.push(e);
+            continue;
+        };
+        let Some(new_mode) = parse_mode_octal(&e.new_mode) else {
+            out.push(e);
+            continue;
+        };
+        if !is_break_eligible_blob_mode(old_mode) || !is_break_eligible_blob_mode(new_mode) {
+            out.push(e);
+            continue;
+        }
+        let Ok(old_obj) = odb.read(&e.old_oid) else {
+            out.push(e);
+            continue;
+        };
+        let new_data = if e.new_oid != zero_oid() {
+            match odb.read(&e.new_oid) {
+                Ok(obj) => obj.data,
+                Err(_) => {
+                    out.push(e);
+                    continue;
+                }
+            }
+        } else if !cached {
+            let Some(wt) = work_root else {
+                out.push(e);
+                continue;
+            };
+            let Some(path) = e.new_path.as_deref().or(e.old_path.as_deref()) else {
+                out.push(e);
+                continue;
+            };
+            match fs::read(wt.join(path)) {
+                Ok(b) => b,
+                Err(_) => {
+                    out.push(e);
+                    continue;
+                }
+            }
+        } else {
+            out.push(e);
+            continue;
+        };
+        let old_data = old_obj.data;
+        if grit_lib::merge_file::is_binary(&old_data) || grit_lib::merge_file::is_binary(&new_data)
+        {
+            out.push(e);
+            continue;
+        }
+        if !should_break_rewrite_pair(&old_data, &new_data, break_score) {
+            out.push(e);
+            continue;
+        }
+        let merge_ms = rewrite_merge_score(&old_data, &new_data).unwrap_or(0);
+        let dissim_pct = if merge_ms < merge_after_break_score {
+            None
+        } else {
+            rewrite_dissimilarity_index_percent(&old_data, &new_data)
+        };
+        let Some(path) = e.old_path.clone().or_else(|| e.new_path.clone()) else {
+            out.push(e);
+            continue;
+        };
+        broken_paths.insert(path.clone());
+        out.push(DiffEntry {
+            status: DiffStatus::Deleted,
+            old_path: Some(path.clone()),
+            new_path: None,
+            old_mode: e.old_mode.clone(),
+            new_mode: "000000".to_owned(),
+            old_oid: e.old_oid,
+            new_oid: zero_oid(),
+            score: dissim_pct,
+        });
+        out.push(DiffEntry {
+            status: DiffStatus::Added,
+            old_path: None,
+            new_path: Some(path),
+            old_mode: "000000".to_owned(),
+            new_mode: e.new_mode.clone(),
+            old_oid: zero_oid(),
+            new_oid: e.new_oid,
+            score: dissim_pct,
+        });
+    }
+    (out, broken_paths)
+}
+
+/// After `-B` + rename detection, drop the leftover delete at a path that is already the
+/// destination of a rename/copy (consumed break half); see `t4008-diff-break-rewrite` #4.
+fn drop_break_delete_superseded_by_rename_dest(entries: Vec<DiffEntry>) -> Vec<DiffEntry> {
+    let mut targets: HashSet<String> = HashSet::new();
+    for e in &entries {
+        if matches!(e.status, DiffStatus::Renamed | DiffStatus::Copied) {
+            if let Some(p) = e.new_path.clone() {
+                targets.insert(p);
+            }
+        }
+    }
+    let mut out: Vec<DiffEntry> = entries
+        .into_iter()
+        .filter(|e| {
+            if e.status != DiffStatus::Deleted {
+                return true;
+            }
+            let Some(p) = e.old_path.as_deref() else {
+                return true;
+            };
+            !targets.contains(p)
+        })
+        .collect();
+    out.sort_by(|a, b| a.path().cmp(b.path()));
+    out
+}
+
+/// Merge delete+add pairs that survived rename/copy back into a single modification (Git
+/// `diffcore_merge_broken`).
+fn merge_broken_rewrite_pairs(
+    entries: Vec<DiffEntry>,
+    broken_paths: &HashSet<String>,
+) -> Vec<DiffEntry> {
+    let mut slots: HashMap<String, (Option<DiffEntry>, Option<DiffEntry>)> = HashMap::new();
+    let mut others = Vec::new();
+    for e in entries {
+        if e.status == DiffStatus::Deleted {
+            if let Some(p) = e.old_path.clone() {
+                if broken_paths.contains(p.as_str()) {
+                    slots.entry(p).or_default().0 = Some(e);
+                    continue;
+                }
+            }
+        }
+        if e.status == DiffStatus::Added {
+            if let Some(p) = e.new_path.clone() {
+                if broken_paths.contains(p.as_str()) {
+                    slots.entry(p).or_default().1 = Some(e);
+                    continue;
+                }
+            }
+        }
+        others.push(e);
+    }
+    let mut merged = Vec::new();
+    for (path, (d_opt, a_opt)) in slots {
+        match (d_opt, a_opt) {
+            (Some(d), Some(a)) => {
+                merged.push(DiffEntry {
+                    status: DiffStatus::Modified,
+                    old_path: Some(path.clone()),
+                    new_path: Some(path),
+                    old_mode: d.old_mode,
+                    new_mode: a.new_mode,
+                    old_oid: d.old_oid,
+                    new_oid: a.new_oid,
+                    score: d.score.or(a.score),
+                });
+            }
+            (Some(d), None) => merged.push(d),
+            (None, Some(a)) => merged.push(a),
+            (None, None) => {}
+        }
+    }
+    others.extend(merged);
+    others.sort_by(|a, b| a.path().cmp(b.path()));
+    others
+}
+
 fn effective_index_path(repo: &Repository) -> Result<PathBuf> {
     if let Ok(raw) = std::env::var("GIT_INDEX_FILE") {
         let path = PathBuf::from(raw);
@@ -1212,6 +1574,32 @@ fn raw_change_to_diff_entry(change: &RawChange) -> DiffEntry {
         old_oid: change.old.map_or_else(zero_oid, |s| s.oid),
         new_oid: change.new.map_or_else(zero_oid, |s| s.oid),
         score: None,
+    }
+}
+
+/// For uncached `diff-index`, added paths may record `new_oid` as zero while the index holds the
+/// real blob. Git still prints the worktree blob hash on the new side of raw output (`t4008` #8).
+fn uncached_added_worktree_blob_oid(repo: &Repository, entry: &DiffEntry) -> Option<ObjectId> {
+    let wt = repo.work_tree.as_deref()?;
+    let path = entry.new_path.as_deref()?;
+    let abs = wt.join(path);
+    let meta = fs::symlink_metadata(&abs).ok()?;
+    if meta.file_type().is_symlink() {
+        let target = fs::read_link(&abs).ok()?;
+        Some(Odb::hash_object_data(
+            ObjectKind::Blob,
+            target.as_os_str().as_bytes(),
+        ))
+    } else if meta.file_type().is_file() {
+        let data = fs::read(&abs).ok()?;
+        let oid = Odb::hash_object_data(ObjectKind::Blob, &data);
+        // Uncached raw adds of the empty blob still print all-zero new OIDs (`t1501-work-tree`).
+        if oid == empty_blob_oid() {
+            return None;
+        }
+        Some(oid)
+    } else {
+        None
     }
 }
 
@@ -1289,7 +1677,16 @@ fn write_raw_diff_entry_z(
     let width = abbrev.unwrap_or(40).clamp(4, 40);
 
     let (old_oid_disp, new_oid_disp) = if diff_index_uncached && entry.status == DiffStatus::Added {
-        ("0".repeat(width), "0".repeat(width))
+        let new_id = uncached_added_worktree_blob_oid(repo, entry).unwrap_or_else(zero_oid);
+        let new_disp = if new_id == zero_oid() {
+            "0".repeat(width)
+        } else {
+            match abbrev {
+                Some(min_len) => abbreviate_object_id(repo, new_id, min_len)?,
+                None => new_id.to_hex(),
+            }
+        };
+        ("0".repeat(width), new_disp)
     } else {
         let old_oid = if entry.old_oid == zero_oid() {
             "0".repeat(width)
@@ -1313,6 +1710,7 @@ fn write_raw_diff_entry_z(
     let status_str = match (entry.status, entry.score) {
         (DiffStatus::Renamed, Some(s)) => format!("R{s:03}"),
         (DiffStatus::Copied, Some(s)) => format!("C{s:03}"),
+        (DiffStatus::TypeChanged, Some(s)) => format!("T{s:03}"),
         _ => entry.status.letter().to_string(),
     };
 
@@ -1348,10 +1746,19 @@ fn render_raw_diff_entry(
 ) -> Result<String> {
     let width = abbrev.unwrap_or(40).clamp(4, 40);
 
-    // `diff-index` uncached raw lines for newly added paths use all-zero object ids on both sides
-    // (t1501-work-tree; matches the harness expectations for tree vs index additions).
+    // Uncached `diff-index`: old side stays zero for adds; new side is the worktree blob hash when
+    // the in-memory entry still uses a zero placeholder (`t4008-diff-break-rewrite` #8).
     let (old_oid_disp, new_oid_disp) = if diff_index_uncached && entry.status == DiffStatus::Added {
-        ("0".repeat(width), "0".repeat(width))
+        let new_id = uncached_added_worktree_blob_oid(repo, entry).unwrap_or_else(zero_oid);
+        let new_disp = if new_id == zero_oid() {
+            "0".repeat(width)
+        } else {
+            match abbrev {
+                Some(min_len) => abbreviate_object_id(repo, new_id, min_len)?,
+                None => new_id.to_hex(),
+            }
+        };
+        ("0".repeat(width), new_disp)
     } else {
         let old_oid = if entry.old_oid == zero_oid() {
             "0".repeat(width)
@@ -1375,6 +1782,7 @@ fn render_raw_diff_entry(
     let status_str = match (entry.status, entry.score) {
         (DiffStatus::Renamed, Some(s)) => format!("R{:03}", s),
         (DiffStatus::Copied, Some(s)) => format!("C{:03}", s),
+        (DiffStatus::TypeChanged, Some(s)) => format!("T{:03}", s),
         _ => entry.status.letter().to_string(),
     };
 

--- a/grit/src/commands/diff_tree.rs
+++ b/grit/src/commands/diff_tree.rs
@@ -1368,10 +1368,11 @@ fn print_diff(
         Vec::new()
     };
     let entries = if let Some(threshold) = opts.find_renames {
-        let mut result = detect_renames(odb, entries.to_vec(), threshold);
+        let mut result = detect_renames(odb, None, entries.to_vec(), threshold);
         if let Some(copy_threshold) = opts.find_copies {
             result = lib_detect_copies(
                 odb,
+                None,
                 result,
                 copy_threshold,
                 opts.find_copies_harder,
@@ -1383,6 +1384,7 @@ fn print_diff(
     } else if let Some(copy_threshold) = opts.find_copies {
         owned_entries = lib_detect_copies(
             odb,
+            None,
             entries.to_vec(),
             copy_threshold,
             opts.find_copies_harder,

--- a/grit/src/commands/log.rs
+++ b/grit/src/commands/log.rs
@@ -7304,7 +7304,7 @@ fn remerge_diff_entries(repo: &Repository, info: &CommitInfo) -> Result<Vec<Diff
     }
     let (remerge_tree, _) = remerge_merge_tree(repo, info.parents[0], info.parents[1])?;
     let raw = diff_trees(&repo.odb, Some(&remerge_tree), Some(&info.tree), "")?;
-    Ok(detect_renames(&repo.odb, raw, 50))
+    Ok(detect_renames(&repo.odb, None, raw, 50))
 }
 
 fn commit_has_remerge_diff_status(
@@ -7408,7 +7408,7 @@ fn follow_filter(
         };
 
         let raw_entries = diff_trees(odb, parent_tree.as_ref(), Some(&info.tree), "")?;
-        let entries = detect_renames(odb, raw_entries, 50);
+        let entries = detect_renames(odb, None, raw_entries, 50);
 
         let mut touches = false;
         for entry in &entries {

--- a/grit/src/commands/merge.rs
+++ b/grit/src/commands/merge.rs
@@ -3796,7 +3796,7 @@ fn detect_merge_renames(
             // Rename detection matrix too large, skip similarity detection
             Vec::new()
         } else {
-            detect_renames(&repo.odb, diff_entries, threshold)
+            detect_renames(&repo.odb, None, diff_entries, threshold)
         };
         for e in detected {
             if matches!(e.status, DiffStatus::Renamed) {

--- a/grit/src/commands/remerge_diff.rs
+++ b/grit/src/commands/remerge_diff.rs
@@ -218,7 +218,7 @@ pub(crate) fn remerge_diff_matches_pickaxe_or_find(
     let (remerge_tree, _conflict_descs) = remerge_merge_tree(repo, parents[0], parents[1])?;
 
     let mut entries = diff_trees(&repo.odb, Some(&remerge_tree), Some(tree), "")?;
-    entries = detect_renames(&repo.odb, entries, 50);
+    entries = detect_renames(&repo.odb, None, entries, 50);
 
     if let Some(p) = opts.pickaxe {
         if !pickaxe_matches(&repo.odb, &entries, p.as_bytes(), opts.pathspecs)? {
@@ -252,7 +252,7 @@ pub(crate) fn write_remerge_diff(
     let (remerge_tree, conflict_descs) = remerge_merge_tree(repo, parents[0], parents[1])?;
 
     let mut entries = diff_trees(&repo.odb, Some(&remerge_tree), Some(tree), "")?;
-    entries = detect_renames(&repo.odb, entries, 50);
+    entries = detect_renames(&repo.odb, None, entries, 50);
 
     if let Some(p) = opts.pickaxe {
         if !pickaxe_matches(&repo.odb, &entries, p.as_bytes(), opts.pathspecs)? {

--- a/grit/src/commands/replay.rs
+++ b/grit/src/commands/replay.rs
@@ -1052,7 +1052,7 @@ fn detect_side_renames(
     let detected = if n_deleted > rename_limit || n_added > rename_limit {
         Vec::new()
     } else {
-        detect_renames(&repo.odb, diff_entries.clone(), threshold)
+        detect_renames(&repo.odb, None, diff_entries.clone(), threshold)
     };
     for e in detected {
         if matches!(e.status, DiffStatus::Renamed) {

--- a/grit/src/commands/show.rs
+++ b/grit/src/commands/show.rs
@@ -1924,6 +1924,7 @@ fn apply_rename_copy_detection(
 
         detect_copies(
             odb,
+            None,
             entries,
             threshold,
             find_copies_harder,
@@ -1935,7 +1936,7 @@ fn apply_rename_copy_detection(
             .as_ref()
             .and_then(|v| v.parse::<u32>().ok())
             .unwrap_or(50);
-        detect_renames(odb, entries, threshold)
+        detect_renames(odb, None, entries, threshold)
     } else {
         entries
     }

--- a/grit/src/commands/status.rs
+++ b/grit/src/commands/status.rs
@@ -342,7 +342,7 @@ pub fn run(mut args: Args) -> Result<()> {
     let staged_raw = diff_index_to_tree(&repo.odb, &index, head_tree.as_ref())?;
     // Detect renames among staged entries when enabled.
     let staged = if let Some(threshold) = status_rename_threshold {
-        detect_renames(&repo.odb, staged_raw.clone(), threshold)
+        detect_renames(&repo.odb, None, staged_raw.clone(), threshold)
     } else {
         staged_raw.clone()
     };
@@ -350,7 +350,7 @@ pub fn run(mut args: Args) -> Result<()> {
     // Diff: unstaged (worktree vs index), with optional rename detection.
     let unstaged_raw = diff_index_to_worktree(&repo.odb, &index, work_tree)?;
     let unstaged = if let Some(threshold) = status_rename_threshold {
-        detect_renames(&repo.odb, unstaged_raw.clone(), threshold)
+        detect_renames(&repo.odb, None, unstaged_raw.clone(), threshold)
     } else {
         unstaged_raw.clone()
     };

--- a/logs/2026-04-10_t4008-diff-break-rewrite.md
+++ b/logs/2026-04-10_t4008-diff-break-rewrite.md
@@ -1,0 +1,33 @@
+# t4008-diff-break-rewrite
+
+## Goal
+
+Make `tests/t4008-diff-break-rewrite.sh` pass (14/14): `diff-index -B`, `-B -M`, `-B -C`, typechange + copy pairing, uncached rename/copy with worktree placeholder OIDs.
+
+## Changes
+
+### `grit-lib` (`diff.rs`)
+
+- `detect_renames(odb, work_root, …)` / `detect_copies(odb, work_root, …)`: optional worktree root to read added-side bytes when `new_oid` is zero (uncached `diff-index`).
+- Skip line-similarity rename pairing across non-regular modes (regular ↔ symlink).
+- `detect_copies`: include `TypeChanged` as copy sources; post-pass to turn `Modified` into `Copied` when new content matches a non-deleted source (symlink preimage → sibling file).
+- Public helpers: `parse_diff_rename_score_token`, `should_break_rewrite_pair`, `GIT_DIFF_*` score constants.
+
+### `grit` (`diff_index.rs`)
+
+- Parse `-B` / `--break-rewrites[=<n>[/<m>]]`.
+- `diff_tree_vs_index`: fix typechange detection (compare `mode & 0170000`, not full `100644`).
+- `diff_tree_vs_worktree`: set status `T` when tree vs worktree types differ after worktree refresh.
+- `apply_diffcore_break_rewrites_split` + `merge_broken_rewrite_pairs` + `drop_break_delete_superseded_by_rename_dest`.
+- When `-B` and `-M`: run `detect_copies` after `detect_renames` (Git combines break + rename + copy detection).
+- Raw output: for uncached `A`, show worktree blob hash on new side when non-empty and not empty-blob (t4008 #8 vs t1501 empty add).
+- `T` raw lines with optional dissimilarity score when `-B`.
+
+### Call-site updates
+
+All `detect_renames` / `detect_copies` call sites pass `None` for `work_root` except `diff-index` (uses repo work tree when uncached).
+
+## Verification
+
+- `./scripts/run-tests.sh t4008-diff-break-rewrite.sh` → 14/14
+- `cargo test -p grit-lib --lib`

--- a/progress.md
+++ b/progress.md
@@ -1,20 +1,21 @@
 # Progress — Grit Test Coverage
 
-**Updated:** 2026-04-09
+**Updated:** 2026-04-10
 
 ## Counts (derived from plan.md)
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   325 |
+| Completed   |   326 |
 | In progress |     5 |
-| Remaining   |   441 |
+| Remaining   |   440 |
 | **Total**   |   771 |
 
-Task lines in `PLAN.md`: 325 completed (`[x]`), 5 in progress (`[~]`), 441 remaining (`[ ]`).
+Task lines in `PLAN.md`: 326 completed (`[x]`), 5 in progress (`[~]`), 440 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t4008-diff-break-rewrite` — 14/14 tests pass (`diff-index -B` / `--break-rewrites`, break-merge with rename/copy, `-B -M` copy-from-typechange, tree↔symlink `T` in uncached path, worktree bytes for zero-OID adds in rename detection; raw add lines show hashed blob when needed)
 - `t3309-notes-merge-auto-resolve` — 31/31 tests pass (`notes merge`: `union` / `cat_sort_uniq` blob combine like Git; successful merge commits use two parents; `notes.mergeStrategy` config errors match upstream expectations)
 - `t4063-diff-blobs` — 18/18 tests pass (`diff`: blob↔blob and `rev:path` pairs without treating blobs as trees; `HEAD:one..HEAD:two` range split; `rev:path` vs worktree file uses tree path + modes + `write_patch_with_prefix`; raw blob OID vs existing file uses filename as old path; `rev_parse::resolve_treeish_blob_at_path` for tree walks)
 - `t5524-pull-msg` — 3/3 tests pass (`git pull --no-rebase --log` merge message preserves `$` in subject lines; `--log=1` limits shortlog; harness CSV/dashboards refreshed; `PLAN.md` marked complete)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-style **break-rewrites** for `grit diff-index` (`-B` / `--break-rewrites`) and wires it correctly with **rename** and **copy** detection so `tests/t4008-diff-break-rewrite.sh` passes **14/14**.

## Key changes

- **`diff-index`**: parse `-B` / `--break-rewrites[=<n>[/<m>]]`, split large in-place blob edits into delete+add before rename/copy, merge surviving pairs, and drop leftover deletes consumed by renames.
- **Type changes**: fix tree↔index and uncached worktree refresh so regular↔symlink shows as `T` (with optional dissimilarity score under `-B`).
- **`grit-lib`**: `detect_renames` / `detect_copies` take an optional **worktree root** to read content when uncached diffs use a **zero OID** placeholder on the new side; skip cross-type rename similarity; treat type-changed paths as copy sources and allow **modified→copy** when content matches a source.
- **`-B` + `-M`**: run copy detection after rename detection (matches Git for scenarios like symlink preimage + modified sibling).
- **Raw output**: for uncached adds, show the **worktree blob hash** on the new side when it is non-empty and not the empty blob (fixes t4008 #8 while keeping empty-add behavior aligned with t1501).

## Verification

- `./scripts/run-tests.sh t4008-diff-break-rewrite.sh` → 14/14
- `cargo test -p grit-lib --lib`

## Commits

1. `fix(grit-lib): worktree-aware rename/copy detection for diff plumbing`
2. `fix(diff-index): implement -B break-rewrites and merge with rename/copy`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40888a97-fa12-4a67-99f6-307bbd91e1e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40888a97-fa12-4a67-99f6-307bbd91e1e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

