### PR TITLE
fix: make t3700-add fully pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -652,7 +652,7 @@ t3600-rm	t3	yes	82	53	29	false	ok	0
 t3601-rm-pathspec-file	t3	yes	5	5	0	true	ok	0
 t3602-rm-sparse-checkout	t3	yes	13	13	0	true	ok	0
 t3650-replay-basics	t3	yes	31	25	6	false	ok	0
-t3700-add	t3	yes	58	44	14	false	ok	0
+t3700-add	t3	yes	58	58	0	true	ok	0
 t3700-add-pathspec-file	t3	yes	24	24	0	true	ok	0
 t3701-add-interactive	t3	yes	130	31	99	false	ok	0
 t3702-add-edit	t3	yes	3	1	2	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,700 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,700 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T03:14:51+00:00" class="gen-time" title="2026-04-10 03:14 UTC">2026-04-10 03:14 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,700</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -219,11 +219,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">56/141 files · 2 skipped · 4,052/5,398 tests</span>
+        <span class="group-meta">57/141 files · 2 skipped · 4,066/5,398 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:75.1%"></div></div>
-        <span class="group-pct pct-blue">75.1%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:75.3%"></div></div>
+        <span class="group-pct pct-blue">75.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35700 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,700 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T03:14:51+00:00" class="gen-time" title="2026-04-10 03:14 UTC">2026-04-10 03:14 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,700</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -6677,14 +6677,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:80.6%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="58" data-passed="44">
+<tr class="" data-group="t3" data-tests="58" data-passed="58" data-full-pass="1">
   <td class="mono">t3700-add</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">58</td>
-  <td class="right">44</td>
+  <td class="right">58</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:75.9%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="24" data-passed="24" data-full-pass="1">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit/src/commands/add.rs
+++ b/grit/src/commands/add.rs
@@ -3,6 +3,7 @@
 //! Stages files from the working tree into the index so they will be
 //! included in the next commit.
 
