### PR TITLE
Recursive submodule fetch (t5526 progress)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,686 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,686 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T02:25:11+00:00" class="gen-time" title="2026-04-10 02:25 UTC">2026-04-10 02:25 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,686</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>758 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35686 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,686 / 45,142 tests · 1,405 files in scope · 758 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T02:25:11+00:00" class="gen-time" title="2026-04-10 02:25 UTC">2026-04-10 02:25 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,686</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/fetch_submodules.rs
+++ b/grit-lib/src/fetch_submodules.rs
@@ -1,0 +1,385 @@
+//! Logic for `git fetch --recurse-submodules` (changed-submodule detection and config).
+//!
+//! Mirrors the subset of Git's `submodule.c` / `submodule-config.c` needed for recursive fetch:
+//! revision walking with merge-aware gitlink diffs, per-submodule recurse mode, and checking
+//! whether recorded gitlink commits are already present in a submodule repository.
+
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::combined_tree_diff::{combined_diff_paths_filtered, CombinedTreeDiffOptions};
+use crate::config::{parse_bool as config_parse_bool, ConfigFile, ConfigScope, ConfigSet};
+use crate::diff::{diff_trees, DiffStatus};
+use crate::error::Result;
+use crate::index::MODE_GITLINK;
+use crate::merge_diff::blob_oid_at_path;
+use crate::objects::{parse_commit, ObjectId, ObjectKind};
+use crate::odb::Odb;
+use crate::refs;
+use crate::repo::Repository;
+use crate::rev_list::{rev_list, RevListOptions};
+use crate::submodule_gitdir::submodule_modules_git_dir;
+
+/// `fetch.recurseSubmodules` / `--recurse-submodules` modes for fetch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FetchRecurseSubmodules {
+    /// Use submodule / `.gitmodules` defaults (Git `RECURSE_SUBMODULES_DEFAULT`).
+    Default,
+    /// Never recurse.
+    Off,
+    /// Always recurse into configured submodules (`yes` / `true`).
+    On,
+    /// Only recurse when the superproject fetch brought in new submodule commits.
+    OnDemand,
+}
+
+/// Parse `fetch.recurseSubmodules` or `--recurse-submodules=<value>` (Git `parse_fetch_recurse_submodules_arg`).
+/// Build the positive OID list for `rev-list` when diffing fetched history (Git `ref_tips_after` ∪ submodule tips).
+pub fn merge_tips_for_changed_walk(
+    submodule_commits: &[ObjectId],
+    tips_after: &[ObjectId],
+) -> Vec<String> {
+    let mut seen: HashSet<ObjectId> = HashSet::new();
+    let mut out: Vec<String> = Vec::new();
+    for o in submodule_commits {
+        if seen.insert(*o) {
+            out.push(o.to_hex());
+        }
+    }
+    for o in tips_after {
+        if seen.insert(*o) {
+            out.push(o.to_hex());
+        }
+    }
+    out
+}
+
+pub fn parse_fetch_recurse_submodules_arg(
+    opt: &str,
+    arg: &str,
+) -> std::result::Result<FetchRecurseSubmodules, String> {
+    let arg = arg.trim();
+    if arg.is_empty() {
+        return Err(format!("option `{opt}` requires a value"));
+    }
+    match config_parse_bool(arg) {
+        Ok(true) => Ok(FetchRecurseSubmodules::On),
+        Ok(false) => Ok(FetchRecurseSubmodules::Off),
+        Err(_) => {
+            if arg.eq_ignore_ascii_case("on-demand") {
+                Ok(FetchRecurseSubmodules::OnDemand)
+            } else if arg.eq_ignore_ascii_case("no") || arg.eq_ignore_ascii_case("false") {
+                Ok(FetchRecurseSubmodules::Off)
+            } else {
+                Err(format!("bad {opt} argument: {arg}"))
+            }
+        }
+    }
+}
+
+/// One submodule that gained new gitlink targets in `rev-list <tips> --not <neg>`.
+#[derive(Debug, Clone)]
+pub struct ChangedSubmoduleFetch {
+    /// Submodule name (`.gitmodules` key or worktree path for unconfigured gitlinks).
+    pub name: String,
+    /// Path in the superproject tree.
+    pub path: String,
+    /// A superproject commit OID whose tree supplies `.gitmodules` / config context.
+    pub super_oid: ObjectId,
+    /// New gitlink commit OIDs observed along the walk (unique, sorted).
+    pub new_commits: Vec<ObjectId>,
+}
+
+fn mode_from_octal(mode_str: &str) -> Option<u32> {
+    u32::from_str_radix(mode_str, 8).ok()
+}
+
+fn is_gitlink_mode(mode_str: &str) -> bool {
+    mode_from_octal(mode_str) == Some(MODE_GITLINK)
+}
+
+/// Map `submodule.<name>.path` -> name from a `.gitmodules` file body.
+fn path_to_submodule_name(gitmodules_text: &str) -> HashMap<String, String> {
+    let Ok(cfg) = ConfigFile::parse(
+        Path::new(".gitmodules"),
+        gitmodules_text,
+        ConfigScope::Local,
+    ) else {
+        return HashMap::new();
+    };
+    let mut name_to_path: HashMap<String, String> = HashMap::new();
+    for e in &cfg.entries {
+        let key = &e.key;
+        if !key.starts_with("submodule.") {
+            continue;
+        }
+        let rest = &key["submodule.".len()..];
+        let Some(last_dot) = rest.rfind('.') else {
+            continue;
+        };
+        let name = rest[..last_dot].to_string();
+        let var = &rest[last_dot + 1..];
+        if var == "path" {
+            if let Some(p) = e.value.as_deref() {
+                name_to_path.insert(name, p.to_string());
+            }
+        }
+    }
+    name_to_path
+        .into_iter()
+        .map(|(name, path)| (path, name))
+        .collect()
+}
+
+fn gitmodules_blob_text(odb: &Odb, commit_tree: &ObjectId) -> Option<String> {
+    let oid = blob_oid_at_path(odb, commit_tree, ".gitmodules")?;
+    let obj = odb.read(&oid).ok()?;
+    if obj.kind != ObjectKind::Blob {
+        return None;
+    }
+    String::from_utf8(obj.data).ok()
+}
+
+fn resolve_submodule_name_for_path(
+    odb: &Odb,
+    commit_tree: &ObjectId,
+    path: &str,
+    super_work_tree: Option<&Path>,
+) -> Option<String> {
+    if let Some(text) = gitmodules_blob_text(odb, commit_tree) {
+        let m = path_to_submodule_name(&text);
+        if let Some(n) = m.get(path) {
+            return Some(n.clone());
+        }
+    }
+    let wt_path = super_work_tree?.join(path);
+    if wt_path.join(".git").exists() {
+        return Some(path.to_string());
+    }
+    None
+}
+
+/// Walk `rev_list(repo, positive_hex, negative_hex)` and collect submodule names whose gitlink
+/// targets changed, matching Git's `collect_changed_submodules` + name resolution.
+pub fn collect_changed_submodules_for_fetch(
+    repo: &Repository,
+    positive_hex: &[String],
+    negative_hex: &[String],
+) -> Result<Vec<ChangedSubmoduleFetch>> {
+    if positive_hex.is_empty() {
+        return Ok(Vec::new());
+    }
+    let options = RevListOptions::default();
+    let walked = rev_list(repo, positive_hex, negative_hex, &options)?;
+    let odb = &repo.odb;
+    let walk_opts = CombinedTreeDiffOptions {
+        recursive: true,
+        tree_in_recursive: false,
+    };
+    let super_wt = repo.work_tree.as_deref();
+
+    let mut by_name: HashMap<String, ChangedSubmoduleFetch> = HashMap::new();
+
+    for commit_oid in walked.commits {
+        let obj = odb.read(&commit_oid)?;
+        if obj.kind != ObjectKind::Commit {
+            continue;
+        }
+        let commit = parse_commit(&obj.data)?;
+        let parents = commit.parents;
+
+        let mut record_gitlink =
+            |path: String, oid: ObjectId, super_tree: &ObjectId| -> Result<()> {
+                let Some(name) = resolve_submodule_name_for_path(odb, super_tree, &path, super_wt)
+                else {
+                    return Ok(());
+                };
+                by_name
+                    .entry(name.clone())
+                    .and_modify(|e| {
+                        if !e.new_commits.contains(&oid) {
+                            e.new_commits.push(oid);
+                        }
+                    })
+                    .or_insert_with(|| ChangedSubmoduleFetch {
+                        name,
+                        path: path.clone(),
+                        super_oid: commit_oid,
+                        new_commits: vec![oid],
+                    });
+                Ok(())
+            };
+
+        if parents.is_empty() {
+            let entries = diff_trees(odb, None, Some(&commit.tree), "")?;
+            for e in entries {
+                if !is_gitlink_mode(&e.new_mode) {
+                    continue;
+                }
+                record_gitlink(e.path().to_string(), e.new_oid, &commit.tree)?;
+            }
+        } else if parents.len() == 1 {
+            let pobj = odb.read(&parents[0])?;
+            if pobj.kind != ObjectKind::Commit {
+                continue;
+            }
+            let parent = parse_commit(&pobj.data)?;
+            let entries = diff_trees(odb, Some(&parent.tree), Some(&commit.tree), "")?;
+            for e in entries {
+                if !matches!(
+                    e.status,
+                    DiffStatus::Added
+                        | DiffStatus::Modified
+                        | DiffStatus::TypeChanged
+                        | DiffStatus::Renamed
+                ) {
+                    continue;
+                }
+                let (mode, oid) = match e.status {
+                    DiffStatus::Deleted => continue,
+                    _ => (&e.new_mode, e.new_oid),
+                };
+                if !is_gitlink_mode(mode) {
+                    continue;
+                }
+                let path = e
+                    .new_path
+                    .as_deref()
+                    .or(e.old_path.as_deref())
+                    .unwrap_or("")
+                    .to_string();
+                if path.is_empty() {
+                    continue;
+                }
+                record_gitlink(path, oid, &commit.tree)?;
+            }
+        } else {
+            let paths =
+                combined_diff_paths_filtered(odb, &commit.tree, &parents, &walk_opts, None)?;
+            for p in paths {
+                if (p.merge_mode & 0o170000) != MODE_GITLINK {
+                    continue;
+                }
+                if p.merge_oid.is_zero() {
+                    continue;
+                }
+                record_gitlink(p.path, p.merge_oid, &commit.tree)?;
+            }
+        }
+    }
+
+    let mut out: Vec<ChangedSubmoduleFetch> = by_name.into_values().collect();
+    for e in &mut out {
+        e.new_commits.sort();
+        e.new_commits.dedup();
+    }
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(out)
+}
+
+/// True when every OID in `commits` exists as a commit object in `sub_odb` and is reachable from
+/// some ref (`git rev-list -n 1 <oids> --not --all` is empty), matching Git's `submodule_has_commits`.
+pub fn submodule_has_all_commits(sub_odb: &Odb, commits: &[ObjectId]) -> Result<bool> {
+    for oid in commits {
+        let obj = match sub_odb.read(oid) {
+            Ok(o) => o,
+            Err(_) => return Ok(false),
+        };
+        if obj.kind != ObjectKind::Commit {
+            return Ok(false);
+        }
+    }
+    if commits.is_empty() {
+        return Ok(true);
+    }
+    let repo_dir = sub_odb
+        .objects_dir()
+        .parent()
+        .unwrap_or_else(|| sub_odb.objects_dir());
+    let all_refs = refs::list_refs(repo_dir, "refs/")?;
+    let mut reachable: HashSet<ObjectId> = HashSet::new();
+    for (_, r_oid) in all_refs {
+        let mut stack = vec![r_oid];
+        while let Some(c) = stack.pop() {
+            if !reachable.insert(c) {
+                continue;
+            }
+            let Ok(obj) = sub_odb.read(&c) else {
+                continue;
+            };
+            if obj.kind != ObjectKind::Commit {
+                continue;
+            }
+            let Ok(parsed) = parse_commit(&obj.data) else {
+                continue;
+            };
+            for p in parsed.parents {
+                stack.push(p);
+            }
+        }
+    }
+    Ok(commits.iter().all(|c| reachable.contains(c)))
+}
+
+/// Whether a submodule at `path` is active for fetch at `super_oid` (Git `is_tree_submodule_active` subset).
+pub fn is_submodule_active_for_fetch(
+    _repo: &Repository,
+    config: &ConfigSet,
+    _super_tree_oid: &ObjectId,
+    _path: &str,
+    submodule_name: &str,
+) -> bool {
+    let active_key = format!("submodule.{submodule_name}.active");
+    if let Some(v) = config.get(&active_key) {
+        if let Ok(b) = config_parse_bool(v.trim()) {
+            return b;
+        }
+    }
+    let url_key = format!("submodule.{submodule_name}.url");
+    config.get(&url_key).is_some()
+}
+
+/// Superproject has at least one submodule under `.git/modules/` (Git `repo_has_absorbed_submodules`).
+pub fn repo_has_absorbed_submodules(super_git_dir: &Path) -> bool {
+    let p = super_git_dir.join("modules");
+    p.is_dir()
+        && fs::read_dir(&p)
+            .map(|mut d| d.next().is_some())
+            .unwrap_or(false)
+}
+
+/// `.gitmodules` says at least one submodule exists (path+url), or absorbed modules exist.
+pub fn might_have_submodules_to_fetch(work_tree: &Path, super_git_dir: &Path) -> bool {
+    if work_tree.join(".gitmodules").exists() {
+        return true;
+    }
+    repo_has_absorbed_submodules(super_git_dir)
+}
+
+/// Open the git directory for a submodule at `rel_path` (work tree or `.git/modules/` fallback).
+pub fn submodule_git_dir_for_fetch(super_repo: &Repository, rel_path: &str) -> Option<PathBuf> {
+    let wt = super_repo.work_tree.as_ref()?;
+    let abs = wt.join(rel_path);
+    if abs.join(".git").exists() {
+        if abs.join(".git").is_file() {
+            let Ok(line) = fs::read_to_string(abs.join(".git")) else {
+                return None;
+            };
+            let line = line.trim();
+            let rest = line.strip_prefix("gitdir:")?.trim();
+            let gd = if Path::new(rest).is_absolute() {
+                PathBuf::from(rest)
+            } else {
+                abs.join(rest)
+            };
+            return fs::canonicalize(&gd).ok().or(Some(gd));
+        }
+        return Some(abs.join(".git"));
+    }
+    let modules = submodule_modules_git_dir(&super_repo.git_dir, rel_path);
+    if modules.join("HEAD").exists() {
+        return Some(modules);
+    }
+    None
+}

