### PR TITLE
fix: make t3416-rebase-onto-threedots fully pass

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -308,7 +308,7 @@ commit → check it off → move on.
 - [ ] `t3907-stash-show-config` ██░░░░░░░░░░░░░░░░░░ 1/10 (9 left) — Test git stash show configuration.
 - [ ] `t3413-rebase-hook` ██████░░░░░░░░░░░░░░ 5/15 (10 left) — git rebase with its hook(s)
 - [x] `t3303-notes-subtrees` — Test commit notes organized in subtrees (23/23)
-- [ ] `t3416-rebase-onto-threedots` ███████░░░░░░░░░░░░░ 7/18 (11 left) — git rebase --onto A...B
+- [x] `t3416-rebase-onto-threedots` — git rebase --onto A...B / --keep-base (18/18)
 - [ ] `t3402-rebase-merge` ███░░░░░░░░░░░░░░░░░ 2/13 (11 left) — git rebase --merge test
 - [ ] `t3602-rm-sparse-checkout` ███░░░░░░░░░░░░░░░░░ 2/13 (11 left) — git rm in sparse checked out working trees
 - [ ] `t3013-ls-files-format` ████████░░░░░░░░░░░░ 8/20 (12 left) — git ls-files --format test

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -603,7 +603,7 @@ t3409-rebase-environ	t3	yes	3	3	0	true	ok	0
 t3412-rebase-root	t3	yes	25	25	0	true	ok	0
 t3413-rebase-hook	t3	yes	15	9	6	false	ok	0
 t3415-rebase-autosquash	t3	yes	28	23	5	false	ok	0
-t3416-rebase-onto-threedots	t3	yes	18	12	6	false	ok	0
+t3416-rebase-onto-threedots	t3	yes	18	18	0	true	ok	0
 t3417-rebase-whitespace-fix	t3	yes	4	4	0	true	ok	0
 t3418-rebase-continue	t3	yes	30	6	24	false	ok	0
 t3419-rebase-patch-id	t3	yes	8	8	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,692 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,692 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T02:36:00+00:00" class="gen-time" title="2026-04-10 02:36 UTC">2026-04-10 02:36 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,692</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -219,11 +219,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">56/141 files · 2 skipped · 4,052/5,398 tests</span>
+        <span class="group-meta">57/141 files · 2 skipped · 4,058/5,398 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:75.1%"></div></div>
-        <span class="group-pct pct-blue">75.1%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:75.2%"></div></div>
+        <span class="group-pct pct-blue">75.2%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35692 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,692 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T02:36:00+00:00" class="gen-time" title="2026-04-10 02:36 UTC">2026-04-10 02:36 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,692</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -6187,14 +6187,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:82.1%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="18" data-passed="12">
+<tr class="" data-group="t3" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t3416-rebase-onto-threedots</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">12</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:66.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="4" data-passed="4" data-full-pass="1">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit/src/commands/rebase.rs
+++ b/grit/src/commands/rebase.rs
@@ -31,7 +31,10 @@ use grit_lib::patch_ids::compute_patch_id;
 use grit_lib::refs::append_reflog;
 use grit_lib::repo::Repository;
 use grit_lib::rev_list::{rev_list, split_revision_token, OrderingMode, RevListOptions};
-use grit_lib::rev_parse::{abbreviate_object_id, resolve_revision};
+use grit_lib::rev_parse::{
+    abbreviate_object_id, peel_to_commit_for_merge_base, resolve_revision,
+    resolve_revision_for_range_end, split_triple_dot_range,
+};
 use grit_lib::state::{resolve_head, HeadState};
 use grit_lib::whitespace_rule::{fix_blob_bytes, parse_whitespace_rule, WS_DEFAULT_RULE};
 use grit_lib::write_tree::write_tree_from_index;
