### PR TITLE
feat(diff): indent heuristic compaction for unified diffs

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -742,7 +742,7 @@ t4057-diff-combined-paths	t4	yes	4	0	4	false	ok	0
 t4058-diff-duplicates	t4	yes	16	8	8	false	ok	0
 t4059-diff-submodule-not-initialized	t4	yes	8	8	0	true	ok	0
 t4060-diff-submodule-option-diff-format	t4	yes	51	29	22	false	ok	0
-t4061-diff-indent	t4	yes	33	2	31	false	ok	0
+t4061-diff-indent	t4	yes	33	6	27	false	ok	0
 t4062-diff-pickaxe	t4	yes	3	3	0	true	ok	0
 t4063-diff-blobs	t4	yes	18	18	0	true	ok	0
 t4064-diff-oidfind	t4	yes	10	10	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,690 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,690 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T01:58:45+00:00" class="gen-time" title="2026-04-10 01:58 UTC">2026-04-10 01:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,690</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>758 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -230,22 +230,22 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">73/178 files · 2 skipped · 2,862/4,438 tests</span>
+        <span class="group-meta">73/178 files · 2 skipped · 2,866/4,438 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.5%"></div></div>
-        <span class="group-pct pct-blue">64.5%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.6%"></div></div>
+        <span class="group-pct pct-blue">64.6%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35690 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,690 / 45,142 tests · 1,405 files in scope · 758 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T01:58:45+00:00" class="gen-time" title="2026-04-10 01:58 UTC">2026-04-10 01:58 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,690</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -7577,14 +7577,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="33" data-passed="2">
+<tr class="" data-group="t4" data-tests="33" data-passed="6">
   <td class="mono">t4061-diff-indent</td>
   <td>t4</td>
   <td></td>
   <td class="right">33</td>
-  <td class="right">2</td>
+  <td class="right">6</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:6.1%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:18.2%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="3" data-passed="3" data-full-pass="1">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/diff.rs
+++ b/grit-lib/src/diff.rs
@@ -23,11 +23,93 @@ use std::fs;
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 
+use crate::config::ConfigSet;
+use crate::diff_indent_heuristic;
 use crate::error::{Error, Result};
 use crate::index::{Index, IndexEntry};
 use crate::objects::{parse_commit, parse_tree, ObjectId, ObjectKind, TreeEntry};
 use crate::odb::Odb;
 use crate::userdiff::FuncnameMatcher;
+
+/// `diff.indentHeuristic` from config (Git defaults to true when unset).
+#[must_use]
+pub fn indent_heuristic_from_config(config: &ConfigSet) -> bool {
+    match config.get_bool("diff.indentHeuristic") {
+        Some(Ok(b)) => b,
+        Some(Err(_)) | None => true,
+    }
+}
+
+/// Resolve indent heuristic: `--no-indent-heuristic` and `--indent-heuristic` override config.
+#[must_use]
+pub fn resolve_indent_heuristic(
+    config: &ConfigSet,
+    cli_indent_heuristic: bool,
+    cli_no_indent_heuristic: bool,
+) -> bool {
+    if cli_no_indent_heuristic {
+        false
+    } else if cli_indent_heuristic {
+        true
+    } else {
+        indent_heuristic_from_config(config)
+    }
+}
+
+/// Parse `--indent-heuristic` / `--no-indent-heuristic` from a plumbing argv slice (last occurrence wins).
+#[must_use]
+pub fn parse_indent_heuristic_cli_flags(argv: &[String]) -> (bool, bool) {
+    let mut indent_heuristic = false;
+    let mut no_indent_heuristic = false;
+    for a in argv {
+        match a.as_str() {
+            "--indent-heuristic" => {
+                indent_heuristic = true;
+                no_indent_heuristic = false;
+            }
+            "--no-indent-heuristic" => {
+                no_indent_heuristic = true;
+                indent_heuristic = false;
+            }
+            _ => {}
+        }
+    }
+    (indent_heuristic, no_indent_heuristic)
+}
+
+/// Line-diff ops for string slices after Git `xdl_change_compact` (and optional indent heuristic).
+#[must_use]
+pub fn diff_slice_ops_compacted(
+    old_lines: &[&str],
+    new_lines: &[&str],
+    algorithm: similar::Algorithm,
+    indent_heuristic: bool,
+) -> Vec<similar::DiffOp> {
+    diff_indent_heuristic::diff_slice_ops_compacted(
+        old_lines,
+        new_lines,
+        algorithm,
+        indent_heuristic,
+    )
+}
+
+/// Map each line in `new_joined` to its origin in `old_joined` after Git-style compaction (for blame).
+#[must_use]
+pub fn map_new_to_old_lines_compacted(
+    old_joined: &str,
+    new_joined: &str,
+    algorithm: similar::Algorithm,
+    indent_heuristic: bool,
+    new_line_count: usize,
+) -> Vec<Option<usize>> {
+    let ops = diff_indent_heuristic::diff_lines_ops_compacted(
+        old_joined,
+        new_joined,
+        algorithm,
+        indent_heuristic,
+    );
+    diff_indent_heuristic::map_new_to_old_from_ops(&ops, new_line_count)
+}
 
 /// The kind of change between two sides of a diff.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1859,6 +1941,7 @@ pub fn unified_diff(
     old_path: &str,
     new_path: &str,
     context_lines: usize,
