### PR TITLE
fix: make t5519-push-alternates pass (alternates-aware push + unpack)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -935,7 +935,7 @@ t5515-fetch-merge-logic	t5	yes	65	1	64	false	ok	0
 t5516-fetch-push	t5	yes	124	40	84	false	ok	0
 t5517-push-mirror	t5	yes	13	7	6	false	ok	0
 t5518-fetch-exit-status	t5	yes	3	2	1	false	ok	0
-t5519-push-alternates	t5	yes	8	7	1	false	ok	0
+t5519-push-alternates	t5	yes	8	8	0	true	ok	0
 t5520-pull	t5	yes	80	19	61	false	ok	0
 t5521-pull-options	t5	yes	22	4	18	false	ok	0
 t5522-pull-symlink	t5	yes	4	1	3	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,687 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,687 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T02:17:30+00:00" class="gen-time" title="2026-04-10 02:17 UTC">2026-04-10 02:17 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,687</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">34/167 files · 17 skipped · 1,567/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.9%"></div></div>
+        <span class="group-pct pct-red">37.9%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35687 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,687 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T02:17:30+00:00" class="gen-time" title="2026-04-10 02:17 UTC">2026-04-10 02:17 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,687</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -9507,14 +9507,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:66.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="8" data-passed="7">
+<tr class="" data-group="t5" data-tests="8" data-passed="8" data-full-pass="1">
   <td class="mono">t5519-push-alternates</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">8</td>
-  <td class="right">7</td>
+  <td class="right">8</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:87.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="80" data-passed="19">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/odb.rs
+++ b/grit-lib/src/odb.rs
@@ -359,6 +359,56 @@ impl Odb {
         Ok(oid)
     }
 
+    /// Write an object as a loose file in this object directory only.
+    ///
+    /// Unlike [`Self::write`], this ignores `info/alternates` and
+    /// `GIT_ALTERNATE_OBJECT_DIRECTORIES`: if the object exists only in an
+    /// alternate store, it is still written here. That matches how Git's
+    /// `unpack-objects` materializes every packed object into the receiving
+    /// repository even when the same OID is already reachable via alternates
+    /// (see `t5519-push-alternates`).
+    ///
+    /// # Errors
+    ///
+    /// Same as [`Self::write`].
+    pub fn write_local(&self, kind: ObjectKind, data: &[u8]) -> Result<ObjectId> {
+        let store_bytes = build_store_bytes(kind, data);
+        let oid = hash_bytes(&store_bytes);
+
+        let path = self.object_path(&oid);
+        if path.exists() {
+            let _ = self.freshen_object(&oid);
+            return Ok(oid);
+        }
+        if self.exists_local(&oid) {
+            let _ = self.freshen_object(&oid);
+            return Ok(oid);
+        }
+
+        let prefix_dir = path
+            .parent()
+            .ok_or_else(|| Error::PathError("object path has no parent".to_owned()))?;
+        fs::create_dir_all(prefix_dir)?;
+
+        let tmp_path = prefix_dir.join(format!("tmp_{}", oid.loose_suffix()));
+        {
+            let tmp_file = fs::File::create(&tmp_path)?;
+            let mut encoder = ZlibEncoder::new(tmp_file, Compression::default());
+            encoder
+                .write_all(&store_bytes)
+                .map_err(|e| Error::Zlib(e.to_string()))?;
+            encoder.finish().map_err(|e| Error::Zlib(e.to_string()))?;
+        }
+        fs::rename(&tmp_path, &path)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = fs::set_permissions(&path, fs::Permissions::from_mode(0o444));
+        }
+
+        Ok(oid)
+    }
+
     /// Write an already-serialized object (header + data) to the loose store.
     ///
     /// Useful when the caller has the full store bytes (e.g. from stdin with
