### PR TITLE
fix: make t3308-notes-merge fully pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -579,7 +579,7 @@ t3304-notes-mixed	t3	yes	6	6	0	true	ok	0
 t3305-notes-fanout	t3	yes	7	7	0	true	ok	0
 t3306-notes-prune	t3	yes	12	6	6	false	ok	0
 t3307-notes-man	t3	yes	3	3	0	true	ok	0
-t3308-notes-merge	t3	yes	19	4	15	false	ok	0
+t3308-notes-merge	t3	yes	19	19	0	true	ok	0
 t3309-notes-merge-auto-resolve	t3	yes	31	31	0	true	ok	0
 t3310-notes-merge-manual-resolve	t3	yes	22	20	2	false	ok	0
 t3311-notes-merge-fanout	t3	yes	24	17	7	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,701 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,701 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T02:25:05+00:00" class="gen-time" title="2026-04-10 02:25 UTC">2026-04-10 02:25 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,701</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -219,11 +219,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">56/141 files · 2 skipped · 4,052/5,398 tests</span>
+        <span class="group-meta">57/141 files · 2 skipped · 4,067/5,398 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:75.1%"></div></div>
-        <span class="group-pct pct-blue">75.1%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:75.3%"></div></div>
+        <span class="group-pct pct-blue">75.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35701 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,701 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T02:25:05+00:00" class="gen-time" title="2026-04-10 02:25 UTC">2026-04-10 02:25 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,701</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -5947,14 +5947,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="19" data-passed="4">
+<tr class="" data-group="t3" data-tests="19" data-passed="19" data-full-pass="1">
   <td class="mono">t3308-notes-merge</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">19</td>
-  <td class="right">4</td>
+  <td class="right">19</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:21.1%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="31" data-passed="31" data-full-pass="1">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit/src/commands/notes.rs
+++ b/grit/src/commands/notes.rs
@@ -8,13 +8,12 @@ use anyhow::{bail, Context, Result};
 use clap::{Args as ClapArgs, Subcommand};
 use merge3::{Merge3, StandardMarkers};
 use std::borrow::Cow;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 
 use grit_lib::config::ConfigSet;