--- a/grit-lib/src/lib.rs
+++ b/grit-lib/src/lib.rs
@@ -36,6 +36,7 @@ pub mod fast_export;
 pub mod fast_import;
 pub mod fetch_head;
 pub mod fetch_negotiator;
+pub mod fetch_submodules;
 pub mod filter_process;
 pub mod fmt_merge_msg;
 pub mod fsck_standalone;

--- a/grit/src/commands/fetch.rs
+++ b/grit/src/commands/fetch.rs
@@ -8,6 +8,7 @@
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::config::ConfigSet;
+use grit_lib::fetch_submodules::FetchRecurseSubmodules;
 use grit_lib::merge_base;
 use grit_lib::objects::{parse_commit, parse_tag, parse_tree, ObjectId, ObjectKind};
 use grit_lib::odb::Odb;
@@ -101,7 +102,7 @@ pub struct Args {
     #[arg(short = 'v', long = "verbose", action = clap::ArgAction::Count)]
     pub verbose: u8,
 
-    /// Number of parallel children for fetching (accepted but ignored).
+    /// Number of parallel submodule fetches (`submodule.fetchJobs` / `fetch.parallel` when unset).
     #[arg(short = 'j', long = "jobs", value_name = "N")]
     pub jobs: Option<usize>,
 
@@ -120,6 +121,14 @@ pub struct Args {
     /// Only negotiate, do not fetch objects.
     #[arg(long)]
     pub negotiate_only: bool,
+
+    /// Do not update refs or FETCH_HEAD; still report what would be fetched.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Do not write FETCH_HEAD (submodule recursion passes this from the superproject).
+    #[arg(long = "no-write-fetch-head")]
+    pub no_write_fetch_head: bool,
 
     /// Allow updating the current branch head (normally refused).
     #[arg(long)]
@@ -142,12 +151,30 @@ pub struct Args {
     /// Disable submodule recursion (overrides config).
     #[arg(long = "no-recurse-submodules")]
     pub no_recurse_submodules: bool,
+
+    /// Internal: default recurse mode for nested submodule fetches (two-arg form `… default yes`).
+    #[arg(
+        long = "recurse-submodules-default",
+        hide = true,
+        num_args = 1,
+        value_name = "MODE"
+    )]
+    pub recurse_submodules_default: Option<String>,
+
+    /// Internal: path prefix for nested submodule fetch (Git hidden option).
+    #[arg(long = "submodule-prefix", hide = true)]
+    pub submodule_prefix: Option<String>,
 }
 
