### PR TITLE
fix: make t7411-submodule-config fully pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1203,7 +1203,7 @@ t7406-submodule-update	t7	yes	70	15	55	false	ok	0
 t7407-submodule-foreach	t7	yes	23	19	4	false	ok	0
 t7408-submodule-reference	t7	yes	16	5	11	false	ok	0
 t7409-submodule-detached-work-tree	t7	yes	3	2	1	false	ok	0
-t7411-submodule-config	t7	yes	20	4	16	false	ok	0
+t7411-submodule-config	t7	yes	20	20	0	true	ok	0
 t7412-submodule-absorbgitdirs	t7	yes	12	5	7	false	ok	0
 t7413-submodule-is-active	t7	yes	10	2	8	false	ok	0
 t7414-submodule-mistakes	t7	yes	5	5	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,702 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,702 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T03:03:44+00:00" class="gen-time" title="2026-04-10 03:03 UTC">2026-04-10 03:03 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,702</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">49/126 files · 11 skipped · 2,510/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.4%"></div></div>
+        <span class="group-pct pct-blue">69.4%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35702 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,702 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T03:03:44+00:00" class="gen-time" title="2026-04-10 03:03 UTC">2026-04-10 03:03 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,702</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">
@@ -12187,14 +12187,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:66.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="20" data-passed="4">
+<tr class="" data-group="t7" data-tests="20" data-passed="20" data-full-pass="1">
   <td class="mono">t7411-submodule-config</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">20</td>
-  <td class="right">4</td>
+  <td class="right">20</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:20.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="12" data-passed="5">

