### PR TITLE
fix: t3901-i18n-patch — encode identities for non-UTF-8 commits on replay

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -661,7 +661,7 @@ t3704-add-pathspec-file	t3	yes	11	11	0	true	ok	0
 t3705-add-sparse-checkout	t3	yes	20	3	17	false	ok	0
 t3800-mktag	t3	yes	151	144	7	false	ok	0
 t3900-i18n-commit	t3	yes	38	16	22	false	ok	0
-t3901-i18n-patch	t3	yes	20	8	12	false	ok	0
+t3901-i18n-patch	t3	yes	20	20	0	true	ok	0
 t3902-quoted	t3	yes	13	12	1	false	ok	0
 t3902-quoted-ls-tree	t3	yes	8	8	0	true	ok	0
 t3903-stash	t3	yes	142	86	56	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,698 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,698 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T03:05:01+00:00" class="gen-time" title="2026-04-10 03:05 UTC">2026-04-10 03:05 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,698</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -219,11 +219,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">56/141 files · 2 skipped · 4,052/5,398 tests</span>
+        <span class="group-meta">57/141 files · 2 skipped · 4,064/5,398 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:75.1%"></div></div>
-        <span class="group-pct pct-blue">75.1%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:75.3%"></div></div>
+        <span class="group-pct pct-blue">75.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35698 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,698 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T03:05:01+00:00" class="gen-time" title="2026-04-10 03:05 UTC">2026-04-10 03:05 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,698</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -6767,14 +6767,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:42.1%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="20" data-passed="8">
+<tr class="" data-group="t3" data-tests="20" data-passed="20" data-full-pass="1">
   <td class="mono">t3901-i18n-patch</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">20</td>
-  <td class="right">8</td>
+  <td class="right">20</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:40.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="13" data-passed="12">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit/src/commands/am.rs
+++ b/grit/src/commands/am.rs
@@ -1716,13 +1716,20 @@ variable i18n.commitEncoding to the encoding your project uses.\n"
         crate::git_commit_encoding::finalize_stored_commit_message(message, commit_enc.as_deref())
     };
 