@@ -271,6 +274,10 @@ pub fn preprocess_rebase_argv(rest: &[String]) -> Vec<String> {
 /// Run the `rebase` command.
 pub fn run(mut args: Args) -> Result<()> {
     validate_compat_syntax(&args)?;
+
+    if args.keep_base && args.onto.is_some() {
+        bail!("options '--keep-base' and '--onto' cannot be used together");
+    }
 
     if args.root {
         if args.keep_base {
@@ -1972,13 +1979,25 @@ fn do_rebase(args: Args, pre_rebase_hook_second: Option<String>) -> Result<()> {
         let upstream_spec = args.upstream.as_deref().unwrap_or("HEAD").to_owned();
         let up_oid = resolve_revision(&repo, &upstream_spec)
             .with_context(|| format!("bad revision '{upstream_spec}'"))?;
-        let (onto, onto_label) = if let Some(ref onto_spec) = args.onto {
-            let oid = resolve_revision(&repo, onto_spec)
-                .with_context(|| format!("bad revision '{onto_spec}'"))?;
-            (oid, onto_spec.clone())
-        } else if args.keep_base {
-            let oid = find_merge_base(&repo, up_oid, head_oid_early).unwrap_or(up_oid);
-            (oid, upstream_spec.clone())
+        let (onto, onto_label) = if args.keep_base {
+            let branch_name = head_state
+                .branch_name()
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| "HEAD".to_string());
+            let onto_spec = format!("{upstream_spec}...{branch_name}");
+            let onto =
+                merge_base_from_triple_dot_onto(&repo, &onto_spec, true, upstream_spec.as_str())?;
+            (onto, onto_spec)
+        } else if let Some(ref onto_spec) = args.onto {
+            if split_triple_dot_range(onto_spec).is_some() {
+                let onto =
+                    merge_base_from_triple_dot_onto(&repo, onto_spec, false, onto_spec.as_str())?;
+                (onto, onto_spec.clone())
+            } else {
+                let oid = resolve_revision(&repo, onto_spec)
+                    .with_context(|| format!("bad revision '{onto_spec}'"))?;
+                (oid, onto_spec.clone())
+            }
         } else {
             (up_oid, upstream_spec.clone())
         };
@@ -2041,11 +2060,23 @@ fn do_rebase(args: Args, pre_rebase_hook_second: Option<String>) -> Result<()> {
     } else {
         args.keep_base
     };
-    let filter_cherry_equivalents = !reapply_cherry_picks && !args.interactive;
+    let upstream_for_replay = if args.keep_base && reapply_cherry_picks {
+        onto_oid
+    } else {
+        upstream_oid
+    };
+    // Interactive rebase normally skips this filter (todo lists all commits); `--keep-base` with
+    // `--no-reapply-cherry-picks` must still omit patch-id duplicates like the merge backend.
+    let filter_cherry_equivalents = !reapply_cherry_picks && (!args.interactive || args.keep_base);
     let mut commits = if args.root {
         collect_commits_for_root_rebase(&repo, head_oid, onto_oid)?
     } else {
-        collect_rebase_todo_commits(&repo, head_oid, upstream_oid, filter_cherry_equivalents)?
+        collect_rebase_todo_commits(
+            &repo,
+            head_oid,
+            upstream_for_replay,
+            filter_cherry_equivalents,
+        )?
     };
 
     if !args.keep_empty && !args.interactive {
@@ -2346,12 +2377,40 @@ fn fast_forward_rebase(
     Ok(())
 }
 
-/// Find the merge-base of two commits.  Returns `None` when there is no
-/// common ancestor.
-fn find_merge_base(repo: &Repository, a: ObjectId, b: ObjectId) -> Option<ObjectId> {
-    grit_lib::merge_base::merge_bases_first_vs_rest(repo, a, &[b])
-        .ok()
-        .and_then(|bases| bases.into_iter().next())
+/// Resolve `A...B` in an `--onto` or synthesized `--keep-base` onto name to a single merge base.
+///
+/// When `keep_base` is true, Git reports `'<upstream>': need exactly one merge base with branch`;
+/// otherwise `'<onto>': need exactly one merge base`.
+fn merge_base_from_triple_dot_onto(
+    repo: &Repository,
+    onto_spec: &str,
+    keep_base: bool,
+    upstream_label: &str,
+) -> Result<ObjectId> {
+    let Some((left_raw, right_raw)) = split_triple_dot_range(onto_spec) else {
+        bail!("internal: expected symmetric-diff revision in onto spec");
+    };
+    let left_tip = if left_raw.is_empty() {
+        resolve_revision_for_range_end(repo, "HEAD")?
+    } else {
+        resolve_revision_for_range_end(repo, left_raw)?
+    };
+    let right_tip = if right_raw.is_empty() {
+        resolve_revision_for_range_end(repo, "HEAD")?
+    } else {
+        resolve_revision_for_range_end(repo, right_raw)?
+    };
+    let left_c = peel_to_commit_for_merge_base(repo, left_tip)?;
+    let right_c = peel_to_commit_for_merge_base(repo, right_tip)?;
+    let bases = merge_bases_first_vs_rest(repo, left_c, &[right_c])?;
+    if bases.len() != 1 {
+        if keep_base {
+            bail!("'{upstream_label}': need exactly one merge base with branch");
+        } else {
+            bail!("'{onto_spec}': need exactly one merge base");
+        }
+    }
+    Ok(bases[0])
 }
 
 /// Commits to replay for a non-interactive rebase, oldest-first.

--- a/logs/2026-04-10_t3416-rebase-onto-threedots.md
+++ b/logs/2026-04-10_t3416-rebase-onto-threedots.md
@@ -1,0 +1,19 @@
+# t3416-rebase-onto-threedots
+
+## Summary
+
+Made `tests/t3416-rebase-onto-threedots.sh` pass 18/18 by aligning `grit rebase` with Git’s `builtin/rebase.c` behavior for symmetric-diff `--onto`, `--keep-base`, and cherry-pick filtering.
+
+## Changes (`grit/src/commands/rebase.rs`)
+
+- Reject `--keep-base` together with `--onto` (Git message: options cannot be used together).
+- When `--onto` contains `...`, resolve via merge bases of the two tips; if not exactly one base, error with `'<spec>': need exactly one merge base` (or `... with branch` for keep-base synthesized onto).
+- `--keep-base`: set onto to merge base of `upstream...<branch>` (branch short name or `HEAD`), same error wording as Git when ambiguous.
+- When `--keep-base` and effective `reapply_cherry_picks` (default true), use `onto` as the upstream for `collect_rebase_todo_commits` so cherry equivalence uses the same symmetric range as Git.
+- `filter_cherry_equivalents` for interactive rebase when `--keep-base` and `--no-reapply-cherry-picks` so the todo list drops patch-id duplicates (test 17).
+
+## Verification
+
+- `cargo build --release -p grit-rs`
+- Manual harness: `bash tests/t3416-rebase-onto-threedots.sh` (18 pass)
+- `cargo test -p grit-lib --lib`

--- a/progress.md
+++ b/progress.md
@@ -1,20 +1,21 @@
 # Progress — Grit Test Coverage
 
-**Updated:** 2026-04-09
+**Updated:** 2026-04-10
 
 ## Counts (derived from plan.md)
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   325 |
+| Completed   |   326 |
 | In progress |     5 |
-| Remaining   |   441 |
+| Remaining   |   440 |
 | **Total**   |   771 |
 
-Task lines in `PLAN.md`: 325 completed (`[x]`), 5 in progress (`[~]`), 441 remaining (`[ ]`).
+Task lines in `PLAN.md`: 326 completed (`[x]`), 5 in progress (`[~]`), 440 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t3416-rebase-onto-threedots` — 18/18 tests pass (`rebase`: `--onto` with `A...B` requires a unique merge base; `--keep-base` uses synthesized `upstream...branch` onto + upstream=onto when reapplying cherry-picks; `--keep-base` + `--onto` rejected; interactive `--keep-base --no-reapply-cherry-picks` still filters patch-id duplicates)
 - `t3309-notes-merge-auto-resolve` — 31/31 tests pass (`notes merge`: `union` / `cat_sort_uniq` blob combine like Git; successful merge commits use two parents; `notes.mergeStrategy` config errors match upstream expectations)
 - `t4063-diff-blobs` — 18/18 tests pass (`diff`: blob↔blob and `rev:path` pairs without treating blobs as trees; `HEAD:one..HEAD:two` range split; `rev:path` vs worktree file uses tree path + modes + `write_patch_with_prefix`; raw blob OID vs existing file uses filename as old path; `rev_parse::resolve_treeish_blob_at_path` for tree walks)
 - `t5524-pull-msg` — 3/3 tests pass (`git pull --no-rebase --log` merge message preserves `$` in subject lines; `--log=1` limits shortlog; harness CSV/dashboards refreshed; `PLAN.md` marked complete)

--- a/test-results.md
+++ b/test-results.md
@@ -1,5 +1,10 @@
 # Test results
 
+**2026-04-10 (t3416 / rebase --onto A...B and --keep-base)**
+
+- `cargo test -p grit-lib --lib`: 160 passed
+- `./scripts/run-tests.sh t3416-rebase-onto-threedots.sh`: 18/18 passed
+
 **2026-04-09 (t4063 / diff blobs)**
 
 - `cargo test -p grit-lib --lib`: 155 passed


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns `grit rebase` with Git’s handling of symmetric-diff `--onto` (`A...B`), `--keep-base`, and cherry-pick filtering so `t3416-rebase-onto-threedots.sh` passes 18/18.

## Changes

- **Incompatible options:** `--keep-base` and `--onto` cannot be used together (matches Git’s error text).
- **`--onto` with `...`:** Resolve to the unique merge base of the two tips; if there are zero or multiple bases, fail with Git-style messages (`need exactly one merge base` / `... with branch` for keep-base).
- **`--keep-base`:** Synthetic onto name `upstream...<branch>` (short branch name or `HEAD`), same merge-base rules as Git.
- **Replay upstream:** When `--keep-base` and cherry picks are reapplied (default), use the merge-base `onto` as the upstream for commit collection, matching `rebase.c` (`options.upstream = options.onto`).
- **Interactive + `--no-reapply-cherry-picks`:** Still run patch-id cherry filtering when building the todo list so duplicate commits are dropped (test 17).

## Verification

- `cargo build --release -p grit-rs`
- `cargo test -p grit-lib --lib` (160 passed)
- `./scripts/run-tests.sh t3416-rebase-onto-threedots.sh` (18/18)

Also refreshed harness CSV/dashboards and updated `PLAN.md` / `progress.md` / `test-results.md` plus a short log under `logs/`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97cfb8f8-a93e-4861-9425-34d3fe1cf677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97cfb8f8-a93e-4861-9425-34d3fe1cf677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

