### PR TITLE
fix: t5581-http-curl-verbose — test-httpd error_git_upload_pack routing

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -552,7 +552,7 @@ commit → check it off → move on.
 - [ ] `t5406-remote-rejects` █████████████░░░░░░░ 2/3 (1 left) — remote push rejects are reported by client
 - [x] `t5314-pack-cycle-detection` — test handling of inter-pack delta cycles during repack
 
-- [ ] `t5581-http-curl-verbose` ██████████░░░░░░░░░░ 1/2 (1 left) — test GIT_CURL_VERBOSE
+- [x] `t5581-http-curl-verbose` — test GIT_CURL_VERBOSE (test-httpd: `/error_git_upload_pack` routing + 500 upload-pack)
 - [ ] `t5554-noop-fetch-negotiator` ░░░░░░░░░░░░░░░░░░░░ 0/1 (1 left) — test noop fetch negotiator
 - [ ] `t5615-alternate-env` ███████████████░░░░░ 7/9 (2 left) — handling of alternates in environment variables
 - [ ] `t5527-fetch-odd-refs` ████████████░░░░░░░░ 3/5 (2 left) — test fetching of oddly-named refs

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -992,7 +992,7 @@ t5572-pull-submodule	t5	yes	69	22	47	false	ok	0
 t5573-pull-verify-signatures	t5	skip	16	0	0	false	ok	0
 t5574-fetch-output	t5	yes	14	1	13	false	ok	0
 t5580-unc-paths	t5	skip	8	0	0	false	ok	0
-t5581-http-curl-verbose	t5	yes	2	1	1	false	ok	0
+t5581-http-curl-verbose	t5	yes	2	2	0	true	ok	0
 t5582-fetch-negative-refspec	t5	yes	16	9	7	false	ok	0
 t5583-push-branches	t5	yes	8	8	0	true	ok	0
 t5600-clone-fail-cleanup	t5	yes	14	11	3	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,687 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,687 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T02:41:10+00:00" class="gen-time" title="2026-04-10 02:41 UTC">2026-04-10 02:41 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,687</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">34/167 files · 17 skipped · 1,567/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.9%"></div></div>
+        <span class="group-pct pct-red">37.9%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35687 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,687 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T02:41:10+00:00" class="gen-time" title="2026-04-10 02:41 UTC">2026-04-10 02:41 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,687</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -10077,14 +10077,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="2" data-passed="1">
+<tr class="" data-group="t5" data-tests="2" data-passed="2" data-full-pass="1">
   <td class="mono">t5581-http-curl-verbose</td>
   <td>t5</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">2</td>
-  <td class="right">1</td>
+  <td class="right">2</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="16" data-passed="9">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit/src/bin/test_httpd.rs
+++ b/grit/src/bin/test_httpd.rs
@@ -169,6 +169,23 @@ struct Request {
     body: Vec<u8>,
 }
 
+/// Strips the upstream test harness prefix `/error_git_upload_pack` so routes match `/smart/...`.
+///
+/// Apache maps `ScriptAliasMatch /error_git_upload_pack/(.*)/git-upload-pack` to `error.sh` only for
+/// that CGI path; other requests under the same URL prefix still use `git-http-backend` via the
+/// `/smart_*` rule. We emulate that by stripping the prefix for routing only.
+fn routing_path(raw_path: &str) -> &str {
+    const PREFIX: &str = "/error_git_upload_pack";
+    let Some(rest) = raw_path.strip_prefix(PREFIX) else {
+        return raw_path;
+    };
+    match rest {
+        "" | "/" => "/",
+        s if s.starts_with('/') => s,
+        _ => raw_path,
+    }
+}
+
 fn read_request(stream: &mut TcpStream) -> Result<Request, String> {
     let mut reader = BufReader::new(stream.try_clone().map_err(|e| e.to_string())?);
 
@@ -270,6 +287,7 @@ fn handle_connection(mut stream: TcpStream, config: &Config) -> Result<(), Strin
     let _ = stream.set_read_timeout(Some(std::time::Duration::from_secs(5)));
 
     let req = read_request(&mut stream)?;
+    let path = routing_path(&req.path);
 
     // Log request
     eprintln!(
@@ -283,12 +301,12 @@ fn handle_connection(mut stream: TcpStream, config: &Config) -> Result<(), Strin
         }
     );
 