+    let (author_raw, committer_raw) =
+        crate::git_commit_encoding::identity_raw_for_serialized_commit(
+            &encoding,
+            &author_ident,
+            &committer_ident,
+        );
+
     let commit_data = CommitData {
         tree: tree_oid,
         parents,
         author: author_ident,
         committer: committer_ident,
-        author_raw: Vec::new(),
-        committer_raw: Vec::new(),
+        author_raw,
+        committer_raw,
         encoding,
         message: stored_msg,
         raw_message,

--- a/grit/src/commands/cherry_pick.rs
+++ b/grit/src/commands/cherry_pick.rs
@@ -22,7 +22,8 @@ use grit_lib::ident::parse_signature_times;
 use grit_lib::index::{Index, IndexEntry, MODE_EXECUTABLE, MODE_SYMLINK};
 use grit_lib::merge_file::{merge, ConflictStyle, MergeFavor, MergeInput};
 use grit_lib::merge_trees::{
-    merge_trees_three_way, TheirsConflictLabel, TreeMergeConflictPresentation, WhitespaceMergeOptions,
+    merge_trees_three_way, TheirsConflictLabel, TreeMergeConflictPresentation,
+    WhitespaceMergeOptions,
 };
 use grit_lib::objects::{
     parse_commit, parse_tree, serialize_commit, CommitData, ObjectId, ObjectKind,
@@ -1661,13 +1662,15 @@ fn bump_committer_if_replay_matches_source(
     stored_msg: &str,
     raw_message: &Option<Vec<u8>>,
 ) -> Result<()> {
+    let (author_raw, committer_raw) =
+        crate::git_commit_encoding::identity_raw_for_serialized_commit(encoding, author, committer);
     let trial = CommitData {
         tree: tree_oid,
         parents: parents.to_vec(),
         author: author.to_owned(),
         committer: committer.clone(),
-        author_raw: Vec::new(),
-        committer_raw: Vec::new(),
+        author_raw,
+        committer_raw,
         encoding: encoding.clone(),
         message: stored_msg.to_owned(),
         raw_message: raw_message.clone(),
@@ -1748,13 +1751,18 @@ fn create_cherry_pick_commit(
         &raw_message,
     )?;
 
+    let (author_raw, committer_raw) =
+        crate::git_commit_encoding::identity_raw_for_serialized_commit(
+            &encoding, &author, &committer,
+        );
+
     let commit_data = CommitData {
         tree: tree_oid,
         parents,
         author,
         committer,
-        author_raw: Vec::new(),
-        committer_raw: Vec::new(),
+        author_raw,
+        committer_raw,
         encoding,
         message: stored_msg,
         raw_message,

--- a/grit/src/commands/commit.rs
+++ b/grit/src/commands/commit.rs
@@ -654,6 +654,9 @@ pub fn run(mut args: Args) -> Result<()> {
     }
 
     let config = ConfigSet::load(Some(&repo.git_dir), true)?;
+    let commit_encoding = config
+        .get("i18n.commitEncoding")
+        .or_else(|| config.get("i18n.commitencoding"));
 
     let mut staged = diff_index_to_tree(&repo.odb, &index, head_tree.as_ref())?;
     let unstaged_raw = if let Some(wt) = work_tree {
@@ -811,10 +814,6 @@ pub fn run(mut args: Args) -> Result<()> {
         }
     }
 
-    // Check i18n.commitEncoding for non-UTF-8 commit messages
-    let commit_encoding = config
-        .get("i18n.commitEncoding")
-        .or_else(|| config.get("i18n.commitencoding"));
     let now = OffsetDateTime::now_utc();
 
     // When amending, preserve original author unless explicitly overridden

--- a/grit/src/commands/rebase.rs
+++ b/grit/src/commands/rebase.rs
@@ -1392,13 +1392,20 @@ fn commit_from_merged_index(
     let now = time::OffsetDateTime::now_utc();
     let committer = resolve_identity(config, "COMMITTER")?;
     let (message, encoding, raw_message) = finalize_message_for_commit_encoding(message, config);
+    let committer_line = format_ident(&committer, now);
+    let (author_raw, committer_raw) =
+        crate::git_commit_encoding::identity_raw_for_serialized_commit(
+            &encoding,
+            author,
+            &committer_line,
+        );
     let commit_data = CommitData {
         tree: tree_oid,
         parents,
         author: author.to_string(),
-        committer: format_ident(&committer, now),
-        author_raw: Vec::new(),
-        committer_raw: Vec::new(),
+        committer: committer_line,
+        author_raw,
+        committer_raw,
         encoding,
         message,
         raw_message,
@@ -3080,13 +3087,20 @@ fn cherry_pick_for_rebase(
         let now = time::OffsetDateTime::now_utc();
         let committer = resolve_identity(&config, "COMMITTER")?;
         let (message, encoding, raw_message) = transcoded_replayed_message(&commit, &config);
+        let committer_line = format_ident(&committer, now);
+        let (author_raw, committer_raw) =
+            crate::git_commit_encoding::identity_raw_for_serialized_commit(
+                &encoding,
+                &commit.author,
+                &committer_line,
+            );
         let commit_data = CommitData {
             tree: head_commit.tree,
             parents: vec![head_oid],
             author: commit.author.clone(),
-            committer: format_ident(&committer, now),
-            author_raw: commit.author_raw.clone(),
-            committer_raw: commit.committer_raw.clone(),
+            committer: committer_line,
+            author_raw,
+            committer_raw,
             encoding,
             message,
             raw_message,
@@ -3152,13 +3166,20 @@ fn cherry_pick_for_rebase(
                         commit_message_after_prepare_hook(repo, git_dir, &message, "message")?;
                     let message =
                         apply_commit_msg_cleanup(&raw_msg, rebase_commit_msg_cleanup(&config));
+                    let committer_line = format_ident(&committer, now);
+                    let (author_raw, committer_raw) =
+                        crate::git_commit_encoding::identity_raw_for_serialized_commit(
+                            &encoding,
+                            &commit.author,
+                            &committer_line,
+                        );
                     let commit_data = CommitData {
                         tree: tree_oid,
                         parents: vec![head_oid],
                         author: commit.author.clone(),
-                        committer: format_ident(&committer, now),
-                        author_raw: commit.author_raw.clone(),
-                        committer_raw: commit.committer_raw.clone(),
+                        committer: committer_line,
+                        author_raw,
+                        committer_raw,
                         encoding,
                         message,
                         raw_message,
@@ -3198,13 +3219,20 @@ fn cherry_pick_for_rebase(
                     finalize_message_for_commit_encoding(cleaned, &config);
                 let now = time::OffsetDateTime::now_utc();
                 let committer = resolve_identity(&config, "COMMITTER")?;
+                let committer_line = format_ident(&committer, now);
+                let (author_raw, committer_raw) =
+                    crate::git_commit_encoding::identity_raw_for_serialized_commit(
+                        &encoding,
+                        &commit.author,
+                        &committer_line,
+                    );
                 let commit_data = CommitData {
                     tree: commit_tree_oid,
                     parents: vec![head_oid],
                     author: commit.author.clone(),
-                    committer: format_ident(&committer, now),
-                    author_raw: commit.author_raw.clone(),
-                    committer_raw: commit.committer_raw.clone(),
+                    committer: committer_line,
+                    author_raw,
+                    committer_raw,
                     encoding,
                     message,
                     raw_message,
@@ -3407,13 +3435,20 @@ fn cherry_pick_for_rebase(
         finalize_message_for_commit_encoding(message, &config)
     };
 
+    let committer_line = format_ident(&committer, now);
+    let (author_raw, committer_raw) =
+        crate::git_commit_encoding::identity_raw_for_serialized_commit(
+            &encoding,
+            &commit.author,
+            &committer_line,
+        );
     let commit_data = CommitData {
         tree: tree_oid,
         parents: vec![head_oid],
         author: commit.author.clone(), // preserve original author
-        committer: format_ident(&committer, now),
-        author_raw: commit.author_raw.clone(),
-        committer_raw: commit.committer_raw.clone(),
+        committer: committer_line,
+        author_raw,
+        committer_raw,
         encoding,
         message,
         raw_message,
@@ -3923,13 +3958,20 @@ fn do_continue() -> Result<()> {
         let tree_oid = write_tree_from_index(&repo.odb, &index, "")?;
         let now = time::OffsetDateTime::now_utc();
         let committer = resolve_identity(&config, "COMMITTER")?;
+        let committer_line = format_ident(&committer, now);
+        let (author_raw, committer_raw) =
+            crate::git_commit_encoding::identity_raw_for_serialized_commit(
+                &encoding,
+                &original_commit.author,
+                &committer_line,
+            );
         let commit_data = CommitData {
             tree: tree_oid,
             parents: vec![head_oid],
             author: original_commit.author.clone(),
-            committer: format_ident(&committer, now),
-            author_raw: original_commit.author_raw.clone(),
-            committer_raw: original_commit.committer_raw.clone(),
+            committer: committer_line,
+            author_raw,
+            committer_raw,
             encoding,
             message,
             raw_message,
@@ -3937,20 +3979,28 @@ fn do_continue() -> Result<()> {
         let commit_bytes = serialize_commit(&commit_data);
         repo.odb.write(ObjectKind::Commit, &commit_bytes)?
     } else {
-        let (message, encoding, raw_message) =
-            read_rebase_continue_message(git_dir, &original_commit, &config)?;
+        let (message, _, _) = read_rebase_continue_message(git_dir, &original_commit, &config)?;
         let tree_oid = write_tree_from_index(&repo.odb, &index, "")?;
         let now = time::OffsetDateTime::now_utc();
         let committer = resolve_identity(&config, "COMMITTER")?;
         let raw_msg = commit_message_after_prepare_hook(&repo, git_dir, &message, "message")?;
-        let message = apply_commit_msg_cleanup(&raw_msg, rebase_commit_msg_cleanup(&config));
+        let cleaned = apply_commit_msg_cleanup(&raw_msg, rebase_commit_msg_cleanup(&config));
+        let (message, encoding, raw_message) =
+            finalize_message_for_commit_encoding(cleaned, &config);
+        let committer_line = format_ident(&committer, now);
+        let (author_raw, committer_raw) =
+            crate::git_commit_encoding::identity_raw_for_serialized_commit(
+                &encoding,
+                &original_commit.author,
+                &committer_line,
+            );
         let commit_data = CommitData {
             tree: tree_oid,
             parents: vec![head_oid],
             author: original_commit.author.clone(),
-            committer: format_ident(&committer, now),
-            author_raw: original_commit.author_raw.clone(),
-            committer_raw: original_commit.committer_raw.clone(),
+            committer: committer_line,
+            author_raw,
+            committer_raw,
             encoding,
             message,
             raw_message,

--- a/grit/src/commands/revert.rs
+++ b/grit/src/commands/revert.rs
@@ -1217,13 +1217,22 @@ fn create_revert_commit(
             commit_enc.as_deref(),
         );
 
+    let author_line = format_ident(&author, now);
+    let committer_line = format_ident(&committer, now);
+    let (author_raw, committer_raw) =
+        crate::git_commit_encoding::identity_raw_for_serialized_commit(
+            &encoding,
+            &author_line,
+            &committer_line,
+        );
+
     let commit_data = CommitData {
         tree: tree_oid,
         parents,
-        author: format_ident(&author, now),
-        committer: format_ident(&committer, now),
-        author_raw: Vec::new(),
-        committer_raw: Vec::new(),
+        author: author_line,
+        committer: committer_line,
+        author_raw,
+        committer_raw,
         encoding,
         message: stored_msg,
         raw_message,

--- a/grit/src/git_commit_encoding.rs
+++ b/grit/src/git_commit_encoding.rs
@@ -145,6 +145,34 @@ fn base64_decode_rfc2047(input: &str) -> Result<Vec<u8>, ()> {
     Ok(output)
 }
 
+/// Raw `author` / `committer` header payloads for a new commit object.
+///
+/// When `encoding` is unset or UTF-8, returns empty vectors so [`grit_lib::objects::serialize_commit`]
+/// writes the Unicode [`String`] fields as UTF-8. When `encoding` is non-UTF-8, encodes the full
+/// identity lines (name, email, timestamp) for storage in that charset — required after replaying a
+/// pick so we do not reuse a picked commit's raw bytes under a different `i18n.commitEncoding`
+/// (upstream `t3901`).
+#[must_use]
+pub fn identity_raw_for_serialized_commit(
+    encoding: &Option<String>,
+    author: &str,
+    committer: &str,
+) -> (Vec<u8>, Vec<u8>) {
+    let is_utf8 = match encoding.as_deref() {
+        None => true,
+        Some(e) => e.eq_ignore_ascii_case("utf-8") || e.eq_ignore_ascii_case("utf8"),
+    };
+    if is_utf8 {
+        return (Vec::new(), Vec::new());
+    }
+    let Some(label) = encoding.as_deref() else {
+        return (Vec::new(), Vec::new());
+    };
+    let author_raw = encode_header_text(label, author).unwrap_or_default();
+    let committer_raw = encode_header_text(label, committer).unwrap_or_default();
+    (author_raw, committer_raw)
+}
+
 /// Unicode commit message body for display (e.g. `format-patch`): uses `raw_message` when set.
 #[must_use]
 pub fn commit_message_unicode_for_display(

--- a/logs/2026-04-10_t3901-i18n-patch.md
+++ b/logs/2026-04-10_t3901-i18n-patch.md
@@ -1,0 +1,16 @@
+# t3901-i18n-patch
+
+## Problem
+
+Replayed commits (rebase/cherry-pick) reused `author_raw`/`committer_raw` from the picked commit while `i18n.commitEncoding` could be UTF-8, so `serialize_commit` wrote Latin-1 bytes for names that `format-patch` then treated as UTF-8 (double-encoded RFC 2047). Revert and `git am` also built commits with `encoding ISO8859-1` but empty raw identity fields, storing UTF-8 in the object.
+
+## Fix
+
+- `commit.rs`: read `i18n.commitEncoding` immediately after loading config so `git commit` encodes env-sourced names under the active encoding (setup commits).
+- `git_commit_encoding.rs`: `identity_raw_for_serialized_commit` — empty raw when UTF-8, else encode full author/committer lines.
+- `rebase.rs`, `cherry_pick.rs`, `revert.rs`, `am.rs`: use helper when writing `CommitData`.
+
+## Validation
+
+- `./scripts/run-tests.sh t3901-i18n-patch.sh` → 20/20
+- `cargo test -p grit-lib --lib`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes **t3901-i18n-patch** pass (20/20) by aligning how we serialize `author` / `committer` lines when `i18n.commitEncoding` is not UTF-8.

## Changes

- **`identity_raw_for_serialized_commit`** in `git_commit_encoding.rs`: when the stored commit has a non-UTF-8 `encoding`, encode the full author and committer lines in that charset; when UTF-8, leave raw fields empty so the Unicode strings serialize as UTF-8.
- **Rebase / cherry-pick**: stop cloning picked commits' `author_raw`/`committer_raw` into replayed commits (that caused Latin-1 bytes to be interpreted as UTF-8 in `format-patch`, i.e. double RFC 2047 encoding in t3901).
- **Revert / am**: same raw-field handling when building commits with `encoding ISO8859-1`.
- **`commit`**: read `i18n.commitEncoding` immediately after config load so commits created with Latin-1 `GIT_*` names during setup use the right encoding.

Harness row for **t3901-i18n-patch** updated to 20/20; dashboards regenerated.

## Validation

- `./scripts/run-tests.sh t3901-i18n-patch.sh`
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25c25e6a-ff33-4025-aca1-b91ab489ff7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25c25e6a-ff33-4025-aca1-b91ab489ff7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

