### PR TITLE
fix: make t4136-apply-check pass (apply patch validation)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -806,7 +806,7 @@ t4132-apply-removal	t4	yes	14	14	0	true	ok	0
 t4133-apply-filenames	t4	yes	4	4	0	true	ok	0
 t4134-apply-submodule	t4	yes	2	1	1	false	ok	0
 t4135-apply-weird-filenames	t4	yes	19	19	0	true	ok	0
-t4136-apply-check	t4	yes	6	3	3	false	ok	0
+t4136-apply-check	t4	yes	6	6	0	true	ok	0
 t4137-apply-submodule	t4	yes	28	11	17	false	ok	0
 t4138-apply-ws-expansion	t4	yes	5	1	4	false	ok	0
 t4139-apply-escape	t4	yes	12	7	5	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,689 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,689 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T02:32:25+00:00" class="gen-time" title="2026-04-10 02:32 UTC">2026-04-10 02:32 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,689</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -230,22 +230,22 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">73/178 files · 2 skipped · 2,862/4,438 tests</span>
+        <span class="group-meta">74/178 files · 2 skipped · 2,865/4,438 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.5%"></div></div>
-        <span class="group-pct pct-blue">64.5%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.6%"></div></div>
+        <span class="group-pct pct-blue">64.6%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35689 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,689 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T02:32:25+00:00" class="gen-time" title="2026-04-10 02:32 UTC">2026-04-10 02:32 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,689</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -8217,14 +8217,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="6" data-passed="3">
+<tr class="" data-group="t4" data-tests="6" data-passed="6" data-full-pass="1">
   <td class="mono">t4136-apply-check</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">6</td>
-  <td class="right">3</td>
+  <td class="right">6</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="28" data-passed="11">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit/src/commands/apply.rs
+++ b/grit/src/commands/apply.rs
@@ -2044,6 +2044,44 @@ fn validate_patch_headers(patches: &[FilePatch], strip: usize) -> Result<()> {
     Ok(())
 }
 
+/// Reject patch input that Git treats as corrupt or internally inconsistent.
+///
+/// `recount` relaxes the no-op hunk check (Git recomputes line counts). `allow_empty` skips the
+/// no-op rejection for empty patch sets only; semantic no-op hunks still fail without `recount`.
+fn validate_patch_semantics(patches: &[FilePatch], recount: bool, allow_empty: bool) -> Result<()> {
+    if patches.is_empty() {
+        return Ok(());
+    }
+
+    for fp in patches {
+        if fp.is_new && fp.is_copy {
+            bail!("inconsistent header lines 2 and 3");
+        }
+        if fp.is_new && fp.is_rename {
+            bail!("inconsistent header lines 2 and 3");
+        }
+
+        if recount || fp.binary_patch.is_some() {
+            continue;
+        }
+
+        for hunk in &fp.hunks {
+            let (adds, removes) = count_hunk_changes(std::slice::from_ref(hunk));
+            if adds == 0 && removes == 0 && !hunk.lines.is_empty() {
+                let line = hunk.first_body_line + hunk.lines.len();
+                bail!("corrupt patch at line {line}");
+            }
+        }
+    }
+
+    // Match Git: a patch file with only no-op file entries is empty for apply purposes.
+    if !allow_empty && patches.iter().all(|fp| fp.hunks.is_empty()) {
+        bail!("No valid patches in input");
+    }
+
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Applying hunks to content
 // ---------------------------------------------------------------------------
@@ -3802,6 +3840,7 @@ pub fn run(mut args: Args) -> Result<()> {
     postprocess_gitlink_file_patches(&mut patches);
     merge_adjacent_blob_to_gitlink_patches(&mut patches);
     validate_patch_headers(&patches, args.strip)?;
+    validate_patch_semantics(&patches, args.recount, args.allow_empty)?;
 
     if args.reverse {
         reverse_patches(&mut patches);

--- a/logs/2026-04-10_t4136-apply-check.md
+++ b/logs/2026-04-10_t4136-apply-check.md
@@ -1,0 +1,17 @@
+# t4136-apply-check
+
+## Goal
+
+Make `tests/t4136-apply-check.sh` fully pass (6/6).
+
+## Changes
+
+- Added `validate_patch_semantics` in `grit/src/commands/apply.rs`:
+  - Reject hunks with body lines but zero `+`/`-` lines (Git: `corrupt patch at line N`), unless `--recount`.
+  - Reject `new file mode` combined with `copy from`/`to` or `rename from`/`to` (Git: `inconsistent header lines 2 and 3`).
+  - Treat patch input where every file entry has no hunks as empty (`No valid patches in input`) unless `--allow-empty`.
+
+## Verification
+
+- `./scripts/run-tests.sh t4136-apply-check.sh` → 6/6
+- `cargo test -p grit-lib --lib` → pass


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns `grit apply` with upstream `git apply` validation exercised by `t4136-apply-check`:

- **No-op hunks:** Patches whose hunks contain only context (no `+`/`-` lines) are rejected with `corrupt patch at line N`, so `--stat` / `--check` / etc. fail instead of reporting zero changes. **`--recount`** skips this check (Git recounts line counts).
- **Invalid headers:** `new file mode` combined with `copy from`/`to` or `rename from`/`to` is rejected with `inconsistent header lines 2 and 3`.
- **Empty patch files:** If every parsed file entry has no hunks, treat as no valid patches (`No valid patches in input`) unless **`--allow-empty`**.

## Test

- `./scripts/run-tests.sh t4136-apply-check.sh` → **6/6**
- `cargo test -p grit-lib --lib` → pass

## Files

- `grit/src/commands/apply.rs` — `validate_patch_semantics` + call from `run`
- Harness/dashboard refresh from the test run
- `logs/2026-04-10_t4136-apply-check.md` — short work log
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2606aea-5199-4a3e-a909-d9e4e2800d27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2606aea-5199-4a3e-a909-d9e4e2800d27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

