### PR TITLE
fix: pass t4050-diff-histogram (histogram diff, bare rev:path, stat)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,6 +503,7 @@ dependencies = [
  "flate2",
  "hex",
  "icu_normalizer",
+ "imara-diff",
  "libc",
  "regex",
  "sha1",
@@ -811,6 +812,16 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "imara-diff"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f01d462f766df78ab820dd06f5eb700233c51f0f4c2e846520eaf4ba6aa5c5c"
+dependencies = [
+ "hashbrown 0.15.5",
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ time = { version = "0.3", features = ["formatting", "parsing"] }
 hex = "0.4"
 tempfile = "3"
 similar = "2"
+imara-diff = { version = "0.2", features = ["unified_diff"] }
 merge3 = "0.2"
 regex = "1"
 unicode-width = "0.2"

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -730,7 +730,7 @@ t4047-diff-numstat	t4	yes	26	26	0	true	ok	0
 t4048-diff-combined-binary	t4	yes	14	14	0	true	ok	0
 t4049-diff-stat-count	t4	yes	4	2	2	false	ok	0
 t4050-diff	t4	yes	219	211	8	false	ok	0
-t4050-diff-histogram	t4	yes	10	8	2	false	ok	0
+t4050-diff-histogram	t4	yes	10	10	0	true	ok	0
 t4051-diff-function-context	t4	yes	42	12	30	false	ok	0
 t4051-diff-function-name	t4	yes	27	7	20	false	ok	0
 t4052-stat-output	t4	yes	89	89	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,688 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,688 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T03:07:41+00:00" class="gen-time" title="2026-04-10 03:07 UTC">2026-04-10 03:07 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,688</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -230,7 +230,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">73/178 files · 2 skipped · 2,862/4,438 tests</span>
+        <span class="group-meta">74/178 files · 2 skipped · 2,864/4,438 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.5%"></div></div>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35688 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,688 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T03:07:41+00:00" class="gen-time" title="2026-04-10 03:07 UTC">2026-04-10 03:07 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,688</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -7457,14 +7457,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:96.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="10" data-passed="8">
+<tr class="" data-group="t4" data-tests="10" data-passed="10" data-full-pass="1">
   <td class="mono">t4050-diff-histogram</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">10</td>
-  <td class="right">8</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:80.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="42" data-passed="12">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/Cargo.toml
+++ b/grit-lib/Cargo.toml
@@ -23,6 +23,7 @@ time.workspace = true
 hex.workspace = true
 tempfile.workspace = true
 similar.workspace = true
+imara-diff.workspace = true
 regex.workspace = true
 libc.workspace = true
 unicode-width.workspace = true

--- a/grit-lib/src/diff.rs
+++ b/grit-lib/src/diff.rs
@@ -15,7 +15,8 @@
 //!
 //! ## Content diff
 //!
-//! Line-level diffing uses the Myers algorithm via the `similar` crate.
+//! Line-level diffing uses the `similar` crate (Myers, patience, minimal) and,
+//! for Git's `histogram` algorithm, `imara-diff` for output compatible with upstream Git.
 //! Output formats: unified patch, raw (`:old-mode new-mode ...`), stat,
 //! numstat.
 
@@ -28,6 +29,113 @@ use crate::index::{Index, IndexEntry};
 use crate::objects::{parse_commit, parse_tree, ObjectId, ObjectKind, TreeEntry};
 use crate::odb::Odb;
 use crate::userdiff::FuncnameMatcher;
+
+/// Splits imara-diff unified body (concatenated hunks) into per-hunk slices for post-processing.
+fn imara_unified_hunk_slices(body: &str) -> Vec<&str> {
+    let mut starts: Vec<usize> = Vec::new();
+    if body.starts_with("@@") {
+        starts.push(0);
+    }
+    for (idx, _) in body.match_indices("\n@@ ") {
+        starts.push(idx + 1);
+    }
+    starts.push(body.len());
+    starts.windows(2).map(|w| &body[w[0]..w[1]]).collect()
+}
+
+/// Effective context length for imara's hunk merger so it approximates Git's
+/// `2 * U + inter_hunk_context` unchanged-line merge threshold.
+fn imara_context_len_for_git(context_lines: usize, inter_hunk_context: usize) -> u32 {
+    (2usize
+        .saturating_mul(context_lines)
+        .saturating_add(inter_hunk_context))
+    .div_ceil(2)
+    .min(u32::MAX as usize) as u32
+}
+
+fn histogram_unified_body_raw(
+    old_content: &str,
+    new_content: &str,
+    context_lines: usize,
+    inter_hunk_context: usize,
+) -> String {
+    use imara_diff::{Algorithm, BasicLineDiffPrinter, Diff, InternedInput, UnifiedDiffConfig};
+
+    let input = InternedInput::new(old_content, new_content);
+    let mut diff = Diff::compute(Algorithm::Histogram, &input);
+    diff.postprocess_lines(&input);
+    let mut config = UnifiedDiffConfig::default();
+    config.context_len(imara_context_len_for_git(context_lines, inter_hunk_context));
+    let printer = BasicLineDiffPrinter(&input.interner);
+    diff.unified_diff(&printer, config, &input).to_string()
+}
+
+/// Unified diff hunks for Git's histogram algorithm (no `---` / `+++` lines).
+///
+/// Used by `--no-index` when whitespace normalization is off so the patch matches upstream Git.
+#[must_use]
+pub fn unified_diff_histogram_hunks_only(
+    old_content: &str,
+    new_content: &str,
+    context_lines: usize,
+    inter_hunk_context: usize,
+) -> String {
+    histogram_unified_body_raw(old_content, new_content, context_lines, inter_hunk_context)
+}
+
+/// Full unified diff (`---` / `+++` / hunks) using Git's histogram algorithm.
+#[must_use]
+pub fn unified_diff_histogram_with_prefix_and_funcname(
+    old_content: &str,
+    new_content: &str,
+    old_path: &str,
+    new_path: &str,
+    context_lines: usize,
+    inter_hunk_context: usize,
+    src_prefix: &str,
+    dst_prefix: &str,
+    funcname_matcher: Option<&FuncnameMatcher>,
+) -> String {
+    let body =
+        histogram_unified_body_raw(old_content, new_content, context_lines, inter_hunk_context);
+
+    let mut output = String::new();
+    if old_path == "/dev/null" {
+        output.push_str("--- /dev/null\n");
+    } else {
+        output.push_str(&format!("--- {src_prefix}{old_path}\n"));
+    }
+    if new_path == "/dev/null" {
+        output.push_str("+++ /dev/null\n");
+    } else {
+        output.push_str(&format!("+++ {dst_prefix}{new_path}\n"));
+    }
+
+    let old_lines: Vec<&str> = old_content.lines().collect();
+    for hunk_str in imara_unified_hunk_slices(&body) {
+        if hunk_str.is_empty() {
+            continue;
+        }
+        if let Some(first_newline) = hunk_str.find('\n') {
+            let header_line = &hunk_str[..first_newline];
+            let rest = &hunk_str[first_newline..];
+            if let Some(func_ctx) =
+                extract_function_context(header_line, &old_lines, funcname_matcher)
+            {
+                output.push_str(header_line);
+                output.push(' ');
+                output.push_str(&func_ctx);
+                output.push_str(rest);
+            } else {
+                output.push_str(hunk_str);
+            }
+        } else {
+            output.push_str(hunk_str);
+        }
+    }
+
+    output
+}
 
 /// The kind of change between two sides of a diff.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1925,6 +2033,7 @@ pub fn unified_diff_with_prefix_and_funcname(
         dst_prefix,
         funcname_matcher,
         similar::Algorithm::Myers,
+        false,
     )
 }
 
