### PR TITLE
fix: test-tool run-command for t0061 (full pass)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -40,7 +40,7 @@ t0052-simple-ipc	t0	yes	9	9	0	true	ok	0
 t0055-beyond-symlinks	t0	yes	3	3	0	true	ok	0
 t0056-git-C	t0	yes	11	11	0	true	ok	0
 t0060-path-utils	t0	yes	219	219	0	true	ok	0
-t0061-run-command	t0	yes	24	4	20	false	ok	0
+t0061-run-command	t0	yes	24	24	0	true	ok	0
 t0062-revision-walking	t0	yes	2	2	0	true	ok	0
 t0066-dir-iterator	t0	yes	10	10	0	true	ok	0
 t0067-parse_pathspec_file	t0	yes	8	8	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,706 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,706 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T02:52:04+00:00" class="gen-time" title="2026-04-10 02:52 UTC">2026-04-10 02:52 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,706</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -186,11 +186,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t0</span>
         <span class="group-desc">Absolute basics and global stuff</span>
-        <span class="group-meta">40/64 files · 21 skipped · 4,885/5,134 tests</span>
+        <span class="group-meta">41/64 files · 21 skipped · 4,905/5,134 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:95.1%"></div></div>
-        <span class="group-pct pct-green">95.1%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:95.5%"></div></div>
+        <span class="group-pct pct-green">95.5%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t1">
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35706 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,706 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T02:52:04+00:00" class="gen-time" title="2026-04-10 02:52 UTC">2026-04-10 02:52 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,706</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -557,14 +557,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t0" data-tests="24" data-passed="4">
+<tr class="" data-group="t0" data-tests="24" data-passed="24" data-full-pass="1">
   <td class="mono">t0061-run-command</td>
   <td>t0</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">24</td>
-  <td class="right">4</td>
+  <td class="right">24</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:16.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t0" data-tests="2" data-passed="2" data-full-pass="1">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -37,6 +37,7 @@ mod precompose;
 pub mod protocol;
 mod protocol_wire;
 mod ssh_transport;
+mod test_tool_run_command;
 mod trace_packet;
 mod transport_passthrough;
 mod wire_trace;