--- a/grit-lib/src/config.rs
+++ b/grit-lib/src/config.rs
@@ -387,6 +387,37 @@ impl Parser {
 /// This checks the value portion (after `=`) for a trailing `\` that is
 /// outside quotes and outside an inline comment. If the `\` is after
 /// a `#` or `;` that starts a comment, it does NOT count as continuation.
+/// True when the value portion (after the first `=`) ends inside an unclosed double-quoted span.
+///
+/// Mirrors Git config continuation rules: a line ending with an open `"` continues on the next
+/// physical line. Outside quotes, `#` / `;` start comments and the line is complete.
+fn entry_line_value_has_unclosed_quote(line: &str) -> bool {
+    let trimmed = line.trim();
+    let Some(eq_pos) = trimmed.find('=') else {
+        return false;
+    };
+    let raw_value = trimmed[eq_pos + 1..].trim_start();
+    let mut in_quote = false;
+    let mut last_was_backslash = false;
+    for ch in raw_value.chars() {
+        match ch {
+            '"' if !last_was_backslash => {
+                in_quote = !in_quote;
+                last_was_backslash = false;
+            }
+            '\\' if in_quote && !last_was_backslash => {
+                last_was_backslash = true;
+                continue;
+            }
+            '#' | ';' if !in_quote && !last_was_backslash => return false,
+            _ => {
+                last_was_backslash = false;
+            }
+        }
+    }
+    in_quote
+}
+
 fn value_line_continues(line: &str) -> bool {
     let trimmed = line.trim();
     if trimmed.is_empty() || trimmed.starts_with('#') || trimmed.starts_with(';') {
@@ -628,6 +659,19 @@ fatal: bad config variable 'fetch.negotiationalgorithm' in file '{file_disp}' at
                 idx += 1;
             }
 
+            while entry_line_value_has_unclosed_quote(&logical_line) && idx < raw_lines.len() {
+                let next = raw_lines[idx].trim_start();
+                logical_line.push_str(next);
+                idx += 1;
+            }
+            if entry_line_value_has_unclosed_quote(&logical_line) {
+                let file_disp = config_error_path_display(path);
+                return Err(Error::ConfigError(format!(
+                    "bad config line {} in file '{file_disp}'",
+                    start_idx + 1
+                )));
+            }
+
             if let Some((key, value)) = parser.try_parse_entry(&logical_line) {
                 if key == "fetch.negotiationalgorithm" && value.is_none() {
                     let file_disp = config_error_path_display(path);
@@ -654,6 +698,83 @@ fatal: bad config variable 'fetch.negotiationalgorithm' in file '{file_disp}' at
             raw_lines,
             include_origin: ConfigIncludeOrigin::Disk,
         })
+    }
+
+    /// Like [`Self::parse`] for `.gitmodules`, but on an unclosed-quote / bad line returns entries
+    /// parsed **before** that line plus the one-based line number of the bad logical line.
+    ///
+    /// Git streams config and still applies entries from valid preceding lines; submodule-config
+    /// tests rely on that when a later `.gitmodules` line is malformed.
+    pub fn parse_gitmodules_best_effort(
+        path: &Path,
+        content: &str,
+        scope: ConfigScope,
+    ) -> (Vec<ConfigEntry>, Option<usize>) {
+        let raw_lines: Vec<String> = content
+            .lines()
+            .map(|l| l.strip_suffix('\r').unwrap_or(l))
+            .map(String::from)
+            .collect();
+        let mut entries = Vec::new();
+        let mut parser = Parser::new();
+
+        let mut idx = 0;
+        while idx < raw_lines.len() {
+            let start_idx = idx;
+            let line = &raw_lines[idx];
+            idx += 1;
+
+            let trimmed = line.trim();
+            if trimmed.starts_with('#') || trimmed.starts_with(';') {
+                continue;
+            }
+
+            let mut inline_remainder = None;
+            if parser.try_parse_section_with_remainder(line, &mut inline_remainder) {
+                if let Some(remainder) = inline_remainder {
+                    if let Some((key, value)) = parser.try_parse_entry(remainder) {
+                        entries.push(ConfigEntry {
+                            key,
+                            value,
+                            scope,
+                            file: Some(path.to_path_buf()),
+                            line: start_idx + 1,
+                        });
+                    }
+                }
+                continue;
+            }
+
+            let mut logical_line = line.clone();
+            while value_line_continues(&logical_line) && idx < raw_lines.len() {
+                let t = logical_line.trim_end();
+                logical_line = t[..t.len() - 1].to_string();
+                let next = raw_lines[idx].trim_start();
+                logical_line.push_str(next);
+                idx += 1;
+            }
+
+            while entry_line_value_has_unclosed_quote(&logical_line) && idx < raw_lines.len() {
+                let next = raw_lines[idx].trim_start();
+                logical_line.push_str(next);
+                idx += 1;
+            }
+            if entry_line_value_has_unclosed_quote(&logical_line) {
+                return (entries, Some(start_idx + 1));
+            }
+
+            if let Some((key, value)) = parser.try_parse_entry(&logical_line) {
+                entries.push(ConfigEntry {
+                    key,
+                    value,
+                    scope,
+                    file: Some(path.to_path_buf()),
+                    line: start_idx + 1,
+                });
+            }
+        }
+
+        (entries, None)
     }
 
     /// Parse like [`Self::parse`] but record a non-disk include origin (blob, stdin, command line).

--- a/grit-lib/src/lib.rs
+++ b/grit-lib/src/lib.rs
@@ -99,6 +99,7 @@ pub mod simple_ipc {
 }
 pub mod state;
 pub mod stripspace;
+pub mod submodule_config_cache;
 pub mod submodule_gitdir;
 pub mod test_tool_progress;
 pub mod textconv_cache;

--- a/grit-lib/src/submodule_config_cache.rs
+++ b/grit-lib/src/submodule_config_cache.rs
@@ -1,0 +1,640 @@
+//! Submodule configuration cache (Git `submodule-config.c` subset for test-tool).
+//!
+//! Parses `.gitmodules` blobs keyed by blob OID and supports lookup by path or
+//! logical submodule name, matching the behavior exercised by `t7411-submodule-config`.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use crate::config::{canonical_key, ConfigFile, ConfigScope};
+use crate::merge_diff::blob_oid_at_path;
+use crate::objects::{parse_commit, ObjectId, ObjectKind};
+use crate::odb::Odb;
+use crate::repo::Repository;
+use crate::rev_parse::resolve_revision;
+
+/// Resolved submodule identity for test output (`Submodule name: 'x' for path 'y'`).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SubmoduleInfo {
+    /// Logical submodule name from `.gitmodules`.
+    pub name: String,
+    /// Checkout path relative to the superproject root.
+    pub path: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum FetchRecurse {
+    None,
+    On,
+    Off,
+    OnDemand,
+    Error,
+}
+
+#[derive(Clone, Debug)]
+struct SubmoduleBuild {
+    name: String,
+    path: Option<String>,
+    url: Option<String>,
+    fetch_recurse: FetchRecurse,
+}
+
+impl SubmoduleBuild {
+    fn new(name: String) -> Self {
+        Self {
+            name,
+            path: None,
+            url: None,
+            fetch_recurse: FetchRecurse::None,
+        }
+    }
+}
+
+/// Cache of parsed `.gitmodules` blobs (by blob OID) plus path/name indexes.
+#[derive(Default)]
+pub struct SubmoduleConfigCache {
+    by_blob: HashMap<ObjectId, Vec<SubmoduleBuild>>,
+    path_index: HashMap<(ObjectId, String), String>,
+    name_index: HashMap<(ObjectId, String), SubmoduleBuild>,
+}
+
+impl SubmoduleConfigCache {
+    /// Creates an empty cache.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Looks up a submodule by checkout path for the given treeish (commit or tree OID).
+    ///
+    /// `treeish` is `None` for the worktree / index / `HEAD` `.gitmodules` layer (Git null OID).
+    pub fn submodule_from_path(
+        &mut self,
+        repo: &Repository,
+        treeish: Option<(ObjectId, ObjectId)>,
+        path: &str,
+    ) -> Result<Option<SubmoduleInfo>, String> {
+        let gm_oid = self.gitmodules_oid_for_treeish(repo, treeish)?;
+        let gm_oid = match gm_oid {
+            Some(o) => o,
+            None => return Ok(None),
+        };
+        self.ensure_blob_parsed(repo, treeish, gm_oid)?;
+        let key_path = norm_path_key(path);
+        let name = self
+            .path_index
+            .get(&(gm_oid, key_path.clone()))
+            .cloned()
+            .or_else(|| self.path_index.get(&(gm_oid, path.to_string())).cloned());
+        let Some(name) = name else {
+            return Ok(None);
+        };
+        let path_out = self
+            .name_index
+            .get(&(gm_oid, name.clone()))
+            .and_then(|b| b.path.clone())
+            .unwrap_or_else(|| path.to_string());
+        Ok(Some(SubmoduleInfo {
+            name,
+            path: path_out,
+        }))
+    }
+
+    /// Looks up a submodule by its logical `.gitmodules` name.
+    pub fn submodule_from_name(
+        &mut self,
+        repo: &Repository,
+        treeish: Option<(ObjectId, ObjectId)>,
+        name: &str,
+    ) -> Result<Option<SubmoduleInfo>, String> {
+        let gm_oid = self.gitmodules_oid_for_treeish(repo, treeish)?;
+        let gm_oid = match gm_oid {
+            Some(o) => o,
+            None => return Ok(None),
+        };
+        self.ensure_blob_parsed(repo, treeish, gm_oid)?;
+        let b = self.name_index.get(&(gm_oid, name.to_string())).cloned();
+        let Some(b) = b else {
+            return Ok(None);
+        };
+        let Some(path) = b.path.clone() else {
+            return Ok(None);
+        };
+        Ok(Some(SubmoduleInfo { name: b.name, path }))
+    }
+
+    fn gitmodules_oid_for_treeish(
+        &self,
+        repo: &Repository,
+        treeish: Option<(ObjectId, ObjectId)>,
+    ) -> Result<Option<ObjectId>, String> {
+        let Some((_rev, tree_oid)) = treeish else {
+            return self.gitmodules_oid_worktree_index_head(repo);
+        };
+        Ok(blob_oid_at_path(&repo.odb, &tree_oid, ".gitmodules"))
+    }
+
+    /// Where to read `.gitmodules` for null treeish: disk, else index blob, else `HEAD` tree (Git `config_from_gitmodules`).
+    fn gitmodules_oid_worktree_index_head(
+        &self,
+        repo: &Repository,
+    ) -> Result<Option<ObjectId>, String> {
+        let Some(wt) = repo.work_tree.as_ref() else {
+            return Ok(None);
+        };
+        if wt.join(".gitmodules").exists() {
+            return Ok(Some(ObjectId::zero()));
+        }
+        let index = repo.load_index().map_err(|e| e.to_string())?;
+        if let Some(ie) = index.get(b".gitmodules", 0) {
+            return Ok(Some(ie.oid));
+        }
+        let head_oid = crate::state::resolve_head(&repo.git_dir)
+            .map_err(|e| e.to_string())?
+            .oid()
+            .copied();
+        let Some(commit_oid) = head_oid else {
+            return Ok(None);
+        };
+        let obj = repo.odb.read(&commit_oid).map_err(|e| e.to_string())?;
+        if obj.kind != ObjectKind::Commit {
+            return Ok(None);
+        }
+        let commit = parse_commit(&obj.data).map_err(|e| e.to_string())?;
+        Ok(blob_oid_at_path(&repo.odb, &commit.tree, ".gitmodules"))
+    }
+
+    fn ensure_blob_parsed(
+        &mut self,
+        repo: &Repository,
+        treeish: Option<(ObjectId, ObjectId)>,
+        gitmodules_blob: ObjectId,
+    ) -> Result<(), String> {
+        if self.by_blob.contains_key(&gitmodules_blob) {
+            return Ok(());
+        }
+        if gitmodules_blob.is_zero() {
+            let Some(wt) = repo.work_tree.as_ref() else {
+                self.by_blob.insert(gitmodules_blob, Vec::new());
+                return Ok(());
+            };
+            let path = wt.join(".gitmodules");
+            let text = if path.exists() {
+                std::fs::read_to_string(&path).map_err(|e| e.to_string())?
+            } else {
+                let index = repo.load_index().map_err(|e| e.to_string())?;
+                if let Some(ie) = index.get(b".gitmodules", 0) {
+                    let obj = repo.odb.read(&ie.oid).map_err(|e| e.to_string())?;
+                    if obj.kind != ObjectKind::Blob {
+                        self.by_blob.insert(gitmodules_blob, Vec::new());
+                        return Ok(());
+                    }
+                    String::from_utf8(obj.data).map_err(|e| e.to_string())?
+                } else {
+                    let head_oid = crate::state::resolve_head(&repo.git_dir)
+                        .ok()
+                        .and_then(|h| h.oid().copied());
+                    let Some(commit_oid) = head_oid else {
+                        self.by_blob.insert(gitmodules_blob, Vec::new());
+                        return Ok(());
+                    };
+                    let obj = repo.odb.read(&commit_oid).map_err(|e| e.to_string())?;
+                    if obj.kind != ObjectKind::Commit {
+                        self.by_blob.insert(gitmodules_blob, Vec::new());
+                        return Ok(());
+                    }
+                    let commit = parse_commit(&obj.data).map_err(|e| e.to_string())?;
+                    let Some(blob_oid) = blob_oid_at_path(&repo.odb, &commit.tree, ".gitmodules")
+                    else {
+                        self.by_blob.insert(gitmodules_blob, Vec::new());
+                        return Ok(());
+                    };
+                    let blob = repo.odb.read(&blob_oid).map_err(|e| e.to_string())?;
+                    if blob.kind != ObjectKind::Blob {
+                        self.by_blob.insert(gitmodules_blob, Vec::new());
+                        return Ok(());
+                    }
+                    String::from_utf8(blob.data).map_err(|e| e.to_string())?
+                }
+            };
+            self.ingest_gitmodules_blob(repo, None, None, ObjectId::zero(), &text, true)?;
+            return Ok(());
+        }
+        let obj = repo
+            .odb
+            .read(&gitmodules_blob)
+            .map_err(|e| format!("failed to read .gitmodules blob: {e}"))?;
+        if obj.kind != ObjectKind::Blob {
+            self.by_blob.insert(gitmodules_blob, Vec::new());
+            return Ok(());
+        }
+        let text = String::from_utf8(obj.data).map_err(|e| e.to_string())?;
+        let commit_for_warn = treeish.map(|(rev, _)| rev).filter(|o| !o.is_zero());
+        self.ingest_gitmodules_blob(
+            repo,
+            commit_for_warn,
+            treeish.map(|(rev, _)| rev),
+            gitmodules_blob,
+            &text,
+            false,
+        )?;
+        Ok(())
+    }
+
+    fn ingest_gitmodules_blob(
+        &mut self,
+        repo: &Repository,
+        treeish_for_warning: Option<ObjectId>,
+        treeish_for_blob_spec: Option<ObjectId>,
+        gitmodules_blob: ObjectId,
+        content: &str,
+        die_on_bad_fetch_recurse: bool,
+    ) -> Result<(), String> {
+        if self.by_blob.contains_key(&gitmodules_blob) {
+            return Ok(());
+        }
+
+        let (git_entries, bad_line) = ConfigFile::parse_gitmodules_best_effort(
+            Path::new(".gitmodules"),
+            content,
+            ConfigScope::Local,
+        );
+        if let Some(line) = bad_line {
+            eprintln!(
+                "{}",
+                gitmodules_config_error(
+                    repo,
+                    treeish_for_blob_spec,
+                    gitmodules_blob,
+                    line,
+                    "bad config",
+                )
+            );
+        }
+
+        let mut by_name: HashMap<String, SubmoduleBuild> = HashMap::new();
+
+        for ent in &git_entries {
+            let Some((name, var)) = submodule_name_and_var(&ent.key) else {
+                continue;
+            };
+            if !check_submodule_name_ok(&name) {
+                eprintln!("warning: ignoring suspicious submodule name: {name}");
+                continue;
+            }
+            let entry = by_name
+                .entry(name.clone())
+                .or_insert_with(|| SubmoduleBuild::new(name.clone()));
+
+            match var.as_str() {
+                "path" => {
+                    let Some(value) = ent.value.as_deref() else {
+                        return Err(gitmodules_config_error(
+                            repo,
+                            treeish_for_blob_spec,
+                            gitmodules_blob,
+                            ent.line,
+                            "bad config",
+                        ));
+                    };
+                    if crate::gitmodules::looks_like_command_line_option(value) {
+                        eprintln!(
+                            "warning: ignoring '{}' which may be interpreted as a command-line option: {value}",
+                            ent.key
+                        );
+                        continue;
+                    }
+                    let overwrite = gitmodules_blob.is_zero();
+                    if entry.path.is_some() && !overwrite {
+                        warn_multiple_config(treeish_for_warning, &entry.name, "path");
+                    } else {
+                        if let Some(old) = &entry.path {
+                            self.path_index_remove(gitmodules_blob, old);
+                        }
+                        entry.path = Some(value.to_string());
+                        self.path_index_insert(gitmodules_blob, value, entry.name.clone());
+                    }
+                }
+                "url" => {
+                    let Some(value) = ent.value.as_deref() else {
+                        return Err(gitmodules_config_error(
+                            repo,
+                            treeish_for_blob_spec,
+                            gitmodules_blob,
+                            ent.line,
+                            "bad config",
+                        ));
+                    };
+                    if crate::gitmodules::looks_like_command_line_option(value) {
+                        eprintln!(
+                            "warning: ignoring '{}' which may be interpreted as a command-line option: {value}",
+                            ent.key
+                        );
+                        continue;
+                    }
+                    let overwrite = gitmodules_blob.is_zero();
+                    if entry.url.is_some() && !overwrite {
+                        warn_multiple_config(treeish_for_warning, &entry.name, "url");
+                    } else {
+                        entry.url = Some(value.to_string());
+                    }
+                }
+                "fetchrecursesubmodules" => {
+                    let value = ent.value.as_deref().unwrap_or("");
+                    let parsed = parse_fetch_recurse(value, die_on_bad_fetch_recurse);
+                    let parsed = parsed?;
+                    let overwrite = gitmodules_blob.is_zero();
+                    if entry.fetch_recurse != FetchRecurse::None && !overwrite {
+                        warn_multiple_config(
+                            treeish_for_warning,
+                            &entry.name,
+                            "fetchrecursesubmodules",
+                        );
+                    } else {
+                        entry.fetch_recurse = parsed;
+                    }
+                }
+                "ignore" => {
+                    let Some(value) = ent.value.as_deref() else {
+                        return Err(gitmodules_config_error(
+                            repo,
+                            treeish_for_blob_spec,
+                            gitmodules_blob,
+                            ent.line,
+                            "bad config",
+                        ));
+                    };
+                    let _ = value;
+                }
+                "branch" => {
+                    let Some(_value) = ent.value.as_deref() else {
+                        return Err(gitmodules_config_error(
+                            repo,
+                            treeish_for_blob_spec,
+                            gitmodules_blob,
+                            ent.line,
+                            "bad config",
+                        ));
+                    };
+                }
+                "update" | "shallow" => {}
+                _ => {}
+            }
+        }
+
+        let list: Vec<SubmoduleBuild> = by_name.into_values().collect();
+        for b in &list {
+            self.name_index
+                .insert((gitmodules_blob, b.name.clone()), b.clone());
+        }
+        self.by_blob.insert(gitmodules_blob, list);
+        Ok(())
+    }
+
+    fn path_index_insert(&mut self, blob: ObjectId, path: &str, name: String) {
+        let key = norm_path_key(path);
+        self.path_index.insert((blob, key), name);
+    }
+
+    fn path_index_remove(&mut self, blob: ObjectId, path: &str) {
+        let key = norm_path_key(path);
+        self.path_index.remove(&(blob, key));
+    }
+
+    /// Prints all values for `key` (canonical submodule config key) from the nested
+    /// submodule repository at `super_path` / `submodule_path`.
+    pub fn print_config_from_nested_gitmodules(
+        _super_repo: &Repository,
+        super_work_tree: &Path,
+        submodule_path: &str,
+        key: &str,
+    ) -> Result<(), String> {
+        let wanted = canonical_key(key).map_err(|e| e.to_string())?;
+        let sub_work = super_work_tree.join(submodule_path);
+        let sub_git = if sub_work.join(".git").is_file() {
+            let gf = std::fs::read_to_string(sub_work.join(".git"))
+                .map_err(|e| format!("read gitfile: {e}"))?;
+            let line = gf.lines().next().unwrap_or("").trim();
+            let Some(rest) = line.strip_prefix("gitdir:") else {
+                return Err("invalid gitfile".into());
+            };
+            let rest = rest.trim();
+            let p = Path::new(rest);
+            if p.is_absolute() {
+                p.to_path_buf()
+            } else {
+                sub_work.join(rest)
+            }
+        } else {
+            sub_work.join(".git")
+        };
+        let sub_repo = Repository::open(&sub_git, Some(&sub_work))
+            .map_err(|e| format!("open submodule repo: {e}"))?;
+
+        let gm_path = sub_work.join(".gitmodules");
+        let (content, _) = if gm_path.exists() {
+            let c = std::fs::read_to_string(&gm_path).map_err(|e| e.to_string())?;
+            (c, gm_path)
+        } else {
+            let index = sub_repo.load_index().map_err(|e| e.to_string())?;
+            if let Some(ie) = index.get(b".gitmodules", 0) {
+                let obj = sub_repo.odb.read(&ie.oid).map_err(|e| e.to_string())?;
+                if obj.kind != ObjectKind::Blob {
+                    return Ok(());
+                }
+                let c = String::from_utf8(obj.data).map_err(|e| e.to_string())?;
+                (c, gm_path)
+            } else {
+                let head_oid = crate::state::resolve_head(&sub_repo.git_dir)
+                    .ok()
+                    .and_then(|h| h.oid().copied());
+                let Some(commit_oid) = head_oid else {
+                    return Ok(());
+                };
+                let obj = sub_repo.odb.read(&commit_oid).map_err(|e| e.to_string())?;
+                if obj.kind != ObjectKind::Commit {
+                    return Ok(());
+                }
+                let commit = parse_commit(&obj.data).map_err(|e| e.to_string())?;
+                let Some(blob_oid) = blob_oid_at_path(&sub_repo.odb, &commit.tree, ".gitmodules")
+                else {
+                    return Ok(());
+                };
+                let blob = sub_repo.odb.read(&blob_oid).map_err(|e| e.to_string())?;
+                if blob.kind != ObjectKind::Blob {
+                    return Ok(());
+                }
+                let c = String::from_utf8(blob.data).map_err(|e| e.to_string())?;
+                (c, gm_path)
+            }
+        };
+
+        let cfg = ConfigFile::parse(Path::new(".gitmodules"), &content, ConfigScope::Local)
+            .map_err(|e| e.to_string())?;
+        for e in &cfg.entries {
+            if e.key == wanted {
+                if let Some(v) = &e.value {
+                    println!("{v}");
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn norm_path_key(path: &str) -> String {
+    path.replace('\\', "/")
+}
+
+fn warn_multiple_config(treeish: Option<ObjectId>, name: &str, option: &str) {
+    let commit_string = treeish
+        .map(|o| o.to_hex())
+        .unwrap_or_else(|| "WORKTREE".to_string());
+    eprintln!(
+        "warning: {commit_string}:.gitmodules, multiple configurations found for \
+'submodule.{name}.{option}'. Skipping second one!"
+    );
+}
+
+fn gitmodules_config_error(
+    repo: &Repository,
+    treeish_for_blob: Option<ObjectId>,
+    gitmodules_blob: ObjectId,
+    line: usize,
+    msg: &str,
+) -> String {
+    if gitmodules_blob.is_zero() {
+        format!("{msg} line {line} in file .gitmodules")
+    } else {
+        let spec = submodule_blob_spec(repo, treeish_for_blob, gitmodules_blob);
+        format!("{msg} line {line} in submodule-blob {spec}")
+    }
+}
+
+/// Git names submodule-blob config sources as `<commit>:.gitmodules` (see `gitmodule_oid_from_commit`).
+fn submodule_blob_spec(
+    repo: &Repository,
+    treeish_for_blob: Option<ObjectId>,
+    blob: ObjectId,
+) -> String {
+    let fallback = format!("{}:.gitmodules", blob.to_hex());
+    let Some(treeish) = treeish_for_blob else {
+        return fallback;
+    };
+    let Ok(obj) = repo.odb.read(&treeish) else {
+        return fallback;
+    };
+    let commit_oid = match obj.kind {
+        ObjectKind::Commit => treeish,
+        ObjectKind::Tree => {
+            let Ok(c) = find_commit_containing_tree(repo, treeish) else {
+                return fallback;
+            };
+            c
+        }
+        _ => return fallback,
+    };
+    format!("{}:.gitmodules", commit_oid.to_hex())
+}
+
+fn find_commit_containing_tree(repo: &Repository, tree_oid: ObjectId) -> Result<ObjectId, ()> {
+    let mut stack = vec![format!("HEAD^{{commit}}")];
+    for name in ["HEAD", "refs/heads/master", "refs/heads/main"] {
+        stack.push(name.to_string());
+    }
+    for spec in stack {
+        let Ok(oid) = resolve_revision(repo, spec.as_str()) else {
+            continue;
+        };
+        let Ok(obj) = repo.odb.read(&oid) else {
+            continue;
+        };
+        if obj.kind != ObjectKind::Commit {
+            continue;
+        }
+        let Ok(c) = parse_commit(&obj.data) else {
+            continue;
+        };
+        if tree_contains_oid(&repo.odb, c.tree, tree_oid)? {
+            return Ok(oid);
+        }
+    }
+    Err(())
+}
+
+fn tree_contains_oid(odb: &Odb, tree: ObjectId, target: ObjectId) -> Result<bool, ()> {
+    let obj = odb.read(&tree).map_err(|_| ())?;
+    if obj.kind != ObjectKind::Tree {
+        return Ok(false);
+    }
+    let entries = crate::objects::parse_tree(&obj.data).map_err(|_| ())?;
+    for e in entries {
+        if e.oid == target {
+            return Ok(true);
+        }
+        if e.mode == 0o040000 && tree_contains_oid(odb, e.oid, target)? {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn submodule_name_and_var(key: &str) -> Option<(String, String)> {
+    let rest = key.strip_prefix("submodule.")?;
+    let dot = rest.rfind('.')?;
+    let name = rest[..dot].to_string();
+    let var = rest[dot + 1..].to_string();
+    if name.is_empty() {
+        return None;
+    }
+    Some((name, var))
+}
+
+fn check_submodule_name_ok(name: &str) -> bool {
+    if name.is_empty() {
+        return false;
+    }
+    let b = name.as_bytes();
+    if b.len() >= 2
+        && b[0] == b'.'
+        && b[1] == b'.'
+        && (b.len() == 2 || b[2] == b'/' || b[2] == b'\\')
+    {
+        return false;
+    }
+    let mut i = 0usize;
+    while i < b.len() {
+        let c = b[i];
+        i += 1;
+        if c == b'/' || c == b'\\' {
+            let j = i;
+            if b.len() >= j + 2
+                && b[j] == b'.'
+                && b[j + 1] == b'.'
+                && (j + 2 >= b.len() || b[j + 2] == b'/' || b[j + 2] == b'\\')
+            {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+fn parse_fetch_recurse(value: &str, die_on_error: bool) -> Result<FetchRecurse, String> {
+    let v = value.trim();
+    match crate::config::parse_bool(v) {
+        Ok(true) => return Ok(FetchRecurse::On),
+        Ok(false) => return Ok(FetchRecurse::Off),
+        Err(_) => {}
+    }
+    if v.eq_ignore_ascii_case("on-demand") {
+        return Ok(FetchRecurse::OnDemand);
+    }
+    if die_on_error {
+        Err(format!(
+            "fatal: bad submodule.fetchRecurseSubmodules argument: '{v}'"
+        ))
+    } else {
+        Ok(FetchRecurse::Error)
+    }
+}

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -4418,6 +4418,8 @@ pub(crate) fn dispatch(subcmd: &str, rest: &[String], opts: &GlobalOpts) -> Resu
                 "path-utils" => run_test_tool_path_utils(&rest[1..]),
                 "subprocess" => run_test_tool_subprocess(&rest[1..]),
                 "submodule" => run_test_tool_submodule(rest),
+                "submodule-config" => run_test_tool_submodule_config(rest),
+                "submodule-nested-repo-config" => run_test_tool_submodule_nested_repo_config(rest),
                 "config" => run_test_tool_config(&rest[1..]),
                 "parse-options" => {
                     let args = preprocess_test_tool_args(rest)?;
@@ -5030,6 +5032,93 @@ fn run_test_tool_path_utils(rest: &[String]) -> Result<()> {
         }
         other => bail!("test-tool path-utils: unknown subcommand '{other}'"),
     }
+}
+
+/// `test-tool submodule-config` — Git `t7411-submodule-config` helper (`test-submodule-config.c`).
+fn run_test_tool_submodule_config(rest: &[String]) -> Result<()> {
+    let args = preprocess_test_tool_args(rest)?;
+    if args.first().map(|s| s.as_str()) != Some("submodule-config") {
+        bail!("internal error: test-tool submodule-config dispatcher");
+    }
+    let mut i = 1usize;
+    let mut lookup_name = false;
+    while i < args.len() {
+        let a = args[i].as_str();
+        if !a.starts_with("--") {
+            break;
+        }
+        if a == "--name" {
+            lookup_name = true;
+        } else {
+            bail!("unknown option: {a}");
+        }
+        i += 1;
+    }
+    let pairs = &args[i..];
+    if pairs.len() % 2 != 0 {
+        bail!("Wrong number of arguments.");
+    }
+    let repo = grit_lib::repo::Repository::discover(None).context("not a git repository")?;
+    let mut cache = grit_lib::submodule_config_cache::SubmoduleConfigCache::new();
+    let mut chunk = 0usize;
+    while chunk < pairs.len() {
+        let commit_spec = pairs[chunk].as_str();
+        let path_or_name = pairs[chunk + 1].as_str();
+        let treeish = if commit_spec.is_empty() {
+            None
+        } else {
+            // `resolve_revision("HEAD")` follows the detached `HEAD` symref in this harness;
+            // Git's submodule-blob label uses the branch tip (`git rev-parse HEAD` on a branch).
+            let rev = if commit_spec == "HEAD" {
+                grit_lib::state::resolve_head(&repo.git_dir)
+                    .map_err(|_| anyhow::anyhow!("Commit not found."))?
+                    .oid()
+                    .copied()
+                    .ok_or_else(|| anyhow::anyhow!("Commit not found."))?
+            } else {
+                grit_lib::rev_parse::resolve_revision(&repo, commit_spec)
+                    .map_err(|_| anyhow::anyhow!("Commit not found."))?
+            };
+            let tree = grit_lib::rev_parse::peel_to_tree(&repo, rev)
+                .map_err(|e| anyhow::anyhow!("Commit not found. ({e})"))?;
+            Some((rev, tree))
+        };
+        let sub = if lookup_name {
+            cache
+                .submodule_from_name(&repo, treeish, path_or_name)
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+        } else {
+            cache
+                .submodule_from_path(&repo, treeish, path_or_name)
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+        };
+        let Some(sub) = sub else {
+            bail!("Submodule not found.");
+        };
+        println!("Submodule name: '{}' for path '{}'", sub.name, sub.path);
+        chunk += 2;
+    }
+    Ok(())
+}
+
+/// `test-tool submodule-nested-repo-config` — nested `.gitmodules` reader (`test-submodule-nested-repo-config.c`).
+fn run_test_tool_submodule_nested_repo_config(rest: &[String]) -> Result<()> {
+    let args = preprocess_test_tool_args(rest)?;
+    if args.first().map(|s| s.as_str()) != Some("submodule-nested-repo-config") {
+        bail!("internal error: test-tool submodule-nested-repo-config dispatcher");
+    }
+    if args.len() != 3 {
+        bail!("Wrong number of arguments.");
+    }
+    let repo = grit_lib::repo::Repository::discover(None).context("not a git repository")?;
+    let wt = repo.work_tree.as_ref().context("bare repository")?;
+    grit_lib::submodule_config_cache::SubmoduleConfigCache::print_config_from_nested_gitmodules(
+        &repo,
+        wt.as_path(),
+        &args[1],
+        &args[2],
+    )
+    .map_err(|e| anyhow::anyhow!("{e}"))
 }
 
 /// Handle `test-tool submodule` subcommands.

--- a/logs/2026-04-10_t7411-submodule-config.md
+++ b/logs/2026-04-10_t7411-submodule-config.md
@@ -1,0 +1,7 @@
+# t7411-submodule-config
+
+- Implemented `test-tool submodule-config` and `test-tool submodule-nested-repo-config` in `grit/src/main.rs`.
+- Added `grit_lib::submodule_config_cache` for `.gitmodules` blob caching, path/name lookup, and nested submodule config printing.
+- Extended `ConfigFile` parsing: unclosed-quote continuation (Git-style) and `parse_gitmodules_best_effort` so valid lines before a bad line still apply (matches Git submodule-config streaming).
+- `HEAD` in submodule-config resolves via `resolve_head` so detached checkout does not change the blob label OID in stderr.
+- Harness: `./scripts/run-tests.sh t7411-submodule-config.sh` → 20/20.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This implements the missing `test-tool` helpers used by `t7411-submodule-config.sh` and aligns `.gitmodules` parsing with Git’s streaming config behavior.

## Changes

- **`test-tool submodule-config`** — Parses `.gitmodules` blobs per revision, looks up submodule by path or `--name`, prints `Submodule name: '…' for path '…'`. Uses `resolve_head` for bare `HEAD` so submodule-blob error labels match `git rev-parse HEAD` on a branch (detached submodule checkouts no longer skew the OID in stderr).
- **`test-tool submodule-nested-repo-config`** — Opens the submodule worktree, resolves `.gitmodules` from disk / index / `HEAD` tree, prints values for the requested key (nested submodule URL tests).
- **`grit_lib::submodule_config_cache`** — Submodule cache keyed by `.gitmodules` blob OID; warnings for duplicate keys; `fetchrecursesubmodules` errors continue parsing like Git when not in worktree mode.
- **`ConfigFile`** — Continuation for unclosed double-quoted values; **`parse_gitmodules_best_effort`** returns entries parsed before a bad line so lookups still succeed when a later line is malformed (matches Git for t7411 test 6).

## Validation

- `./scripts/run-tests.sh t7411-submodule-config.sh` — **20/20**
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a5cf2a0-3eef-4c58-b8ed-148609afafea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a5cf2a0-3eef-4c58-b8ed-148609afafea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