@@ -379,6 +429,51 @@ impl Odb {
             return Ok(oid);
         }
         if self.exists(&oid) {
+            let _ = self.freshen_object(&oid);
+            return Ok(oid);
+        }
+
+        let prefix_dir = path
+            .parent()
+            .ok_or_else(|| Error::PathError("object path has no parent".to_owned()))?;
+        fs::create_dir_all(prefix_dir)?;
+
+        let tmp_path = prefix_dir.join(format!("tmp_{}", oid.loose_suffix()));
+        {
+            let tmp_file = fs::File::create(&tmp_path)?;
+            let mut encoder = ZlibEncoder::new(tmp_file, Compression::default());
+            encoder
+                .write_all(store_bytes)
+                .map_err(|e| Error::Zlib(e.to_string()))?;
+            encoder.finish().map_err(|e| Error::Zlib(e.to_string()))?;
+        }
+        fs::rename(&tmp_path, &path)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = fs::set_permissions(&path, fs::Permissions::from_mode(0o444));
+        }
+
+        Ok(oid)
+    }
+
+    /// Like [`Self::write_raw`] but only consults this object directory, not alternates.
+    ///
+    /// See [`Self::write_local`].
+    ///
+    /// # Errors
+    ///
+    /// Same as [`Self::write_raw`].
+    pub fn write_raw_local(&self, store_bytes: &[u8]) -> Result<ObjectId> {
+        parse_object_bytes(store_bytes)?;
+
+        let oid = hash_bytes(store_bytes);
+        let path = self.object_path(&oid);
+        if path.exists() {
+            let _ = self.freshen_object(&oid);
+            return Ok(oid);
+        }
+        if self.exists_local(&oid) {
             let _ = self.freshen_object(&oid);
             return Ok(oid);
         }

--- a/grit-lib/src/unpack_objects.rs
+++ b/grit-lib/src/unpack_objects.rs
@@ -518,7 +518,9 @@ fn write_or_hash(kind: ObjectKind, data: &[u8], odb: &Odb, dry_run: bool) -> Res
     if dry_run {
         Ok(Odb::hash_object_data(kind, data))
     } else {
-        odb.write(kind, data)
+        // Always materialize into this ODB: objects reachable only via alternates must still be
+        // written locally (matches git unpack-objects; t5519-push-alternates).
+        odb.write_local(kind, data)
     }
 }
 