+    indent_heuristic: bool,
 ) -> String {
     unified_diff_with_prefix(
         old_content,
@@ -1869,6 +1952,7 @@ pub fn unified_diff(
         0,
         "a/",
         "b/",
+        indent_heuristic,
     )
 }
 
@@ -1886,6 +1970,7 @@ pub fn unified_diff_with_prefix(
     inter_hunk_context: usize,
     src_prefix: &str,
     dst_prefix: &str,
+    indent_heuristic: bool,
 ) -> String {
     unified_diff_with_prefix_and_funcname(
         old_content,
@@ -1897,6 +1982,7 @@ pub fn unified_diff_with_prefix(
         src_prefix,
         dst_prefix,
         None,
+        indent_heuristic,
     )
 }
 
@@ -1913,6 +1999,7 @@ pub fn unified_diff_with_prefix_and_funcname(
     src_prefix: &str,
     dst_prefix: &str,
     funcname_matcher: Option<&FuncnameMatcher>,
+    indent_heuristic: bool,
 ) -> String {
     unified_diff_with_prefix_and_funcname_and_algorithm(
         old_content,
@@ -1925,6 +2012,7 @@ pub fn unified_diff_with_prefix_and_funcname(
         dst_prefix,
         funcname_matcher,
         similar::Algorithm::Myers,
+        indent_heuristic,
     )
 }
 
@@ -1942,12 +2030,19 @@ pub fn unified_diff_with_prefix_and_funcname_and_algorithm(
     dst_prefix: &str,
     funcname_matcher: Option<&FuncnameMatcher>,
     algorithm: similar::Algorithm,
+    indent_heuristic: bool,
 ) -> String {
     use similar::{group_diff_ops, udiff::UnifiedDiffHunk, TextDiff};
 
     let diff = TextDiff::configure()
         .algorithm(algorithm)
         .diff_lines(old_content, new_content);
+    let compacted_ops = diff_indent_heuristic::diff_lines_ops_compacted(
+        old_content,
+        new_content,
+        algorithm,
+        indent_heuristic,
+    );
 
     let mut output = String::new();
     if old_path == "/dev/null" {
@@ -1971,7 +2066,7 @@ pub fn unified_diff_with_prefix_and_funcname_and_algorithm(
         .saturating_mul(2)
         .saturating_add(inter_hunk_context);
     let group_radius = max_common_gap.div_ceil(2);
-    let op_groups = group_diff_ops(diff.ops().to_vec(), group_radius);
+    let op_groups = group_diff_ops(compacted_ops, group_radius);
 
     for ops in op_groups {
         if ops.is_empty() {
@@ -2021,6 +2116,7 @@ pub fn anchored_unified_diff(
     context_lines: usize,
     anchors: &[String],
     algorithm: similar::Algorithm,
+    indent_heuristic: bool,
 ) -> String {
     use similar::TextDiff;
 
@@ -2068,6 +2164,7 @@ pub fn anchored_unified_diff(
             "b/",
             None,
             algorithm,
+            indent_heuristic,
         );
     }
 
@@ -2092,12 +2189,45 @@ pub fn anchored_unified_diff(
     // Each anchor line itself is a fixed context match.
 
     // Collect all diff operations
-    struct DiffOp {
+    struct LineDiffOp {
         tag: char, // ' ', '+', '-'
         line: String,
     }
 
-    let mut ops: Vec<DiffOp> = Vec::new();
+    let append_segment_diff =
+        |ops: &mut Vec<LineDiffOp>, old_seg_input: &str, new_seg_input: &str| {
+            use similar::ChangeTag;
+            let old_ls: Vec<&str> = old_seg_input.lines().collect();
+            let new_ls: Vec<&str> = new_seg_input.lines().collect();
+            if old_ls.is_empty() && new_ls.is_empty() {
+                return;
+            }
+            let seg_diff = TextDiff::configure()
+                .algorithm(algorithm)
+                .diff_slices(&old_ls, &new_ls);
+            let raw = seg_diff.ops().to_vec();
+            let compacted = diff_indent_heuristic::apply_change_compact_to_ops(
+                &raw,
+                &old_ls,
+                &new_ls,
+                indent_heuristic,
+            );
+            for op in &compacted {
+                for ch in op.iter_changes(&old_ls, &new_ls) {
+                    let t = match ch.tag() {
+                        ChangeTag::Equal => ' ',
+                        ChangeTag::Delete => '-',
+                        ChangeTag::Insert => '+',
+                    };
+                    ops.push(LineDiffOp {
+                        tag: t,
+                        line: ch.value().to_string(),
+                    });
+                }
+            }
+        };
+
+    let mut ops: Vec<LineDiffOp> = Vec::new();
     let mut old_pos = 0usize;
     let mut new_pos = 0usize;
 
@@ -2120,24 +2250,11 @@ pub fn anchored_unified_diff(
             } else {
                 format!("{}\n", new_seg_text)
             };
-            let seg_diff = TextDiff::configure()
-                .algorithm(algorithm)
-                .diff_lines(&old_seg_input, &new_seg_input);
-            for change in seg_diff.iter_all_changes() {
-                let tag = match change.tag() {
-                    similar::ChangeTag::Equal => ' ',
-                    similar::ChangeTag::Delete => '-',
-                    similar::ChangeTag::Insert => '+',
-                };
-                ops.push(DiffOp {
-                    tag,
-                    line: change.value().trim_end_matches('\n').to_string(),
-                });
-            }
+            append_segment_diff(&mut ops, &old_seg_input, &new_seg_input);
         }
 
         // The anchor line itself is always context
-        ops.push(DiffOp {
+        ops.push(LineDiffOp {
             tag: ' ',
             line: old_lines[old_anchor].to_string(),
         });
@@ -2163,20 +2280,7 @@ pub fn anchored_unified_diff(
         } else {
             format!("{}\n", new_seg_text)
         };
-        let seg_diff = TextDiff::configure()
-            .algorithm(algorithm)
-            .diff_lines(&old_seg_input, &new_seg_input);
-        for change in seg_diff.iter_all_changes() {
-            let tag = match change.tag() {
-                similar::ChangeTag::Equal => ' ',
-                similar::ChangeTag::Delete => '-',
-                similar::ChangeTag::Insert => '+',
-            };
-            ops.push(DiffOp {
-                tag,
-                line: change.value().trim_end_matches('\n').to_string(),
-            });
-        }
+        append_segment_diff(&mut ops, &old_seg_input, &new_seg_input);
     }
 
     // Now format as unified diff with hunks

--- a/grit-lib/src/diff_indent_heuristic.rs
+++ b/grit-lib/src/diff_indent_heuristic.rs
@@ -1,0 +1,649 @@
+//! Git-compatible diff hunk sliding (`xdl_change_compact`) including the indent heuristic.
+//!
+//! Ported from Git's `xdiff/xdiffi.c` (`xdl_change_compact`, `score_split`, etc.).
+
+use similar::{Algorithm, DiffOp, DiffTag, TextDiff};
+
+const MAX_INDENT: i32 = 200;
+const MAX_BLANKS: i32 = 20;
+const START_OF_FILE_PENALTY: i32 = 1;
+const END_OF_FILE_PENALTY: i32 = 21;
+const TOTAL_BLANK_WEIGHT: i32 = -30;
+const POST_BLANK_WEIGHT: i32 = 6;
+const RELATIVE_INDENT_PENALTY: i32 = -4;
+const RELATIVE_INDENT_WITH_BLANK_PENALTY: i32 = 10;
+const RELATIVE_OUTDENT_PENALTY: i32 = 24;
+const RELATIVE_OUTDENT_WITH_BLANK_PENALTY: i32 = 17;
+const RELATIVE_DEDENT_PENALTY: i32 = 23;
+const RELATIVE_DEDENT_WITH_BLANK_PENALTY: i32 = 17;
+const INDENT_WEIGHT: i32 = 60;
+const INDENT_HEURISTIC_MAX_SLIDING: isize = 100;
+
+#[derive(Clone)]
+struct XdFile<'a> {
+    lines: &'a [&'a str],
+    /// `changed[i]` matches Git's `xdf->changed`: length `nrec + 1`, last entry always false.
+    changed: Vec<bool>,
+}
+
+impl<'a> XdFile<'a> {
+    fn from_mask(lines: &'a [&'a str], mut changed: Vec<bool>) -> Self {
+        let n = lines.len();
+        changed.resize(n + 1, false);
+        if !changed.is_empty() {
+            changed[n] = false;
+        }
+        Self { lines, changed }
+    }
+
+    fn nrec(&self) -> usize {
+        self.lines.len()
+    }
+
+    fn changed_at(&self, i: isize) -> bool {
+        if i < 0 {
+            return false;
+        }
+        let u = i as usize;
+        if u >= self.changed.len() {
+            return false;
+        }
+        self.changed[u]
+    }
+
+    fn set_changed(&mut self, i: usize, v: bool) {
+        if i < self.changed.len() {
+            self.changed[i] = v;
+        }
+    }
+
+    fn into_changed(self) -> Vec<bool> {
+        let n = self.lines.len();
+        let mut c = self.changed;
+        c.truncate(n);
+        c
+    }
+}
+
+fn get_indent(line: &str) -> i32 {
+    let mut ret = 0_i32;
+    for c in line.chars() {
+        if c == ' ' {
+            ret += 1;
+        } else if c == '\t' {
+            ret += 8 - ret % 8;
+        } else if c.is_whitespace() {
+            // Git ignores other whitespace in indent (no advance)
+        } else {
+            return ret;
+        }
+        if ret >= MAX_INDENT {
+            return MAX_INDENT;
+        }
+    }
+    -1
+}
+
+#[derive(Default)]
+struct SplitMeasurement {
+    end_of_file: i32,
+    indent: i32,
+    pre_blank: i32,
+    pre_indent: i32,
+    post_blank: i32,
+    post_indent: i32,
+}
+
+fn measure_split(xdf: &XdFile<'_>, split: isize, m: &mut SplitMeasurement) {
+    let n = xdf.nrec() as isize;
+    if split >= n {
+        m.end_of_file = 1;
+        m.indent = -1;
+    } else {
+        m.end_of_file = 0;
+        m.indent = get_indent(xdf.lines[split as usize]);
+    }
+
+    m.pre_blank = 0;
+    m.pre_indent = -1;
+    let mut i = split - 1;
+    loop {
+        if i < 0 {
+            break;
+        }
+        m.pre_indent = get_indent(xdf.lines[i as usize]);
+        if m.pre_indent != -1 {
+            break;
+        }
+        m.pre_blank += 1;
+        if m.pre_blank == MAX_BLANKS {
+            m.pre_indent = 0;
+            break;
+        }
+        i -= 1;
+    }
+
+    m.post_blank = 0;
+    m.post_indent = -1;
+    i = split + 1;
+    loop {
+        if i >= n {
+            break;
+        }
+        m.post_indent = get_indent(xdf.lines[i as usize]);
+        if m.post_indent != -1 {
+            break;
+        }
+        m.post_blank += 1;
+        if m.post_blank == MAX_BLANKS {
+            m.post_indent = 0;
+            break;
+        }
+        i += 1;
+    }
+}
+
+#[derive(Default, Clone)]
+struct SplitScore {
+    effective_indent: i32,
+    penalty: i32,
+}
+
+fn score_add_split(m: &SplitMeasurement, s: &mut SplitScore) {
+    
+    
+    
+    
+
+    if m.pre_indent == -1 && m.pre_blank == 0 {
+        s.penalty += START_OF_FILE_PENALTY;
+    }
+
+    if m.end_of_file != 0 {
+        s.penalty += END_OF_FILE_PENALTY;
+    }
+
+    let post_blank = if m.indent == -1 { 1 + m.post_blank } else { 0 };
+    let total_blank = m.pre_blank + post_blank;
+
+    s.penalty += TOTAL_BLANK_WEIGHT * total_blank;
+    s.penalty += POST_BLANK_WEIGHT * post_blank;
+
+    let indent = if m.indent != -1 {
+        m.indent
+    } else {
+        m.post_indent
+    };
+
+    let any_blanks = total_blank != 0;
+
+    s.effective_indent += indent;
+
+    if indent == -1 {
+        // no-op
+    } else if m.pre_indent == -1 {
+        // no-op
+    } else if indent > m.pre_indent {
+        s.penalty += if any_blanks {
+            RELATIVE_INDENT_WITH_BLANK_PENALTY
+        } else {
+            RELATIVE_INDENT_PENALTY
+        };
+    } else if indent == m.pre_indent {
+        // no-op
+    } else if m.post_indent != -1 && m.post_indent > indent {
+        s.penalty += if any_blanks {
+            RELATIVE_OUTDENT_WITH_BLANK_PENALTY
+        } else {
+            RELATIVE_OUTDENT_PENALTY
+        };
+    } else {
+        s.penalty += if any_blanks {
+            RELATIVE_DEDENT_WITH_BLANK_PENALTY
+        } else {
+            RELATIVE_DEDENT_PENALTY
+        };
+    }
+}
+
+fn score_cmp(s1: &SplitScore, s2: &SplitScore) -> i32 {
+    let cmp_indents = (s1.effective_indent > s2.effective_indent) as i32
+        - (s1.effective_indent < s2.effective_indent) as i32;
+    INDENT_WEIGHT * cmp_indents + (s1.penalty - s2.penalty)
+}
+
+#[derive(Clone, Copy)]
+struct XdlGroup {
+    start: isize,
+    end: isize,
+}
+
+fn group_init(xdf: &XdFile<'_>, g: &mut XdlGroup) {
+    g.start = 0;
+    g.end = 0;
+    let n = xdf.nrec() as isize;
+    while g.end < n && xdf.changed_at(g.end) {
+        g.end += 1;
+    }
+}
+
+fn group_next(xdf: &XdFile<'_>, g: &mut XdlGroup) -> bool {
+    let n = xdf.nrec() as isize;
+    if g.end == n {
+        return false;
+    }
+    g.start = g.end + 1;
+    g.end = g.start;
+    while g.end < n && xdf.changed_at(g.end) {
+        g.end += 1;
+    }
+    true
+}
+
+fn group_previous(xdf: &XdFile<'_>, g: &mut XdlGroup) -> bool {
+    if g.start == 0 {
+        return false;
+    }
+    g.end = g.start - 1;
+    g.start = g.end;
+    while g.start > 0 && xdf.changed_at(g.start - 1) {
+        g.start -= 1;
+    }
+    true
+}
+
+fn recs_match(xdf: &XdFile<'_>, i: isize, j: isize) -> bool {
+    if i < 0 || j < 0 {
+        return false;
+    }
+    let ui = i as usize;
+    let uj = j as usize;
+    if ui >= xdf.nrec() || uj >= xdf.nrec() {
+        return false;
+    }
+    xdf.lines[ui] == xdf.lines[uj]
+}
+
+fn group_slide_down(xdf: &mut XdFile<'_>, g: &mut XdlGroup) -> bool {
+    let n = xdf.nrec() as isize;
+    if g.end < n && recs_match(xdf, g.start, g.end) {
+        xdf.set_changed(g.start as usize, false);
+        xdf.set_changed(g.end as usize, true);
+        g.start += 1;
+        g.end += 1;
+        while g.end < n && xdf.changed_at(g.end) {
+            g.end += 1;
+        }
+        return true;
+    }
+    false
+}
+
+fn group_slide_up(xdf: &mut XdFile<'_>, g: &mut XdlGroup) -> bool {
+    if g.start > 0 && recs_match(xdf, g.start - 1, g.end - 1) {
+        g.start -= 1;
+        g.end -= 1;
+        xdf.set_changed(g.start as usize, true);
+        xdf.set_changed(g.end as usize, false);
+        while g.start > 0 && xdf.changed_at(g.start - 1) {
+            g.start -= 1;
+        }
+        return true;
+    }
+    false
+}
+
+fn change_compact_one(xdf: &mut XdFile<'_>, xdfo: &mut XdFile<'_>, indent_heuristic: bool) {
+    let mut g = XdlGroup { start: 0, end: 0 };
+    let mut go = XdlGroup { start: 0, end: 0 };
+    group_init(xdf, &mut g);
+    group_init(xdfo, &mut go);
+
+    loop {
+        if g.end != g.start {
+            loop {
+                let groupsize = g.end - g.start;
+                let mut end_matching_other = -1_isize;
+
+                while !group_slide_up(xdf, &mut g) {
+                    let slid = group_previous(xdfo, &mut go);
+                    debug_assert!(slid, "group sync broken sliding up");
+                }
+
+                let earliest_end = g.end;
+                if go.end > go.start {
+                    end_matching_other = g.end;
+                }
+
+                loop {
+                    if !group_slide_down(xdf, &mut g) {
+                        break;
+                    }
+                    let slid = group_next(xdfo, &mut go);
+                    debug_assert!(slid, "group sync broken sliding down");
+                    if go.end > go.start {
+                        end_matching_other = g.end;
+                    }
+                }
+
+                if groupsize != g.end - g.start {
+                    continue;
+                }
+
+                if g.end == earliest_end {
+                    // no shifting was possible
+                } else if end_matching_other != -1 {
+                    while go.end == go.start {
+                        let slid = group_slide_up(xdf, &mut g);
+                        debug_assert!(slid, "match disappeared");
+                        let p = group_previous(xdfo, &mut go);
+                        debug_assert!(p, "group sync broken sliding to match");
+                    }
+                } else if indent_heuristic {
+                    apply_indent_heuristic_shift(
+                        xdf,
+                        xdfo,
+                        &mut g,
+                        &mut go,
+                        groupsize,
+                        earliest_end,
+                    );
+                }
+                break;
+            }
+        }
+
+        if !group_next(xdf, &mut g) {
+            break;
+        }
+        let advanced = group_next(xdfo, &mut go);
+        debug_assert!(advanced, "group sync broken at end of file");
+    }
+}
+
+fn apply_indent_heuristic_shift(
+    xdf: &mut XdFile<'_>,
+    xdfo: &mut XdFile<'_>,
+    g: &mut XdlGroup,
+    go: &mut XdlGroup,
+    groupsize: isize,
+    earliest_end: isize,
+) {
+    let mut shift = earliest_end;
+    if g.end - groupsize - 1 > shift {
+        shift = g.end - groupsize - 1;
+    }
+    if g.end - INDENT_HEURISTIC_MAX_SLIDING > shift {
+        shift = g.end - INDENT_HEURISTIC_MAX_SLIDING;
+    }
+
+    let mut best_shift: Option<isize> = None;
+    let mut best_score = SplitScore::default();
+
+    let mut s = shift;
+    while s <= g.end {
+        let mut m = SplitMeasurement::default();
+        let mut score = SplitScore::default();
+        measure_split(xdf, s, &mut m);
+        score_add_split(&m, &mut score);
+        measure_split(xdf, s - groupsize, &mut m);
+        score_add_split(&m, &mut score);
+
+        if best_shift.is_none() || score_cmp(&score, &best_score) <= 0 {
+            best_score.effective_indent = score.effective_indent;
+            best_score.penalty = score.penalty;
+            best_shift = Some(s);
+        }
+        s += 1;
+    }
+
+    let Some(best_shift) = best_shift else {
+        return;
+    };
+    while g.end > best_shift {
+        let _ = group_slide_up(xdf, g);
+        let _ = group_previous(xdfo, go);
+    }
+}
+
+fn change_compact_both_passes(
+    old_lines: &[&str],
+    new_lines: &[&str],
+    changed_old: &mut Vec<bool>,
+    changed_new: &mut Vec<bool>,
+    indent_heuristic: bool,
+) {
+    let c_old = std::mem::take(changed_old);
+    let c_new = std::mem::take(changed_new);
+    let mut xdf = XdFile::from_mask(old_lines, c_old);
+    let mut xdfo = XdFile::from_mask(new_lines, c_new);
+
+    change_compact_one(&mut xdf, &mut xdfo, indent_heuristic);
+    *changed_old = xdf.into_changed();
+    *changed_new = xdfo.into_changed();
+
+    let mut xdf2 = XdFile::from_mask(new_lines, std::mem::take(changed_new));
+    let mut xdfo2 = XdFile::from_mask(old_lines, std::mem::take(changed_old));
+    change_compact_one(&mut xdf2, &mut xdfo2, indent_heuristic);
+    *changed_new = xdf2.into_changed();
+    *changed_old = xdfo2.into_changed();
+}
+
+/// Initial `changed[]` masks from a line diff (Myers etc.), matching Git's xdf `changed` flags.
+fn masks_from_ops(ops: &[DiffOp], old_len: usize, new_len: usize) -> (Vec<bool>, Vec<bool>) {
+    let mut c1 = vec![false; old_len];
+    let mut c2 = vec![false; new_len];
+    for op in ops {
+        match op.tag() {
+            DiffTag::Equal => {}
+            DiffTag::Delete => {
+                for i in op.old_range() {
+                    if i < old_len {
+                        c1[i] = true;
+                    }
+                }
+            }
+            DiffTag::Insert => {
+                for j in op.new_range() {
+                    if j < new_len {
+                        c2[j] = true;
+                    }
+                }
+            }
+            DiffTag::Replace => {
+                for i in op.old_range() {
+                    if i < old_len {
+                        c1[i] = true;
+                    }
+                }
+                for j in op.new_range() {
+                    if j < new_len {
+                        c2[j] = true;
+                    }
+                }
+            }
+        }
+    }
+    (c1, c2)
+}
+
+/// Rebuild `DiffOp` list from compacted masks (Git `xdl_build_script`, reversed collect).
+fn ops_from_masks(old_lines: &[&str], new_lines: &[&str], c1: &[bool], c2: &[bool]) -> Vec<DiffOp> {
+    let n1 = old_lines.len() as isize;
+    let n2 = new_lines.len() as isize;
+    let mut out_rev: Vec<DiffOp> = Vec::new();
+
+    let changed1 = |i: isize| -> bool {
+        if i < 0 || i >= n1 {
+            return false;
+        }
+        c1[i as usize]
+    };
+    let changed2 = |i: isize| -> bool {
+        if i < 0 || i >= n2 {
+            return false;
+        }
+        c2[i as usize]
+    };
+
+    let mut i1 = n1;
+    let mut i2 = n2;
+    while i1 > 0 || i2 > 0 {
+        if changed1(i1 - 1) || changed2(i2 - 1) {
+            let l1 = i1;
+            let l2 = i2;
+            while i1 > 0 && changed1(i1 - 1) {
+                i1 -= 1;
+            }
+            while i2 > 0 && changed2(i2 - 1) {
+                i2 -= 1;
+            }
+            let chg1 = (l1 - i1) as usize;
+            let chg2 = (l2 - i2) as usize;
+            let i1u = i1 as usize;
+            let i2u = i2 as usize;
+
+            if chg1 > 0 && chg2 > 0 {
+                out_rev.push(DiffOp::Replace {
+                    old_index: i1u,
+                    old_len: chg1,
+                    new_index: i2u,
+                    new_len: chg2,
+                });
+            } else if chg1 > 0 {
+                out_rev.push(DiffOp::Delete {
+                    old_index: i1u,
+                    old_len: chg1,
+                    new_index: i2u,
+                });
+            } else if chg2 > 0 {
+                out_rev.push(DiffOp::Insert {
+                    old_index: i1u,
+                    new_index: i2u,
+                    new_len: chg2,
+                });
+            }
+        } else {
+            // equal line
+            i1 -= 1;
+            i2 -= 1;
+            out_rev.push(DiffOp::Equal {
+                old_index: i1 as usize,
+                new_index: i2 as usize,
+                len: 1,
+            });
+        }
+    }
+
+    out_rev.reverse();
+    merge_adjacent_equal_ops(out_rev)
+}
+
+fn merge_adjacent_equal_ops(ops: Vec<DiffOp>) -> Vec<DiffOp> {
+    if ops.is_empty() {
+        return ops;
+    }
+    let mut merged: Vec<DiffOp> = Vec::with_capacity(ops.len());
+    for op in ops {
+        if let (
+            Some(DiffOp::Equal {
+                old_index: o0,
+                new_index: n0,
+                len: l0,
+            }),
+            DiffOp::Equal {
+                old_index: o1,
+                new_index: n1,
+                len: l1,
+            },
+        ) = (merged.last(), op)
+        {
+            if o0 + l0 == o1 && n0 + l0 == n1 {
+                let last = merged.len() - 1;
+                if let DiffOp::Equal { len, .. } = &mut merged[last] {
+                    *len += l1;
+                }
+                continue;
+            }
+        }
+        merged.push(op);
+    }
+    merged
+}
+
+/// Apply Git `xdl_change_compact` twice (old/new), optionally with `XDF_INDENT_HEURISTIC`.
+pub fn apply_change_compact_to_ops(
+    ops: &[DiffOp],
+    old_lines: &[&str],
+    new_lines: &[&str],
+    indent_heuristic: bool,
+) -> Vec<DiffOp> {
+    let (mut c1, mut c2) = masks_from_ops(ops, old_lines.len(), new_lines.len());
+    change_compact_both_passes(old_lines, new_lines, &mut c1, &mut c2, indent_heuristic);
+    ops_from_masks(old_lines, new_lines, &c1, &c2)
+}
+
+/// Line-diff then Git-style compaction; used by unified diff generation.
+pub fn diff_lines_ops_compacted(
+    old_content: &str,
+    new_content: &str,
+    algorithm: Algorithm,
+    indent_heuristic: bool,
+) -> Vec<DiffOp> {
+    let diff = TextDiff::configure()
+        .algorithm(algorithm)
+        .diff_lines(old_content, new_content);
+    let old_lines: Vec<&str> = old_content.lines().collect();
+    let new_lines: Vec<&str> = new_content.lines().collect();
+    let raw = diff.ops().to_vec();
+    apply_change_compact_to_ops(&raw, &old_lines, &new_lines, indent_heuristic)
+}
+
+/// Like [`diff_lines_ops_compacted`] but for pre-split line slices (e.g. `--no-index` compare keys).
+pub fn diff_slice_ops_compacted(
+    old_lines: &[&str],
+    new_lines: &[&str],
+    algorithm: Algorithm,
+    indent_heuristic: bool,
+) -> Vec<DiffOp> {
+    let diff = TextDiff::configure()
+        .algorithm(algorithm)
+        .diff_slices(old_lines, new_lines);
+    let raw = diff.ops().to_vec();
+    apply_change_compact_to_ops(&raw, old_lines, new_lines, indent_heuristic)
+}
+
+/// Map each line in `new` to its origin line in `old` (if any), matching [`similar::TextDiff::iter_all_changes`]
+/// semantics over `ops` (typically compacted ops).
+pub(crate) fn map_new_to_old_from_ops(ops: &[DiffOp], new_line_count: usize) -> Vec<Option<usize>> {
+    let mut result = vec![None; new_line_count];
+    let mut old_idx: usize = 0;
+    let mut new_idx: usize = 0;
+
+    for op in ops {
+        match op.tag() {
+            DiffTag::Equal => {
+                let len = op.new_range().len();
+                for k in 0..len {
+                    if new_idx + k < result.len() {
+                        result[new_idx + k] = Some(old_idx + k);
+                    }
+                }
+                old_idx += len;
+                new_idx += len;
+            }
+            DiffTag::Delete => {
+                old_idx += op.old_range().len();
+            }
+            DiffTag::Insert => {
+                new_idx += op.new_range().len();
+            }
+            DiffTag::Replace => {
+                old_idx += op.old_range().len();
+                new_idx += op.new_range().len();
+            }
+        }
+    }
+
+    result
+}

--- a/grit-lib/src/lib.rs
+++ b/grit-lib/src/lib.rs
@@ -29,6 +29,7 @@ pub mod connectivity;
 pub mod crlf;
 pub mod delta_encode;
 pub mod diff;
+mod diff_indent_heuristic;
 pub mod diffstat;
 pub mod error;
 mod ewah_bitmap;

--- a/grit-lib/src/merge_diff.rs
+++ b/grit-lib/src/merge_diff.rs
@@ -444,7 +444,7 @@ pub fn format_parent_patch(
     } else {
         blob_text_for_diff(git_dir, config, path, &new_blob, use_textconv)
     };
-    let patch = crate::diff::unified_diff(&old_t, &new_t, path, path, context);
+    let patch = crate::diff::unified_diff(&old_t, &new_t, path, path, context, true);
     out.push_str(&patch);
     Some(out)
 }

--- a/grit/src/commands/diff.rs
+++ b/grit/src/commands/diff.rs
@@ -23,10 +23,11 @@ use grit_lib::crlf::{
 };
 use grit_lib::diff::{
     anchored_unified_diff, count_changes, count_changes_with_algorithm, count_git_lines,
-    detect_renames, diff_index_to_tree, diff_index_to_worktree, diff_tree_to_worktree, diff_trees,
-    diffcore_count_changes, empty_blob_oid, rewrite_dissimilarity_index_percent,
-    should_break_rewrite_for_stat, unified_diff,
-    unified_diff_with_prefix_and_funcname_and_algorithm, zero_oid, DiffEntry, DiffStatus,
+    detect_renames, diff_index_to_tree, diff_index_to_worktree, diff_slice_ops_compacted,
+    diff_tree_to_worktree, diff_trees, diffcore_count_changes, empty_blob_oid,
+    resolve_indent_heuristic, rewrite_dissimilarity_index_percent, should_break_rewrite_for_stat,
+    unified_diff, unified_diff_with_prefix_and_funcname_and_algorithm, zero_oid, DiffEntry,
+    DiffStatus,
 };
 use grit_lib::diffstat::{terminal_columns, write_diffstat_block, DiffstatOptions, FileStatInput};
 use grit_lib::error::Error;
@@ -45,7 +46,7 @@ use grit_lib::rev_parse::{
 };
 use grit_lib::userdiff::matcher_for_path_parsed;
 use regex::Regex;
-use similar::{ChangeTag, TextDiff};
+use similar::{group_diff_ops, udiff::UnifiedDiffHunk, ChangeTag, TextDiff};
 use std::fmt::Write as FmtWrite;
 use std::sync::Arc;
 
@@ -416,6 +417,7 @@ fn no_index_unified_patch_body(
     context_lines: usize,
     mode: &WhitespaceMode,
     algorithm: similar::Algorithm,
+    indent_heuristic: bool,
 ) -> String {
     let old_slots = no_index_build_line_slots(old_bytes, mode);
     let new_slots = no_index_build_line_slots(new_bytes, mode);
@@ -440,6 +442,8 @@ fn no_index_unified_patch_body(
     let diff = TextDiff::configure()
         .algorithm(algorithm)
         .diff_slices(&old_compare, &new_compare);
+    let compacted_ops =
+        diff_slice_ops_compacted(&old_compare, &new_compare, algorithm, indent_heuristic);
 
     let old_label = if old_path == "/dev/null" {
         "--- /dev/null\n".to_string()
@@ -467,12 +471,23 @@ fn no_index_unified_patch_body(
     output.push_str(&old_label);
     output.push_str(&new_label);
 
-    for hunk in diff
-        .unified_diff()
-        .context_radius(context_lines)
-        .iter_hunks()
-    {
-        output.push_str(&format!("{}\n", hunk.header()));
+    let max_common_gap = context_lines.saturating_mul(2);
+    let group_radius = max_common_gap.div_ceil(2);
+    let op_groups = group_diff_ops(compacted_ops, group_radius);
+
+    for ops in op_groups {
+        if ops.is_empty() {
+            continue;
+        }
+        let hunk = UnifiedDiffHunk::new(ops, &diff, false);
+        let hunk_str = format!("{hunk}");
+        let Some(first_newline) = hunk_str.find('\n') else {
+            output.push_str(&hunk_str);
+            continue;
+        };
+        let header_line = &hunk_str[..first_newline];
+        output.push_str(header_line);
+        output.push('\n');
         for change in hunk.iter_changes() {
             match change.tag() {
                 ChangeTag::Equal => {
@@ -1113,6 +1128,11 @@ pub fn run(mut args: Args) -> Result<()> {
     let diff_algo_cli = parse_cli_diff_algorithm_from_argv();
 
     let emit_unified_patch = diff_emit_unified_patch_from_argv(&raw_args);
+    let indent_heuristic = resolve_indent_heuristic(
+        &diff_config_early,
+        args.indent_heuristic,
+        args.no_indent_heuristic,
+    );
 
     let cwd = env::current_dir().context("failed to read current directory")?;
     let pathspec_prefix = repo
@@ -1158,6 +1178,7 @@ pub fn run(mut args: Args) -> Result<()> {
             diff_algo_cli,
             &cwd,
             quote_path_fully,
+            indent_heuristic,
         );
     }
 
@@ -1189,6 +1210,7 @@ pub fn run(mut args: Args) -> Result<()> {
                             diff_algo_cli,
                             &cwd,
                             quote_path_fully,
+                            indent_heuristic,
                         );
                     }
                 }
@@ -2178,6 +2200,7 @@ pub fn run(mut args: Args) -> Result<()> {
                     args.no_ext_diff,
                     external_diff_cmd.as_deref(),
                     relative_prefix_for_paths.as_deref(),
+                    indent_heuristic,
                 )?;
             }
         }
@@ -2206,6 +2229,7 @@ fn run_diff_blob_vs_file(
     diff_algo_cli: Option<similar::Algorithm>,
     cwd: &Path,
     quote_path_fully: bool,
+    indent_heuristic: bool,
 ) -> Result<()> {
     let wt = repo
         .work_tree
@@ -2395,6 +2419,7 @@ fn run_diff_blob_vs_file(
             args.no_ext_diff,
             external_diff_cmd.as_deref(),
             relative_prefix_for_paths.as_deref(),
+            indent_heuristic,
         )?;
     }
 
@@ -2483,6 +2508,11 @@ fn run_diff_two_paths(
             .unwrap_or(3)
     };
 
+    let diff_cfg = grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true)
+        .unwrap_or_else(|_| grit_lib::config::ConfigSet::new());
+    let indent_h =
+        resolve_indent_heuristic(&diff_cfg, args.indent_heuristic, args.no_indent_heuristic);
+
     let old_label = format!("{src_prefix}{path_in_repo}");
     let new_label = format!("{dst_prefix}{path_other}");
     let patch = unified_diff(
@@ -2491,6 +2521,7 @@ fn run_diff_two_paths(
         &old_label,
         &new_label,
         context_lines,
+        indent_h,
     );
 
     let mut out = io::stdout().lock();
@@ -2620,6 +2651,11 @@ fn run_no_index(args: Args) -> Result<()> {
         ignore_case_attrs,
     };
     let diff_algo_cli = parse_cli_diff_algorithm_from_argv();
+    let indent_heuristic = resolve_indent_heuristic(
+        diff_algo_ctx.config.as_ref(),
+        args.indent_heuristic,
+        args.no_indent_heuristic,
+    );
 
     // Read file or symlink target (for symlinks, read the target path as content)
     let read_path_or_symlink = |p: &Path, name: &str| -> Result<Vec<u8>> {
@@ -2773,6 +2809,7 @@ fn run_no_index(args: Args) -> Result<()> {
             context_lines,
             &args.anchored,
             line_algo_anchored,
+            indent_heuristic,
         )
     } else {
         no_index_unified_patch_body(
@@ -2783,6 +2820,7 @@ fn run_no_index(args: Args) -> Result<()> {
             context_lines,
             &ws_mode,
             algo_no_index,
+            indent_heuristic,
         )
     };
 
@@ -2918,6 +2956,11 @@ fn run_no_index_dirs(args: Args, dir_a: &Path, dir_b: &Path) -> Result<()> {
         ignore_case_attrs,
     };
     let diff_algo_cli = parse_cli_diff_algorithm_from_argv();
+    let indent_heuristic = resolve_indent_heuristic(
+        diff_algo_ctx.config.as_ref(),
+        args.indent_heuristic,
+        args.no_indent_heuristic,
+    );
     let patch_abbrev = if args.full_index {
         40usize
     } else if let Some(n) = args.abbrev {
@@ -3038,6 +3081,7 @@ fn run_no_index_dirs(args: Args, dir_a: &Path, dir_b: &Path) -> Result<()> {
             "b/",
             func_matcher.as_ref(),
             algo,
+            indent_heuristic,
         );
         write!(out, "{patch}")?;
     }
@@ -4454,6 +4498,7 @@ fn write_patch_with_prefix(
     no_ext_diff: bool,
     external_diff_cmd: Option<&str>,
     relative_prefix: Option<&str>,
+    indent_heuristic: bool,
 ) -> Result<()> {
     for entry in entries {
         let old_path = entry.old_path.as_deref().unwrap_or("/dev/null");
@@ -4485,6 +4530,7 @@ fn write_patch_with_prefix(
                         true,
                         submodule_ignore,
                         &path_for_attrs,
+                        indent_heuristic,
                     )?;
                     continue;
                 }
@@ -4716,6 +4762,7 @@ fn write_patch_with_prefix(
                 display_old,
                 display_new,
                 context_lines,
+                indent_heuristic,
             );
             let patch = if suppress_blank_empty {
                 strip_blank_context_trailing_space(&patch)
@@ -4748,6 +4795,7 @@ fn write_patch_with_prefix(
                 dst_prefix,
                 func_matcher.as_ref(),
                 algo,
+                indent_heuristic,
             );
             let patch = if suppress_blank_empty {
                 strip_blank_context_trailing_space(&patch)
@@ -4806,8 +4854,9 @@ fn word_diff_output(
     old_path: &str,
     new_path: &str,
     context_lines: usize,
+    indent_heuristic: bool,
 ) -> String {
-    use similar::{ChangeTag, TextDiff};
+    use similar::{Algorithm, ChangeTag, TextDiff};
 
     let mut output = String::new();
     output.push_str(&format!("--- a/{old_path}\n"));
@@ -4816,68 +4865,32 @@ fn word_diff_output(
     let old_lines: Vec<&str> = old_content.lines().collect();
     let new_lines: Vec<&str> = new_content.lines().collect();
 
-    let line_diff = TextDiff::from_slices(&old_lines, &new_lines);
+    let line_diff = TextDiff::configure()
+        .algorithm(Algorithm::Myers)
+        .diff_slices(&old_lines, &new_lines);
+    let compacted =
+        diff_slice_ops_compacted(&old_lines, &new_lines, Algorithm::Myers, indent_heuristic);
+    let max_common_gap = context_lines.saturating_mul(2);
+    let group_radius = max_common_gap.div_ceil(2);
+    let op_groups = group_diff_ops(compacted, group_radius);
 
-    for hunk in line_diff
-        .unified_diff()
-        .context_radius(context_lines)
-        .iter_hunks()
-    {
-        // Write the hunk header with function context.
+    for ops in op_groups {
+        if ops.is_empty() {
+            continue;
+        }
+        let hunk = UnifiedDiffHunk::new(ops, &line_diff, false);
         let hunk_str = format!("{hunk}");
-        if let Some(header_end) = hunk_str.find('\n') {
-            let header = &hunk_str[..header_end];
-            output.push_str(header);
-            // Add function context (like Git does).
-            if let Some(func) = find_func_context(header, &old_lines) {
-                output.push(' ');
-                output.push_str(&func);
-            }
-            output.push('\n');
+        let Some(header_end) = hunk_str.find('\n') else {
+            output.push_str(&hunk_str);
+            continue;
+        };
+        let header = &hunk_str[..header_end];
+        output.push_str(header);
+        if let Some(func) = find_func_context(header, &old_lines) {
+            output.push(' ');
+            output.push_str(&func);
         }
-
-        // Process each change in the hunk
-        for change in hunk.iter_changes() {
-            match change.tag() {
-                ChangeTag::Equal => {
-                    output.push_str(change.value());
-                    output.push('\n');
-                }
-                ChangeTag::Delete => {
-                    // Look for a corresponding insert to do word-level diff
-                    // For simplicity, output the whole line as deleted
-                    // We'll handle paired changes below
-                }
-                ChangeTag::Insert => {}
-            }
-        }
-    }
-
-    // Simpler approach: use the similar crate's word-level diff directly
-    output.clear();
-    output.push_str(&format!("--- a/{old_path}\n"));
-    output.push_str(&format!("+++ b/{new_path}\n"));
-
-    // Build unified diff with word-level changes within each hunk
-    let line_diff = TextDiff::from_lines(old_content, new_content);
-
-    for hunk in line_diff
-        .unified_diff()
-        .context_radius(context_lines)
-        .iter_hunks()
-    {
-        // Write hunk header with function context.
-        let hunk_str = format!("{hunk}");
-        if let Some(header_end) = hunk_str.find('\n') {
-            let header = &hunk_str[..header_end];
-            output.push_str(header);
-            let old_lines_for_ctx: Vec<&str> = old_content.lines().collect();
-            if let Some(func) = find_func_context(header, &old_lines_for_ctx) {
-                output.push(' ');
-                output.push_str(&func);
-            }
-            output.push('\n');
-        }
+        output.push('\n');
 
         // Collect changes and pair deletions with insertions
         let changes: Vec<_> = hunk.iter_changes().collect();

--- a/grit/src/commands/diff_files.rs
+++ b/grit/src/commands/diff_files.rs
@@ -5,8 +5,10 @@
 
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
+use grit_lib::config::ConfigSet;
 use grit_lib::diff::{
     count_changes, detect_copies, empty_blob_oid, format_stat_line,
+    parse_indent_heuristic_cli_flags, resolve_indent_heuristic,
     rewrite_dissimilarity_index_percent, should_break_rewrite_for_stat, stat_matches, unified_diff,
     zero_oid, DiffEntry, DiffStatus,
 };
@@ -41,7 +43,10 @@ pub fn run(mut args: Args) -> Result<()> {
     if grit_lib::precompose_config::effective_core_precomposeunicode(Some(&repo.git_dir)) {
         crate::precompose::precompose_plumbing_argv(&mut args.args);
     }
-    let options = parse_options(&args.args)?;
+    let mut options = parse_options(&args.args)?;
+    let diff_cfg = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+    let (cli_ind, cli_no) = parse_indent_heuristic_cli_flags(&args.args);
+    options.indent_heuristic = resolve_indent_heuristic(&diff_cfg, cli_ind, cli_no);
 
     let Some(work_tree) = repo.work_tree.clone() else {
         bail!("this operation must be run in a work tree");
@@ -181,7 +186,13 @@ pub fn run(mut args: Args) -> Result<()> {
             }
             OutputFormat::Patch => {
                 for entry in &diff_entries {
-                    print_patch_from_diff_entry(entry, &repo, &work_tree, options.abbrev)?;
+                    print_patch_from_diff_entry(
+                        entry,
+                        &repo,
+                        &work_tree,
+                        options.abbrev,
+                        options.indent_heuristic,
+                    )?;
                 }
             }
             OutputFormat::Stat => {
@@ -356,6 +367,7 @@ struct Options {
     summary: bool,
     /// Detect complete rewrites (`-B` / `--break-rewrites`) for summary/raw dissimilarity.
     break_rewrites: bool,
+    indent_heuristic: bool,
 }
 
 /// A single changed file: index side vs working tree.
@@ -482,7 +494,9 @@ fn parse_options(argv: &[String]) -> Result<Options> {
                 | "--full-index"
                 | "--no-ext-diff"
                 | "--no-prefix"
-                | "--no-abbrev" => {}
+                | "--no-abbrev"
+                | "--indent-heuristic"
+                | "--no-indent-heuristic" => {}
                 "-M" | "--find-renames" => {
                     find_renames = Some(50);
                 }
@@ -578,6 +592,7 @@ fn parse_options(argv: &[String]) -> Result<Options> {
         reverse,
         summary,
         break_rewrites,
+        indent_heuristic: false,
     })
 }
 
@@ -927,6 +942,7 @@ fn print_patch_from_diff_entry(
     repo: &Repository,
     work_tree: &Path,
     abbrev: Option<usize>,
+    indent_heuristic: bool,
 ) -> Result<()> {
     let (old_content, new_content) = load_patch_contents_for_diff_entry(entry, repo, work_tree)?;
     let old_path = entry
@@ -1003,7 +1019,14 @@ fn print_patch_from_diff_entry(
     {
         println!("{header}");
     } else if old_content != new_content {
-        let patch = unified_diff(&old_content, &new_content, display_path, display_path, 3);
+        let patch = unified_diff(
+            &old_content,
+            &new_content,
+            display_path,
+            display_path,
+            3,
+            indent_heuristic,
+        );
         let body: String = patch.lines().skip(2).map(|l| format!("\n{l}")).collect();
         println!("{header}\n--- {old_label}\n+++ {new_label}{body}");
     } else {

--- a/grit/src/commands/diff_index.rs
+++ b/grit/src/commands/diff_index.rs
@@ -37,10 +37,11 @@ pub fn run(mut args: Args) -> Result<()> {
     if grit_lib::precompose_config::effective_core_precomposeunicode(Some(&repo.git_dir)) {
         crate::precompose::precompose_plumbing_argv(&mut args.args);
     }
-    let options = parse_options(&args.args)?;
-    let quote_fully = grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true)
-        .unwrap_or_default()
-        .quote_path_fully();
+    let mut options = parse_options(&args.args)?;
+    let diff_cfg = grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+    let (cli_ind, cli_no) = grit_lib::diff::parse_indent_heuristic_cli_flags(&args.args);
+    options.indent_heuristic = grit_lib::diff::resolve_indent_heuristic(&diff_cfg, cli_ind, cli_no);
+    let quote_fully = diff_cfg.quote_path_fully();
     let tree_oid = resolve_tree_ish(&repo, &options.tree_ish)?;
 
     let mut tree_map = BTreeMap::new();
@@ -295,6 +296,7 @@ pub fn run(mut args: Args) -> Result<()> {
                     options.submodule_diff,
                     sm_ignore,
                     p,
+                    options.indent_heuristic,
                 )?;
             }
         } else if options.name_status {
@@ -492,6 +494,8 @@ struct Options {
     ignore_all_space: bool,
     nul_terminated: bool,
     relative: bool,
+    /// Effective `diff.indentHeuristic` (CLI overrides config; set in `run()` after parse).
+    indent_heuristic: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -710,6 +714,7 @@ fn parse_options(argv: &[String]) -> Result<Options> {
                         _ => bail!("unsupported option: {arg}"),
                     };
                 }
+                "--indent-heuristic" | "--no-indent-heuristic" => {}
                 _ => bail!("unsupported option: {arg}"),
             }
             idx += 1;
@@ -753,6 +758,7 @@ fn parse_options(argv: &[String]) -> Result<Options> {
         ignore_all_space,
         nul_terminated,
         relative,
+        indent_heuristic: false,
     })
 }
 
@@ -1498,6 +1504,7 @@ pub(crate) fn write_submodule_diff_recursive(
     ignore_dirty_for_inner: bool,
     submodule_ignore: SubmoduleIgnoreFlags,
     context_lines: usize,
+    indent_heuristic: bool,
 ) -> Result<()> {
     let z = zero_oid();
     let super_wt = super_repo
@@ -1588,6 +1595,7 @@ pub(crate) fn write_submodule_diff_recursive(
                         true,
                         submodule_ignore,
                         &inner_full,
+                        indent_heuristic,
                     )?;
                 } else {
                     write_patch_entry_inner(
@@ -1598,6 +1606,7 @@ pub(crate) fn write_submodule_diff_recursive(
                         context_lines,
                         Some(&sub_path),
                         full_path_from_root,
+                        indent_heuristic,
                     )?;
                 }
             }
@@ -1617,6 +1626,7 @@ pub(crate) fn write_submodule_diff_recursive(
                         true,
                         submodule_ignore,
                         &inner_full,
+                        indent_heuristic,
                     )?;
                 } else {
                     write_patch_entry_inner(
@@ -1627,6 +1637,7 @@ pub(crate) fn write_submodule_diff_recursive(
                         context_lines,
                         None,
                         full_path_from_root,
+                        indent_heuristic,
                     )?;
                 }
             }
@@ -1675,6 +1686,7 @@ pub(crate) fn write_submodule_diff_recursive(
                     true,
                     submodule_ignore,
                     &inner_full,
+                    indent_heuristic,
                 )?;
             } else {
                 write_patch_entry_inner(
@@ -1685,6 +1697,7 @@ pub(crate) fn write_submodule_diff_recursive(
                     context_lines,
                     Some(&sub_path),
                     full_path_from_root,
+                    indent_heuristic,
                 )?;
             }
         }
@@ -1704,6 +1717,7 @@ pub(crate) fn write_submodule_diff_recursive(
                     true,
                     submodule_ignore,
                     &inner_full,
+                    indent_heuristic,
                 )?;
             } else {
                 write_patch_entry_inner(
@@ -1714,6 +1728,7 @@ pub(crate) fn write_submodule_diff_recursive(
                     context_lines,
                     None,
                     full_path_from_root,
+                    indent_heuristic,
                 )?;
             }
         }
@@ -1733,6 +1748,7 @@ pub(crate) fn write_patch_entry(
     submodule_diff: bool,
     submodule_ignore: SubmoduleIgnoreFlags,
     full_path_from_root: &str,
+    indent_heuristic: bool,
 ) -> Result<()> {
     let z = zero_oid();
 
@@ -1757,7 +1773,16 @@ pub(crate) fn write_patch_entry(
             blob_del.new_path = None;
             blob_del.new_mode = "000000".to_owned();
             blob_del.new_oid = z;
-            write_patch_entry_inner(out, repo, odb, &blob_del, context_lines, work_tree, "")?;
+            write_patch_entry_inner(
+                out,
+                repo,
+                odb,
+                &blob_del,
+                context_lines,
+                work_tree,
+                "",
+                indent_heuristic,
+            )?;
             write_submodule_diff_recursive(
                 out,
                 repo,
@@ -1768,6 +1793,7 @@ pub(crate) fn write_patch_entry(
                 submodule_ignore.ignore_dirty,
                 submodule_ignore,
                 context_lines,
+                indent_heuristic,
             )?;
             return Ok(());
         }
@@ -1784,6 +1810,7 @@ pub(crate) fn write_patch_entry(
                 submodule_ignore.ignore_dirty,
                 submodule_ignore,
                 context_lines,
+                indent_heuristic,
             )?;
             let mut blob_add = entry.clone();
             blob_add.status = DiffStatus::Added;
@@ -1800,6 +1827,7 @@ pub(crate) fn write_patch_entry(
                 context_lines,
                 work_tree,
                 "",
+                indent_heuristic,
             );
         }
 
@@ -1833,12 +1861,22 @@ pub(crate) fn write_patch_entry(
                 submodule_ignore.ignore_dirty,
                 submodule_ignore,
                 context_lines,
+                indent_heuristic,
             )?;
             return Ok(());
         }
     }
 
-    write_patch_entry_inner(out, repo, odb, entry, context_lines, work_tree, "")
+    write_patch_entry_inner(
+        out,
+        repo,
+        odb,
+        entry,
+        context_lines,
+        work_tree,
+        "",
+        indent_heuristic,
+    )
 }
 
 pub(crate) fn write_patch_entry_inner(
@@ -1849,6 +1887,7 @@ pub(crate) fn write_patch_entry_inner(
     context_lines: usize,
     work_tree: Option<&Path>,
     path_prefix: &str,
+    indent_heuristic: bool,
 ) -> Result<()> {
     use grit_lib::diff::unified_diff_with_prefix;
 
@@ -2170,6 +2209,7 @@ pub(crate) fn write_patch_entry_inner(
         0,
         "",
         "",
+        indent_heuristic,
     );
     write!(out, "{patch}")?;
 

--- a/grit/src/commands/diff_tree.rs
+++ b/grit/src/commands/diff_tree.rs
@@ -141,6 +141,8 @@ struct Options {
     submodule_mode: Option<String>,
     /// Object id spec for `--find-object` (resolved against the repo before the walk).
     find_object: Option<String>,
+    /// `diff.indentHeuristic` after CLI `--indent-heuristic` / `--no-indent-heuristic`.
+    indent_heuristic: bool,
 }
 
 impl Default for Options {
@@ -184,6 +186,7 @@ impl Default for Options {
             pickaxe_all: false,
             submodule_mode: None,
             find_object: None,
+            indent_heuristic: false,
         }
     }
 }
@@ -206,6 +209,9 @@ fn spec_names_commit_or_tree(repo: &Repository, spec: &str) -> bool {
 /// Parse the raw argument vector.
 fn parse_options(repo: &Repository, argv: &[String]) -> Result<Options> {
     let mut opts = Options::default();
+    let cfg_early = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+    let (cli_ind, cli_no) = grit_lib::diff::parse_indent_heuristic_cli_flags(argv);
+    opts.indent_heuristic = grit_lib::diff::resolve_indent_heuristic(&cfg_early, cli_ind, cli_no);
     let mut end_of_options = false;
     let mut i = 0usize;
 
@@ -373,6 +379,8 @@ fn parse_options(repo: &Repository, argv: &[String]) -> Result<Options> {
                 }
                 "--pickaxe-regex" => opts.pickaxe_regex = true,
                 "--pickaxe-all" => opts.pickaxe_all = true,
+                "--indent-heuristic" => {}
+                "--no-indent-heuristic" => {}
                 s if s.starts_with("-S") => {
                     if s.len() > 2 {
                         opts.pickaxe_string = Some(s[2..].to_owned());
@@ -539,6 +547,7 @@ fn run_one_commit(repo: &Repository, opts: &Options, out: &mut impl Write) -> Re
                     find_object: None,
                     submodule_mode: None,
                     context_lines: opts.context_lines,
+                    indent_heuristic: opts.indent_heuristic,
                 };
                 let mut buf = Vec::new();
                 write_remerge_diff(&mut buf, repo, &commit.tree, &commit.parents, &ro)?;
@@ -749,6 +758,7 @@ fn process_stdin_commit(
             find_object: None,
             submodule_mode: None,
             context_lines: opts.context_lines,
+            indent_heuristic: opts.indent_heuristic,
         };
         let mut buf = Vec::new();
         write_remerge_diff(&mut buf, repo, &commit.tree, &parent_oids, &ro)?;
@@ -1470,6 +1480,7 @@ fn print_diff(
                     opts.full_index,
                     git_dir,
                     quote_fully,
+                    opts.indent_heuristic,
                 )?;
             }
         }
@@ -1568,6 +1579,7 @@ fn write_patch_entry(
     full_index: bool,
     git_dir: &Path,
     quote_fully: bool,
+    indent_heuristic: bool,
 ) -> Result<bool> {
     let (old_content, new_content) = read_blob_pair(odb, entry)?;
 
@@ -1678,6 +1690,7 @@ fn write_patch_entry(
         0,
         "",
         "",
+        indent_heuristic,
     );
     write!(out, "{patch}")?;
 

--- a/grit/src/commands/format_patch.rs
+++ b/grit/src/commands/format_patch.rs
@@ -7,7 +7,9 @@
 use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::config::ConfigSet;
-use grit_lib::diff::{count_changes, diff_trees, unified_diff, zero_oid};
+use grit_lib::diff::{
+    count_changes, diff_trees, indent_heuristic_from_config, unified_diff, zero_oid,
+};
 use grit_lib::diffstat::{
     write_diffstat_block, DiffstatOptions, FileStatInput, FORMAT_PATCH_STAT_WIDTH,
 };
@@ -524,6 +526,7 @@ pub fn run(mut args: Args) -> Result<()> {
             &opts,
             include_base,
             &log_output_encoding,
+            indent_heuristic_from_config(&config),
         )?;
 
         if args.stdout {
@@ -964,6 +967,7 @@ fn format_single_patch(
     opts: &PatchOptions,
     include_base: bool,
     log_output_encoding: &str,
+    indent_heuristic: bool,
 ) -> Result<String> {
     let mut out = String::new();
     let charset_label = rfc2047_charset_label(log_output_encoding);
@@ -1003,7 +1007,14 @@ fn format_single_patch(
         write_diff_header_to_string(&mut diff_text, entry);
         let old_content = read_blob_content(odb, &entry.old_oid);
         let new_content = read_blob_content(odb, &entry.new_oid);
-        let patch = unified_diff(&old_content, &new_content, old_path, new_path, 3);
+        let patch = unified_diff(
+            &old_content,
+            &new_content,
+            old_path,
+            new_path,
+            3,
+            indent_heuristic,
+        );
         diff_text.push_str(&patch);
     }
 

--- a/grit/src/commands/log.rs
+++ b/grit/src/commands/log.rs
@@ -13,8 +13,8 @@ use grit_lib::commit_graph_file::{
 use grit_lib::config::ConfigSet;
 use grit_lib::crlf::{get_file_attrs, load_gitattributes, DiffAttr};
 use grit_lib::diff::{
-    count_changes, diff_trees, diff_trees_show_tree_entries, format_raw, unified_diff, zero_oid,
-    DiffEntry, DiffStatus,
+    count_changes, diff_trees, diff_trees_show_tree_entries, format_raw,
+    indent_heuristic_from_config, unified_diff, zero_oid, DiffEntry, DiffStatus,
 };
 use grit_lib::diffstat::{terminal_columns, write_diffstat_block, DiffstatOptions, FileStatInput};
 use grit_lib::git_date::parse::parse_date_basic;
@@ -5022,6 +5022,7 @@ fn commit_pickaxe_matches(
                 entry.old_path.as_deref().unwrap_or(path),
                 entry.new_path.as_deref().unwrap_or(path),
                 3,
+                indent_heuristic_from_config(&config),
             );
             if pickaxe_g_matches_diff_lines(re, &patch) {
                 return Ok(true);
@@ -6644,6 +6645,8 @@ fn write_commit_diff(
 ) -> Result<()> {
     let odb = &repo.odb;
     let git_dir = &repo.git_dir;
+    let log_config = ConfigSet::load(Some(git_dir), true).unwrap_or_default();
+    let indent_heuristic = indent_heuristic_from_config(&log_config);
     let is_merge = info.parents.len() > 1;
 
     if !log_commit_needs_diff_output(args, info, git_dir)? {
@@ -6665,6 +6668,7 @@ fn write_commit_diff(
             find_object: find_oid,
             submodule_mode: None,
             context_lines: patch_context,
+            indent_heuristic,
         };
         return write_remerge_diff(out, repo, &info.tree, &info.parents, &opts);
     }
@@ -6720,6 +6724,7 @@ fn write_commit_diff(
                 show_patch,
                 false,
                 patch_context,
+                indent_heuristic,
             )?;
         }
         return Ok(());
@@ -6771,6 +6776,7 @@ fn write_commit_diff(
         show_patch,
         is_merge,
         patch_context,
+        indent_heuristic,
     )?;
 
     Ok(())
@@ -6787,6 +6793,7 @@ fn write_commit_diff_body(
     show_patch: bool,
     treat_as_merge_for_format: bool,
     patch_context: usize,
+    indent_heuristic: bool,
 ) -> Result<()> {
     let combined_style = merge_diff_is_combined_style(args, treat_as_merge_for_format, git_dir)?;
     let list_raw_name = if combined_style {
@@ -6841,7 +6848,7 @@ fn write_commit_diff_body(
 
     if show_patch {
         for entry in list_patch {
-            log_write_patch_entry(out, odb, entry, args, patch_context)?;
+            log_write_patch_entry(out, odb, entry, args, patch_context, indent_heuristic)?;
         }
     }
 
@@ -6855,6 +6862,7 @@ fn log_write_patch_entry(
     entry: &DiffEntry,
     args: &Args,
     context_lines: usize,
+    indent_heuristic: bool,
 ) -> Result<()> {
     let old_path = entry
         .old_path
@@ -6954,6 +6962,7 @@ fn log_write_patch_entry(
         0,
         src_pfx,
         dst_pfx,
+        indent_heuristic,
     );
     let patch = apply_diff_output_indicators(&patch, args);
     write!(out, "{patch}")?;

--- a/grit/src/commands/remerge_diff.rs
+++ b/grit/src/commands/remerge_diff.rs
@@ -22,6 +22,7 @@ pub(crate) struct RemergeDiffOptions<'a> {
     pub find_object: Option<ObjectId>,
     pub submodule_mode: Option<&'a str>,
     pub context_lines: usize,
+    pub indent_heuristic: bool,
 }
 
 fn path_matches_pathspecs(pathspecs: &[String], path: &str) -> bool {
@@ -451,6 +452,7 @@ pub(crate) fn write_remerge_diff(
                     e,
                     use_textconv,
                     opts.context_lines,
+                    opts.indent_heuristic,
                 )?;
                 continue;
             }
@@ -473,6 +475,7 @@ pub(crate) fn write_remerge_diff(
                 e,
                 use_textconv,
                 opts.context_lines,
+                opts.indent_heuristic,
             )?;
         } else if d.kind == "file/directory" {
             let old_path = d.subject_path.as_str();
@@ -529,6 +532,7 @@ pub(crate) fn write_remerge_diff(
                                 &del,
                                 use_textconv,
                                 opts.context_lines,
+                                opts.indent_heuristic,
                             )?;
                         }
                     }
@@ -608,6 +612,7 @@ pub(crate) fn write_remerge_diff(
             e,
             use_textconv,
             opts.context_lines,
+            opts.indent_heuristic,
         )?;
     }
 
@@ -622,6 +627,7 @@ fn emit_patch_for_entry(
     e: &DiffEntry,
     use_textconv: bool,
     context_lines: usize,
+    indent_heuristic: bool,
 ) -> Result<()> {
     let old_path = e.old_path.as_deref().unwrap_or("/dev/null");
     let new_path = e.new_path.as_deref().unwrap_or("/dev/null");
@@ -656,6 +662,7 @@ fn emit_patch_for_entry(
         old_path,
         new_path,
         context_lines,
+        indent_heuristic,
     );
     write!(out, "{patch}")?;
     Ok(())

--- a/grit/src/commands/reset.rs
+++ b/grit/src/commands/reset.rs
@@ -739,6 +739,7 @@ fn reset_patch(repo: &Repository, rest: &[String]) -> Result<()> {
                 &index_bytes,
                 &ops[s..e],
                 3,
+                true,
             );
 
             writeln!(out, "diff --git a/{path_str} b/{path_str}").ok();

--- a/grit/src/commands/show.rs
+++ b/grit/src/commands/show.rs
@@ -12,8 +12,8 @@ use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::config::ConfigSet;
 use grit_lib::diff::{
-    anchored_unified_diff, detect_copies, detect_renames, diff_trees, unified_diff, zero_oid,
-    DiffEntry,
+    anchored_unified_diff, detect_copies, detect_renames, diff_trees,
+    parse_indent_heuristic_cli_flags, resolve_indent_heuristic, unified_diff, zero_oid, DiffEntry,
 };
 use grit_lib::diffstat::{terminal_columns, write_diffstat_block, DiffstatOptions, FileStatInput};
 use grit_lib::merge_base::merge_bases_first_vs_rest;
@@ -208,6 +208,14 @@ pub struct Args {
     #[arg(long = "numstat")]
     pub numstat: bool,
 
+    /// Enable indent heuristic (plumbing compatibility; also parsed from argv).
+    #[arg(long = "indent-heuristic", hide = true)]
+    pub indent_heuristic: bool,
+
+    /// Disable indent heuristic.
+    #[arg(long = "no-indent-heuristic", hide = true)]
+    pub no_indent_heuristic: bool,
+
     /// Show diff against a mechanical re-merge of the parents (merge commits).
     #[arg(long = "remerge-diff")]
     pub remerge_diff: bool,
@@ -258,6 +266,14 @@ pub fn run(mut args: Args) -> Result<()> {
         }
     }
     maybe_warn_deprecated_grafts(&repo)?;
+
+    let diff_cfg = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+    let (argv_ind, argv_no) = parse_indent_heuristic_cli_flags(&args.objects);
+    let indent_heuristic = resolve_indent_heuristic(
+        &diff_cfg,
+        args.indent_heuristic || argv_ind,
+        args.no_indent_heuristic || argv_no,
+    );
 
     let mut raw_objects = args.objects.clone();
     while let Some(first) = raw_objects.first() {
@@ -347,6 +363,7 @@ pub fn run(mut args: Args) -> Result<()> {
             find_object: find_oid,
             submodule_mode: args.submodule.as_deref(),
             context_lines: args.unified.unwrap_or(3),
+            indent_heuristic,
         };
 
         let mut candidates: BTreeSet<ObjectId> = BTreeSet::new();
@@ -397,6 +414,7 @@ pub fn run(mut args: Args) -> Result<()> {
             find_object: None,
             submodule_mode: args.submodule.as_deref(),
             context_lines: args.unified.unwrap_or(3),
+            indent_heuristic,
         };
 
         let mut remerge_shown = false;
@@ -415,6 +433,7 @@ pub fn run(mut args: Args) -> Result<()> {
                 &pathspecs,
                 Some(&emit_opts),
                 None,
+                indent_heuristic,
             )?;
             remerge_shown = true;
         }
@@ -469,6 +488,7 @@ pub fn run(mut args: Args) -> Result<()> {
                     &pathspecs,
                     None,
                     Some(parent_oid),
+                    indent_heuristic,
                 )?;
                 shown = true;
             }
@@ -516,7 +536,16 @@ pub fn run(mut args: Args) -> Result<()> {
                         writeln!(out)?;
                     }
                     show_commit(
-                        &mut out, &repo, &oid, &obj.data, &args, &notes_map, &pathspecs, None, None,
+                        &mut out,
+                        &repo,
+                        &oid,
+                        &obj.data,
+                        &args,
+                        &notes_map,
+                        &pathspecs,
+                        None,
+                        None,
+                        indent_heuristic,
                     )?;
                     shown = true;
                 }
@@ -541,7 +570,16 @@ pub fn run(mut args: Args) -> Result<()> {
                 writeln!(out)?;
             }
             show_commit(
-                &mut out, &repo, &oid, &obj.data, &args, &notes_map, &pathspecs, None, None,
+                &mut out,
+                &repo,
+                &oid,
+                &obj.data,
+                &args,
+                &notes_map,
+                &pathspecs,
+                None,
+                None,
+                indent_heuristic,
             )?;
             shown = true;
         }
@@ -562,11 +600,28 @@ pub fn run(mut args: Args) -> Result<()> {
         match obj.kind {
             ObjectKind::Commit => {
                 show_commit(
-                    &mut out, &repo, &oid, &obj.data, &args, &notes_map, &pathspecs, None, None,
+                    &mut out,
+                    &repo,
+                    &oid,
+                    &obj.data,
+                    &args,
+                    &notes_map,
+                    &pathspecs,
+                    None,
+                    None,
+                    indent_heuristic,
                 )?;
             }
             ObjectKind::Tag => {
-                show_tag(&mut out, &repo, spec, &obj.data, &args, &notes_map)?;
+                show_tag(
+                    &mut out,
+                    &repo,
+                    spec,
+                    &obj.data,
+                    &args,
+                    &notes_map,
+                    indent_heuristic,
+                )?;
             }
             ObjectKind::Tree => {
                 show_tree_named(&mut out, &repo, spec, oid)?;
@@ -712,9 +767,11 @@ fn show_commit(
     pathspecs: &[String],
     remerge_emit_opts: Option<&crate::commands::remerge_diff::RemergeDiffOptions<'_>>,
     merge_from_parent: Option<ObjectId>,
+    indent_heuristic: bool,
 ) -> Result<()> {
     let odb = &repo.odb;
     let commit = parse_commit(data).context("parsing commit")?;
+    let config = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
     let hex = oid.to_hex();
 
     if args.oneline || args.format.as_deref() == Some("oneline") {
@@ -742,6 +799,7 @@ fn show_commit(
                         find_object: find_oid,
                         submodule_mode: args.submodule.as_deref(),
                         context_lines: args.unified.unwrap_or(3),
+                        indent_heuristic,
                     };
                     write_remerge_diff(&mut remerge_buf, repo, &commit.tree, &commit.parents, &o)?;
                 }
@@ -902,6 +960,7 @@ fn show_commit(
                     find_object: find_oid,
                     submodule_mode: args.submodule.as_deref(),
                     context_lines: args.unified.unwrap_or(3),
+                    indent_heuristic,
                 };
                 write_remerge_diff(out, repo, &commit.tree, &commit.parents, &o)?;
             }
@@ -909,7 +968,6 @@ fn show_commit(
         return Ok(());
     }
 
-    let config = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
     let abbrev_len = if args.no_abbrev {
         40usize
     } else {
@@ -1267,9 +1325,17 @@ fn show_commit(
                 context,
                 &args.anchored,
                 line_algo,
+                indent_heuristic,
             )
         } else {
-            unified_diff(&old_content, &new_content, old_path, new_path, context)
+            unified_diff(
+                &old_content,
+                &new_content,
+                old_path,
+                new_path,
+                context,
+                indent_heuristic,
+            )
         };
         write!(out, "{patch}")?;
     }
@@ -1499,6 +1565,7 @@ fn show_tag(
     data: &[u8],
     args: &Args,
     notes_map: &HashMap<ObjectId, Vec<u8>>,
+    indent_heuristic: bool,
 ) -> Result<()> {
     let odb = &repo.odb;
     let tag = parse_tag(data).context("parsing tag")?;
@@ -1535,10 +1602,19 @@ fn show_tag(
                 &[],
                 None,
                 None,
+                indent_heuristic,
             )?;
         }
         ObjectKind::Tag => {
-            show_tag(out, repo, "", &tagged_obj.data, args, notes_map)?;
+            show_tag(
+                out,
+                repo,
+                "",
+                &tagged_obj.data,
+                args,
+                notes_map,
+                indent_heuristic,
+            )?;
         }
         ObjectKind::Tree => {
             let tree_oid = peel_to_tree(repo, tag.object).context("peeling tag to tree")?;

--- a/grit/src/commands/stash.rs
+++ b/grit/src/commands/stash.rs
@@ -912,6 +912,7 @@ fn do_stash_patch_push(
                     &cur_work,
                     &ops[s..e],
                     3,
+                    true,
                 );
 
                 writeln!(out, "diff --git a/{path} b/{path}").ok();
@@ -1170,6 +1171,7 @@ pub(crate) fn partial_unified_for_op_range(
     work_bytes: &[u8],
     op_slice: &[similar::DiffOp],
     context: usize,
+    indent_heuristic: bool,
 ) -> String {
     let head_str = String::from_utf8_lossy(head_bytes);
     let work_str = String::from_utf8_lossy(work_bytes);
@@ -1223,7 +1225,14 @@ pub(crate) fn partial_unified_for_op_range(
         }
     }
 
-    let full = unified_diff(&old_partial, &new_partial, path, path, context);
+    let full = unified_diff(
+        &old_partial,
+        &new_partial,
+        path,
+        path,
+        context,
+        indent_heuristic,
+    );
     let mut tail: String = full
         .lines()
         .skip_while(|l| !l.starts_with("@@ "))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Rust port of Git’s change-compaction / indent-heuristic behavior (`xdl_change_compact`–style sliding of change groups), integrates it into `grit-lib` unified diff generation, and wires `diff.indentHeuristic` plus `--indent-heuristic` / `--no-indent-heuristic` through diff-related commands (diff, diff-tree, diff-index, diff-files, log, show, stash, format-patch, remerge paths).

## Validation

- `cargo fmt`
- `cargo clippy --fix --allow-dirty -p grit-lib -p grit-rs`
- `cargo test -p grit-lib --lib` (160 passed)
- `./scripts/run-tests.sh t4061-diff-indent.sh` → **6/33** (work in progress; blame and remaining cases still need alignment with Git)

## Note

There is an unrelated local modification in `grit/src/commands/cherry_pick.rs` that was **not** included in this commit.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-644a7112-b7e1-4bfd-add4-02ca2ea843a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-644a7112-b7e1-4bfd-add4-02ca2ea843a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

