### PR TITLE
fix: t12830-diff-cached-mode-change --stat assertion

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -336,7 +336,7 @@ t12790-update-ref-stderr-msg	t1	yes	33	33	0	true	ok	0
 t12800-check-ignore-recursive	t1	yes	38	38	0	true	ok	0
 t12810-merge-file-binary-text	t1	yes	38	38	0	true	ok	0
 t12820-diff-no-index-symlink	t1	yes	41	41	0	true	ok	0
-t12830-diff-cached-mode-change	t1	yes	38	37	1	false	ok	0
+t12830-diff-cached-mode-change	t1	yes	38	38	0	true	ok	0
 t12840-diff-tree-empty-commit	t1	yes	36	36	0	true	ok	0
 t12880-log-notes-display	t1	yes	34	33	1	false	ok	0
 t12890-log-grep-author	t1	yes	33	33	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,687 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,687 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T02:12:52+00:00" class="gen-time" title="2026-04-10 02:12 UTC">2026-04-10 02:12 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,687</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -197,7 +197,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">275/368 files · 8 skipped · 11,694/12,747 tests</span>
+        <span class="group-meta">276/368 files · 8 skipped · 11,695/12,747 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-green" style="width:91.7%"></div></div>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35687 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,687 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T02:12:52+00:00" class="gen-time" title="2026-04-10 02:12 UTC">2026-04-10 02:12 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,687</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -3517,14 +3517,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="38" data-passed="37">
+<tr class="" data-group="t1" data-tests="38" data-passed="38" data-full-pass="1">
   <td class="mono">t12830-diff-cached-mode-change</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">38</td>
-  <td class="right">37</td>
+  <td class="right">38</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:97.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="36" data-passed="36" data-full-pass="1">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/logs/2026-04-10_t12830-diff-cached-mode-change-stat.md
+++ b/logs/2026-04-10_t12830-diff-cached-mode-change-stat.md
@@ -1,0 +1,13 @@
+# t12830-diff-cached-mode-change
+
+## Issue
+
+Test 33 (`mode-only change with diff --cached --stat shows 0 changes`) used `! grep "insertion" actual`. Git (and grit) emit the summary line `1 file changed, 0 insertions(+), 0 deletions(-)`, which contains the substring `insertion`, so the negated grep always failed.
+
+## Fix
+
+Assert the full zero-count summary line instead of forbidding the word "insertion".
+
+## Verification
+
+- `./scripts/run-tests.sh t12830-diff-cached-mode-change.sh` → 38/38 pass.

--- a/tests/t12830-diff-cached-mode-change.sh
+++ b/tests/t12830-diff-cached-mode-change.sh
@@ -219,7 +219,7 @@ test_expect_success 'mode-only change with diff --cached --stat shows 0 changes'
      grit diff --cached --stat >../actual
     ) &&
     grep "1 file changed" actual &&
-    ! grep "insertion" actual
+    grep "0 insertions(+), 0 deletions(-)" actual
 '
 
 test_expect_success 'commit mode-only change' '


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t12830-diff-cached-mode-change` was failing on test 33 because it ran `! grep "insertion"` on `grit diff --cached --stat` output. Git-compatible stat summaries include the phrase `0 insertions(+), 0 deletions(-)`, so the substring `insertion` is always present and the test could never pass.

## Changes

- Update test 33 to assert the full zero-count summary line: `0 insertions(+), 0 deletions(-)`.
- Refreshed harness artifacts (`data/test-files.csv`, dashboards) after a full 38/38 pass.
- Added `logs/2026-04-10_t12830-diff-cached-mode-change-stat.md`.

## Verification

- `./scripts/run-tests.sh t12830-diff-cached-mode-change.sh` → 38/38
- `cargo test -p grit-lib --lib` → pass

No Rust behavior change was required; grit already matched Git’s stat output for this scenario.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea5aaa81-e8bb-4a97-a64d-9a27290744e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea5aaa81-e8bb-4a97-a64d-9a27290744e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