-    let needs_auth = if req.path.starts_with("/auth-push/") {
-        req.path.contains("git-receive-pack") || req.query.contains("service=git-receive-pack")
-    } else if req.path.starts_with("/auth-fetch/") {
-        req.path.contains("git-upload-pack") && req.method == "POST"
+    let needs_auth = if path.starts_with("/auth-push/") {
+        path.contains("git-receive-pack") || req.query.contains("service=git-receive-pack")
+    } else if path.starts_with("/auth-fetch/") {
+        path.contains("git-upload-pack") && req.method == "POST"
     } else {
-        req.path.starts_with("/auth/")
+        path.starts_with("/auth/")
     };
     if needs_auth {
         if let (Some(ref user), Some(ref pass)) = (&config.auth_user, &config.auth_pass) {
@@ -305,9 +323,24 @@ fn handle_connection(mut stream: TcpStream, config: &Config) -> Result<(), Strin
         }
     }
 
+    // Matches Apache `ScriptAliasMatch /error_git_upload_pack/(.*)/git-upload-pack error.sh/`.
+    if req.path.starts_with("/error_git_upload_pack/")
+        && path.ends_with("/git-upload-pack")
+        && req.method == "POST"
+    {
+        log_access(config, &req.method, &req.path, &req.query, 500);
+        return send_response(
+            &mut stream,
+            500,
+            "Intentional Breakage",
+            &[("Content-Type", "text/plain")],
+            b"this is the error message\n",
+        );
+    }
+
     // Route: /auth/smart/, /auth-push/smart/, /auth-fetch/smart/
     for pfx in &["/auth/smart", "/auth-push/smart", "/auth-fetch/smart"] {
-        if req.path.starts_with(&format!("{}/", pfx)) {
+        if path.starts_with(&format!("{}/", pfx)) {
             let r = handle_smart_http_with_path(&mut stream, &req, config, pfx);
             log_access(
                 config,
@@ -320,7 +353,7 @@ fn handle_connection(mut stream: TcpStream, config: &Config) -> Result<(), Strin
         }
     }
     // Route: /smart/<repo> → git-http-backend CGI
-    if req.path.starts_with("/smart/") {
+    if path.starts_with("/smart/") {
         let r = handle_smart_http(&mut stream, &req, config);
         log_access(
             config,
@@ -333,19 +366,19 @@ fn handle_connection(mut stream: TcpStream, config: &Config) -> Result<(), Strin
     }
 
     // Route: /dumb/<path> → static file serving
-    if req.path.starts_with("/dumb/") {
-        let rel_path = &req.path["/dumb/".len()..];
+    if path.starts_with("/dumb/") {
+        let rel_path = &path["/dumb/".len()..];
         return serve_static_file(&mut stream, config, rel_path);
     }
 
     // Route: /auth/dumb/<path> → auth + static file (already checked auth above)
-    if req.path.starts_with("/auth/dumb/") {
-        let rel_path = &req.path["/auth/dumb/".len()..];
+    if path.starts_with("/auth/dumb/") {
+        let rel_path = &path["/auth/dumb/".len()..];
         return serve_static_file(&mut stream, config, rel_path);
     }
 
     // Fallback: try serving from document root directly
-    let rel_path = req.path.trim_start_matches('/');
+    let rel_path = path.trim_start_matches('/');
     if !rel_path.is_empty() {
         let full_path = config.root.join(rel_path);
         if full_path.exists() && full_path.is_file() {
@@ -451,7 +484,8 @@ fn handle_smart_http_with_path(
     config: &Config,
     prefix: &str,
 ) -> Result<(), String> {
-    let smart_path = &req.path[prefix.len()..]; // e.g., /repo.git/info/refs
+    let path = routing_path(&req.path);
+    let smart_path = &path[prefix.len()..]; // e.g., /repo.git/info/refs
 
     let path_translated = format!("{}{}", config.root.display(), smart_path);
 

--- a/logs/2026-04-10_t5581-http-curl-verbose.md
+++ b/logs/2026-04-10_t5581-http-curl-verbose.md
@@ -1,0 +1,33 @@
+# t5581-http-curl-verbose
+
+## Symptom
+
+Harness reported 1/2: second test greps `curl_log` for libcurl-style
+`<= Recv header: HTTP/1.1 500 Intentional Breakage` after cloning
+`$HTTPD_URL/error_git_upload_pack/smart/repo.git` with `GIT_CURL_VERBOSE=1`.
+
+HTTP clone uses system `git` (hybrid wrapper in `tests/lib-httpd.sh`); failure was in **test-httpd**, not grit HTTP client.
+
+## Root cause
+
+`grit/src/bin/test_httpd.rs` did not implement Apache’s `ScriptAliasMatch` for
+`/error_git_upload_pack/(.*)/git-upload-pack` → `error.sh`, and did not strip the
+`/error_git_upload_pack` prefix for routing, so `/error_git_upload_pack/smart/...`
+never hit the `/smart/` git-http-backend path.
+
+## Fix
+
+- `routing_path()`: strip `/error_git_upload_pack` so paths route like `/smart/repo.git/...`.
+- Early handler: for original path under `/error_git_upload_pack/`, POST to `.../git-upload-pack` → HTTP 500 `Intentional Breakage` + plain body (matches upstream `error.sh`).
+- `handle_smart_http_with_path`: use `routing_path(&req.path)` when computing `PATH_INFO` / `PATH_TRANSLATED`.
+
+## Verification
+
+```bash
+./scripts/run-tests.sh t5581-http-curl-verbose.sh
+# ✓ 2/2
+```
+
+## Commit
+
+(fix committed on branch `cursor/-bc-884eadf4-465b-4312-8f23-c1a91cb7c3e4-40ee`)

--- a/progress.md
+++ b/progress.md
@@ -1,20 +1,21 @@
 # Progress — Grit Test Coverage
 
-**Updated:** 2026-04-09
+**Updated:** 2026-04-10
 
 ## Counts (derived from plan.md)
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   325 |
+| Completed   |   326 |
 | In progress |     5 |
-| Remaining   |   441 |
+| Remaining   |   440 |
 | **Total**   |   771 |
 
-Task lines in `PLAN.md`: 325 completed (`[x]`), 5 in progress (`[~]`), 441 remaining (`[ ]`).
+Task lines in `PLAN.md`: 326 completed (`[x]`), 5 in progress (`[~]`), 440 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t5581-http-curl-verbose` — 2/2 tests pass (test-httpd strips `/error_git_upload_pack` for smart routing like Apache; POST `.../git-upload-pack` returns 500 Intentional Breakage so `GIT_CURL_VERBOSE` clone logs match upstream grep)
 - `t3309-notes-merge-auto-resolve` — 31/31 tests pass (`notes merge`: `union` / `cat_sort_uniq` blob combine like Git; successful merge commits use two parents; `notes.mergeStrategy` config errors match upstream expectations)
 - `t4063-diff-blobs` — 18/18 tests pass (`diff`: blob↔blob and `rev:path` pairs without treating blobs as trees; `HEAD:one..HEAD:two` range split; `rev:path` vs worktree file uses tree path + modes + `write_patch_with_prefix`; raw blob OID vs existing file uses filename as old path; `rev_parse::resolve_treeish_blob_at_path` for tree walks)
 - `t5524-pull-msg` — 3/3 tests pass (`git pull --no-rebase --log` merge message preserves `$` in subject lines; `--log=1` limits shortlog; harness CSV/dashboards refreshed; `PLAN.md` marked complete)

--- a/test-results.md
+++ b/test-results.md
@@ -1,5 +1,10 @@
 # Test results
 
+**2026-04-10 (t5581 / GIT_CURL_VERBOSE)**
+
+- `cargo test -p grit-lib --lib`: 160 passed
+- `./scripts/run-tests.sh t5581-http-curl-verbose.sh`: 2/2 passed
+
 **2026-04-09 (t4063 / diff blobs)**
 
 - `cargo test -p grit-lib --lib`: 155 passed


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t5581-http-curl-verbose` failed because the Rust `test-httpd` did not match Apache’s behavior for the `/error_git_upload_pack` prefix used in the upstream HTTP test layout.

## Changes

- **`grit/src/bin/test_httpd.rs`**
  - Add `routing_path()` to strip `/error_git_upload_pack` so requests route like `/smart/repo.git/...` and reach `git-http-backend` for `info/refs`.
  - For `POST` to `.../git-upload-pack` under that prefix, respond with **HTTP 500** `Intentional Breakage` and a short plain body (same role as upstream `error.sh`).
  - Use the routed path when computing `PATH_INFO` for smart HTTP with auth prefixes.

- **Harness metadata**: refreshed `data/test-files.csv` and dashboards after `./scripts/run-tests.sh t5581-http-curl-verbose.sh` (2/2).
- **Project tracking**: `PLAN.md`, `progress.md`, `test-results.md`, `logs/2026-04-10_t5581-http-curl-verbose.md`.

## Verification

- `cargo test -p grit-lib --lib` — 160 passed
- `./scripts/run-tests.sh t5581-http-curl-verbose.sh` — 2/2 passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-884eadf4-465b-4312-8f23-c1a91cb7c3e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-884eadf4-465b-4312-8f23-c1a91cb7c3e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

