### PR TITLE
fix: make t7817-grep-sparse-checkout pass (8/8)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1278,7 +1278,7 @@ t7813-grep-icase-iso	t7	yes	2	2	0	true	ok	0
 t7814-grep-recurse-submodules	t7	yes	27	19	8	false	ok	7
 t7815-grep-binary	t7	yes	22	22	0	true	ok	0
 t7816-grep-binary-pattern	t7	yes	145	145	0	true	ok	0
-t7817-grep-sparse-checkout	t7	yes	8	5	3	false	ok	0
+t7817-grep-sparse-checkout	t7	yes	8	8	0	true	ok	0
 t7818-grep-extended	t7	yes	11	8	3	false	ok	0
 t7900-maintenance	t7	yes	72	31	41	false	ok	0
 t7901-stash-resolve-merge	t7	yes	7	7	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,689 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,689 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T02:12:48+00:00" class="gen-time" title="2026-04-10 02:12 UTC">2026-04-10 02:12 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,689</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">49/126 files · 11 skipped · 2,497/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.1%"></div></div>
+        <span class="group-pct pct-blue">69.1%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35689 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,689 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T02:12:48+00:00" class="gen-time" title="2026-04-10 02:12 UTC">2026-04-10 02:12 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,689</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">
@@ -12937,14 +12937,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="8" data-passed="5">
+<tr class="" data-group="t7" data-tests="8" data-passed="8" data-full-pass="1">
   <td class="mono">t7817-grep-sparse-checkout</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">8</td>
-  <td class="right">5</td>
+  <td class="right">8</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:62.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="11" data-passed="8">

--- a/grit-lib/src/ignore.rs
+++ b/grit-lib/src/ignore.rs
@@ -646,21 +646,28 @@ impl SparsePattern {
             return None;
         }
 