+use crate::explicit_exit::SilentNonZeroExit;
 use anyhow::{anyhow, bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::attributes::{parse_gitattributes_file_content, validate_rules_for_add};
@@ -19,11 +20,124 @@ use grit_lib::refs;
 use grit_lib::repo::Repository;
 use grit_lib::unicode_normalization::{precompose_utf8_path, precompose_utf8_segment};
 use grit_lib::wildmatch::wildmatch;
+use std::cell::{Cell, RefCell};
 use std::collections::HashSet;
 use std::fs;
 use std::io::Read;
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
+
+/// Error when a nested repository has no checked-out commit (empty `HEAD` / unborn branch).
+#[derive(Debug)]
+struct EmbeddedRepoNoCommitError(String);
+
+impl std::fmt::Display for EmbeddedRepoNoCommitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let base = self.0.trim_end_matches('/');
+        write!(f, "'{base}/' does not have a commit checked out")
+    }
+}
+
+impl std::error::Error for EmbeddedRepoNoCommitError {}
+
+/// Read `extensions.objectformat` from a repository `config` (default `sha1`).
+fn read_object_format_from_git_dir(git_dir: &Path) -> String {
+    let config_path = git_dir.join("config");
+    let Ok(content) = fs::read_to_string(&config_path) else {
+        return "sha1".to_owned();
+    };
+    let mut in_extensions = false;
+    let mut object_format: Option<String> = None;
+    for line in content.lines() {
+        let t = line.trim();
+        if t.starts_with('[') {
+            in_extensions = t.eq_ignore_ascii_case("[extensions]");
+            continue;
+        }
+        if !in_extensions {
+            continue;
+        }
+        let Some((k, v)) = t.split_once('=') else {
+            continue;
+        };
+        if k.trim().eq_ignore_ascii_case("objectformat") {
+            object_format = Some(v.trim().to_lowercase());
+        }
+    }
+    object_format.unwrap_or_else(|| "sha1".to_owned())
+}
+
+thread_local! {
+    static DRY_RUN_STDOUT_LINES: RefCell<Vec<String>> = RefCell::new(Vec::new());
+    static DRY_RUN_CAPTURE_MULTISPEC: Cell<bool> = Cell::new(false);
+    static EMBEDDED_REPO_FULL_HINT_EMITTED: Cell<bool> = Cell::new(false);
+}
+
+fn dry_run_stdout_begin_multispec_capture() {
+    DRY_RUN_CAPTURE_MULTISPEC.set(true);
+    DRY_RUN_STDOUT_LINES.with(|v| v.borrow_mut().clear());
+}
+
+fn dry_run_stdout_push_line(line: String) {
+    if DRY_RUN_CAPTURE_MULTISPEC.get() {
+        DRY_RUN_STDOUT_LINES.with(|v| v.borrow_mut().push(line));
+    } else {
+        println!("{line}");
+    }
+}
+
+fn dry_run_stdout_finish_multispec_capture() {
+    if !DRY_RUN_CAPTURE_MULTISPEC.get() {
+        return;
+    }
+    DRY_RUN_CAPTURE_MULTISPEC.set(false);
+    DRY_RUN_STDOUT_LINES.with(|v| {
+        let mut lines = std::mem::take(&mut *v.borrow_mut());
+        lines.sort();
+        for line in lines {
+            println!("{line}");
+        }
+    });
+}
+
+fn dry_run_stdout_abort_multispec_capture() {
+    if !DRY_RUN_CAPTURE_MULTISPEC.get() {
+        return;
+    }
+    DRY_RUN_CAPTURE_MULTISPEC.set(false);
+    DRY_RUN_STDOUT_LINES.with(|v| {
+        v.borrow_mut().clear();
+    });
+}
+
+fn finish_dry_stdout_before_exit() {
+    dry_run_stdout_finish_multispec_capture();
+}
+
+struct DryRunMultispecStdoutGuard(bool);
+
+impl DryRunMultispecStdoutGuard {
+    fn maybe_begin(dry_run: bool, pathspec_count: usize) -> Self {
+        if dry_run && pathspec_count > 1 {
+            dry_run_stdout_begin_multispec_capture();
+            Self(true)
+        } else {
+            Self(false)
+        }
+    }
+}
+
+impl Drop for DryRunMultispecStdoutGuard {
+    fn drop(&mut self) {
+        if self.0 {
+            dry_run_stdout_finish_multispec_capture();
+        }
+    }
+}
+
+fn error_is_chmod_on_non_regular(e: &anyhow::Error) -> bool {
+    format!("{e:#}").contains("cannot chmod")
+}
 
 fn resolved_env_index_path(repo: &Repository) -> PathBuf {
     if let Ok(raw) = std::env::var("GIT_INDEX_FILE") {
@@ -103,6 +217,10 @@ pub struct Args {
     /// Continue adding files when some cannot be added.
     #[arg(long = "ignore-errors")]
     pub ignore_errors: bool,
+
+    /// Force failing paths to abort even when `add.ignore-errors` is set in config.
+    #[arg(long = "no-ignore-errors")]
+    pub no_ignore_errors: bool,
 
     /// Suppress warning for non-existent pathspecs (with --refresh).
     #[arg(long = "ignore-missing")]
@@ -243,6 +361,9 @@ pub fn run(mut args: Args) -> Result<()> {
         }
     }
 
+    let _dry_stdout_guard =
+        DryRunMultispecStdoutGuard::maybe_begin(args.dry_run, args.pathspec.len());
+
     // "git add" with no pathspecs and no flags: give advice
     if args.pathspec.is_empty()
         && !args.all
@@ -284,11 +405,12 @@ pub fn run(mut args: Args) -> Result<()> {
     let add_cfg = AddConfig {
         core_filemode,
         precompose_unicode,
-        ignore_errors: args.ignore_errors
+        ignore_errors: (args.ignore_errors
             || config
                 .get_bool("add.ignore-errors")
                 .and_then(|r| r.ok())
-                .unwrap_or(false),
+                .unwrap_or(false))
+            && !args.no_ignore_errors,
         conv,
         attrs,
         config: config.clone(),
@@ -308,13 +430,15 @@ pub fn run(mut args: Args) -> Result<()> {
     }
 
     let is_root_pathspec = args.pathspec.iter().any(|p| p == ":/");
+    let mut silent_exit_after_write: Option<i32> = None;
+    let mut deferred_chmod: Option<anyhow::Error> = None;
     if args.all || args.pathspec.iter().any(|p| p == ".") || is_root_pathspec {
         let effective_prefix = if is_root_pathspec {
             None
         } else {
             prefix.as_deref()
         };
-        add_all(
+        let (need_exit1, chmod_e) = add_all(
             odb,
             &mut index,
             work_tree,
@@ -324,6 +448,10 @@ pub fn run(mut args: Args) -> Result<()> {
             &mut ignore_matcher,
             &add_cfg,
         )?;
+        if need_exit1 {
+            silent_exit_after_write = Some(1);
+        }
+        deferred_chmod = chmod_e;
     } else if args.update {
         update_tracked(
             odb,
@@ -337,6 +465,7 @@ pub fn run(mut args: Args) -> Result<()> {
     } else {
         let mut had_errors = false;
         let mut had_ignored = false;
+        let mut chmod_deferred: Option<anyhow::Error> = None;
         for pathspec in &args.pathspec {
             let resolved =
                 crate::pathspec::resolve_pathspec(pathspec, work_tree, prefix.as_deref());
@@ -356,12 +485,27 @@ pub fn run(mut args: Args) -> Result<()> {
                     Ok(()) => {}
                     Err(AddPathError::Ignored(msg)) => {
                         eprintln!("{msg}");
-                        had_ignored = true;
                         had_errors = true;
+                        if !(args.dry_run && args.ignore_missing) {
+                            had_ignored = true;
+                        }
+                    }
+                    Err(AddPathError::DryRunFatalPathspec { message }) => {
+                        println!("{message}");
+                        return Err(anyhow::Error::new(SilentNonZeroExit { code: 128 }));
+                    }
+                    Err(AddPathError::EmbeddedNoCommit { rel_path }) => {
+                        eprintln!("error: '{rel_path}' does not have a commit checked out");
+                        eprintln!("error: unable to index file '{rel_path}'");
+                        eprintln!("fatal: adding files failed");
+                        std::process::exit(128);
                     }
                     Err(AddPathError::IoError(e)) => {
                         if add_cfg.ignore_errors {
                             eprintln!("warning: {e}");
+                            had_errors = true;
+                        } else if args.chmod.is_some() && error_is_chmod_on_non_regular(&e) {
+                            chmod_deferred = chmod_deferred.or(Some(e));
                             had_errors = true;
                         } else {
                             if is_unwritable_odb_error(&e) {
@@ -380,6 +524,9 @@ pub fn run(mut args: Args) -> Result<()> {
                         if add_cfg.ignore_errors {
                             eprintln!("warning: {e}");
                             had_errors = true;
+                        } else if args.chmod.is_some() && error_is_chmod_on_non_regular(&e) {
+                            chmod_deferred = chmod_deferred.or(Some(e));
+                            had_errors = true;
                         } else {
                             return Err(e);
                         }
@@ -387,6 +534,8 @@ pub fn run(mut args: Args) -> Result<()> {
                 }
             } // end expanded loop
         }
+
+        deferred_chmod = chmod_deferred;
 
         if had_ignored {
             if !args.dry_run {
@@ -398,17 +547,30 @@ pub fn run(mut args: Args) -> Result<()> {
             if !args.dry_run {
                 write_index_or_lock_err(&repo, &mut index, &index_path)?;
             }
-            if !add_cfg.ignore_errors {
+            if add_cfg.ignore_errors {
+                finish_dry_stdout_before_exit();
+                return Err(anyhow::Error::new(SilentNonZeroExit { code: 1 }));
+            }
+            if args.dry_run && args.ignore_missing {
+                finish_dry_stdout_before_exit();
+                return Err(anyhow::Error::new(SilentNonZeroExit { code: 1 }));
+            }
+            if deferred_chmod.is_none() {
                 bail!("adding files failed");
-            } else {
-                // With --ignore-errors, still exit non-zero if there were errors
-                std::process::exit(1);
             }
         }
     }
 
     if !args.dry_run {
         write_index_or_lock_err(&repo, &mut index, &index_path)?;
+    }
+
+    if let Some(e) = deferred_chmod {
+        return Err(e);
+    }
+
+    if let Some(code) = silent_exit_after_write {
+        return Err(anyhow::Error::new(SilentNonZeroExit { code }));
     }
 
     Ok(())
@@ -464,7 +626,7 @@ pub(crate) fn stage_pathspecs_for_commit(
             if is_real_dir {
                 if is_nested_embedded_git_repo(&abs_path, repo) {
                     stage_gitlink(
-                        odb, &mut index, work_tree, &resolved, &abs_path, false, false, false,
+                        odb, &mut index, repo, &resolved, &abs_path, false, false, false,
                     )?;
                     matched_paths.insert(resolved.as_bytes().to_vec());
                     continue;
@@ -565,6 +727,14 @@ pub(crate) fn stage_pathspecs_for_commit(
 enum AddPathError {
     Ignored(String),
     IoError(anyhow::Error),
+    /// Nested `.git` with no resolvable HEAD commit (matches Git's add error shape).
+    EmbeddedNoCommit {
+        rel_path: String,
+    },
+    /// `git add --dry-run`: missing pathspec — print `fatal: ...` on stdout and exit 128.
+    DryRunFatalPathspec {
+        message: String,
+    },
     Other(anyhow::Error),
 }
 
@@ -607,32 +777,31 @@ fn run_refresh(
         }
     } else {
         for pathspec in &args.pathspec {
-            let resolved = crate::pathspec::resolve_pathspec(pathspec, work_tree, prefix);
-            let found = index.entries.iter_mut().any(|ie| {
-                let path_str = String::from_utf8_lossy(&ie.path);
-                if path_str == resolved || path_str.starts_with(&format!("{resolved}/")) {
-                    let abs_path = work_tree.join(path_str.as_ref());
-                    if let Ok(meta) = fs::symlink_metadata(&abs_path) {
-                        ie.ctime_sec = meta.ctime() as u32;
-                        ie.ctime_nsec = meta.ctime_nsec() as u32;
-                        ie.mtime_sec = meta.mtime() as u32;
-                        ie.mtime_nsec = meta.mtime_nsec() as u32;
-                        ie.dev = meta.dev() as u32;
-                        ie.ino = meta.ino() as u32;
-                        ie.uid = meta.uid();
-                        ie.gid = meta.gid();
-                        ie.size = meta.len() as u32;
-                    }
-                    true
-                } else {
-                    false
+            let mut found = false;
+            for ie in &mut index.entries {
+                if ie.stage() != 0 {
+                    continue;
                 }
-            });
+                let path_str = String::from_utf8_lossy(&ie.path);
+                if !crate::pathspec::pathspec_matches(pathspec, path_str.as_ref()) {
+                    continue;
+                }
+                found = true;
+                let abs_path = work_tree.join(path_str.as_ref());
+                if let Ok(meta) = fs::symlink_metadata(&abs_path) {
+                    ie.ctime_sec = meta.ctime() as u32;
+                    ie.ctime_nsec = meta.ctime_nsec() as u32;
+                    ie.mtime_sec = meta.mtime() as u32;
+                    ie.mtime_nsec = meta.mtime_nsec() as u32;
+                    ie.dev = meta.dev() as u32;
+                    ie.ino = meta.ino() as u32;
+                    ie.uid = meta.uid();
+                    ie.gid = meta.gid();
+                    ie.size = meta.len() as u32;
+                }
+            }
             if !found && !args.ignore_missing {
-                eprintln!(
-                    "fatal: pathspec '{}' did not match any file(s) known to git",
-                    pathspec
-                );
+                eprintln!("fatal: pathspec '{}' did not match any files", pathspec);
                 std::process::exit(128);
             }
         }
@@ -734,7 +903,7 @@ fn add_all(
     repo: &Repository,
     ignore_matcher: &mut Option<IgnoreMatcher>,
     add_cfg: &AddConfig,
-) -> Result<()> {
+) -> Result<(bool, Option<anyhow::Error>)> {
     let scan_root = match prefix {
         Some(p) if !p.is_empty() => work_tree.join(p),
         _ => work_tree.to_path_buf(),
@@ -751,28 +920,38 @@ fn add_all(
         add_cfg.precompose_unicode,
     )?;
 
+    let mut chmod_err: Option<anyhow::Error> = None;
+    if !args.dry_run {
+        let mut ignored_some = false;
+        for (rel_path, abs_path) in &paths {
+            if let Err(e) = stage_file(
+                odb,
+                index,
+                work_tree,
+                rel_path,
+                abs_path,
+                repo,
+                &StageFileContext::from(args),
+                add_cfg,
+            ) {
+                if add_cfg.ignore_errors {
+                    eprintln!("warning: {e}");
+                    ignored_some = true;
+                } else if args.chmod.is_some() && error_is_chmod_on_non_regular(&e) {
+                    chmod_err = chmod_err.or(Some(e));
+                } else {
+                    return Err(e);
+                }
+            }
+        }
+        if add_cfg.ignore_errors && ignored_some {
+            return Ok((true, chmod_err));
+        }
+    }
+
     // Build a set of worktree paths for fast deletion detection
     let worktree_paths: std::collections::HashSet<&str> =
         paths.iter().map(|(r, _)| r.as_str()).collect();
-
-    for (rel_path, abs_path) in &paths {
-        if let Err(e) = stage_file(
-            odb,
-            index,
-            work_tree,
-            rel_path,
-            abs_path,
-            repo,
-            &StageFileContext::from(args),
-            add_cfg,
-        ) {
-            if add_cfg.ignore_errors {
-                eprintln!("warning: {e}");
-            } else {
-                return Err(e);
-            }
-        }
-    }
 
     // Handle deletions: index entries whose files are not in the worktree scan
     let prefix_bytes = prefix.map(|p| p.as_bytes());
@@ -807,7 +986,22 @@ fn add_all(
         }
     }
 
-    Ok(())
+    if args.dry_run {
+        for (rel_path, abs_path) in &paths {
+            stage_file(
+                odb,
+                index,
+                work_tree,
+                rel_path,
+                abs_path,
+                repo,
+                &StageFileContext::from(args),
+                add_cfg,
+            )?;
+        }
+    }
+
+    Ok((false, chmod_err))
 }
 
 /// Update only already-tracked files.
@@ -897,7 +1091,7 @@ fn update_tracked(
             let is_embedded_repo = abs_path.join(".git").exists();
             if is_plain_directory && !is_embedded_repo {
                 if args.verbose || args.dry_run {
-                    println!("remove '{path_str}'");
+                    dry_run_stdout_push_line(format!("remove '{path_str}'"));
                 }
                 if !args.dry_run {
                     index.remove(raw_path);
@@ -911,7 +1105,7 @@ fn update_tracked(
                     );
                     let current = index.get(raw_path, 0);
                     if current.map(|e| e.oid != oid).unwrap_or(false) {
-                        println!("add '{path_str}'");
+                        dry_run_stdout_push_line(format!("add '{path_str}'"));
                     }
                 }
             } else {
@@ -928,7 +1122,7 @@ fn update_tracked(
             }
         } else {
             if args.verbose || args.dry_run {
-                println!("remove '{path_str}'");
+                dry_run_stdout_push_line(format!("remove '{path_str}'"));
             }
             if !args.dry_run {
                 index.remove(raw_path);
@@ -1047,6 +1241,30 @@ fn add_path(
                 path
             )));
         }
+        if args.dry_run && args.ignore_missing {
+            if !args.force {
+                if let Some(ref mut matcher) = ignore_matcher {
+                    let (is_ignored, _) = matcher
+                        .check_path(repo, Some(&*index), path, false)
+                        .map_err(|e| AddPathError::Other(e.into()))?;
+                    if is_ignored {
+                        return Err(AddPathError::Ignored(format!(
+                            "The following paths are ignored by one of your .gitignore files:\n\
+                             {path}\n\
+                             hint: Use -f if you really want to add them.\n\
+                             hint: Disable this message with \"git config set advice.addIgnoredFile false\""
+                        )));
+                    }
+                }
+            }
+            return Ok(());
+        }
+        if args.dry_run && DRY_RUN_CAPTURE_MULTISPEC.get() {
+            dry_run_stdout_abort_multispec_capture();
+            return Err(AddPathError::DryRunFatalPathspec {
+                message: format!("fatal: pathspec '{path}' did not match any files"),
+            });
+        }
         return Err(AddPathError::Other(anyhow::anyhow!(
             "pathspec '{}' did not match any files",
             path
@@ -1072,7 +1290,8 @@ fn add_path(
                     return Err(AddPathError::Ignored(format!(
                         "The following paths are ignored by one of your .gitignore files:\n\
                          {path}\n\
-                         Use -f if you really want to add them."
+                         hint: Use -f if you really want to add them.\n\
+                         hint: Disable this message with \"git config set advice.addIgnoredFile false\""
                     )));
                 }
             }
@@ -1083,14 +1302,22 @@ fn add_path(
             return stage_gitlink(
                 odb,
                 index,
-                work_tree,
+                repo,
                 path,
                 &abs_path,
                 args.dry_run,
                 args.verbose,
                 args.no_warn_embedded_repo,
             )
-            .map_err(AddPathError::IoError);
+            .map_err(|e| {
+                if e.downcast_ref::<EmbeddedRepoNoCommitError>().is_some() {
+                    AddPathError::EmbeddedNoCommit {
+                        rel_path: format!("{}/", path.trim_end_matches('/')),
+                    }
+                } else {
+                    AddPathError::IoError(e)
+                }
+            });
         }
 
         let mut paths: Vec<(String, PathBuf)> = Vec::new();
@@ -1137,7 +1364,8 @@ fn add_path(
                     return Err(AddPathError::Ignored(format!(
                         "The following paths are ignored by one of your .gitignore files:\n\
                          {path}\n\
-                         Use -f if you really want to add them."
+                         hint: Use -f if you really want to add them.\n\
+                         hint: Disable this message with \"git config set advice.addIgnoredFile false\""
                     )));
                 }
             }
@@ -1193,7 +1421,7 @@ fn embedded_repository_git_dir(worktree: &Path) -> Result<PathBuf> {
 fn stage_gitlink(
     _odb: &Odb,
     index: &mut Index,
-    _work_tree: &Path,
+    repo: &Repository,
     rel_path: &str,
     abs_path: &Path,
     dry_run: bool,
@@ -1201,10 +1429,19 @@ fn stage_gitlink(
     no_warn_embedded_repo: bool,
 ) -> Result<()> {
     let git_dir = embedded_repository_git_dir(abs_path)?;
+    let super_fmt = read_object_format_from_git_dir(&repo.git_dir);
+    let embedded_fmt = read_object_format_from_git_dir(&git_dir);
+    if super_fmt != embedded_fmt {
+        bail!("cannot add a submodule of a different hash algorithm");
+    }
+
     let embedded_head_path = git_dir.join("HEAD");
     let head_content = fs::read_to_string(&embedded_head_path)
         .with_context(|| format!("cannot read HEAD of embedded repo '{}'", rel_path))?;
     let head_trimmed = head_content.trim();
+    if head_trimmed.is_empty() {
+        return Err(EmbeddedRepoNoCommitError(rel_path.to_owned()).into());
+    }
 
     // Resolve HEAD: prefer `refs::resolve_ref` (packed-refs, worktrees). If `HEAD` is a stale
     // symref to `refs/heads/master` while only `main` exists (common with
@@ -1223,8 +1460,7 @@ fn stage_gitlink(
                         }
                     }
                 }
-                found
-                    .ok_or_else(|| anyhow!("cannot resolve HEAD in embedded repo '{}'", rel_path))?
+                found.ok_or_else(|| EmbeddedRepoNoCommitError(rel_path.to_owned()))?
             }
         }
     } else {
@@ -1238,26 +1474,32 @@ fn stage_gitlink(
         .map(|e| e.mode == 0o160000)
         .unwrap_or(false);
 
-    // Warn about embedded repository unless suppressed
+    // Warn about embedded repository unless suppressed (Git prints the full hint block once).
     if !no_warn_embedded_repo && !already_tracked {
         eprintln!("warning: adding embedded git repository: {}", rel_path);
-        eprintln!("hint: You've added another git repository inside your current repository.");
-        eprintln!("hint: Clones of the outer repository will not contain the contents of");
-        eprintln!("hint: the embedded repository and will not know how to obtain it.");
-        eprintln!("hint: If you meant to add a submodule, use:");
-        eprintln!("hint: ");
-        eprintln!("hint: \tgit submodule add <url> {}", rel_path);
-        eprintln!("hint: ");
-        eprintln!("hint: If you added this path by mistake, you can remove it from the");
-        eprintln!("hint: index with:");
-        eprintln!("hint: ");
-        eprintln!("hint: \tgit rm --cached {}", rel_path);
-        eprintln!("hint: ");
-        eprintln!("hint: See \"git help submodule\" for more information.");
+        if !EMBEDDED_REPO_FULL_HINT_EMITTED.get() {
+            EMBEDDED_REPO_FULL_HINT_EMITTED.set(true);
+            eprintln!("hint: You've added another git repository inside your current repository.");
+            eprintln!("hint: Clones of the outer repository will not contain the contents of");
+            eprintln!("hint: the embedded repository and will not know how to obtain it.");
+            eprintln!("hint: If you meant to add a submodule, use:");
+            eprintln!("hint:");
+            eprintln!("hint: \tgit submodule add <url> {}", rel_path);
+            eprintln!("hint:");
+            eprintln!("hint: If you added this path by mistake, you can remove it from the");
+            eprintln!("hint: index with:");
+            eprintln!("hint:");
+            eprintln!("hint: \tgit rm --cached {}", rel_path);
+            eprintln!("hint:");
+            eprintln!("hint: See \"git help submodule\" for more information.");
+            eprintln!(
+                "hint: Disable this message with \"git config set advice.addEmbeddedRepo false\""
+            );
+        }
     }
 
     if dry_run {
-        println!("add '{}'", rel_path);
+        dry_run_stdout_push_line(format!("add '{rel_path}'"));
         return Ok(());
     }
 
@@ -1284,7 +1526,7 @@ fn stage_gitlink(
     index.add_or_replace(entry);
 
     if verbose {
-        println!("add '{}'", rel_path);
+        println!("add '{rel_path}'");
     }
 
     Ok(())
@@ -1339,11 +1581,15 @@ pub(crate) fn stage_file(
     add_cfg: &AddConfig,
 ) -> Result<()> {
     if ctx.dry_run {
-        if ctx.chmod.is_some() {
-            // Don't actually stage, just check if the file exists
+        if let Some(chmod_val) = ctx.chmod {
+            let meta = fs::symlink_metadata(abs_path)?;
+            if meta.file_type().is_symlink() {
+                eprintln!("warning: cannot chmod {} '{}'", chmod_val, rel_path);
+                return Err(anyhow::anyhow!("cannot chmod {} '{}'", chmod_val, rel_path));
+            }
             return Ok(());
         }
-        println!("add '{rel_path}'");
+        dry_run_stdout_push_line(format!("add '{rel_path}'"));
         return Ok(());
     }
 
@@ -1371,7 +1617,7 @@ pub(crate) fn stage_file(
         return stage_gitlink(
             odb,
             index,
-            _work_tree,
+            repo,
             rel_path,
             abs_path,
             ctx.dry_run,
@@ -1414,7 +1660,7 @@ pub(crate) fn stage_file(
         entry.set_intent_to_add(true);
         index.add_or_replace(entry);
         if ctx.verbose {
-            println!("add '{rel_path}'");
+            dry_run_stdout_push_line(format!("add '{rel_path}'"));
         }
         return Ok(());
     }
@@ -1509,7 +1755,7 @@ pub(crate) fn stage_file(
     index.stage_file(entry);
 
     if ctx.verbose {
-        println!("add '{rel_path}'");
+        dry_run_stdout_push_line(format!("add '{rel_path}'"));
     }
 
     Ok(())
@@ -1754,6 +2000,24 @@ fn check_symlink_in_path(work_tree: &Path, rel_path: &Path) -> Option<PathBuf> {
     None
 }
 
+/// Strip Git pathspec backslash escapes so the result matches the on-disk filename (`fo\\[ou\\]bar` → `fo[ou]bar`).
+fn unescape_pathspec_literal(pathspec: &str) -> String {
+    let b = pathspec.as_bytes();
+    let mut out = String::with_capacity(pathspec.len());
+    let mut i = 0usize;
+    while i < b.len() {
+        if b[i] == b'\\' && i + 1 < b.len() && matches!(b[i + 1], b'[' | b']' | b'*' | b'?' | b'\\')
+        {
+            out.push(char::from(b[i + 1]));
+            i += 2;
+        } else {
+            out.push(char::from(b[i]));
+            i += 1;
+        }
+    }
+    out
+}
+
 /// Expand a pathspec containing glob characters against the working tree.
 ///
 /// If the pathspec does not contain glob characters, returns it unchanged.
@@ -1763,6 +2027,13 @@ pub(crate) fn expand_glob_pathspec(
     work_tree: &Path,
     precompose_unicode: bool,
 ) -> Vec<String> {
+    // Prefer an exact on-disk spelling first. Upstream shell tests often use single-quoted bodies
+    // where `touch fo\\[ou\\]bar` creates a filename that literally contains backslashes before `[`
+    // (t3700-add.sh), not the unescaped `fo[ou]bar` form.
+    if fs::symlink_metadata(work_tree.join(pathspec)).is_ok() {
+        return vec![pathspec.to_owned()];
+    }
+
     if !crate::pathspec::has_glob_chars(pathspec) {
         return vec![pathspec.to_owned()];
     }
@@ -1780,6 +2051,8 @@ pub(crate) fn expand_glob_pathspec(
     } else {
         work_tree.join(dir_prefix)
     };
+
+    let pattern_fs = unescape_pathspec_literal(pattern);
 
     let mut matches = Vec::new();
     if let Ok(entries) = fs::read_dir(&search_dir) {
@@ -1811,11 +2084,11 @@ pub(crate) fn expand_glob_pathspec(
 
     // Git pathspec: a bracket pattern like `[abc]` matches one character class member *and*
     // the literal filename `[abc]` when present (wildmatch alone does not match that literal).
-    if pattern.contains('[') && fs::symlink_metadata(search_dir.join(pattern)).is_ok() {
+    if pattern.contains('[') && fs::symlink_metadata(search_dir.join(&pattern_fs)).is_ok() {
         let rel = if dir_prefix.is_empty() {
-            pattern.to_string()
+            pattern_fs.clone()
         } else {
-            format!("{dir_prefix}/{pattern}")
+            format!("{dir_prefix}/{pattern_fs}")
         };
         if !matches.contains(&rel) {
             matches.push(rel);

--- a/grit/src/commands/diff_files.rs
+++ b/grit/src/commands/diff_files.rs
@@ -647,8 +647,12 @@ fn collect_changes(
                 WorktreeStatus::Modified(wt_mode, wt_oid) => {
                     let idx_canonical = canonicalize_mode(*idx_mode);
                     let content_matches = wt_oid == *idx_oid && wt_mode == idx_canonical;
+                    let stat_agrees = fs::symlink_metadata(&abs)
+                        .map(|m| stat_matches(idx_entry, &m))
+                        .unwrap_or(false);
                     if content_matches
                         && index_stat_is_trusted(idx_entry)
+                        && stat_agrees
                         && !idx_entry.intent_to_add()
                     {
                         continue;

--- a/grit/src/commands/diff_index.rs
+++ b/grit/src/commands/diff_index.rs
@@ -1072,7 +1072,28 @@ fn diff_tree_vs_worktree(
         // Stat differs — must read and hash the file
         match read_worktree_snapshot_from_meta(repo, &abs, &meta)? {
             Some(worktree_snapshot) => {
-                if worktree_snapshot != *index_snapshot {
+                if worktree_snapshot == *index_snapshot {
+                    // Index stat cache is stale (e.g. after `read-tree` zeroed stat fields) while
+                    // tree, index OID, and work tree content still agree — Git reports `M` with a
+                    // zero OID on the work-tree side (`t3700-add.sh` refresh tests).
+                    if let Some(ts) = tree_snap {
+                        if ts == *index_snapshot {
+                            let wt_placeholder = Snapshot {
+                                mode: worktree_snapshot.mode,
+                                oid: zero_oid(),
+                            };
+                            merged.insert(
+                                path.clone(),
+                                RawChange {
+                                    path: path.clone(),
+                                    status: 'M',
+                                    old: Some(ts),
+                                    new: Some(wt_placeholder),
+                                },
+                            );
+                        }
+                    }
+                } else if worktree_snapshot != *index_snapshot {
                     if tree_snap.is_none() {
                         // Staged add only in the index: refresh the `new` snapshot from the work
                         // tree (e.g. `chmod` after `git add`) while keeping status `A` so rename

--- a/grit/src/commands/ls_files.rs
+++ b/grit/src/commands/ls_files.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
 use std::borrow::Cow;
 use std::collections::BTreeSet;
+use std::fs;
 use std::io::{self, Write};
 use std::path::Component;
 use std::path::{Path, PathBuf};
@@ -890,6 +891,20 @@ fn glob_match_inner(pattern: &[u8], text: &[u8]) -> bool {
     let mut star_ti = 0;
 
     while ti < text.len() {
+        if pi < pattern.len() && pattern[pi] == b'\\' && pi + 1 < pattern.len() {
+            if pattern[pi + 1] == text[ti] {
+                pi += 2;
+                ti += 1;
+                continue;
+            } else if star_pi != usize::MAX {
+                star_ti += 1;
+                ti = star_ti;
+                pi = star_pi + 1;
+            } else {
+                return false;
+            }
+            continue;
+        }
         if pi < pattern.len() && pattern[pi] == b'?' && text[ti] != b'/' {
             pi += 1;
             ti += 1;
@@ -1002,6 +1017,20 @@ fn resolve_pathspec(
         return Ok(Pathspec::Literal(rest.as_bytes().to_vec()));
     }
     if has_glob_chars(&nfc_lossy) {
+        // If the pathspec spells an existing work-tree path literally (e.g. `fo[ou]bar` when
+        // `foobar` also exists), Git treats it as a literal path, not a character class
+        // (`t3700-add.sh`).
+        let combined_glob = if pathspec.is_absolute() {
+            pathspec.to_path_buf()
+        } else {
+            cwd.join(std::path::Path::new(nfc_lossy.as_str()))
+        };
+        let normalized_glob = normalize_path(&combined_glob);
+        if let Ok(rel_exact) = normalized_glob.strip_prefix(work_tree) {
+            if fs::symlink_metadata(work_tree.join(rel_exact)).is_ok() {
+                return Ok(Pathspec::Literal(path_to_bytes(rel_exact)));
+            }
+        }
         // For glob pathspecs, prepend the cwd prefix (relative to work_tree)
         let prefix = cwd_prefix_bytes(work_tree, cwd)?;
         let prefix_str = String::from_utf8_lossy(&prefix).into_owned();

--- a/grit/src/commands/stage.rs
+++ b/grit/src/commands/stage.rs
@@ -58,6 +58,7 @@ pub fn run(args: Args) -> Result<()> {
         renormalize: false,
         refresh: false,
         ignore_errors: false,
+        no_ignore_errors: false,
         ignore_missing: false,
         no_warn_embedded_repo: false,
         pathspec_from_file: None,

--- a/grit/src/commands/update_index.rs
+++ b/grit/src/commands/update_index.rs
@@ -397,6 +397,10 @@ pub fn run(args: Args, raw_rest: &[String]) -> Result<()> {
     let cwd = std::env::current_dir().context("resolving current directory")?;
 
     let config = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+    let core_filemode = config
+        .get_bool("core.filemode")
+        .and_then(|r| r.ok())
+        .unwrap_or(true);
     let conv = crlf::ConversionConfig::from_config(&config);
     let attrs = crlf::load_gitattributes(work_tree);
 
@@ -582,6 +586,7 @@ pub fn run(args: Args, raw_rest: &[String]) -> Result<()> {
             &args,
             &paths,
             symlinks_enabled,
+            core_filemode,
             &config,
             &conv,
             &attrs,
@@ -812,7 +817,13 @@ pub fn run(args: Args, raw_rest: &[String]) -> Result<()> {
 
         let mut mode = {
             use std::os::unix::fs::MetadataExt;
-            normalize_mode(meta.mode())
+            if core_filemode {
+                normalize_mode(meta.mode())
+            } else if meta.file_type().is_symlink() {
+                grit_lib::index::MODE_SYMLINK
+            } else {
+                grit_lib::index::MODE_REGULAR
+            }
         };
         let existing_mode = index.get(&rel_bytes, 0).map(|e| e.mode);
         // On filesystems without symlink support (core.symlinks=false), keep
@@ -1252,6 +1263,7 @@ fn run_update_index_again(
     args: &Args,
     pathspec_paths: &[PathBuf],
     symlinks_enabled: bool,
+    core_filemode: bool,
     config: &ConfigSet,
     conv: &crlf::ConversionConfig,
     attrs: &[crlf::AttrRule],
@@ -1374,7 +1386,13 @@ fn run_update_index_again(
             Ok(meta) => {
                 let mut mode = {
                     use std::os::unix::fs::MetadataExt;
-                    normalize_mode(meta.mode())
+                    if core_filemode {
+                        normalize_mode(meta.mode())
+                    } else if meta.file_type().is_symlink() {
+                        grit_lib::index::MODE_SYMLINK
+                    } else {
+                        grit_lib::index::MODE_REGULAR
+                    }
                 };
                 let existing_mode = index.get(&path_bytes, 0).map(|e| e.mode);
                 if !symlinks_enabled

--- a/logs/2026-04-10_t3700-add.md
+++ b/logs/2026-04-10_t3700-add.md
@@ -1,0 +1,15 @@
+# t3700-add — full pass
+
+## Summary
+
+- `git add`: `--refresh` pathspec matching + stat refresh; `--no-ignore-errors`; dry-run multi-pathspec ordering and fatal pathspec on stdout; `--ignore-missing` + ignored missing paths; embedded repo hints (spacing, single full hint block); object-format mismatch for submodules; empty nested repo error shape; `--chmod` partial success with deferred error after index write; `add_all` + `--ignore-errors` exit 1 after write.
+- `update-index`: honor `core.filemode` when adding blobs (t3700 update-index --add).
+- `diff-index`: report `M` with zero OID when index stat is stale but tree/index/worktree agree (post `read-tree`).
+- `diff-files`: require `stat_matches` before skipping as clean when content matches (t3700 refresh + chmtime).
+- `ls-files`: literal path when glob chars match an existing file; glob_match respects backslash escapes.
+- `tests/test-lib.sh`: forward `-F` to `grep` in `test_grep` (matches upstream; fixes bracket pathspec assertion).
+
+## Validation
+
+- `./scripts/run-tests.sh t3700-add.sh` — 58/58 pass (1 skip CASE_INSENSITIVE_FS).
+- `cargo test -p grit-lib --lib`

--- a/tests/test-lib.sh
+++ b/tests/test-lib.sh
@@ -360,11 +360,13 @@ test_declared_prereq () {
 test_grep () {
 	local negate=""
 	local invert=""
+	local fixed=""
 	while test $# -gt 0; do
 		case "$1" in
 		-e) shift; break ;;
 		!) negate=1; shift ;;
 		-v) invert="-v"; shift ;;
+		-F) fixed="-F"; shift ;;
 		--) shift; break ;;
 		-*) shift ;;
 		*) break ;;
@@ -375,9 +377,9 @@ test_grep () {
 	# Always pass the pattern via -e so values like "--quiet" are not parsed as grep options.
 	if test -n "$negate"
 	then
-		! command grep $invert -e "$pattern" "$@"
+		! command grep $fixed $invert -e "$pattern" "$@"
 	else
-		command grep $invert -e "$pattern" "$@"
+		command grep $fixed $invert -e "$pattern" "$@"
 	fi
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This branch makes `tests/t3700-add.sh` pass **58/58** runnable tests (one `CASE_INSENSITIVE_FS` skip unchanged).

### Grit changes

- **`git add`**: `--refresh` (pathspec matching + stat updates), `--no-ignore-errors`, dry-run ordering and fatal pathspec output, `--ignore-missing` with ignored missing paths, embedded-repo warnings (Git-shaped blank `hint:` lines, single long hint block), submodule hash-algorithm check, empty nested repo errors, `--chmod` with symlink + other paths (defer error until after index write), `add_all` + `--ignore-errors` non-zero exit after successful index write.
- **`update-index`**: honor `core.filemode` when adding files (matches `git update-index --add` with `filemode=0`).
- **`diff-index`**: when index stat cache is stale but tree/index OID and worktree agree, emit the same `M` + zero-OID line Git uses after `read-tree`.
- **`diff-files`**: do not treat “content matches” as clean unless disk stat also matches the index (fixes `chmtime` + `--refresh` expectations).
- **`ls-files`**: if a “glob” pathspec names a path that exists literally on disk, treat it as literal; teach glob matching about backslash escapes.

### Harness

- **`tests/test-lib.sh`**: `test_grep` now forwards `-F` to `grep` (upstream-style; required for the bracket-pathspec assertion in t3700).

### Artifacts

- Refreshed `data/test-files.csv` and dashboard HTML/SVG via `./scripts/run-tests.sh t3700-add.sh`.
- Log: `logs/2026-04-10_t3700-add.md`.

## Validation

- `./scripts/run-tests.sh t3700-add.sh`
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c6f58eaf-9b78-44cb-9c8b-739a64177e0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6f58eaf-9b78-44cb-9c8b-739a64177e0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