--- a/grit/src/commands/push.rs
+++ b/grit/src/commands/push.rs
@@ -12,6 +12,8 @@ use grit_lib::gitmodules::{oids_from_copied_object_paths, verify_gitmodules_for_
 use grit_lib::hooks::{run_hook, run_hook_capture, HookResult};
 use grit_lib::merge_base::is_ancestor;
 use grit_lib::objects::ObjectId;
+use grit_lib::odb::Odb;
+use grit_lib::pack::read_pack_index;
 use grit_lib::push_submodules::{
     collect_changed_gitlinks_for_push, find_unpushed_submodule_paths,
     format_unpushed_submodules_error, head_ref_short_name, parse_push_recurse_submodules_arg,
@@ -23,6 +25,7 @@ use grit_lib::repo::Repository;
 use grit_lib::rev_parse;
 use grit_lib::state::{resolve_head, HeadState};
 
+use std::collections::HashSet;
 use std::fs;
 use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
@@ -2728,9 +2731,13 @@ fn maybe_print_push_object_progress(show: bool) {
 
 /// Copy all objects (loose + packs) from src to dst, skipping existing.
 /// Copy objects and return the list of newly created files (for rollback).
+///
+/// Objects already reachable from `dst` via `objects/info/alternates` are not
+/// copied (`Odb::exists`), matching Git's send-pack behaviour (`t5519-push-alternates`).
 fn copy_objects_tracked(src_git_dir: &Path, dst_git_dir: &Path) -> Result<Vec<PathBuf>> {
     let src_objects = src_git_dir.join("objects");
     let dst_objects = dst_git_dir.join("objects");
+    let dst_odb = Odb::new(&dst_objects);
     let mut copied = Vec::new();
 
     if src_objects.is_dir() {
@@ -2748,6 +2755,15 @@ fn copy_objects_tracked(src_git_dir: &Path, dst_git_dir: &Path) -> Result<Vec<Pa
             for inner in fs::read_dir(entry.path())? {
                 let inner = inner?;
                 if inner.file_type()?.is_file() {
+                    let file_name = inner.file_name();
+                    let suffix = file_name.to_string_lossy();
+                    let hex = format!("{name_str}{suffix}");
+                    let Ok(oid) = ObjectId::from_hex(&hex) else {
+                        continue;
+                    };
+                    if dst_odb.exists(&oid) {
+                        continue;
+                    }
                     let dst_file = dst_dir.join(inner.file_name());
                     if !dst_file.exists() {
                         fs::create_dir_all(&dst_dir)?;
@@ -2765,16 +2781,45 @@ fn copy_objects_tracked(src_git_dir: &Path, dst_git_dir: &Path) -> Result<Vec<Pa
     let dst_pack = dst_objects.join("pack");
     if src_pack.is_dir() {
         fs::create_dir_all(&dst_pack)?;
+        let mut skip_pack_stems: HashSet<String> = HashSet::new();
         for entry in fs::read_dir(&src_pack)? {
             let entry = entry?;
-            if entry.file_type()?.is_file() {
-                let dst_file = dst_pack.join(entry.file_name());
-                if !dst_file.exists() {
-                    if fs::hard_link(entry.path(), &dst_file).is_err() {
-                        fs::copy(entry.path(), &dst_file)?;
-                    }
-                    copied.push(dst_file);
+            let path = entry.path();
+            if !entry.file_type()?.is_file() {
+                continue;
+            }
+            if path.extension().and_then(|s| s.to_str()) != Some("idx") {
+                continue;
+            }
+            let skip = read_pack_index(&path)
+                .map(|idx| idx.entries.iter().all(|e| dst_odb.exists(&e.oid)))
+                .unwrap_or(false);
+            if skip {
+                if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                    skip_pack_stems.insert(stem.to_owned());
                 }
+            }
+        }
+        for entry in fs::read_dir(&src_pack)? {
+            let entry = entry?;
+            if !entry.file_type()?.is_file() {
+                continue;
+            }
+            let path = entry.path();
+            let ext = path.extension().and_then(|s| s.to_str());
+            if matches!(ext, Some("idx") | Some("pack")) {
+                if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                    if skip_pack_stems.contains(stem) {
+                        continue;
+                    }
+                }
+            }
+            let dst_file = dst_pack.join(entry.file_name());
+            if !dst_file.exists() {
+                if fs::hard_link(entry.path(), &dst_file).is_err() {
+                    fs::copy(entry.path(), &dst_file)?;
+                }
+                copied.push(dst_file);
             }
         }
     }

--- a/logs/2026-04-10_t5519-push-alternates.md
+++ b/logs/2026-04-10_t5519-push-alternates.md
@@ -1,0 +1,16 @@
+# t5519-push-alternates
+
+## Failure
+
+Test 3 expected Alice’s second commit to stay out of `bob-pub` when `bob-pub` uses `objects/info/alternates` to `alice-pub/objects`. Grit’s local `git push` copies loose objects from the sender without checking the destination ODB (including alternates), so the commit object was copied into `bob-pub` anyway.
+
+## Fixes
+
+1. **`grit-lib`**: `Odb::write_local` / `write_raw_local` — write into the primary store even when the OID exists only in alternates. `unpack_objects` uses `write_local` so receive-pack materializes packed objects locally (matches Git’s unpack-objects).
+
+2. **`grit push`**: `copy_objects_tracked` — skip copying a loose object when `Odb::exists` on the remote `objects/` is true (local loose/pack + alternates). Skip copying a `.pack`/`.idx` pair when every OID in the index already exists on the destination (clone pack deduped against alternate).
+
+## Verification
+
+- `./scripts/run-tests.sh t5519-push-alternates.sh` → 8/8
+- `cargo test -p grit-lib --lib`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t5519-push-alternates` failed because grit’s **local file `push`** copied every loose object from the sender into the remote without checking whether the remote already had those objects via `objects/info/alternates`. The test removes alternates and expects Alice’s second commit to be absent from `bob-pub`.

## Changes

- **`grit push` / `copy_objects_tracked`**: Skip copying a loose object when `Odb::exists` on the destination `objects/` is true (covers local loose, packs, and alternates). Skip copying a `.pack`/`.idx` pair when every OID in the index already exists on the destination (avoids duplicating clone packs when the alternate already holds the objects).
- **`grit-lib`**: Add `Odb::write_local` / `write_raw_local` and use `write_local` from `unpack_objects` so receive-pack always materializes packed objects into the primary store even when the same OID exists only in an alternate (matches Git’s unpack-objects behaviour).

## Verification

- `./scripts/run-tests.sh t5519-push-alternates.sh` → **8/8**
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47de0317-dfb3-4ace-89a4-f27f8a04c6fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47de0317-dfb3-4ace-89a4-f27f8a04c6fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