-use grit_lib::diff::{diff_trees, zero_oid, DiffStatus};
 use grit_lib::merge_base::merge_bases_first_vs_rest;
 use grit_lib::objects::{
     parse_commit, parse_tree, serialize_commit, serialize_tree, tree_entry_cmp, CommitData,
@@ -134,6 +133,14 @@ pub enum NotesSubcommand {
         #[arg(long)]
         abort: bool,
 
+        /// More verbose output (repeat for more detail; matches Git).
+        #[arg(short = 'v', long = "verbose", action = clap::ArgAction::Count)]
+        verbose: u8,
+
+        /// Quieter output (repeat for less; matches Git).
+        #[arg(short = 'q', long = "quiet", action = clap::ArgAction::Count)]
+        quiet: u8,
+
         /// Merge strategy (manual, ours, theirs, union, cat_sort_uniq).
         #[arg(short = 's', long = "strategy")]
         strategy: Option<String>,
@@ -176,23 +183,37 @@ pub fn run(args: Args) -> Result<()> {
         format!("refs/notes/{notes_ref}")
     };
 
-    // Validate the notes ref — refuse refs outside refs/notes/.
-    if notes_ref.starts_with("refs/heads/") || notes_ref.starts_with("refs/remotes/") {
-        bail!(
-            "refusing to {} notes in {}",
-            match &args.command {
-                Some(NotesSubcommand::Add { .. }) => "add",
-                Some(NotesSubcommand::Edit { .. }) => "edit",
-                Some(NotesSubcommand::Append { .. }) => "append",
-                Some(NotesSubcommand::Remove { .. }) => "remove",
-                Some(NotesSubcommand::Copy { .. }) => "copy",
-                _ => "use",
-            },
-            notes_ref
-        );
+    // Match Git's `init_notes_check`: notes must live under `refs/notes/` (prefix includes a slash
+    // after `notes`, so `refs/notes` and `refs/heads/main` are rejected).
+    if !notes_ref.starts_with("refs/notes/") {
+        let verb = match &args.command {
+            Some(NotesSubcommand::Add { .. }) => "add",
+            Some(NotesSubcommand::Edit { .. }) => "edit",
+            Some(NotesSubcommand::Append { .. }) => "append",
+            Some(NotesSubcommand::Remove { .. }) => "remove",
+            Some(NotesSubcommand::Copy { .. }) => "copy",
+            Some(NotesSubcommand::Merge { .. }) => "merge",
+            Some(NotesSubcommand::Prune { .. }) => "prune",
+            Some(NotesSubcommand::List { .. }) => "use",
+            Some(NotesSubcommand::Show { .. }) => "show",
+            Some(NotesSubcommand::GetRef) => "use",
+            None => "use",
+        };
+        bail!("refusing to {verb} notes in {notes_ref} (outside of refs/notes/)");
     }
     if notes_ref == "/" {
         bail!("refusing to use notes ref '/'");
+    }
+    // Reject refnames Git cannot store as a single ref (revision syntax like `y:path`, `foo^{`, etc.).
+    // `refs/notes/y:` still starts with `refs/notes/` but must fail like upstream `refs_read_ref`.
+    let tail = notes_ref
+        .strip_prefix("refs/notes/")
+        .expect("checked refs/notes/ prefix");
+    if tail.is_empty() || tail.ends_with('/') {
+        bail!("Failed to resolve local notes ref '{notes_ref}'");
+    }
+    if tail.contains(':') || tail.contains('^') || tail.contains('{') {
+        bail!("Failed to resolve local notes ref '{notes_ref}'");
     }
 
     match args.command {
@@ -233,6 +254,8 @@ pub fn run(args: Args) -> Result<()> {
         Some(NotesSubcommand::Merge {
             commit,
             abort,
+            verbose,
+            quiet,
             strategy,
             source_ref,
         }) => merge_notes_dispatch(
@@ -240,6 +263,8 @@ pub fn run(args: Args) -> Result<()> {
             &notes_ref,
             commit,
             abort,
+            verbose,
+            quiet,
             strategy.as_deref(),
             source_ref.as_deref(),
         ),
@@ -1010,12 +1035,23 @@ fatal: unable to parse 'notes.mergeStrategy' from command-line config"
     })
 }
 
-fn note_path_to_object_id(path: &str) -> Option<ObjectId> {
-    let compact: String = path.chars().filter(|c| *c != '/').collect();
-    if compact.len() != 40 || !compact.chars().all(|c| c.is_ascii_hexdigit()) {
-        return None;
+/// Map annotated object → note blob OID for one notes tree (any fanout layout).
+fn notes_tree_blob_by_object(
+    repo: &Repository,
+    tree_oid: &ObjectId,
+) -> Result<HashMap<ObjectId, ObjectId>> {
+    let mut flat = Vec::new();
+    collect_notes_tree_entries(repo, tree_oid, b"", &mut flat)?;
+    let mut map = HashMap::new();
+    for entry in flat {
+        let Some(hex) = note_object_name(&entry.path) else {
+            continue;
+        };
+        let obj = ObjectId::from_hex(&hex)
+            .map_err(|e| anyhow::anyhow!("invalid note object id in tree: {e}"))?;
+        map.insert(obj, entry.oid);
     }
-    ObjectId::from_hex(&compact).ok()
+    Ok(map)
 }
 
 fn diff_note_blob_changes(
@@ -1023,35 +1059,28 @@ fn diff_note_blob_changes(
     old_tree: Option<&ObjectId>,
     new_tree: Option<&ObjectId>,
 ) -> Result<Vec<(ObjectId, Option<ObjectId>, Option<ObjectId>)>> {
-    let entries = diff_trees(&repo.odb, old_tree, new_tree, "")?;
+    let old_map = match old_tree {
+        Some(t) => notes_tree_blob_by_object(repo, t)?,
+        None => HashMap::new(),
+    };
+    let new_map = match new_tree {
+        Some(t) => notes_tree_blob_by_object(repo, t)?,
+        None => HashMap::new(),
+    };
+    let keys: BTreeSet<ObjectId> = old_map.keys().chain(new_map.keys()).copied().collect();
     let mut out = Vec::new();
-    for e in entries {
-        let Some(obj) = e
-            .path()
-            .parse::<ObjectId>()
-            .ok()
-            .or_else(|| note_path_to_object_id(e.path()))
-        else {
-            continue;
-        };
-        match e.status {
-            DiffStatus::Added => {
-                if e.new_oid != zero_oid() {
-                    out.push((obj, None, Some(e.new_oid)));
-                }
-            }
-            DiffStatus::Deleted => {
-                if e.old_oid != zero_oid() {
-                    out.push((obj, Some(e.old_oid), None));
-                }
-            }
-            DiffStatus::Modified | DiffStatus::TypeChanged => {
-                out.push((obj, Some(e.old_oid), Some(e.new_oid)));
+    for obj in keys {
+        let o_old = old_map.get(&obj).copied();
+        let o_new = new_map.get(&obj).copied();
+        match (o_old, o_new) {
+            (None, Some(new_b)) => out.push((obj, None, Some(new_b))),
+            (Some(old_b), None) => out.push((obj, Some(old_b), None)),
+            (Some(old_b), Some(new_b)) if old_b != new_b => {
+                out.push((obj, Some(old_b), Some(new_b)));
             }
             _ => {}
         }
     }
-    out.sort_by(|a, b| a.0.cmp(&b.0));
     Ok(out)
 }
 
@@ -1649,6 +1678,8 @@ fn merge_notes_dispatch(
     notes_ref: &str,
     do_commit: bool,
     do_abort: bool,
+    verbose: u8,
+    quiet: u8,
     strategy: Option<&str>,
     source_ref: Option<&str>,
 ) -> Result<()> {
@@ -1670,6 +1701,10 @@ fn merge_notes_dispatch(
     }
     let src_raw = source_ref.expect("checked");
     let remote_ref = expand_notes_ref(src_raw);
+    let verbosity = i32::from(verbose).saturating_sub(i32::from(quiet));
+    if verbosity > 0 {
+        eprintln!("Merging notes from {remote_ref} into {notes_ref}");
+    }
     let strategy = if let Some(s) = strategy {
         parse_notes_merge_strategy_cli(s)?
     } else {

--- a/grit/src/commands/upload_pack.rs
+++ b/grit/src/commands/upload_pack.rs
@@ -331,7 +331,7 @@ fn advertise_refs_with_caps(repo: &Repository, server_proto: u8) -> Result<()> {
 
 fn list_all_refs(git_dir: &Path) -> Result<Vec<(String, ObjectId)>> {
     let mut result = Vec::new();
-    for prefix in &["refs/heads/", "refs/tags/", "refs/remotes/"] {
+    for prefix in &["refs/heads/", "refs/tags/", "refs/remotes/", "refs/notes/"] {
         if let Ok(entries) = refs::list_refs(git_dir, prefix) {
             result.extend(entries);
         }

--- a/grit/src/fetch_transport.rs
+++ b/grit/src/fetch_transport.rs
@@ -302,7 +302,15 @@ pub(crate) fn collect_wants(
             .map(|(a, _)| a)
             .unwrap_or(spec_clean);
         if src.contains('*') {
-            bail!("glob refspec in upload-pack fetch not supported");
+            for (refname, oid) in advertised {
+                if *oid == zero_oid() {
+                    continue;
+                }
+                if let Some(_matched) = match_glob_refspec_src(src, refname) {
+                    push_want_unique(&mut wants, *oid);
+                }
+            }
+            continue;
         }
         let remote_ref = if src.starts_with("refs/") {
             src.to_string()
@@ -324,6 +332,24 @@ pub(crate) fn collect_wants(
         wants.push(oid);
     }
     Ok(wants)
+}
+
+/// Match `src` against `refname` when `src` contains a single `*` (Git refspec glob).
+/// Returns `Some(())` when the ref matches; the matched segment is not needed for want collection.
+fn match_glob_refspec_src(src: &str, refname: &str) -> Option<()> {
+    let star_pos = src.find('*')?;
+    if src[star_pos + 1..].contains('*') {
+        return None;
+    }
+    let prefix = &src[..star_pos];
+    let suffix = &src[star_pos + 1..];
+    if !refname.starts_with(prefix) || !refname.ends_with(suffix) {
+        return None;
+    }
+    if refname.len() < prefix.len() + suffix.len() {
+        return None;
+    }
+    Some(())
 }
 
 /// Pushes `oid` onto `wants` if it is not already present (order-preserving).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This makes `tests/t3308-notes-merge.sh` pass end-to-end (19/19).

## Changes

- **Upload-pack advertisement**: include `refs/notes/` so local `git fetch` with glob refspecs like `refs/notes/*:refs/remote-notes/origin/*` can resolve wants and copy objects.
- **`collect_wants` (upload-pack path)**: support single-`*` glob refspec sources by matching advertised ref names, instead of bailing.
- **Notes merge**: diff notes trees by **annotated commit → blob** (logical map) rather than raw tree paths, so fanout-only layout differences between refs are not treated as modifications (fixes the no-op merge case after `x` stayed flat while `y` gained fanout).
- **`core.notesRef` validation**: require `refs/notes/<tail>` for all notes subcommands; reject empty tail, trailing `/`, and revision-syntax characters (`:`, `^`, `{`) with messages aligned to Git’s “Failed to resolve local notes ref …” / “outside refs/notes/” behavior.
- **`git notes merge`**: accept `-v`/`-q` (counting flags) so `-vvv` from the test suite parses; emit a one-line stderr trace when verbosity &gt; 0.

## Validation

- `./scripts/run-tests.sh t3308-notes-merge.sh` → 19/19
- `cargo test -p grit-lib --lib`
- `cargo clippy -p grit-rs --fix --allow-dirty`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4236ce1d-39a5-44d1-93a0-630f318968b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4236ce1d-39a5-44d1-93a0-630f318968b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