@@ -4022,6 +4023,7 @@ pub(crate) const KNOWN_COMMANDS: &[&str] = &[
     "switch",
     "symbolic-ref",
     "tag",
+    "test-tool",
     "unpack-file",
     "unpack-objects",
     "update-index",
@@ -4416,6 +4418,7 @@ pub(crate) fn dispatch(subcmd: &str, rest: &[String], opts: &GlobalOpts) -> Resu
                 "lazy-init-name-hash" => run_test_tool_lazy_init_name_hash(rest),
                 "rot13-filter" => commands::test_tool_rot13_filter::run(&rest[1..]),
                 "path-utils" => run_test_tool_path_utils(&rest[1..]),
+                "run-command" => test_tool_run_command::run(&rest[1..]),
                 "subprocess" => run_test_tool_subprocess(&rest[1..]),
                 "submodule" => run_test_tool_submodule(rest),
                 "config" => run_test_tool_config(&rest[1..]),

--- a/grit/src/test_tool_run_command.rs
+++ b/grit/src/test_tool_run_command.rs
@@ -1,0 +1,606 @@
+//! `test-tool run-command` — mirrors `git/t/helper/test-run-command.c` (t0061).
+
+use anyhow::{bail, Result};
+use std::collections::BTreeMap;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{ChildStdin, Command, Stdio};
+use std::sync::Arc;
+use std::thread;
+
+const PRELOAD: &str = "preloaded output of a child\n";
+const ASKING_STOP: &str = "asking for a quick stop\n";
+const NO_JOBS: &str = "no further jobs available\n";
+
+fn sq_quote_buf(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('\'');
+    let mut rest = s;
+    while !rest.is_empty() {
+        let take = rest.find(|c| c == '\'' || c == '!').unwrap_or(rest.len());
+        out.push_str(&rest[..take]);
+        rest = &rest[take..];
+        if let Some(c) = rest.chars().next() {
+            out.push_str("'\\");
+            out.push(c);
+            out.push('\'');
+            rest = &rest[c.len_utf8()..];
+        }
+    }
+    out.push('\'');
+    out
+}
+
+fn sq_quote_buf_pretty(s: &str) -> String {
+    const OK_PUNCT: &[u8] = b"+,-./:=@_^";
+    if s.is_empty() {
+        return "''".to_string();
+    }
+    if s.chars()
+        .all(|c| c.is_ascii_alphanumeric() || OK_PUNCT.contains(&(c as u8)))
+    {
+        return s.to_string();
+    }
+    sq_quote_buf(s)
+}
+
+fn trace_add_env(delta: &[String]) -> String {
+    let mut map: BTreeMap<String, Option<String>> = BTreeMap::new();
+    for entry in delta {
+        if let Some((k, v)) = entry.split_once('=') {
+            map.insert(k.to_string(), Some(v.to_string()));
+        } else {
+            map.insert(entry.clone(), None);
+        }
+    }
+    let mut out = String::new();
+    let mut printed_unset = false;
+    for (var, val) in &map {
+        if val.is_none() && std::env::var_os(var).is_some() {
+            if !printed_unset {
+                out.push_str(" unset");
+                printed_unset = true;
+            }
+            out.push(' ');
+            out.push_str(var);
+        }
+    }
+    if printed_unset {
+        out.push(';');
+    }
+    for (var, val) in &map {
+        let Some(val) = val else {
+            continue;
+        };
+        let old = std::env::var(var).ok();
+        if old.as_deref() == Some(val.as_str()) {
+            continue;
+        }
+        out.push(' ');
+        out.push_str(var);
+        out.push('=');
+        out.push_str(&sq_quote_buf_pretty(val));
+    }
+    out
+}
+
+fn trace_start_command_line(argv: &[String]) {
+    let Ok(trace_val) = std::env::var("GIT_TRACE") else {
+        return;
+    };
+    if trace_val.is_empty() || trace_val == "0" || trace_val.eq_ignore_ascii_case("false") {
+        return;
+    }
+    let mut line = String::from("trace: start_command:");
+    for (i, a) in argv.iter().enumerate() {
+        if i > 0 {
+            line.push(' ');
+        }
+        line.push_str(&sq_quote_buf_pretty(a));
+    }
+    line.push('\n');
+    crate::write_git_trace(&trace_val, &line);
+}
+
+fn trace_run_command_line(env_delta: &[String], argv: &[String]) {
+    let Ok(trace_val) = std::env::var("GIT_TRACE") else {
+        return;
+    };
+    if trace_val.is_empty() || trace_val == "0" || trace_val.eq_ignore_ascii_case("false") {
+        return;
+    }
+    let mut line = String::from("trace: run_command:");
+    line.push_str(&trace_add_env(env_delta));
+    for a in argv {
+        line.push(' ');
+        line.push_str(&sq_quote_buf_pretty(a));
+    }
+    line.push('\n');
+    crate::write_git_trace(&trace_val, &line);
+}
+
+fn is_executable_file(path: &Path) -> std::io::Result<bool> {
+    use std::os::unix::fs::PermissionsExt;
+    let meta = std::fs::metadata(path)?;
+    if !meta.is_file() {
+        return Ok(false);
+    }
+    Ok(meta.permissions().mode() & 0o100 != 0)
+}
+
+fn locate_in_path(file: &str) -> Option<PathBuf> {
+    if file.contains('/') {
+        return None;
+    }
+    let path = std::env::var_os("PATH")?;
+    let path = path.to_string_lossy();
+    for raw in path.split(':') {
+        let base = if raw.is_empty() { "." } else { raw };
+        let candidate = Path::new(base).join(file);
+        if is_executable_file(&candidate).unwrap_or(false) {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn resolve_program(argv0: &str) -> Result<PathBuf, std::io::Error> {
+    if argv0.contains('/') {
+        let p = Path::new(argv0);
+        if !p.exists() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "not found",
+            ));
+        }
+        return Ok(p.to_path_buf());
+    }
+    locate_in_path(argv0)
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "not in PATH"))
+}
+
+fn apply_env_delta(cmd: &mut Command, delta: &[String]) {
+    let mut map: BTreeMap<String, Option<String>> = BTreeMap::new();
+    for e in delta {
+        if let Some((k, v)) = e.split_once('=') {
+            map.insert(k.to_string(), Some(v.to_string()));
+        } else {
+            map.insert(e.clone(), None);
+        }
+    }
+    for (k, v) in map {
+        match v {
+            Some(val) => {
+                cmd.env(k, val);
+            }
+            None => {
+                cmd.env_remove(&k);
+            }
+        }
+    }
+}
+
+fn error_errno_cannot_exec(arg0: &str, err: &std::io::Error) {
+    eprintln!("fatal: cannot exec '{arg0}': {err}");
+}
+
+fn error_errno_cannot_run(arg0: &str, err: &std::io::Error) {
+    eprintln!("fatal: cannot run '{arg0}': {err}");
+}
+
+fn spawn_with_shell_fallback(
+    program: &Path,
+    argv: &[String],
+    env_delta: &[String],
+    use_stdin_pipe: bool,
+) -> std::io::Result<std::process::Child> {
+    let stdin = if use_stdin_pipe {
+        Stdio::piped()
+    } else {
+        Stdio::null()
+    };
+    let stdout = Stdio::piped();
+    let stderr = Stdio::piped();
+    let mut cmd = Command::new(program);
+    cmd.args(&argv[1..]);
+    cmd.stdin(stdin);
+    cmd.stdout(stdout);
+    cmd.stderr(stderr);
+    apply_env_delta(&mut cmd, env_delta);
+    match cmd.spawn() {
+        Ok(c) => Ok(c),
+        Err(e) if e.raw_os_error() == Some(libc::ENOEXEC) => {
+            let stdin2 = if use_stdin_pipe {
+                Stdio::piped()
+            } else {
+                Stdio::null()
+            };
+            let mut sh = Command::new("/bin/sh");
+            sh.arg(program);
+            sh.args(&argv[1..]);
+            sh.stdin(stdin2);
+            sh.stdout(Stdio::piped());
+            sh.stderr(Stdio::piped());
+            apply_env_delta(&mut sh, env_delta);
+            sh.spawn()
+        }
+        Err(e) => Err(e),
+    }
+}
+
+fn feed_stdin_line(stdin: &mut ChildStdin, lines_left: &mut i32) -> std::io::Result<bool> {
+    if *lines_left <= 0 {
+        return Ok(true);
+    }
+    let line = format!("sample stdin {}\n", *lines_left - 1);
+    *lines_left -= 1;
+    match stdin.write_all(line.as_bytes()) {
+        Ok(()) => Ok(*lines_left == 0),
+        Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => Ok(true),
+        Err(e) => Err(e),
+    }
+}
+
+fn run_processes_parallel_grouped(
+    jobs: usize,
+    argv: &[String],
+    use_stdin: bool,
+    no_jobs_mode: bool,
+    task_finished_abort: bool,
+) -> Result<()> {
+    use std::sync::mpsc::{self, Receiver, Sender};
+
+    if no_jobs_mode {
+        std::io::stderr().write_all(NO_JOBS.as_bytes())?;
+        return Ok(());
+    }
+
+    #[derive(Debug)]
+    enum WorkerToMain {
+        Stderr(usize, Vec<u8>),
+        Finished(usize),
+    }
+
+    let (tx, rx): (Sender<WorkerToMain>, Receiver<WorkerToMain>) = mpsc::channel();
+    let argv = Arc::new(argv.to_vec());
+
+    let mut buffered_output: Vec<u8> = Vec::new();
+    let mut output_owner: usize = 0;
+    let mut tasks_spawned: usize = 0;
+    let mut nr_running: usize = 0;
+    let mut shutdown = false;
+    let mut slot_busy: Vec<bool> = vec![false; jobs];
+    let mut err_bufs: Vec<Vec<u8>> = vec![Vec::new(); jobs];
+    let mut handles: Vec<Option<thread::JoinHandle<()>>> = (0..jobs).map(|_| None).collect();
+
+    let find_free_slot = |busy: &[bool]| busy.iter().position(|b| !*b);
+
+    let start_worker = |slot: usize,
+                        argv: Arc<Vec<String>>,
+                        use_stdin: bool,
+                        tx: Sender<WorkerToMain>,
+                        handles: &mut [Option<thread::JoinHandle<()>>]| {
+        let txw = tx.clone();
+        let av = Arc::clone(&argv);
+        let h = thread::spawn(move || {
+            let _ = txw.send(WorkerToMain::Stderr(slot, PRELOAD.as_bytes().to_vec()));
+            let mut child =
+                match spawn_with_shell_fallback(Path::new(&av[0]), av.as_ref(), &[], use_stdin) {
+                    Ok(c) => c,
+                    Err(_) => {
+                        let _ = txw.send(WorkerToMain::Finished(slot));
+                        return;
+                    }
+                };
+            if use_stdin {
+                if let Some(mut stdin) = child.stdin.take() {
+                    let mut left = 2i32;
+                    let _ = feed_stdin_line(&mut stdin, &mut left);
+                    let _ = feed_stdin_line(&mut stdin, &mut left);
+                }
+            }
+            let mut stderr = child.stderr.take().expect("stderr");
+            let mut stdout = child.stdout.take().expect("stdout");
+            let mut buf = [0u8; 4096];
+            loop {
+                match stderr.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        let _ = txw.send(WorkerToMain::Stderr(slot, buf[..n].to_vec()));
+                    }
+                    Err(_) => break,
+                }
+            }
+            // Git uses `stdout_to_stderr` for grouped parallel children; merge stdout into stderr.
+            loop {
+                match stdout.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        let _ = txw.send(WorkerToMain::Stderr(slot, buf[..n].to_vec()));
+                    }
+                    Err(_) => break,
+                }
+            }
+            let _ = child.wait();
+            let _ = txw.send(WorkerToMain::Finished(slot));
+        });
+        handles[slot] = Some(h);
+    };
+
+    loop {
+        while !shutdown && nr_running < jobs && tasks_spawned < 4 {
+            let Some(si) = find_free_slot(&slot_busy) else {
+                break;
+            };
+            tasks_spawned += 1;
+            slot_busy[si] = true;
+            err_bufs[si].clear();
+            start_worker(si, Arc::clone(&argv), use_stdin, tx.clone(), &mut handles);
+            nr_running += 1;
+        }
+
+        if nr_running == 0 && (tasks_spawned >= 4 || shutdown) {
+            break;
+        }
+
+        match rx.recv_timeout(std::time::Duration::from_millis(50)) {
+            Ok(WorkerToMain::Stderr(slot, chunk)) => {
+                err_bufs[slot].extend_from_slice(&chunk);
+                if slot == output_owner {
+                    std::io::stderr().write_all(&err_bufs[slot])?;
+                    err_bufs[slot].clear();
+                }
+            }
+            Ok(WorkerToMain::Finished(slot)) => {
+                if let Some(h) = handles[slot].take() {
+                    let _ = h.join();
+                }
+                slot_busy[slot] = false;
+                nr_running = nr_running.saturating_sub(1);
+
+                if task_finished_abort {
+                    buffered_output.extend_from_slice(ASKING_STOP.as_bytes());
+                    shutdown = true;
+                }
+
+                if slot != output_owner {
+                    buffered_output.append(&mut err_bufs[slot]);
+                } else {
+                    std::io::stderr().write_all(&err_bufs[slot])?;
+                    err_bufs[slot].clear();
+                    std::io::stderr().write_all(&buffered_output)?;
+                    buffered_output.clear();
+                    let mut next = output_owner;
+                    for off in 0..jobs {
+                        let j = (output_owner + off) % jobs;
+                        if slot_busy[j] {
+                            next = j;
+                            break;
+                        }
+                    }
+                    output_owner = next;
+                }
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+
+    for h in handles.into_iter().flatten() {
+        let _ = h.join();
+    }
+
+    std::io::stderr().write_all(&buffered_output)?;
+    Ok(())
+}
+
+fn run_processes_parallel_ungrouped(
+    jobs: usize,
+    argv: &[String],
+    use_stdin: bool,
+    no_jobs_mode: bool,
+    task_finished_abort: bool,
+) -> Result<()> {
+    if no_jobs_mode {
+        eprint!("{NO_JOBS}");
+        return Ok(());
+    }
+
+    let argv = Arc::new(argv.to_vec());
+    let mut pending: Vec<thread::JoinHandle<()>> = Vec::new();
+    let mut tasks_spawned: usize = 0;
+    let mut shutdown = false;
+
+    while tasks_spawned < 4 || !pending.is_empty() {
+        while pending.len() < jobs && tasks_spawned < 4 && !shutdown {
+            tasks_spawned += 1;
+            let av = Arc::clone(&argv);
+            let use_stdin_f = use_stdin;
+            pending.push(thread::spawn(move || {
+                eprint!("{PRELOAD}");
+                let mut child =
+                    spawn_with_shell_fallback(Path::new(&av[0]), av.as_ref(), &[], use_stdin_f)
+                        .expect("spawn");
+
+                if use_stdin_f {
+                    if let Some(mut stdin) = child.stdin.take() {
+                        let mut left = 2i32;
+                        let _ = feed_stdin_line(&mut stdin, &mut left);
+                        let _ = feed_stdin_line(&mut stdin, &mut left);
+                    }
+                }
+
+                let mut stderr = child.stderr.take().expect("stderr");
+                let mut stdout = child.stdout.take().expect("stdout");
+                let out_h = thread::spawn(move || {
+                    let mut buf = [0u8; 4096];
+                    loop {
+                        match stdout.read(&mut buf) {
+                            Ok(0) => break,
+                            Ok(n) => {
+                                let _ = std::io::stdout().write_all(&buf[..n]);
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                });
+                let mut buf = [0u8; 4096];
+                loop {
+                    match stderr.read(&mut buf) {
+                        Ok(0) => break,
+                        Ok(n) => {
+                            let _ = std::io::stderr().write_all(&buf[..n]);
+                        }
+                        Err(_) => break,
+                    }
+                }
+                let _ = out_h.join();
+                let _ = child.wait();
+            }));
+        }
+
+        if pending.is_empty() {
+            break;
+        }
+
+        let t = pending.remove(0);
+        t.join().map_err(|_| anyhow::anyhow!("worker panicked"))?;
+        if task_finished_abort {
+            eprint!("{ASKING_STOP}");
+            shutdown = true;
+        }
+    }
+
+    Ok(())
+}
+
+/// Args after the `test-tool run-command` token (i.e. same slice Git's `cmd__run_command` sees as `argv[1..]`).
+pub fn run(args: &[String]) -> Result<()> {
+    let mut argv = args.to_vec();
+
+    let mut env_delta: Vec<String> = Vec::new();
+    while argv.len() >= 2 && argv[0] == "env" {
+        env_delta.push(argv[1].clone());
+        argv.drain(0..2);
+    }
+
+    let mut ungroup = false;
+    if argv.first().map(|s| s.as_str()) == Some("--ungroup") {
+        ungroup = true;
+        argv.remove(0);
+    }
+
+    if argv.len() < 2 {
+        bail!("check usage");
+    }
+
+    let mode = argv[0].clone();
+    let tail = argv[1..].to_vec();
+
+    match mode.as_str() {
+        "start-command-ENOENT" => {
+            if tail.is_empty() {
+                bail!("check usage");
+            }
+            let target = &tail[0];
+            match resolve_program(target) {
+                Ok(program) => {
+                    let mut cmd = Command::new(&program);
+                    cmd.args(&tail[1..]);
+                    apply_env_delta(&mut cmd, &env_delta);
+                    match cmd.spawn() {
+                        Ok(mut c) => {
+                            let _ = c.wait();
+                            std::process::exit(1);
+                        }
+                        Err(e) if e.raw_os_error() == Some(libc::ENOENT) => {
+                            error_errno_cannot_exec(target, &e);
+                            std::process::exit(0);
+                        }
+                        Err(e) => {
+                            error_errno_cannot_run(target, &e);
+                            std::process::exit(1);
+                        }
+                    }
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    error_errno_cannot_run(target, &e);
+                    std::process::exit(0);
+                }
+                Err(e) => {
+                    error_errno_cannot_run(target, &e);
+                    std::process::exit(1);
+                }
+            }
+        }
+        "run-command" => {
+            if tail.is_empty() {
+                bail!("check usage");
+            }
+            let program = match resolve_program(&tail[0]) {
+                Ok(p) => p,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    error_errno_cannot_run(&tail[0], &e);
+                    std::process::exit(1);
+                }
+                Err(e) => {
+                    error_errno_cannot_run(&tail[0], &e);
+                    std::process::exit(1);
+                }
+            };
+            let mut start_argv: Vec<String> = Vec::new();
+            start_argv.push(program.to_string_lossy().into_owned());
+            start_argv.extend_from_slice(&tail[1..]);
+            trace_start_command_line(&start_argv);
+            trace_run_command_line(&env_delta, &tail);
+            let mut cmd = Command::new(&program);
+            cmd.args(&tail[1..]);
+            apply_env_delta(&mut cmd, &env_delta);
+            match cmd.status() {
+                Ok(s) => std::process::exit(s.code().unwrap_or(1)),
+                Err(e) if e.raw_os_error() == Some(libc::ENOEXEC) => {
+                    let mut sh = Command::new("/bin/sh");
+                    sh.arg(&program);
+                    sh.args(&tail[1..]);
+                    apply_env_delta(&mut sh, &env_delta);
+                    match sh.status() {
+                        Ok(s) => std::process::exit(s.code().unwrap_or(1)),
+                        Err(e2) => {
+                            error_errno_cannot_exec(&tail[0], &e2);
+                            std::process::exit(1);
+                        }
+                    }
+                }
+                Err(e) => {
+                    error_errno_cannot_exec(&tail[0], &e);
+                    std::process::exit(1);
+                }
+            }
+        }
+        "run-command-parallel"
+        | "run-command-abort"
+        | "run-command-no-jobs"
+        | "run-command-stdin" => {
+            if tail.len() < 2 {
+                bail!("check usage");
+            }
+            let jobs: usize = tail[0]
+                .parse()
+                .map_err(|_| anyhow::anyhow!("invalid job count"))?;
+            if jobs == 0 {
+                bail!("invalid job count");
+            }
+            let cmd_argv = tail[1..].to_vec();
+            let use_stdin = mode == "run-command-stdin";
+            let no_jobs = mode == "run-command-no-jobs";
+            let abort = mode == "run-command-abort";
+            if ungroup {
+                run_processes_parallel_ungrouped(jobs, &cmd_argv, use_stdin, no_jobs, abort)?;
+            } else {
+                run_processes_parallel_grouped(jobs, &cmd_argv, use_stdin, no_jobs, abort)?;
+            }
+        }
+        other => bail!("check usage: unknown mode '{other}'"),
+    }
+    Ok(())
+}

--- a/logs/2026-04-10_t0061-run-command.md
+++ b/logs/2026-04-10_t0061-run-command.md
@@ -1,0 +1,5 @@
+# t0061-run-command
+
+- Implemented `grit test-tool run-command` in `grit/src/test_tool_run_command.rs` (start-command-ENOENT, run-command with PATH + ENOEXEC shell fallback, parallel grouped/ungrouped modes, stdin feed, abort/no-jobs, GIT_TRACE env + start_command line).
+- Registered `test-tool` in `KNOWN_COMMANDS` so alias dispatch does not emit a spurious `git-test-tool` trace line (fixes t0061 GIT_TRACE sed pipeline).
+- Refreshed `data/test-files.csv` and dashboards via `./scripts/run-tests.sh t0061-run-command.sh`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements `grit test-tool run-command` to match Git's `test-run-command.c` behavior exercised by `t0061-run-command.sh`: ENOENT handling, PATH resolution (skip non-executables and directories), `ENOEXEC` → `/bin/sh` fallback for scripts without shebang, parallel grouped/ungrouped modes, stdin feeding, abort/no-jobs messages, and `GIT_TRACE` lines compatible with the test's `sed` pipeline.

Registers `test-tool` in `KNOWN_COMMANDS` so it is not treated as an external `git-test-tool` helper (which produced an extra trace line and broke the GIT_TRACE test).

## Testing

- `./scripts/run-tests.sh t0061-run-command.sh` → 24/24 pass
- `cargo test -p grit-lib --lib`

## Notes

Workspace `cargo clippy -- -D warnings` currently fails with many pre-existing grit-lib lints; scoped check used `read_lints` on edited files instead.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-571ca176-a498-4cb4-9b19-73aa2cfe3002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-571ca176-a498-4cb4-9b19-73aa2cfe3002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