-        let mut anchored = false;
-        if let Some(rest) = raw.strip_prefix('/') {
-            anchored = true;
-            raw = rest.to_owned();
+        // Git `parse_path_pattern`: trailing `/` sets `PATTERN_FLAG_MUSTBEDIR` and shortens the
+        // active pattern length without turning `/*` into an empty body (that would drop the rule).
+        let mut directory_only = false;
+        if raw.len() > 1 && raw.ends_with('/') {
+            directory_only = true;
+            raw.pop();
         }
         if raw.is_empty() {
             return None;
         }
 
-        let mut directory_only = false;
-        if let Some(rest) = raw.strip_suffix('/') {
-            directory_only = true;
+        let mut anchored = false;
+        if let Some(rest) = raw.strip_prefix('/') {
+            anchored = true;
             raw = rest.to_owned();
         }
-        if raw.is_empty() {
+        // After `/*` → pop `/` we get `"/"` then strip leading `/` → empty. Git keeps this as the
+        // root glob `*` (include all top-level names in non-cone sparse files).
+        if raw.is_empty() && anchored && directory_only {
+            raw = "*".to_owned();
+            directory_only = false;
+        } else if raw.is_empty() {
             return None;
         }
 
@@ -684,9 +691,21 @@ fn sparse_pattern_matches(p: &SparsePattern, pathname: &str, as_directory: bool)
     if p.directory_only && !as_directory {
         return false;
     }
+    // On-disk `!/*/` parses as directory-only anchored `*`. For regular files we exclude nested
+    // paths only (`dir/c`, not `a`). When walking parents (`as_directory`), Git still matches this
+    // pattern against directory paths like `dir` so `dir/c` can be excluded (t7817).
+    if p.directory_only && p.anchored && !p.has_slash && p.body == "*" {
+        let trimmed = pathname.trim_end_matches('/');
+        return trimmed.contains('/') || as_directory;
+    }
     if !p.has_slash && !p.anchored {
         sparse_unanchored_basename_matches(&p.body, pathname)
             || wildmatch(p.body.as_bytes(), pathname.as_bytes(), WM_PATHNAME)
+    } else if p.anchored && !p.has_slash && p.body == "*" && !p.directory_only {
+        // Sparse line `/*`: include only top-level paths (one segment). `WM_PATHNAME` keeps `*`
+        // from matching `/`, but we match against the bare pathname; require no `/` so `dir/c` is
+        // not included by `/*` alone (t7817 — excluded via `!/*/` on the parent directory pass).
+        !pathname.contains('/')
     } else {
         wildmatch(p.body.as_bytes(), pathname.as_bytes(), WM_PATHNAME)
     }
@@ -729,7 +748,7 @@ fn sparse_list_last_match(
 /// each step uses last-match-wins over patterns; `UNDECIDED` falls back to the parent
 /// directory until the decision is made or the path is rejected at the top level.
 #[must_use]
-pub fn path_in_sparse_checkout(path: &str, lines: &[String]) -> bool {
+pub fn path_in_sparse_checkout(path: &str, lines: &[String], work_tree: Option<&Path>) -> bool {
     if path.is_empty() {
         return true;
     }
@@ -746,19 +765,18 @@ pub fn path_in_sparse_checkout(path: &str, lines: &[String]) -> bool {
 
     loop {
         let pathname = &path[..end];
+        let dtype_is_dir = work_tree.is_some_and(|wt| wt.join(pathname).is_dir()) || as_directory;
 
-        match sparse_list_last_match(pathname, as_directory, &parsed) {
+        match sparse_list_last_match(pathname, dtype_is_dir, &parsed) {
             Some(true) => return true,
             Some(false) => return false,
             None => {
-                if end == 0 {
+                let Some(slash) = path[..end].rfind('/') else {
+                    // Top-level path with no matching rule: Git stops here (UNDECIDED → excluded),
+                    // not at an empty pathname.
                     return false;
-                }
-                if let Some(slash) = path[..end].rfind('/') {
-                    end = slash;
-                } else {
-                    end = 0;
-                }
+                };
+                end = slash;
                 as_directory = true;
             }
         }

--- a/grit-lib/src/sparse_checkout.rs
+++ b/grit-lib/src/sparse_checkout.rs
@@ -20,6 +20,12 @@ impl NonConePatterns {
         Self { lines }
     }
 
+    /// Sparse-checkout pattern lines in file order (for Git-style inclusion checks).
+    #[must_use]
+    pub fn lines(&self) -> &[String] {
+        &self.lines
+    }
+
     /// Parse a sparse-checkout file into ordered patterns (non-cone mode).
     #[must_use]
     pub fn parse(content: &str) -> Self {
@@ -396,13 +402,14 @@ pub fn path_in_sparse_checkout(
     cone_config: bool,
     cone: Option<&ConePatterns>,
     non_cone: &NonConePatterns,
+    work_tree: Option<&std::path::Path>,
 ) -> bool {
     if cone_config {
         if let Some(c) = cone {
             return c.path_included(path);
         }
     }
-    non_cone.path_included(path)
+    crate::ignore::path_in_sparse_checkout(path, non_cone.lines(), work_tree)
 }
 
 /// Apply sparse-checkout rules to `index`: stage-0 entries get `skip-worktree` when excluded.
@@ -417,6 +424,7 @@ pub fn path_in_sparse_checkout(
 /// - `index` — index to update in place; bumped to version 3 when any entry is marked skip-worktree.
 pub fn apply_sparse_checkout_skip_worktree(
     git_dir: &std::path::Path,
+    work_tree: Option<&std::path::Path>,
     index: &mut crate::index::Index,
 ) {
     let config = crate::config::ConfigSet::load(Some(git_dir), true)
@@ -457,12 +465,17 @@ pub fn apply_sparse_checkout_skip_worktree(
             continue;
         }
         let path_str = String::from_utf8_lossy(&entry.path);
-        let included = path_in_sparse_checkout(
-            path_str.as_ref(),
-            effective_cone,
-            cone_struct.as_ref(),
-            &non_cone,
-        );
+        let included = if effective_cone {
+            path_in_sparse_checkout(
+                path_str.as_ref(),
+                true,
+                cone_struct.as_ref(),
+                &non_cone,
+                work_tree,
+            )
+        } else {
+            crate::ignore::path_in_sparse_checkout(path_str.as_ref(), non_cone.lines(), work_tree)
+        };
         entry.set_skip_worktree(!included);
         if !included {
             any_skip = true;
@@ -558,6 +571,11 @@ pub fn clear_skip_worktree_from_present_files(
     let mut found = PathFoundData { dir: String::new() };
     for entry in &mut index.entries {
         if entry.stage() != 0 || !entry.skip_worktree() {
+            continue;
+        }
+        // With assume-unchanged (CE_VALID), Git keeps skip-worktree for `git grep` semantics
+        // (t7817: present file + both bits still excluded from work-tree index grep).
+        if entry.assume_unchanged() {
             continue;
         }
         let rel = String::from_utf8_lossy(&entry.path);
@@ -1057,9 +1075,9 @@ pub fn path_matches_sparse_patterns(path: &str, patterns: &[String], cone_mode: 
             let inner = prefix_with_slash.trim_start_matches('/');
             if inner.is_empty() {
                 false
-            } else if negated && core_pattern == "/*/" {
-                // Cone expanded form: after `/*` includes all top-level names, `!/*/` removes
-                // nested paths (two+ segments). Single-segment paths like `a` stay included.
+            } else if inner == "*" {
+                // `/*/` and `!/*/` in expanded-cone files: match only nested paths (contain `/`),
+                // not every top-level name (plain `wildmatch("*", …)` would match `sub2`, etc.).
                 let trimmed = path.trim_end_matches('/');
                 trimmed.contains('/')
             } else if inner.contains('*') || inner.contains('?') || inner.contains('[') {

--- a/grit/src/commands/checkout.rs
+++ b/grit/src/commands/checkout.rs
@@ -2525,7 +2525,7 @@ fn switch_to_tree(
         new_index.sort();
     }
 
-    apply_sparse_checkout_skip_worktree(&repo.git_dir, &mut new_index);
+    apply_sparse_checkout_skip_worktree(&repo.git_dir, repo.work_tree.as_deref(), &mut new_index);
 
     // Perform the actual working tree update.
     // When force, write all entries even if OID matches (to restore dirty files).

--- a/grit/src/commands/grep.rs
+++ b/grit/src/commands/grep.rs
@@ -20,6 +20,7 @@ use grit_lib::objects::{parse_commit, parse_tree, ObjectId, ObjectKind};
 use grit_lib::refs::resolve_ref;
 use grit_lib::repo::Repository;
 use grit_lib::rev_parse::{discover_optional, resolve_revision, show_prefix, split_treeish_colon};
+use grit_lib::sparse_checkout::clear_skip_worktree_from_present_files;
 use grit_lib::wildmatch::wildmatch;
 
 use crate::pathspec::resolve_pathspec;
@@ -1070,7 +1071,10 @@ fn grep_worktree(
         .as_deref()
         .ok_or_else(|| anyhow::anyhow!("cannot grep in bare repository"))?;
 
-    let index = repo.load_index().context("loading index")?;
+    let mut index = repo.load_index().context("loading index")?;
+    // Match Git: present files clear skip-worktree for in-memory grep (superproject and nested
+    // submodules — t7817 `sub/B/b` with cone sparse inside `sub`).
+    clear_skip_worktree_from_present_files(&repo.git_dir, work_tree, &mut index);
     let diff_attrs = load_diff_attrs(work_tree);
     let mut seen_stage0 = std::collections::HashSet::new();
     let mut unmerged_worktree_grepped = std::collections::HashSet::new();
@@ -1200,6 +1204,12 @@ fn grep_worktree(
             continue;
         }
         if !seen_stage0.insert(path_str.clone()) {
+            continue;
+        }
+
+        // `git grep` on the work tree never reads the index for paths that have both
+        // assume-unchanged and skip-worktree (t7817).
+        if entry.assume_unchanged() && entry.skip_worktree() {
             continue;
         }
 

--- a/grit/src/commands/merge.rs
+++ b/grit/src/commands/merge.rs
@@ -989,7 +989,7 @@ fn merge_unborn(repo: &Repository, head: &HeadState, args: &Args) -> Result<()> 
     let mut index = Index::new();
     index.entries = entries;
     index.sort();
-    apply_sparse_checkout_skip_worktree(&repo.git_dir, &mut index);
+    apply_sparse_checkout_skip_worktree(&repo.git_dir, repo.work_tree.as_deref(), &mut index);
 
     if let Some(ref wt) = repo.work_tree {
         checkout_entries(
@@ -1033,7 +1033,7 @@ fn do_fast_forward(
     let current_index = repo.load_index()?;
     let old_tree = commit_tree(repo, head_oid)?;
     let mut new_index = compose_fast_forward_index(repo, commit.tree, old_tree, &current_index)?;
-    apply_sparse_checkout_skip_worktree(&repo.git_dir, &mut new_index);
+    apply_sparse_checkout_skip_worktree(&repo.git_dir, repo.work_tree.as_deref(), &mut new_index);
     let old_entries = tree_to_map(tree_to_index_entries(repo, &old_tree, "")?);
     let index_dirty_vs_head = diff_index::index_cached_differs_from_head(repo)?;
     let index_already_at_target = index_matches_commit_tree(repo, merge_oid)?;
@@ -1542,7 +1542,11 @@ Aborting"
         None,
         None,
     )?;
-    apply_sparse_checkout_skip_worktree(&repo.git_dir, &mut merge_result.index);
+    apply_sparse_checkout_skip_worktree(
+        &repo.git_dir,
+        repo.work_tree.as_deref(),
+        &mut merge_result.index,
+    );
 
     let append_strategy_failed = std::env::var("GIT_MERGE_VERBOSITY")
         .ok()
@@ -2561,7 +2565,7 @@ fn do_octopus_merge(
     final_index.entries = current_tree_entries;
     final_index.sort();
     compose_octopus_final_index(&pre_merge_index, &mut final_index);
-    apply_sparse_checkout_skip_worktree(&repo.git_dir, &mut final_index);
+    apply_sparse_checkout_skip_worktree(&repo.git_dir, repo.work_tree.as_deref(), &mut final_index);
     repo.write_index(&mut final_index)?;
 
     let sparse_on = sparse_checkout_enabled(&repo.git_dir);
@@ -2882,7 +2886,7 @@ fn do_strategy_theirs(
     let mut new_index = Index::new();
     new_index.entries = entries;
     new_index.sort();
-    apply_sparse_checkout_skip_worktree(&repo.git_dir, &mut new_index);
+    apply_sparse_checkout_skip_worktree(&repo.git_dir, repo.work_tree.as_deref(), &mut new_index);
 
     if let Some(ref wt) = repo.work_tree {
         let old_tree = commit_tree(repo, head_oid)?;
@@ -3097,7 +3101,7 @@ fn do_squash(
     let mut new_index = Index::new();
     new_index.entries = entries;
     new_index.sort();
-    apply_sparse_checkout_skip_worktree(&repo.git_dir, &mut new_index);
+    apply_sparse_checkout_skip_worktree(&repo.git_dir, repo.work_tree.as_deref(), &mut new_index);
 
     if let Some(ref wt) = repo.work_tree {
         checkout_entries(
@@ -3148,6 +3152,35 @@ fn do_squash_from_merge(
     Ok(())
 }
 
+/// Remove work tree paths that are `skip-worktree` in `index` so merge abort does not leave
+/// conflict-marker files that `checkout_entries` skipped (sparse-checkout, t7817).
+fn remove_skip_worktree_paths_from_worktree(work_tree: &Path, index: &Index) -> Result<()> {
+    for entry in &index.entries {
+        if entry.stage() != 0 || !entry.skip_worktree() {
+            continue;
+        }
+        if entry.mode == MODE_TREE {
+            continue;
+        }
+        let path_str = String::from_utf8_lossy(&entry.path);
+        let abs = work_tree.join(path_str.as_ref());
+        let meta = match fs::symlink_metadata(&abs) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if entry.mode == MODE_GITLINK && meta.is_dir() && abs.join(".git").exists() {
+            continue;
+        }
+        if meta.is_dir() {
+            let _ = fs::remove_dir_all(&abs);
+        } else {
+            let _ = fs::remove_file(&abs);
+        }
+        remove_empty_parent_dirs_merge(work_tree, &abs);
+    }
+    Ok(())
+}
+
 /// Abort an in-progress merge.
 fn merge_abort() -> Result<()> {
     let repo = Repository::discover(None).context("not a git repository")?;
@@ -3175,16 +3208,17 @@ fn merge_abort() -> Result<()> {
     let mut index = Index::new();
     index.entries = entries;
     index.sort();
-    apply_sparse_checkout_skip_worktree(&repo.git_dir, &mut index);
+    apply_sparse_checkout_skip_worktree(&repo.git_dir, repo.work_tree.as_deref(), &mut index);
 
+    let sparse_on = sparse_checkout_enabled(&repo.git_dir);
     if let Some(ref wt) = repo.work_tree {
-        checkout_entries(
-            &repo,
-            wt,
-            &index,
-            None,
-            sparse_checkout_enabled(&repo.git_dir),
-        )?;
+        checkout_entries(&repo, wt, &index, None, sparse_on)?;
+        // `checkout_entries` skips skip-worktree paths, so conflict markers left in the work tree
+        // (e.g. t7817 file `b` outside the sparse cone) are not overwritten. Remove them so
+        // `git checkout main` and later `git grep --cached` see a consistent tree (matches Git).
+        if sparse_on {
+            remove_skip_worktree_paths_from_worktree(wt, &index)?;
+        }
     }
     refresh_index_stat_cache_from_worktree(&repo, &mut index)?;
     repo.write_index(&mut index)?;

--- a/grit/src/commands/read_tree.rs
+++ b/grit/src/commands/read_tree.rs
@@ -314,7 +314,7 @@ pub fn run(args: Args) -> Result<()> {
     }
 
     // Apply sparse checkout: set skip-worktree on entries not matching patterns
-    apply_sparse_checkout(&repo.git_dir, &mut new_index)?;
+    apply_sparse_checkout(&repo.git_dir, repo.work_tree.as_deref(), &mut new_index)?;
 
     if args.update {
         validate_worktree_updates(
@@ -816,8 +816,12 @@ fn stage_entry(index: &mut Index, src: &IndexEntry, stage: u8) {
 }
 
 /// Check if `core.sparseCheckout` is enabled and apply skip-worktree bits.
-fn apply_sparse_checkout(git_dir: &Path, index: &mut Index) -> Result<()> {
-    apply_sparse_checkout_skip_worktree(git_dir, index);
+fn apply_sparse_checkout(
+    git_dir: &Path,
+    work_tree: Option<&Path>,
+    index: &mut Index,
+) -> Result<()> {
+    apply_sparse_checkout_skip_worktree(git_dir, work_tree, index);
     Ok(())
 }
 
@@ -1255,7 +1259,7 @@ pub fn am_clean_index(
     let orig_map = tree_to_map(tree_to_index_entries(repo, &orig_tree_oid, "", prot)?);
     let mut phase2 = two_way_merge(repo, &phase1, &head_map, &orig_map)?;
 
-    apply_sparse_checkout(&repo.git_dir, &mut phase2)?;
+    apply_sparse_checkout(&repo.git_dir, repo.work_tree.as_deref(), &mut phase2)?;
 
     if repo.work_tree.is_some() {
         checkout_index_entries(repo, &phase1, &phase2)?;

--- a/grit/src/commands/rm.rs
+++ b/grit/src/commands/rm.rs
@@ -259,7 +259,13 @@ pub fn run(mut args: Args) -> Result<()> {
                 .into_iter()
                 .filter(|p| {
                     index.get(p.as_bytes(), 0).is_some_and(|e| {
-                        rm_entry_matches_sparse_worktree(e, p, &sparse_patterns, cone_cfg)
+                        rm_entry_matches_sparse_worktree(
+                            e,
+                            p,
+                            &sparse_patterns,
+                            cone_cfg,
+                            Some(work_tree),
+                        )
                     })
                 })
                 .collect()
@@ -436,6 +442,7 @@ fn rm_entry_matches_sparse_worktree(
     path: &str,
     patterns: &[String],
     cone_cfg: bool,
+    work_tree: Option<&std::path::Path>,
 ) -> bool {
     if entry.skip_worktree() {
         return false;
@@ -445,7 +452,7 @@ fn rm_entry_matches_sparse_worktree(
     } else if cone_cfg {
         path_in_sparse_checkout_patterns(path, patterns, true)
     } else {
-        path_in_sparse_checkout_lines(path, patterns)
+        path_in_sparse_checkout_lines(path, patterns, work_tree)
     };
     in_sparse
 }

--- a/grit/src/commands/sparse_checkout.rs
+++ b/grit/src/commands/sparse_checkout.rs
@@ -9,7 +9,7 @@ use clap::{Args as ClapArgs, Subcommand};
 use grit_lib::config::{ConfigFile, ConfigScope};
 use grit_lib::error::Error as GritError;
 use grit_lib::ignore::path_in_sparse_checkout as path_in_sparse_checkout_lines;
-use grit_lib::index::MODE_TREE;
+use grit_lib::index::{MODE_GITLINK, MODE_TREE};
 use grit_lib::objects::parse_commit;
 use grit_lib::repo::Repository;
 use grit_lib::sparse_checkout::{
@@ -686,10 +686,12 @@ fn cmd_disable(repo: &Repository) -> Result<()> {
         .as_deref()
         .ok_or_else(|| anyhow::anyhow!("this operation must be run in a work tree"))?;
 
+    // Match Git `sparse_checkout_disable`: build an in-memory `/*` pattern list to expand the
+    // work tree to a full checkout, but do **not** overwrite `info/sparse-checkout` with only
+    // `/*` — that would erase stored rules like `!b` and break a later `sparse-checkout init`
+    // (t7817).
     set_sparse_config(repo, true)?;
     set_sparse_index_config(repo, false)?;
-
-    write_sparse_file(repo, "/*\n")?;
 
     let patterns = vec!["/*".to_string()];
     apply_sparse_patterns(repo, &patterns, false)?;
@@ -776,7 +778,13 @@ fn cmd_check_rules(repo: &Repository, args: &CheckRulesArgs) -> Result<()> {
             }
             let path = String::from_utf8_lossy(&line);
             let path = path.as_ref();
-            if path_in_sparse_checkout(path, effective_cone, cone_pat.as_ref(), &non_cone) {
+            if path_in_sparse_checkout(
+                path,
+                effective_cone,
+                cone_pat.as_ref(),
+                &non_cone,
+                repo.work_tree.as_deref(),
+            ) {
                 out.write_all(line.as_slice())?;
                 out.write_all(&[0])?;
             }
@@ -793,7 +801,13 @@ fn cmd_check_rules(repo: &Repository, args: &CheckRulesArgs) -> Result<()> {
             }
             let path = String::from_utf8_lossy(&line);
             let path = path.as_ref();
-            if path_in_sparse_checkout(path, effective_cone, cone_pat.as_ref(), &non_cone) {
+            if path_in_sparse_checkout(
+                path,
+                effective_cone,
+                cone_pat.as_ref(),
+                &non_cone,
+                repo.work_tree.as_deref(),
+            ) {
                 writeln!(out, "{path}")?;
             }
         }
@@ -1117,9 +1131,15 @@ fn apply_sparse_patterns(repo: &Repository, patterns: &[String], cone_mode: bool
         // Non-cone mode must use Git's `path_in_sparse_checkout` (parent walk + last-match),
         // not `NonConePatterns::path_included` (sequential toggles). See t3602-rm-sparse-checkout.
         let matches = if effective_cone {
-            path_in_sparse_checkout(&path_str, true, cone_struct.as_ref(), &non_cone)
+            path_in_sparse_checkout(
+                &path_str,
+                true,
+                cone_struct.as_ref(),
+                &non_cone,
+                Some(work_tree),
+            )
         } else {
-            path_in_sparse_checkout_lines(&path_str, patterns)
+            path_in_sparse_checkout_lines(&path_str, patterns, Some(work_tree))
         };
 
         if matches {
@@ -1198,23 +1218,85 @@ fn apply_sparse_patterns(repo: &Repository, patterns: &[String], cone_mode: bool
         .iter()
         .map(|e| String::from_utf8_lossy(&e.path).into_owned())
         .collect();
+    let gitlink_paths: HashSet<String> = index
+        .entries
+        .iter()
+        .filter(|e| e.stage() == 0 && e.mode == MODE_GITLINK)
+        .map(|e| String::from_utf8_lossy(&e.path).into_owned())
+        .collect();
     remove_untracked_outside_sparse(
         work_tree,
         work_tree,
         &indexed_paths,
+        &gitlink_paths,
         patterns,
         effective_cone,
         cone_struct.as_ref(),
         &non_cone,
     )?;
 
+    // Submodule work trees keep their own `info/sparse-checkout`. After the superproject applies
+    // sparsity we skip cleaning inside gitlink dirs (so we do not delete `sub/B/b`), so re-run the
+    // submodule's sparse rules so paths like `sub/A` are pruned (t7817).
+    for entry in &index.entries {
+        if entry.stage() != 0 || entry.mode != MODE_GITLINK {
+            continue;
+        }
+        let rel = String::from_utf8_lossy(&entry.path);
+        let included = if effective_cone {
+            path_in_sparse_checkout(
+                rel.as_ref(),
+                true,
+                cone_struct.as_ref(),
+                &non_cone,
+                Some(work_tree),
+            )
+        } else {
+            path_in_sparse_checkout_lines(rel.as_ref(), patterns, Some(work_tree))
+        };
+        if !included {
+            continue;
+        }
+        let sub_wt = work_tree.join(rel.as_ref());
+        if let Ok(sub_repo) = open_gitlink_worktree_repo(&sub_wt) {
+            let _ = reapply_sparse_checkout_if_configured(&sub_repo);
+        }
+    }
+
     Ok(())
+}
+
+fn open_gitlink_worktree_repo(sub_work_tree: &Path) -> Result<Repository> {
+    let git_path = sub_work_tree.join(".git");
+    if !git_path.try_exists().context("stat submodule .git")? {
+        bail!("missing .git in {}", sub_work_tree.display());
+    }
+    if git_path.is_dir() {
+        Repository::open(&git_path, Some(sub_work_tree)).context("open submodule repository")
+    } else {
+        let content =
+            fs::read_to_string(&git_path).with_context(|| git_path.display().to_string())?;
+        let gitdir = content
+            .trim()
+            .strip_prefix("gitdir: ")
+            .ok_or_else(|| anyhow::anyhow!("invalid gitdir file {}", git_path.display()))?;
+        let gitdir_path = if Path::new(gitdir).is_absolute() {
+            PathBuf::from(gitdir)
+        } else {
+            sub_work_tree.join(gitdir)
+        };
+        let gitdir_path = gitdir_path
+            .canonicalize()
+            .with_context(|| format!("resolve gitdir {}", gitdir_path.display()))?;
+        Repository::open(&gitdir_path, Some(sub_work_tree)).context("open submodule repository")
+    }
 }
 
 fn remove_untracked_outside_sparse(
     work_tree: &Path,
     current: &Path,
     indexed_paths: &HashSet<String>,
+    gitlink_paths: &HashSet<String>,
     patterns: &[String],
     effective_cone: bool,
     cone_struct: Option<&ConePatterns>,
@@ -1231,15 +1313,24 @@ fn remove_untracked_outside_sparse(
             .unwrap_or(&path)
             .to_string_lossy()
             .replace('\\', "/");
-        if rel == ".git" || rel.starts_with(".git/") {
+        // Skip the main repo's `.git` and every nested `.git` (e.g. `sub/.git` for submodules).
+        if rel == ".git"
+            || rel.starts_with(".git/")
+            || rel.ends_with("/.git")
+            || rel.contains("/.git/")
+        {
             continue;
         }
         let meta = fs::symlink_metadata(&path).context("stat work tree path")?;
         if meta.is_dir() {
+            if gitlink_paths.contains(&rel) {
+                continue;
+            }
             remove_untracked_outside_sparse(
                 work_tree,
                 &path,
                 indexed_paths,
+                gitlink_paths,
                 patterns,
                 effective_cone,
                 cone_struct,
@@ -1250,9 +1341,9 @@ fn remove_untracked_outside_sparse(
                 .unwrap_or(false)
             {
                 let included = if effective_cone {
-                    path_in_sparse_checkout(&rel, true, cone_struct, non_cone)
+                    path_in_sparse_checkout(&rel, true, cone_struct, non_cone, Some(work_tree))
                 } else {
-                    path_in_sparse_checkout_lines(&rel, patterns)
+                    path_in_sparse_checkout_lines(&rel, patterns, Some(work_tree))
                 };
                 if !included && !indexed_paths.contains(&rel) {
                     let _ = fs::remove_dir(&path);
@@ -1270,9 +1361,9 @@ fn remove_untracked_outside_sparse(
             continue;
         }
         let included = if effective_cone {
-            path_in_sparse_checkout(&rel, true, cone_struct, non_cone)
+            path_in_sparse_checkout(&rel, true, cone_struct, non_cone, Some(work_tree))
         } else {
-            path_in_sparse_checkout_lines(&rel, patterns)
+            path_in_sparse_checkout_lines(&rel, patterns, Some(work_tree))
         };
         if !included {
             let _ = fs::remove_file(&path);
@@ -1295,7 +1386,7 @@ pub(crate) fn path_matches_sparse_patterns(
     if cone_mode {
         return grit_lib::sparse_checkout::path_matches_sparse_patterns(path, patterns, cone_mode);
     }
-    path_in_sparse_checkout_lines(path, patterns)
+    path_in_sparse_checkout_lines(path, patterns, None)
 }
 
 fn list_files_under_dir(dir: &Path, work_tree: &Path) -> Result<Vec<String>> {

--- a/grit/src/commands/update_index.rs
+++ b/grit/src/commands/update_index.rs
@@ -634,6 +634,35 @@ pub fn run(args: Args, raw_rest: &[String]) -> Result<()> {
             continue;
         }
 
+        // Bit updates must run even when the entry already has skip-worktree (e.g. t7817:
+        // `git update-index --skip-worktree sub2` on a gitlink).
+        if args.assume_unchanged {
+            if let Some(e) = index.get_mut(&rel_bytes, 0) {
+                e.set_assume_unchanged(true);
+            }
+            continue;
+        }
+        if args.no_assume_unchanged {
+            if let Some(e) = index.get_mut(&rel_bytes, 0) {
+                e.set_assume_unchanged(false);
+            }
+            continue;
+        }
+        if args.skip_worktree {
+            if let Some(e) = index.get_mut(&rel_bytes, 0) {
+                e.set_skip_worktree(true);
+                // Skip-worktree lives in extended flags; v2 index serialization drops them.
+                index.version = index.version.max(3);
+            }
+            continue;
+        }
+        if args.no_skip_worktree {
+            if let Some(e) = index.get_mut(&rel_bytes, 0) {
+                e.set_skip_worktree(false);
+            }
+            continue;
+        }
+
         // Git `read-cache.c:process_path`: skip-worktree entries are not refreshed from disk.
         // Plain `update-index <path>` is a no-op; `--remove` drops the index entry even when
         // the file still exists, unless `--ignore-skip-worktree-entries` is set.
@@ -663,34 +692,6 @@ pub fn run(args: Args, raw_rest: &[String]) -> Result<()> {
                 continue;
             }
             // File exists on disk — fall through to update it in the index.
-        }
-
-        if args.assume_unchanged {
-            if let Some(e) = index.get_mut(&rel_bytes, 0) {
-                e.set_assume_unchanged(true);
-            }
-            continue;
-        }
-        if args.no_assume_unchanged {
-            if let Some(e) = index.get_mut(&rel_bytes, 0) {
-                e.set_assume_unchanged(false);
-            }
-            continue;
-        }
-        if args.skip_worktree {
-            if let Some(e) = index.get_mut(&rel_bytes, 0) {
-                e.set_skip_worktree(true);
-                if e.flags_extended.is_some() {
-                    index.version = 3;
-                }
-            }
-            continue;
-        }
-        if args.no_skip_worktree {
-            if let Some(e) = index.get_mut(&rel_bytes, 0) {
-                e.set_skip_worktree(false);
-            }
-            continue;
         }
 
         // --chmod=+x or --chmod=-x without --add: change the mode of an existing entry.

--- a/logs/2026-04-09_t7817-grep-sparse-checkout.md
+++ b/logs/2026-04-09_t7817-grep-sparse-checkout.md
@@ -1,0 +1,20 @@
+# t7817-grep-sparse-checkout
+
+## Summary
+
+Made `tests/t7817-grep-sparse-checkout.sh` pass 8/8.
+
+## Key fixes
+
+- **Non-cone sparse matching** (`grit-lib/src/ignore.rs`): parse `/*` / `!/*/` like Git; parent-walk stops at top level without false include; optional work-tree dtype for directory-only patterns; anchored `/*` matches single segment only; `!/*/` directory pass matches nested paths.
+- **`path_matches_sparse_patterns`** (`grit-lib/src/sparse_checkout.rs`): `inner == "*"` for `/*/` lines; skip clearing skip-worktree when `assume_unchanged` (grep work-tree semantics).
+- **`apply_sparse_checkout_skip_worktree`**: takes optional work tree; threaded through read-tree/checkout/merge/rm.
+- **`sparse-checkout disable`**: apply in-memory `/*` only — do not overwrite stored pattern file with lone `/*` (t7817 merge flow).
+- **Submodule cleanup**: skip `remove_untracked_outside_sparse` inside gitlink dirs; reapply submodule sparse after super apply.
+- **`update-index`**: bit flags before skip-worktree early-continue; promote index to v3 when setting skip-worktree.
+- **`merge --abort`**: remove work-tree files for restored `skip-worktree` entries so conflict markers do not block `checkout main` (root cause of tests 4/6/8 failing after test 3).
+- **`grep`**: `clear_skip_worktree_from_present_files` before work-tree walk; skip both bits for work-tree path; CE_VALID+skip-worktree early continue.
+
+## Validation
+
+`./scripts/run-tests.sh t7817-grep-sparse-checkout.sh` → 8/8


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes `tests/t7817-grep-sparse-checkout.sh` pass all 8 cases by aligning sparse-checkout and grep behavior with Git for non-cone patterns, submodules, merge abort, and index flags.

## Changes

- **Sparse / ignore** (`grit-lib`): Git-style parsing for `/*`, `!/*/` and parent-walk semantics; optional worktree for directory-only pattern resolution; do not clear `skip-worktree` when `assume-unchanged` is also set (fixes `grep --cached` expectations).
- **Commands**: Thread worktree into `apply_sparse_checkout_skip_worktree` from checkout/read-tree/merge/rm; `sparse-checkout disable` applies in-memory `/*` without erasing stored patterns; submodule untracked cleanup skips gitlink trees and reapplies submodule sparse rules; `update-index --skip-worktree` applies reliably with index v3; `merge --abort` removes conflict files for restored `skip-worktree` paths; `grep` skips CE_VALID+skip-worktree for worktree search.
- **Harness**: Updated `data/test-files.csv` and generated dashboards after `./scripts/run-tests.sh t7817-grep-sparse-checkout.sh`.

## Validation

- `./scripts/run-tests.sh t7817-grep-sparse-checkout.sh` → 8/8
- `cargo test -p grit-lib --lib` → pass
- `cargo fmt`, `cargo check`, `cargo clippy --fix --allow-dirty -p grit-lib -p grit-rs`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1edadf08-2d90-49e7-89f1-f072b52d6406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1edadf08-2d90-49e7-89f1-f072b52d6406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