@@ -1942,7 +2051,22 @@ pub fn unified_diff_with_prefix_and_funcname_and_algorithm(
     dst_prefix: &str,
     funcname_matcher: Option<&FuncnameMatcher>,
     algorithm: similar::Algorithm,
+    use_git_histogram: bool,
 ) -> String {
+    if use_git_histogram {
+        return unified_diff_histogram_with_prefix_and_funcname(
+            old_content,
+            new_content,
+            old_path,
+            new_path,
+            context_lines,
+            inter_hunk_context,
+            src_prefix,
+            dst_prefix,
+            funcname_matcher,
+        );
+    }
+
     use similar::{group_diff_ops, udiff::UnifiedDiffHunk, TextDiff};
 
     let diff = TextDiff::configure()
@@ -2012,7 +2136,8 @@ pub fn unified_diff_with_prefix_and_funcname_and_algorithm(
 /// This produces diffs where the anchored text stays as context and surrounding
 /// lines are shown as additions/removals.
 ///
-/// Segment diffs use `algorithm` (Git maps `--histogram` to patience-style line diff in our stack).
+/// Segment diffs use `algorithm`. When `use_git_histogram` is true, histogram uses imara-diff
+/// (Git-compatible); otherwise `algorithm` is passed to `similar`.
 pub fn anchored_unified_diff(
     old_content: &str,
     new_content: &str,
@@ -2021,6 +2146,7 @@ pub fn anchored_unified_diff(
     context_lines: usize,
     anchors: &[String],
     algorithm: similar::Algorithm,
+    use_git_histogram: bool,
 ) -> String {
     use similar::TextDiff;
 
@@ -2068,6 +2194,7 @@ pub fn anchored_unified_diff(
             "b/",
             None,
             algorithm,
+            use_git_histogram,
         );
     }
 
@@ -2402,7 +2529,7 @@ pub fn format_stat_line_width(
 ///
 /// Returns `(insertions, deletions)`.
 pub fn count_changes(old_content: &str, new_content: &str) -> (usize, usize) {
-    count_changes_with_algorithm(old_content, new_content, similar::Algorithm::Myers)
+    count_changes_with_algorithm(old_content, new_content, similar::Algorithm::Myers, false)
 }
 
 /// Count insertions and deletions using the given line-diff algorithm.
@@ -2414,7 +2541,16 @@ pub fn count_changes_with_algorithm(
     old_content: &str,
     new_content: &str,
     algorithm: similar::Algorithm,
+    use_git_histogram: bool,
 ) -> (usize, usize) {
+    if use_git_histogram {
+        use imara_diff::{Algorithm, Diff, InternedInput};
+        let input = InternedInput::new(old_content, new_content);
+        let mut d = Diff::compute(Algorithm::Histogram, &input);
+        d.postprocess_lines(&input);
+        return (d.count_additions() as usize, d.count_removals() as usize);
+    }
+
     use similar::{ChangeTag, TextDiff};
 
     let diff = TextDiff::configure()

--- a/grit-lib/src/rev_parse.rs
+++ b/grit-lib/src/rev_parse.rs
@@ -899,10 +899,36 @@ fn normalize_path_components(path: PathBuf) -> PathBuf {
     out
 }
 
+/// Normalize `treeish:path` path segment for tree lookup when there is no work tree (bare repo).
+///
+/// Paths are interpreted relative to the repository root; `./` / `../` / `.` still require a work
+/// tree in Git and are rejected here.
+fn normalize_colon_path_for_bare_tree(raw_path: &str) -> Result<String> {
+    let cwd_relative = raw_path.starts_with("./") || raw_path.starts_with("../") || raw_path == ".";
+    if cwd_relative {
+        return Err(Error::InvalidRef(
+            "relative path syntax can't be used outside working tree".to_owned(),
+        ));
+    }
+    let s = raw_path.trim_start_matches('/');
+    let mut stack: Vec<&str> = Vec::new();
+    for part in s.split('/') {
+        if part.is_empty() || part == "." {
+            continue;
+        }
+        if part == ".." {
+            let _ = stack.pop();
+        } else {
+            stack.push(part);
+        }
+    }
+    Ok(stack.join("/"))
+}
+
 fn normalize_colon_path_for_tree(repo: &Repository, raw_path: &str) -> Result<String> {
-    let work_tree = repo.work_tree.as_ref().ok_or_else(|| {
-        Error::InvalidRef("relative path syntax can't be used outside working tree".to_owned())
-    })?;
+    let Some(work_tree) = repo.work_tree.as_ref() else {
+        return normalize_colon_path_for_bare_tree(raw_path);
+    };
 
     let cwd = std::env::current_dir().map_err(Error::Io)?;
     let wt_canon = work_tree.canonicalize().map_err(Error::Io)?;

--- a/grit/src/commands/diff.rs
+++ b/grit/src/commands/diff.rs
@@ -24,8 +24,8 @@ use grit_lib::crlf::{
 use grit_lib::diff::{
     anchored_unified_diff, count_changes, count_changes_with_algorithm, count_git_lines,
     detect_renames, diff_index_to_tree, diff_index_to_worktree, diff_tree_to_worktree, diff_trees,
-    diffcore_count_changes, empty_blob_oid, rewrite_dissimilarity_index_percent,
-    should_break_rewrite_for_stat, unified_diff,
+    diffcore_count_changes, empty_blob_oid, format_stat_line, rewrite_dissimilarity_index_percent,
+    should_break_rewrite_for_stat, unified_diff, unified_diff_histogram_hunks_only,
     unified_diff_with_prefix_and_funcname_and_algorithm, zero_oid, DiffEntry, DiffStatus,
 };
 use grit_lib::diffstat::{terminal_columns, write_diffstat_block, DiffstatOptions, FileStatInput};
@@ -59,40 +59,75 @@ struct DiffAlgoContext {
     ignore_case_attrs: bool,
 }
 
-/// Map a Git `diff.algorithm` / driver algorithm string to a `similar` line algorithm.
-fn match_grit_diff_algorithm_name(name: &str) -> Option<similar::Algorithm> {
+/// Map a Git `diff.algorithm` / driver algorithm string to a line diff backend.
+///
+/// Histogram uses `imara-diff` for Git-compatible hunks; patience/minimal/myers use `similar`.
+fn match_grit_diff_algorithm_name(name: &str) -> Option<(similar::Algorithm, bool)> {
     match name.to_ascii_lowercase().as_str() {
-        "myers" | "default" => Some(similar::Algorithm::Myers),
-        "histogram" | "patience" => Some(similar::Algorithm::Patience),
-        "minimal" => Some(similar::Algorithm::Lcs),
+        "myers" | "default" => Some((similar::Algorithm::Myers, false)),
+        "histogram" => Some((similar::Algorithm::Patience, true)),
+        "patience" => Some((similar::Algorithm::Patience, false)),
+        "minimal" => Some((similar::Algorithm::Lcs, false)),
         _ => None,
     }
 }
 
-fn diff_algo_from_config_default(cfg: &grit_lib::config::ConfigSet) -> similar::Algorithm {
+fn diff_algo_from_config_default(cfg: &grit_lib::config::ConfigSet) -> (similar::Algorithm, bool) {
     cfg.get("diff.algorithm")
         .as_deref()
         .and_then(match_grit_diff_algorithm_name)
-        .unwrap_or(similar::Algorithm::Myers)
+        .unwrap_or((similar::Algorithm::Myers, false))
 }
 
 /// Last algorithm-related flag on the argv wins (matches Git).
-fn parse_cli_diff_algorithm_from_argv() -> Option<similar::Algorithm> {
+#[derive(Clone, Copy, Debug, Default)]
+struct CliDiffAlgo {
+    similar: similar::Algorithm,
+    histogram_git: bool,
+}
+
+fn parse_cli_diff_algorithm_from_argv() -> Option<CliDiffAlgo> {
     let argv: Vec<String> = std::env::args().collect();
-    let mut last = None;
+    let mut last: Option<CliDiffAlgo> = None;
     let mut i = 0usize;
     while i < argv.len() {
         let a = argv[i].as_str();
         match a {
-            "--histogram" | "--patience" => last = Some(similar::Algorithm::Patience),
-            "--minimal" => last = Some(similar::Algorithm::Lcs),
+            "--histogram" => {
+                last = Some(CliDiffAlgo {
+                    similar: similar::Algorithm::Patience,
+                    histogram_git: true,
+                });
+            }
+            "--patience" => {
+                last = Some(CliDiffAlgo {
+                    similar: similar::Algorithm::Patience,
+                    histogram_git: false,
+                });
+            }
+            "--minimal" => {
+                last = Some(CliDiffAlgo {
+                    similar: similar::Algorithm::Lcs,
+                    histogram_git: false,
+                });
+            }
             s if s.starts_with("--diff-algorithm=") => {
                 let v = s.strip_prefix("--diff-algorithm=").unwrap_or("");
-                last = match_grit_diff_algorithm_name(v);
+                if let Some((algo, hg)) = match_grit_diff_algorithm_name(v) {
+                    last = Some(CliDiffAlgo {
+                        similar: algo,
+                        histogram_git: hg,
+                    });
+                }
             }
             "--diff-algorithm" => {
                 if let Some(v) = argv.get(i + 1) {
-                    last = match_grit_diff_algorithm_name(v);
+                    if let Some((algo, hg)) = match_grit_diff_algorithm_name(v) {
+                        last = Some(CliDiffAlgo {
+                            similar: algo,
+                            histogram_git: hg,
+                        });
+                    }
                     i += 1;
                 }
             }
@@ -105,11 +140,11 @@ fn parse_cli_diff_algorithm_from_argv() -> Option<similar::Algorithm> {
 
 fn diff_algorithm_for_path(
     rel_path: &str,
-    cli_override: Option<similar::Algorithm>,
+    cli_override: Option<CliDiffAlgo>,
     ctx: &DiffAlgoContext,
-) -> similar::Algorithm {
-    if let Some(a) = cli_override {
-        return a;
+) -> (similar::Algorithm, bool) {
+    if let Some(c) = cli_override {
+        return (c.similar, c.histogram_git);
     }
     let map = collect_attrs_for_path(
         &ctx.attrs.rules,
@@ -119,8 +154,8 @@ fn diff_algorithm_for_path(
     );
     if let Some(AttrValue::Value(driver)) = map.get("diff") {
         if let Some(algo_key) = ctx.config.get(&format!("diff.{driver}.algorithm")) {
-            if let Some(a) = match_grit_diff_algorithm_name(&algo_key) {
-                return a;
+            if let Some((a, hg)) = match_grit_diff_algorithm_name(&algo_key) {
+                return (a, hg);
             }
         }
     }
@@ -414,8 +449,10 @@ fn no_index_unified_patch_body(
     old_path: &str,
     new_path: &str,
     context_lines: usize,
+    inter_hunk_context: usize,
     mode: &WhitespaceMode,
     algorithm: similar::Algorithm,
+    use_git_histogram: bool,
 ) -> String {
     let old_slots = no_index_build_line_slots(old_bytes, mode);
     let new_slots = no_index_build_line_slots(new_bytes, mode);
@@ -436,6 +473,32 @@ fn no_index_unified_patch_body(
     let new_compare_owned: Vec<String> = new_slots.iter().map(|s| line_key(&s.compare)).collect();
     let old_compare: Vec<&str> = old_compare_owned.iter().map(|s| s.as_str()).collect();
     let new_compare: Vec<&str> = new_compare_owned.iter().map(|s| s.as_str()).collect();
+
+    if use_git_histogram && !mode.any() {
+        let old_str = String::from_utf8_lossy(old_bytes);
+        let new_str = String::from_utf8_lossy(new_bytes);
+        let hunks = unified_diff_histogram_hunks_only(
+            old_str.as_ref(),
+            new_str.as_ref(),
+            context_lines,
+            inter_hunk_context,
+        );
+        let old_label = if old_path == "/dev/null" {
+            "--- /dev/null\n".to_string()
+        } else {
+            format!("--- a/{old_path}\n")
+        };
+        let new_label = if new_path == "/dev/null" {
+            "+++ /dev/null\n".to_string()
+        } else {
+            format!("+++ b/{new_path}\n")
+        };
+        let mut output = String::new();
+        output.push_str(&old_label);
+        output.push_str(&new_label);
+        output.push_str(&hunks);
+        return output;
+    }
 
     let diff = TextDiff::configure()
         .algorithm(algorithm)
@@ -504,10 +567,10 @@ fn no_index_unified_patch_body(
 }
 
 /// Resolve line-diff algorithm for `git diff` from flags and argv order (last wins).
-fn effective_line_diff_algorithm(args: &Args) -> similar::Algorithm {
+fn effective_line_diff_algorithm(args: &Args) -> (similar::Algorithm, bool) {
     let raw: Vec<String> = std::env::args().collect();
-    let mut best: Option<(usize, similar::Algorithm)> = None;
-    let mut record = |pos: Option<usize>, algo: similar::Algorithm| {
+    let mut best: Option<(usize, CliDiffAlgo)> = None;
+    let mut record = |pos: Option<usize>, algo: CliDiffAlgo| {
         if let Some(p) = pos {
             if best.is_none_or(|(bp, _)| p >= bp) {
                 best = Some((p, algo));
@@ -516,28 +579,55 @@ fn effective_line_diff_algorithm(args: &Args) -> similar::Algorithm {
     };
     record(
         raw.iter().rposition(|a| a == "--histogram"),
-        similar::Algorithm::Patience,
+        CliDiffAlgo {
+            similar: similar::Algorithm::Patience,
+            histogram_git: true,
+        },
     );
     record(
         raw.iter().rposition(|a| a == "--patience"),
-        similar::Algorithm::Patience,
+        CliDiffAlgo {
+            similar: similar::Algorithm::Patience,
+            histogram_git: false,
+        },
     );
     record(
         raw.iter().rposition(|a| a == "--minimal"),
-        similar::Algorithm::Myers,
+        CliDiffAlgo {
+            similar: similar::Algorithm::Lcs,
+            histogram_git: false,
+        },
     );
     if let Some(name) = args.diff_algorithm.as_deref() {
         let pos = raw
             .iter()
             .rposition(|a| a == "--diff-algorithm" || a.starts_with("--diff-algorithm="));
-        let algo = match name.to_lowercase().as_str() {
-            "histogram" | "patience" => similar::Algorithm::Patience,
-            "minimal" | "myers" => similar::Algorithm::Myers,
-            _ => similar::Algorithm::Myers,
+        let c = match name.to_lowercase().as_str() {
+            "histogram" => CliDiffAlgo {
+                similar: similar::Algorithm::Patience,
+                histogram_git: true,
+            },
+            "patience" => CliDiffAlgo {
+                similar: similar::Algorithm::Patience,
+                histogram_git: false,
+            },
+            "minimal" => CliDiffAlgo {
+                similar: similar::Algorithm::Lcs,
+                histogram_git: false,
+            },
+            "myers" | "default" => CliDiffAlgo {
+                similar: similar::Algorithm::Myers,
+                histogram_git: false,
+            },
+            _ => CliDiffAlgo {
+                similar: similar::Algorithm::Myers,
+                histogram_git: false,
+            },
         };
-        record(pos, algo);
+        record(pos, c);
     }
-    best.map(|(_, a)| a).unwrap_or(similar::Algorithm::Myers)
+    best.map(|(_, a)| (a.similar, a.histogram_git))
+        .unwrap_or((similar::Algorithm::Myers, false))
 }
 
 /// Short blob id for `index` lines (matches `git rev-parse --short` default length).
@@ -2203,7 +2293,7 @@ fn run_diff_blob_vs_file(
     merged_attrs: Arc<grit_lib::attributes::ParsedGitAttributes>,
     diff_config: grit_lib::config::ConfigSet,
     ignore_case_attrs: bool,
-    diff_algo_cli: Option<similar::Algorithm>,
+    diff_algo_cli: Option<CliDiffAlgo>,
     cwd: &Path,
     quote_path_fully: bool,
 ) -> Result<()> {
@@ -2673,6 +2763,15 @@ fn run_no_index(args: Args) -> Result<()> {
         std::process::exit(1);
     }
     let context_lines = args.unified.unwrap_or(3);
+    let inter_hunk_context = args
+        .inter_hunk_context
+        .or_else(|| {
+            grit_lib::config::ConfigSet::load(None, true)
+                .ok()
+                .and_then(|cfg| cfg.get("diff.interhunkcontext"))
+                .and_then(|s| s.parse().ok())
+        })
+        .unwrap_or(0);
     let patch_abbrev = if args.full_index {
         40usize
     } else if let Some(n) = args.abbrev {
@@ -2684,7 +2783,7 @@ fn run_no_index(args: Args) -> Result<()> {
     let stdout = io::stdout();
     let mut out = stdout.lock();
 
-    let algo_for_paths = |rel_a: &str, rel_b: &str| -> similar::Algorithm {
+    let algo_for_paths = |rel_a: &str, rel_b: &str| -> (similar::Algorithm, bool) {
         let a = diff_algorithm_for_path(rel_a, diff_algo_cli, &diff_algo_ctx);
         let b = diff_algorithm_for_path(rel_b, diff_algo_cli, &diff_algo_ctx);
         if a == b {
@@ -2705,23 +2804,23 @@ fn run_no_index(args: Args) -> Result<()> {
     }
 
     if args.numstat {
-        let algo = algo_for_paths(path_a_str.as_str(), path_b_str.as_str());
-        let (adds, dels) = count_changes_with_algorithm(&text_a, &text_b, algo);
+        let (algo, hist) = algo_for_paths(path_a_str.as_str(), path_b_str.as_str());
+        let (adds, dels) = count_changes_with_algorithm(&text_a, &text_b, algo, hist);
         writeln!(out, "{}\t{}\t{}", adds, dels, path_b_str)?;
         std::process::exit(1);
     }
 
     if args.stat.is_some() || args.shortstat {
-        let algo = algo_for_paths(path_a_str.as_str(), path_b_str.as_str());
-        let (adds, dels) = count_changes_with_algorithm(&text_a, &text_b, algo);
+        let (algo, hist) = algo_for_paths(path_a_str.as_str(), path_b_str.as_str());
+        let (adds, dels) = count_changes_with_algorithm(&text_a, &text_b, algo, hist);
         if args.stat.is_some() {
             let display = if path_a_str != path_b_str {
                 format!("{path_a_str} => {path_b_str}")
             } else {
                 path_a_str.clone()
             };
-            let total = adds + dels;
-            writeln!(out, " {} | {}", display, total)?;
+            let stat_line = format_stat_line(&display, adds, dels, display.len());
+            writeln!(out, "{stat_line}")?;
         }
         let mut summary = " 1 file changed".to_string();
         if adds > 0 {
@@ -2760,8 +2859,9 @@ fn run_no_index(args: Args) -> Result<()> {
         false
     };
 
-    let line_algo_anchored = effective_line_diff_algorithm(&args);
-    let algo_no_index = parse_cli_diff_algorithm_from_argv()
+    let (line_algo_anchored, line_hist_anchored) = effective_line_diff_algorithm(&args);
+    let (algo_sim, algo_hist) = parse_cli_diff_algorithm_from_argv()
+        .map(|c| (c.similar, c.histogram_git))
         .unwrap_or_else(|| algo_for_paths(path_a_str.as_str(), path_b_str.as_str()));
 
     let diff_body = if use_anchored {
@@ -2773,6 +2873,7 @@ fn run_no_index(args: Args) -> Result<()> {
             context_lines,
             &args.anchored,
             line_algo_anchored,
+            line_hist_anchored,
         )
     } else {
         no_index_unified_patch_body(
@@ -2781,8 +2882,10 @@ fn run_no_index(args: Args) -> Result<()> {
             paths[0].as_str(),
             paths[1].as_str(),
             context_lines,
+            inter_hunk_context,
             &ws_mode,
-            algo_no_index,
+            algo_sim,
+            algo_hist,
         )
     };
 
@@ -3018,7 +3121,8 @@ fn run_no_index_dirs(args: Args, dir_a: &Path, dir_b: &Path) -> Result<()> {
             writeln!(out, "old mode {mode_a}")?;
             writeln!(out, "new mode {mode_b}")?;
         }
-        let algo = diff_algorithm_for_path(rel.as_str(), diff_algo_cli, &diff_algo_ctx);
+        let (algo, use_git_histogram) =
+            diff_algorithm_for_path(rel.as_str(), diff_algo_cli, &diff_algo_ctx);
         let func_matcher = matcher_for_path_parsed(
             diff_algo_ctx.config.as_ref(),
             &diff_algo_ctx.attrs.rules,
@@ -3038,6 +3142,7 @@ fn run_no_index_dirs(args: Args, dir_a: &Path, dir_b: &Path) -> Result<()> {
             "b/",
             func_matcher.as_ref(),
             algo,
+            use_git_histogram,
         );
         write!(out, "{patch}")?;
     }
@@ -4078,7 +4183,7 @@ fn stat_ins_del_for_entry(
     line_ignore: Option<&[Regex]>,
     ws_mode: &WhitespaceMode,
     algo_ctx: &DiffAlgoContext,
-    algo_cli: Option<similar::Algorithm>,
+    algo_cli: Option<CliDiffAlgo>,
 ) -> (usize, usize) {
     let old_raw = read_content_raw(odb, &entry.old_oid);
     let new_raw = read_content_raw_or_worktree(odb, &entry.new_oid, work_tree, entry.path());
@@ -4102,8 +4207,8 @@ fn stat_ins_del_for_entry(
         old_content = ws_mode.normalize(&old_content);
         new_content = ws_mode.normalize(&new_content);
     }
-    let algo = diff_algorithm_for_path(entry.path(), algo_cli, algo_ctx);
-    count_changes_with_algorithm(&old_content, &new_content, algo)
+    let (algo, hist) = diff_algorithm_for_path(entry.path(), algo_cli, algo_ctx);
+    count_changes_with_algorithm(&old_content, &new_content, algo, hist)
 }
 
 /// Write a GIT binary patch block (used by --binary).
@@ -4449,7 +4554,7 @@ fn write_patch_with_prefix(
     submodule_ignore: SubmoduleIgnoreFlags,
     line_ignore: Option<&[Regex]>,
     algo_ctx: &DiffAlgoContext,
-    algo_cli: Option<similar::Algorithm>,
+    algo_cli: Option<CliDiffAlgo>,
     cached: bool,
     no_ext_diff: bool,
     external_diff_cmd: Option<&str>,
@@ -4728,7 +4833,8 @@ fn write_patch_with_prefix(
                 write!(out, "{patch}")?;
             }
         } else {
-            let algo = diff_algorithm_for_path(path_for_attrs.as_str(), algo_cli, algo_ctx);
+            let (algo, use_git_histogram) =
+                diff_algorithm_for_path(path_for_attrs.as_str(), algo_cli, algo_ctx);
             let func_matcher = matcher_for_path_parsed(
                 algo_ctx.config.as_ref(),
                 &algo_ctx.attrs.rules,
@@ -4748,6 +4854,7 @@ fn write_patch_with_prefix(
                 dst_prefix,
                 func_matcher.as_ref(),
                 algo,
+                use_git_histogram,
             );
             let patch = if suppress_blank_empty {
                 strip_blank_context_trailing_space(&patch)
@@ -4967,7 +5074,7 @@ fn write_shortstat(
     line_ignore: Option<&[Regex]>,
     ws_mode: &WhitespaceMode,
     algo_ctx: &DiffAlgoContext,
-    algo_cli: Option<similar::Algorithm>,
+    algo_cli: Option<CliDiffAlgo>,
 ) -> Result<()> {
     if entries.is_empty() {
         return Ok(());
@@ -5048,7 +5155,7 @@ fn write_stat(
     ws_mode: &WhitespaceMode,
     quote_path_fully: bool,
     algo_ctx: &DiffAlgoContext,
-    algo_cli: Option<similar::Algorithm>,
+    algo_cli: Option<CliDiffAlgo>,
 ) -> Result<()> {
     if entries.is_empty() {
         return Ok(());
@@ -5165,7 +5272,7 @@ fn write_numstat(
     line_ignore: Option<&[Regex]>,
     ws_mode: &WhitespaceMode,
     algo_ctx: &DiffAlgoContext,
-    algo_cli: Option<similar::Algorithm>,
+    algo_cli: Option<CliDiffAlgo>,
 ) -> Result<()> {
     for entry in entries {
         let (ins, del) = stat_ins_del_for_entry(

--- a/grit/src/commands/show.rs
+++ b/grit/src/commands/show.rs
@@ -1267,6 +1267,7 @@ fn show_commit(
                 context,
                 &args.anchored,
                 line_algo,
+                false,
             )
         } else {
             unified_diff(&old_content, &new_content, old_path, new_path, context)

--- a/logs/2026-04-10_t4050-diff-histogram.md
+++ b/logs/2026-04-10_t4050-diff-histogram.md
@@ -1,0 +1,18 @@
+# t4050-diff-histogram
+
+## Goal
+
+Make `tests/t4050-diff-histogram.sh` pass (10/10).
+
+## Changes
+
+1. **Git-compatible histogram line diff** — Added `imara-diff` (workspace dep) and wired `histogram` separately from `patience` in `grit diff`. Histogram uses imara-diff with `postprocess_lines` and unified output; patience/minimal/myers still use `similar`. `--no-index` uses histogram hunks from raw file text when no whitespace rules apply (matches Git).
+
+2. **Bare repo `rev:path`** — `normalize_colon_path_for_tree` in `rev_parse.rs` now resolves simple paths in bare repos without a work tree (rejects `./` / `../` like Git).
+
+3. **`--stat --no-index`** — Per-file line uses `format_stat_line` so the `+`/`-` bar matches Git (t4050 `expect_diffstat`).
+
+## Validation
+
+- `cargo test -p grit-lib --lib`
+- `./scripts/run-tests.sh t4050-diff-histogram.sh` → 10/10


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes `t4050-diff-histogram` fully pass (10/10).

## Changes

- **Histogram vs patience**: `histogram` now uses **imara-diff** (Git-style histogram + postprocess) for unified hunks and insertion/deletion counts. `patience` continues to use **similar**’s patience algorithm. CLI/config/attributes distinguish the two (`--histogram` sets the Git histogram path; `--patience` does not).
- **Bare repo `HEAD:path`**: `rev_parse` normalizes `treeish:path` paths for bare repositories (no work tree) so `git -C bare.git diff HEAD:file1 HEAD:file2` works with `--attr-source`.
- **`diff --stat --no-index`**: Per-file stat line uses the same `+`/`-` bar formatting as Git (`format_stat_line`), matching the test’s `expect_diffstat`.

## Testing

- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t4050-diff-histogram.sh` → 10/10

## Dependency

- Workspace: `imara-diff` 0.2 with `unified_diff` feature (pulled into `grit-lib`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3ab37f8-27fb-4cfe-b1b9-0da26d4805c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3ab37f8-27fb-4cfe-b1b9-0da26d4805c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