-pub fn run(mut args: Args) -> Result<()> {
+pub fn run(args: Args) -> Result<()> {
     if args.negotiate_only {
         // Negotiate-only mode: just exit successfully without fetching.
         return Ok(());
+    }
+
+    let mut args = args;
+    if args.dry_run {
+        args.no_write_fetch_head = true;
     }
 
     // `git fetch tag <name>` is parsed as remote=`tag` unless we lift the magic keyword.
@@ -166,6 +193,8 @@ pub fn run(mut args: Args) -> Result<()> {
 
     let git_dir = resolve_git_dir()?;
     let config = ConfigSet::load(Some(&git_dir), true)?;
+
+    crate::fetch_submodule_record::begin_fetch_submodule_record(&git_dir);
 
     // Validate fetch.output config if set
     if let Some(val) = config.get("fetch.output") {
@@ -238,8 +267,18 @@ pub fn run(mut args: Args) -> Result<()> {
         }
     };
 
-    if result.is_ok() && should_recurse_fetch_submodules(&config, &args) {
-        super::submodule::recursive_fetch_submodules(true)?;
+    if result.is_ok() && !args.porcelain {
+        let recurse = effective_fetch_recurse_submodules(&git_dir, &config, &args)?;
+        if recurse != FetchRecurseSubmodules::Off
+            && matches!(
+                recurse,
+                FetchRecurseSubmodules::On | FetchRecurseSubmodules::OnDemand
+            )
+        {
+            crate::fetch_submodule_recurse::recursive_fetch_submodules_after_fetch(
+                &git_dir, &config, &args, recurse,
+            )?;
+        }
     }
     result
 }
@@ -344,26 +383,109 @@ fn default_fetch_remote_name(git_dir: &Path, config: &ConfigSet) -> String {
     }
 }
 
-fn should_recurse_fetch_submodules(config: &ConfigSet, args: &Args) -> bool {
+fn config_bool_truthy(v: &str) -> bool {
+    let l = v.trim().to_ascii_lowercase();
+    matches!(l.as_str(), "true" | "yes" | "on" | "1")
+}
+
+fn config_bool_falsey(v: &str) -> bool {
+    let l = v.trim().to_ascii_lowercase();
+    matches!(l.as_str(), "false" | "no" | "off" | "0")
+}
+
+/// Effective `fetch --recurse-submodules` mode after config / `.gitmodules` (Git `fetch_config` + `fetch_config_from_gitmodules`).
+fn effective_fetch_recurse_submodules(
+    git_dir: &Path,
+    config: &ConfigSet,
+    args: &Args,
+) -> Result<FetchRecurseSubmodules> {
     if args.no_recurse_submodules {
-        return false;
+        return Ok(FetchRecurseSubmodules::Off);
     }
-    if args.recurse_submodules.as_deref() == Some("no")
-        || args.recurse_submodules.as_deref() == Some("false")
-    {
-        return false;
+    if let Some(ref v) = args.recurse_submodules {
+        let t = v.trim();
+        if t.eq_ignore_ascii_case("no") || t.eq_ignore_ascii_case("false") {
+            return Ok(FetchRecurseSubmodules::Off);
+        }
+        return grit_lib::fetch_submodules::parse_fetch_recurse_submodules_arg(
+            "--recurse-submodules",
+            t,
+        )
+        .map_err(|e| anyhow::anyhow!(e));
     }
-    if args.recurse_submodules.is_some() {
-        return true;
+    if let Some(v) = config.get("submodule.recurse") {
+        if config_bool_truthy(&v) {
+            return Ok(FetchRecurseSubmodules::On);
+        }
+        if config_bool_falsey(&v) {
+            return Ok(FetchRecurseSubmodules::Off);
+        }
     }
-    config
+    let mut mode = if let Some(v) = config
         .get("fetch.recursesubmodules")
         .or_else(|| config.get("fetch.recurseSubmodules"))
-        .map(|v| {
-            let l = v.to_ascii_lowercase();
-            l == "true" || l == "yes" || l == "on" || l == "1"
-        })
-        .unwrap_or(false)
+    {
+        grit_lib::fetch_submodules::parse_fetch_recurse_submodules_arg(
+            "fetch.recurseSubmodules",
+            &v,
+        )
+        .map_err(|e| anyhow::anyhow!(e))?
+    } else {
+        FetchRecurseSubmodules::Default
+    };
+
+    if mode == FetchRecurseSubmodules::Default {
+        if let Some(m) = fetch_recurse_from_gitmodules_file(git_dir, config)? {
+            mode = m;
+        }
+    }
+    Ok(mode)
+}
+
+fn fetch_recurse_from_gitmodules_file(
+    git_dir: &Path,
+    config: &ConfigSet,
+) -> Result<Option<FetchRecurseSubmodules>> {
+    let repo = Repository::open(git_dir, None).ok();
+    let work_tree = repo.as_ref().and_then(|r| r.work_tree.clone());
+    let Some(wt) = work_tree else {
+        return Ok(None);
+    };
+    let path = wt.join(".gitmodules");
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content = fs::read_to_string(&path).unwrap_or_default();
+    let gm =
+        grit_lib::config::ConfigFile::parse(&path, &content, grit_lib::config::ConfigScope::Local)
+            .ok();
+    let Some(gm) = gm else {
+        return Ok(None);
+    };
+    let mut found: Option<FetchRecurseSubmodules> = None;
+    for e in &gm.entries {
+        if !e.key.starts_with("submodule.") {
+            continue;
+        }
+        if !e.key.ends_with(".fetchrecursesubmodules") {
+            continue;
+        }
+        let raw = config
+            .get(&e.key)
+            .or_else(|| e.value.clone())
+            .unwrap_or_default();
+        let m = grit_lib::fetch_submodules::parse_fetch_recurse_submodules_arg(&e.key, &raw)
+            .map_err(|err| anyhow::anyhow!(err))?;
+        found = Some(m);
+    }
+    Ok(found)
+}
+
+fn note_submodule_fetch_tip(old_oid: Option<&ObjectId>, new_oid: &ObjectId) {
+    if old_oid == Some(new_oid) {
+        return;
+    }
+    crate::fetch_submodule_record::record_submodule_tip(new_oid);
 }
 
 /// Build the upload-pack `want` list for a configured (non-CLI) fetch: only refs matched by
@@ -1112,8 +1234,11 @@ fn fetch_remote(
                                 );
                             }
                         }
-                        refs::write_ref(git_dir, &local_ref, remote_oid)
-                            .with_context(|| format!("updating ref {local_ref}"))?;
+                        note_submodule_fetch_tip(old_oid.as_ref(), remote_oid);
+                        if !args.dry_run {
+                            refs::write_ref(git_dir, &local_ref, remote_oid)
+                                .with_context(|| format!("updating ref {local_ref}"))?;
+                        }
 
                         if !args.quiet {
                             let short = local_ref
@@ -1218,8 +1343,11 @@ fn fetch_remote(
                             );
                         }
                     }
-                    refs::write_ref(git_dir, &local_ref, &remote_oid)
-                        .with_context(|| format!("updating ref {local_ref}"))?;
+                    note_submodule_fetch_tip(old_oid.as_ref(), &remote_oid);
+                    if !args.dry_run {
+                        refs::write_ref(git_dir, &local_ref, &remote_oid)
+                            .with_context(|| format!("updating ref {local_ref}"))?;
+                    }
 
                     if !args.quiet {
                         let short = local_ref
@@ -1372,16 +1500,19 @@ fn fetch_remote(
                 has_updates = true;
             }
 
-            refs::write_ref(git_dir, &local_ref, &remote_oid)
-                .with_context(|| format!("updating ref {local_ref}"))?;
-            let _ = append_fetch_reflog(
-                git_dir,
-                &local_ref,
-                old_oid.as_ref(),
-                &remote_oid,
-                &url,
-                branch,
-            );
+            note_submodule_fetch_tip(old_oid.as_ref(), &remote_oid);
+            if !args.dry_run {
+                refs::write_ref(git_dir, &local_ref, &remote_oid)
+                    .with_context(|| format!("updating ref {local_ref}"))?;
+                let _ = append_fetch_reflog(
+                    git_dir,
+                    &local_ref,
+                    old_oid.as_ref(),
+                    &remote_oid,
+                    &url,
+                    branch,
+                );
+            }
 
             let tracking_print = local_ref
                 .strip_prefix("refs/remotes/")
@@ -1426,9 +1557,13 @@ fn fetch_remote(
                 has_updates = true;
             }
 
-            refs::write_ref(git_dir, refname, remote_oid)
-                .with_context(|| format!("updating tag {refname}"))?;
-            let _ = append_fetch_reflog(git_dir, refname, old_oid.as_ref(), remote_oid, &url, "");
+            note_submodule_fetch_tip(old_oid.as_ref(), remote_oid);
+            if !args.dry_run {
+                refs::write_ref(git_dir, refname, remote_oid)
+                    .with_context(|| format!("updating tag {refname}"))?;
+                let _ =
+                    append_fetch_reflog(git_dir, refname, old_oid.as_ref(), remote_oid, &url, "");
+            }
 
             if !args.quiet {
                 let tag_name = refname.strip_prefix("refs/tags/").unwrap_or(refname);
@@ -1607,12 +1742,29 @@ fn fetch_remote(
         }
     }
 
-    if !fetch_head_entries.is_empty() {
+    if !fetch_head_entries.is_empty() && !args.no_write_fetch_head {
         sort_fetch_head_lines(&mut fetch_head_entries, &fetch_head_refspecs);
         let fetch_head_path = git_dir.join("FETCH_HEAD");
         let content = fetch_head_entries.join("\n") + "\n";
         fs::write(&fetch_head_path, content).context("writing FETCH_HEAD")?;
     }
+
+    if user_passed_cli_refspecs && !prefetch_left_no_positive {
+        for spec in cli_refspecs {
+            if spec.starts_with('^') {
+                continue;
+            }
+            let sc = spec.strip_prefix('+').unwrap_or(spec.as_str());
+            let src = sc.split_once(':').map(|(a, _)| a).unwrap_or(sc);
+            if src.len() == 40 {
+                if let Ok(oid) = ObjectId::from_hex(src) {
+                    note_submodule_fetch_tip(None, &oid);
+                }
+            }
+        }
+    }
+
+    crate::fetch_submodule_record::finish_record_tips_after(git_dir);
 
     if args.filter.as_deref() == Some("blob:none") {
         apply_blob_none_filter(git_dir, remote_repo.as_ref(), &remote_heads)
@@ -3303,13 +3455,19 @@ fn fetch_branch_merge_rank(
 }
 
 fn configured_remote_base(git_dir: &Path) -> PathBuf {
-    if git_dir.file_name().is_some_and(|name| name == ".git") {
-        git_dir
-            .parent()
+    let gd = git_dir
+        .canonicalize()
+        .unwrap_or_else(|_| git_dir.to_path_buf());
+    let s = gd.to_string_lossy();
+    if let Some(idx) = s.find("/.git/modules/") {
+        return PathBuf::from(s[..idx].to_string());
+    }
+    if gd.file_name().is_some_and(|name| name == ".git") {
+        gd.parent()
             .map(Path::to_path_buf)
-            .unwrap_or_else(|| git_dir.to_path_buf())
+            .unwrap_or_else(|| gd.clone())
     } else {
-        git_dir.to_path_buf()
+        gd
     }
 }
 

--- a/grit/src/commands/pull.rs
+++ b/grit/src/commands/pull.rs
@@ -288,8 +288,12 @@ pub fn run(args: Args) -> Result<()> {
         verbose: 0,
         update_refs: false,
         upload_pack: None,
+        dry_run: false,
+        no_write_fetch_head: false,
         recurse_submodules: fetch_recurse,
         no_recurse_submodules: args.no_recurse_submodules,
+        recurse_submodules_default: None,
+        submodule_prefix: None,
     };
     super::fetch::run(fetch_args)?;
 

--- a/grit/src/commands/submodule.rs
+++ b/grit/src/commands/submodule.rs
@@ -746,46 +746,6 @@ fn refresh_gitlink_index_stat(repo: &Repository, rel_path: &str) -> Result<()> {
     Ok(())
 }
 
-/// Run `grit fetch` in each initialized submodule (and nested submodules when `recursive`).
-pub(crate) fn recursive_fetch_submodules(recursive: bool) -> Result<()> {
-    let repo = Repository::discover(None).context("not a git repository")?;
-    let work_tree = repo.work_tree.as_ref().context("bare repository")?;
-    let modules = parse_gitmodules_with_repo(work_tree, Some(&repo))?;
-    let grit_bin = grit_exe::grit_executable();
-
-    fn fetch_one(
-        grit_bin: &std::path::Path,
-        sub_path: &std::path::Path,
-        recursive: bool,
-    ) -> Result<()> {
-        if !sub_path.join(".git").exists() {
-            return Ok(());
-        }
-        let status = std::process::Command::new(grit_bin)
-            .args(["fetch", "origin"])
-            .current_dir(sub_path)
-            .status()
-            .context("submodule fetch")?;
-        if !status.success() {
-            bail!("submodule fetch failed in {}", sub_path.display());
-        }
-        if recursive {
-            let sub_repo = Repository::discover(Some(sub_path)).context("open submodule repo")?;
-            let sub_wt = sub_repo.work_tree.as_ref().context("bare submodule")?;
-            let nested = parse_gitmodules_with_repo(sub_wt, Some(&sub_repo)).unwrap_or_default();
-            for m in nested {
-                fetch_one(grit_bin, &sub_wt.join(&m.path), true)?;
-            }
-        }
-        Ok(())
-    }
-
-    for m in modules {
-        fetch_one(&grit_bin, &work_tree.join(&m.path), recursive)?;
-    }
-    Ok(())
-}
-
 /// Run the `submodule` command (no leading `--quiet` / `--cached`; use [`run_from_argv`] from main).
 pub fn run(args: Args) -> Result<()> {
     run_with_top_opts(SubmoduleTopOpts::default(), args)
@@ -918,7 +878,7 @@ fn default_remote_for_config(config: &ConfigFile, head_branch: Option<&str>) -> 
     "origin".to_string()
 }
 
-fn get_default_remote_for_path(path: &str) -> Result<String> {
+pub(crate) fn get_default_remote_for_path(path: &str) -> Result<String> {
     let repo = Repository::discover(None).context("not a git repository")?;
     let path_buf = Path::new(path);
     let abs_sub = if path_buf.is_absolute() {
@@ -965,16 +925,25 @@ fn resolve_submodule_chain(
     let mut parent_wt = top_work.to_path_buf();
     let mut parent_git = top_repo.git_dir.clone();
 
-    for (idx, seg) in components.iter().enumerate() {
-        let is_last = idx + 1 == components.len();
+    let mut idx = 0usize;
+    while idx < components.len() {
         let parent_repo = Repository::open(&parent_git, Some(&parent_wt))
             .context("open repository for submodule walk")?;
         let modules = parse_gitmodules_with_repo(&parent_wt, Some(&parent_repo))?;
-        let Some(sm) = modules.iter().find(|m| m.path == *seg) else {
+        let mut sm_match: Option<SubmoduleInfo> = None;
+        for len in (1..=components.len() - idx).rev() {
+            let rel: String = components[idx..idx + len].join("/");
+            if let Some(sm) = modules.iter().find(|m| m.path == rel) {
+                sm_match = Some(sm.clone());
+                break;
+            }
+        }
+        let Some(sm) = sm_match else {
             return submodule_path_not_handle_error(sub_rel);
         };
+        let is_last = idx + sm.path.split('/').count() == components.len();
 
-        let seg_work = parent_wt.join(seg);
+        let seg_work = parent_wt.join(&sm.path);
         if !seg_work.join(".git").exists() {
             return submodule_path_not_handle_error(display_path);
         }
@@ -983,11 +952,12 @@ fn resolve_submodule_chain(
         };
 
         if is_last {
-            return Ok((git_dir, seg_work, parent_wt, parent_git, sm.clone()));
+            return Ok((git_dir, seg_work, parent_wt, parent_git, sm));
         }
 
         parent_wt = seg_work;
         parent_git = git_dir;
+        idx += sm.path.split('/').filter(|s| !s.is_empty()).count();
     }
 
     Err(anyhow::anyhow!(
@@ -1061,7 +1031,7 @@ fn relativize_submodule_gitfile(from_dir: &Path, to_path: &Path) -> Result<PathB
     Ok(out)
 }
 
-fn parse_gitmodules_with_repo(
+pub(crate) fn parse_gitmodules_with_repo(
     work_tree: &Path,
     repo: Option<&Repository>,
 ) -> Result<Vec<SubmoduleInfo>> {

--- a/grit/src/fetch_submodule_record.rs
+++ b/grit/src/fetch_submodule_record.rs
@@ -1,0 +1,67 @@
+//! Record ref tips and updated-ref OIDs during `git fetch` for `--recurse-submodules` (Git
+//! `ref_tips_before_fetch` / `check_for_new_submodule_commits`).
+
+use grit_lib::objects::ObjectId;
+use std::cell::RefCell;
+
+thread_local! {
+    static RECORD: RefCell<Option<FetchSubmoduleRecord>> = const { RefCell::new(None) };
+}
+
+/// When set, submodule-fetch logic can observe which refs moved during this fetch.
+pub struct FetchSubmoduleRecord {
+    pub tips_before: Vec<ObjectId>,
+    pub tips_after: RefCell<Vec<ObjectId>>,
+    pub submodule_commits: RefCell<Vec<ObjectId>>,
+}
+
+/// Begin recording for this `fetch` process (each nested `grit fetch` subprocess gets its own record).
+pub fn begin_fetch_submodule_record(git_dir: &std::path::Path) {
+    let tips: Vec<ObjectId> = grit_lib::refs::list_refs(git_dir, "refs/")
+        .ok()
+        .map(|v| v.into_iter().map(|(_, o)| o).collect())
+        .unwrap_or_default();
+    RECORD.with(|r| {
+        if r.borrow().is_some() {
+            return;
+        }
+        *r.borrow_mut() = Some(FetchSubmoduleRecord {
+            tips_before: tips,
+            tips_after: RefCell::new(Vec::new()),
+            submodule_commits: RefCell::new(Vec::new()),
+        });
+    });
+}
+
+/// Merge ref tips after this fetch into the running record (`git fetch --all` runs multiple fetches).
+pub fn finish_record_tips_after(git_dir: &std::path::Path) {
+    let tips: Vec<ObjectId> = grit_lib::refs::list_refs(git_dir, "refs/")
+        .ok()
+        .map(|v| v.into_iter().map(|(_, o)| o).collect())
+        .unwrap_or_default();
+    RECORD.with(|r| {
+        if let Some(rec) = r.borrow_mut().as_mut() {
+            let mut after = rec.tips_after.borrow_mut();
+            for o in tips {
+                if !after.contains(&o) {
+                    after.push(o);
+                }
+            }
+        }
+    });
+}
+
+/// Record a superproject commit OID whose tree may contain new submodule pointers (Git
+/// `check_for_new_submodule_commits`).
+pub fn record_submodule_tip(oid: &ObjectId) {
+    RECORD.with(|r| {
+        if let Some(rec) = r.borrow().as_ref() {
+            rec.submodule_commits.borrow_mut().push(*oid);
+        }
+    });
+}
+
+/// Take recorded state for `fetch_submodules` (clears thread-local).
+pub fn take_fetch_submodule_record() -> Option<FetchSubmoduleRecord> {
+    RECORD.with(|r| r.borrow_mut().take())
+}

--- a/grit/src/fetch_submodule_recurse.rs
+++ b/grit/src/fetch_submodule_recurse.rs
@@ -1,0 +1,406 @@
+//! Recursive `git fetch` into submodules (Git `fetch_submodules` / `submodule.c`).
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+use grit_lib::config::ConfigFile;
+use grit_lib::diff::zero_oid;
+use grit_lib::fetch_submodules::{
+    collect_changed_submodules_for_fetch, is_submodule_active_for_fetch,
+    might_have_submodules_to_fetch, parse_fetch_recurse_submodules_arg,
+    submodule_git_dir_for_fetch, submodule_has_all_commits, ChangedSubmoduleFetch,
+    FetchRecurseSubmodules,
+};
+use grit_lib::index::MODE_GITLINK;
+use grit_lib::name_rev;
+use grit_lib::objects::ObjectId;
+use grit_lib::odb::Odb;
+use grit_lib::repo::Repository;
+use grit_lib::state::resolve_head;
+
+use crate::commands::fetch::Args as FetchArgs;
+use crate::commands::submodule::{get_default_remote_for_path, parse_gitmodules_with_repo};
+use crate::grit_exe;
+
+fn parse_gitmodules_file(work_tree: &Path) -> Option<ConfigFile> {
+    let p = work_tree.join(".gitmodules");
+    let content = std::fs::read_to_string(&p).ok()?;
+    ConfigFile::parse(&p, &content, grit_lib::config::ConfigScope::Local).ok()
+}
+
+fn gitmodules_fetch_recurse_value(gm: &ConfigFile, submodule_name: &str) -> Option<String> {
+    let key_lc = format!("submodule.{submodule_name}.fetchrecursesubmodules");
+    for e in &gm.entries {
+        if e.key == key_lc {
+            return e.value.clone();
+        }
+    }
+    None
+}
+
+fn effective_submodule_fetch_recurse(
+    name: &str,
+    cmd: FetchRecurseSubmodules,
+    default: FetchRecurseSubmodules,
+    config: &grit_lib::config::ConfigSet,
+    gm: Option<&ConfigFile>,
+) -> Result<FetchRecurseSubmodules> {
+    if cmd != FetchRecurseSubmodules::Default {
+        return Ok(cmd);
+    }
+    let key = format!("submodule.{name}.fetchRecurseSubmodules");
+    let key_alt = format!("submodule.{name}.fetchrecursesubmodules");
+    let from_config = config.get(&key).or_else(|| config.get(&key_alt));
+    let from_gm = gm.and_then(|g| gitmodules_fetch_recurse_value(g, name));
+    let raw = from_config.or_else(|| from_gm.clone());
+    if let Some(v) = raw {
+        return parse_fetch_recurse_submodules_arg(&key, v.trim()).map_err(|e| anyhow::anyhow!(e));
+    }
+    Ok(default)
+}
+
+fn fetch_parallel_job_count(args: &FetchArgs, config: &grit_lib::config::ConfigSet) -> usize {
+    if let Some(j) = args.jobs {
+        if j == 0 {
+            return std::thread::available_parallelism()
+                .map(|n| n.get())
+                .unwrap_or(1);
+        }
+        return j;
+    }
+    if let Some(v) = config
+        .get("submodule.fetchjobs")
+        .or_else(|| config.get("submodule.fetchJobs"))
+    {
+        if let Ok(n) = v.trim().parse::<usize>() {
+            if n == 0 {
+                return std::thread::available_parallelism()
+                    .map(|x| x.get())
+                    .unwrap_or(1);
+            }
+            if n > 0 {
+                return n;
+            }
+        }
+    }
+    if let Some(v) = config.get("fetch.parallel") {
+        if let Ok(n) = v.trim().parse::<usize>() {
+            if n == 0 {
+                return std::thread::available_parallelism()
+                    .map(|x| x.get())
+                    .unwrap_or(1);
+            }
+            if n > 0 {
+                return n;
+            }
+        }
+    }
+    1
+}
+
+fn trace_parallel_tasks(n: usize) {
+    if let Ok(trace_val) = std::env::var("GIT_TRACE") {
+        if trace_val.is_empty() || trace_val == "0" || trace_val.eq_ignore_ascii_case("false") {
+            return;
+        }
+        let line = format!("run_processes_parallel: preparing to run up to {n} tasks\n");
+        crate::write_git_trace(&trace_val, &line);
+    }
+}
+
+fn forward_parent_fetch_flags(cmd: FetchRecurseSubmodules, args: &FetchArgs) -> Vec<String> {
+    let mut v = Vec::new();
+    if args.dry_run {
+        v.push("--dry-run".to_string());
+    }
+    if args.quiet {
+        v.push("-q".to_string());
+    }
+    if args.no_write_fetch_head {
+        v.push("--no-write-fetch-head".to_string());
+    }
+    match cmd {
+        FetchRecurseSubmodules::On => v.push("--recurse-submodules".to_string()),
+        FetchRecurseSubmodules::Off => v.push("--no-recurse-submodules".to_string()),
+        FetchRecurseSubmodules::OnDemand => v.push("--recurse-submodules=on-demand".to_string()),
+        FetchRecurseSubmodules::Default => {}
+    }
+    v
+}
+
+struct SubmoduleFetchWork {
+    /// Directory for the child process (`submodule/` when checked out, else the git dir).
+    process_cwd: std::path::PathBuf,
+    /// Pass `--work-tree=.` only when `process_cwd` is the git dir (unpopulated module).
+    work_tree_dot: bool,
+    /// Path relative to the repo whose index listed this submodule (super or nested).
+    display_path: String,
+    remote: String,
+    default_token: &'static str,
+    oids: Vec<ObjectId>,
+}
+
+fn head_tree_oid(repo: &Repository) -> Option<ObjectId> {
+    let head = resolve_head(&repo.git_dir).ok()?;
+    let oid = head.oid()?;
+    let obj = repo.odb.read(oid).ok()?;
+    if obj.kind != grit_lib::objects::ObjectKind::Commit {
+        return None;
+    }
+    let c = grit_lib::objects::parse_commit(&obj.data).ok()?;
+    Some(c.tree)
+}
+
+/// After a successful top-level `fetch`, recurse into submodules like Git's `fetch_submodules`.
+pub(crate) fn recursive_fetch_submodules_after_fetch(
+    super_git_dir: &Path,
+    config: &grit_lib::config::ConfigSet,
+    args: &FetchArgs,
+    cmd_recurse: FetchRecurseSubmodules,
+) -> Result<()> {
+    let Some(record) = crate::fetch_submodule_record::take_fetch_submodule_record() else {
+        return Ok(());
+    };
+    let cwd = std::env::current_dir().context("cwd")?;
+    let repo = Repository::discover(Some(cwd.as_path())).context("open repository")?;
+    let work_tree = repo.work_tree.as_ref().context("bare repository")?;
+    if !might_have_submodules_to_fetch(work_tree, super_git_dir) {
+        return Ok(());
+    }
+    let gm_file = parse_gitmodules_file(work_tree);
+
+    let positive = grit_lib::fetch_submodules::merge_tips_for_changed_walk(
+        &record.submodule_commits.borrow(),
+        &record.tips_after.borrow(),
+    );
+    let negative: Vec<String> = record.tips_before.iter().map(|o| o.to_hex()).collect();
+    let mut changed_list = collect_changed_submodules_for_fetch(&repo, &positive, &negative)?;
+    let mut changed_by_name: HashMap<String, ChangedSubmoduleFetch> = HashMap::new();
+    for c in changed_list.drain(..) {
+        changed_by_name.insert(c.name.clone(), c);
+    }
+
+    let default_child = if let Some(ref s) = args.recurse_submodules_default {
+        parse_fetch_recurse_submodules_arg("--recurse-submodules-default", s)
+            .map_err(|e| anyhow::anyhow!(e))?
+    } else {
+        FetchRecurseSubmodules::OnDemand
+    };
+
+    let mut filtered_changed: HashMap<String, ChangedSubmoduleFetch> = HashMap::new();
+    for (name, cs) in changed_by_name {
+        if !is_submodule_active_for_fetch(&repo, config, &cs.super_oid, &cs.path, &name) {
+            continue;
+        }
+        let Some(gd) = submodule_git_dir_for_fetch(&repo, &cs.path) else {
+            continue;
+        };
+        let odb = Odb::new(&gd.join("objects"));
+        if submodule_has_all_commits(&odb, &cs.new_commits)? {
+            continue;
+        }
+        filtered_changed.insert(name, cs);
+    }
+    let changed_by_name = filtered_changed;
+
+    let modules = parse_gitmodules_with_repo(work_tree, Some(&repo))?;
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut work: Vec<SubmoduleFetchWork> = Vec::new();
+
+    let head_tree = head_tree_oid(&repo);
+
+    let index_path = repo.index_path();
+    let index = repo.load_index_at(&index_path).ok();
+    if let Some(ref idx) = index {
+        for e in &idx.entries {
+            if e.stage() != 0 || e.mode != MODE_GITLINK {
+                continue;
+            }
+            let path = String::from_utf8_lossy(&e.path).to_string();
+            let Some(sm) = modules.iter().find(|m| m.path == path) else {
+                continue;
+            };
+            let tree_for_active = head_tree.unwrap_or_else(zero_oid);
+            if !is_submodule_active_for_fetch(&repo, config, &tree_for_active, &path, &sm.name) {
+                continue;
+            }
+            let mode = effective_submodule_fetch_recurse(
+                &sm.name,
+                cmd_recurse,
+                default_child,
+                config,
+                gm_file.as_ref(),
+            )?;
+            let include = match mode {
+                FetchRecurseSubmodules::Off => false,
+                FetchRecurseSubmodules::On => true,
+                FetchRecurseSubmodules::OnDemand | FetchRecurseSubmodules::Default => {
+                    changed_by_name.contains_key(&sm.name)
+                }
+            };
+            if !include {
+                continue;
+            }
+            let Some(gd) = submodule_git_dir_for_fetch(&repo, &path) else {
+                let abs = work_tree.join(&path);
+                if abs.is_dir()
+                    && std::fs::read_dir(&abs)
+                        .map(|d| d.count() > 0)
+                        .unwrap_or(false)
+                {
+                    bail!("Could not access submodule '{path}'");
+                }
+                continue;
+            };
+            if seen.insert(sm.name.clone()) {
+                let remote = get_default_remote_for_path(&path)?;
+                let abs_sm = work_tree.join(&path);
+                let (process_cwd, work_tree_dot) = if abs_sm.join(".git").exists() {
+                    (abs_sm, false)
+                } else {
+                    (gd.clone(), true)
+                };
+                work.push(SubmoduleFetchWork {
+                    process_cwd,
+                    work_tree_dot,
+                    display_path: path.clone(),
+                    remote,
+                    default_token: if mode == FetchRecurseSubmodules::On {
+                        "yes"
+                    } else {
+                        "on-demand"
+                    },
+                    oids: Vec::new(),
+                });
+            }
+        }
+    }
+
+    let mut changed_names: Vec<String> = changed_by_name.keys().cloned().collect();
+    changed_names.sort();
+    for name in changed_names {
+        if seen.contains(&name) {
+            continue;
+        }
+        let Some(cs) = changed_by_name.get(&name) else {
+            continue;
+        };
+        if !is_submodule_active_for_fetch(&repo, config, &cs.super_oid, &cs.path, &name) {
+            continue;
+        }
+        let mode = effective_submodule_fetch_recurse(
+            &name,
+            cmd_recurse,
+            default_child,
+            config,
+            gm_file.as_ref(),
+        )?;
+        let include = match mode {
+            FetchRecurseSubmodules::Off => false,
+            FetchRecurseSubmodules::On => true,
+            FetchRecurseSubmodules::OnDemand | FetchRecurseSubmodules::Default => true,
+        };
+        if !include {
+            continue;
+        }
+        let Some(gd) = submodule_git_dir_for_fetch(&repo, &cs.path) else {
+            bail!(
+                "Could not access submodule '{}' at commit {}",
+                cs.path,
+                cs.super_oid.to_hex()
+            );
+        };
+        seen.insert(name.clone());
+        let remote = get_default_remote_for_path(&cs.path)?;
+        let abs_sm = work_tree.join(&cs.path);
+        let (process_cwd, work_tree_dot) = if abs_sm.join(".git").exists() {
+            (abs_sm, false)
+        } else {
+            (gd.clone(), true)
+        };
+        work.push(SubmoduleFetchWork {
+            process_cwd,
+            work_tree_dot,
+            display_path: cs.path.clone(),
+            remote,
+            default_token: "on-demand",
+            oids: cs.new_commits.clone(),
+        });
+    }
+
+    let jobs = fetch_parallel_job_count(args, config).max(1);
+    trace_parallel_tasks(jobs);
+
+    let grit_bin = grit_exe::grit_executable();
+    let prefix_raw = args.submodule_prefix.as_deref().unwrap_or("");
+    let prefix_trim = prefix_raw.trim_end_matches('/');
+    let forward = forward_parent_fetch_flags(cmd_recurse, args);
+
+    for w in work {
+        let full_prefix = if prefix_trim.is_empty() {
+            format!("{}/", w.display_path)
+        } else {
+            format!("{prefix_trim}/{}/", w.display_path)
+        };
+        let stderr_path = if prefix_trim.is_empty() {
+            w.display_path.clone()
+        } else {
+            format!("{prefix_trim}/{}", w.display_path)
+        };
+        if !args.quiet {
+            if w.oids.is_empty() {
+                eprintln!("Fetching submodule {stderr_path}");
+            } else {
+                let abbrev = cs_super_abbrev(super_git_dir, &changed_by_name, &stderr_path);
+                eprintln!("Fetching submodule {stderr_path} at commit {abbrev}");
+            }
+        }
+
+        let mut argv: Vec<String> = vec!["fetch".into()];
+        argv.extend(forward.clone());
+        argv.push("--recurse-submodules-default".into());
+        argv.push(w.default_token.to_string());
+        argv.push(format!("--submodule-prefix={full_prefix}"));
+        if w.work_tree_dot {
+            argv.push("--work-tree=.".into());
+        }
+        argv.push(w.remote.clone());
+        for o in &w.oids {
+            argv.push(o.to_hex());
+        }
+
+        let trace_argv: Vec<String> = std::iter::once("git".to_string())
+            .chain(argv.iter().cloned())
+            .collect();
+        crate::trace2_emit_git_subcommand_argv(&trace_argv);
+
+        let status = std::process::Command::new(&grit_bin)
+            .current_dir(&w.process_cwd)
+            .args(&argv)
+            .status()
+            .with_context(|| format!("submodule fetch {}", w.display_path))?;
+        if !status.success() {
+            bail!("submodule fetch failed for {}", w.display_path);
+        }
+    }
+
+    Ok(())
+}
+
+fn cs_super_abbrev(
+    super_git_dir: &Path,
+    changed: &HashMap<String, ChangedSubmoduleFetch>,
+    path: &str,
+) -> String {
+    for cs in changed.values() {
+        if cs.path == path {
+            return short_oid(&cs.super_oid, super_git_dir);
+        }
+    }
+    "???????".to_string()
+}
+
+fn short_oid(oid: &ObjectId, _super_git_dir: &Path) -> String {
+    name_rev::abbrev_oid(*oid, 7)
+}

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -21,6 +21,8 @@ mod commands;
 mod dotfile;
 mod explicit_exit;
 mod ext_transport;
+mod fetch_submodule_record;
+mod fetch_submodule_recurse;
 mod fetch_transport;
 mod file_upload_pack_v2;
 mod git_column;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements a large slice of Git’s `fetch --recurse-submodules` behavior: recording ref tips across fetches, walking newly fetched history for gitlink changes, spawning nested `grit fetch` with the right flags, fixing nested submodule path resolution for multi-segment `.gitmodules` entries, and correcting `From …` display URLs when the current repo’s git dir lives under `.git/modules/`.

## Test status

`t5526-fetch-submodules.sh` is **not** fully passing yet (harness last run: **16/56**). This commit is incremental scaffolding toward full parity.

## Key changes

- `grit-lib`: new `fetch_submodules` module (rev-list–based changed gitlink collection, recurse parsing helpers).
- `grit fetch`: `--dry-run`, `--no-write-fetch-head`, hidden `--recurse-submodules-default` / `--submodule-prefix`; records submodule-related OIDs; merges tips for `fetch --all`; skips submodule recursion in `--porcelain` mode (Git compatibility).
- `resolve_submodule_chain`: match longest `.gitmodules` path prefix so nested paths like `subdir/deepsubmodule` resolve.
- `configured_remote_base`: strip `/.git/modules/...` so relative file URLs match upstream tests.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e1c050c-da4d-4f76-bcd3-4916f8653124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e1c050c-da4d-4f76-bcd3-4916f8653124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

