### PR TITLE
fix: pass t1404-update-ref-errors (update-ref refname checks)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -404,7 +404,7 @@ t1400-update-ref	t1	skip	254	0	0	false	ok	0
 t1401-symbolic-ref	t1	yes	25	25	0	true	ok	0
 t1402-check-ref-format	t1	yes	99	99	0	true	ok	0
 t1403-show-ref	t1	yes	12	12	0	true	ok	0
-t1404-update-ref-errors	t1	yes	38	1	37	false	ok	0
+t1404-update-ref-errors	t1	yes	38	38	0	true	ok	0
 t1405-main-ref-store	t1	yes	16	2	14	false	ok	0
 t1405-main-ref-store-reftable	t1	yes	29	29	0	true	ok	0
 t1406-submodule-ref-store	t1	yes	15	8	7	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,723 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,723 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T03:34:56+00:00" class="gen-time" title="2026-04-10 03:34 UTC">2026-04-10 03:34 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,723</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -197,11 +197,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">275/368 files · 8 skipped · 11,694/12,747 tests</span>
+        <span class="group-meta">276/368 files · 8 skipped · 11,731/12,747 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:91.7%"></div></div>
-        <span class="group-pct pct-green">91.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:92.0%"></div></div>
+        <span class="group-pct pct-green">92.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t2">
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35723 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,723 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T03:34:56+00:00" class="gen-time" title="2026-04-10 03:34 UTC">2026-04-10 03:34 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,723</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -4197,14 +4197,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="38" data-passed="1">
+<tr class="" data-group="t1" data-tests="38" data-passed="38" data-full-pass="1">
   <td class="mono">t1404-update-ref-errors</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">38</td>
-  <td class="right">1</td>
+  <td class="right">38</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:2.6%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="16" data-passed="2">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/refs.rs
+++ b/grit-lib/src/refs.rs
@@ -13,7 +13,7 @@
 //! When `extensions.refStorage = reftable`, the reftable backend is used
 //! instead.  The public API is the same; dispatch is handled internally.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -223,6 +223,14 @@ fn read_raw_ref_files(git_dir: &Path, refname: &str) -> Result<RawRefLookup> {
     Ok(RawRefLookup::NotFound)
 }
 
+/// Lock file path for a loose ref file (`<refpath>.lock`), matching Git's naming for nested refs.
+#[must_use]
+pub fn lock_path_for_ref(path: &Path) -> PathBuf {
+    let mut s = path.as_os_str().to_owned();
+    s.push(".lock");
+    PathBuf::from(s)
+}
+
 fn read_raw_ref_at(path: PathBuf) -> Result<Option<RawRefLookup>> {
     match fs::symlink_metadata(&path) {
         Ok(meta) => {
@@ -234,6 +242,37 @@ fn read_raw_ref_at(path: PathBuf) -> Result<Option<RawRefLookup>> {
         Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
         Err(e) => Err(Error::Io(e)),
     }
+}
+
+fn packed_ref_with_prefix(git_dir: &Path, prefix_with_slash: &str) -> Result<Option<String>> {
+    let packed = git_dir.join("packed-refs");
+    let content = match fs::read_to_string(&packed) {
+        Ok(c) => c,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(Error::Io(e)),
+    };
+    let mut best: Option<String> = None;
+    for line in content.lines() {
+        if line.is_empty() || line.starts_with('#') || line.starts_with('^') {
+            continue;
+        }
+        let mut parts = line.split_whitespace();
+        let _oid = parts.next();
+        let Some(name) = parts.next() else {
+            continue;
+        };
+        let name = name.trim();
+        if name.starts_with(prefix_with_slash) {
+            let take = match &best {
+                None => true,
+                Some(b) => name < b.as_str(),
+            };
+            if take {
+                best = Some(name.to_owned());
+            }
+        }
+    }
+    Ok(best)
 }
 
 fn packed_ref_name_exists(git_dir: &Path, refname: &str) -> Result<bool> {
@@ -256,6 +295,208 @@ fn packed_ref_name_exists(git_dir: &Path, refname: &str) -> Result<bool> {
         }
     }
     Ok(false)
+}
+
+/// Why a reference name cannot be created (Git `refs_verify_refname_available` style).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RefnameUnavailable {
+    /// An ancestor ref already exists in the store (e.g. `refs/foo` blocks `refs/foo/bar`).
+    AncestorExists {
+        /// Existing ref that blocks creation.
+        blocking: String,
+        /// Ref the caller tried to create.
+        new_ref: String,
+    },
+    /// A descendant ref already exists (e.g. `refs/foo/bar` blocks `refs/foo`).
+    DescendantExists {
+        /// Existing ref under `new_ref/`.
+        blocking: String,
+        /// Ref the caller tried to create.
+        new_ref: String,
+    },
+    /// Two refnames in the same batch are mutually incompatible (parent vs child).
+    SameBatch {
+        /// Ref being validated (Git prints this first).
+        refname: String,
+        /// Other ref in the batch (parent dirname or descendant name).
+        other: String,
+    },
+}
+
+impl RefnameUnavailable {
+    /// Suffix after `cannot lock ref '<display_ref>': ` for stderr (no trailing newline).
+    #[must_use]
+    pub fn lock_message_suffix(&self) -> String {
+        match self {
+            RefnameUnavailable::AncestorExists { blocking, new_ref } => {
+                format!("'{blocking}' exists; cannot create '{new_ref}'")
+            }
+            RefnameUnavailable::DescendantExists { blocking, new_ref } => {
+                format!("'{blocking}' exists; cannot create '{new_ref}'")
+            }
+            RefnameUnavailable::SameBatch { refname, other } => {
+                format!("cannot process '{refname}' and '{other}' at the same time")
+            }
+        }
+    }
+}
+
+fn find_descendant_in_sorted_extras(
+    dirname_with_slash: &str,
+    extras: &BTreeSet<String>,
+) -> Option<String> {
+    let start = extras
+        .range(dirname_with_slash.to_string()..)
+        .next()
+        .cloned()?;
+    if start.starts_with(dirname_with_slash) {
+        Some(start)
+    } else {
+        None
+    }
+}
+
+/// Verify that `refname` can be created without directory/file conflicts with the ref store
+/// and with other refnames queued in the same transaction (`extras`).
+///
+/// `skip` names are ignored when checking the filesystem (updates that delete or replace
+/// those refs in the same batch). Matches Git's `refs_verify_refname_available`.
+///
+/// # Parameters
+///
+/// - `git_dir` — repository git directory.
+/// - `refname` — full ref name to create.
+/// - `extras` — other refnames touched in the same stdin batch / transaction (sorted set).
+/// - `skip` — refnames that may be deleted or updated away in the same batch.
+pub fn verify_refname_available_for_create(
+    git_dir: &Path,
+    refname: &str,
+    extras: &BTreeSet<String>,
+    skip: &HashSet<String>,
+) -> std::result::Result<(), RefnameUnavailable> {
+    // `Repository::git_dir` may be a relative path (e.g. `.git`); resolve so lookups match the
+    // on-disk ref store regardless of process cwd (test harness runs from `trash/.git/...`).
+    let git_dir = fs::canonicalize(git_dir).unwrap_or_else(|_| git_dir.to_path_buf());
+    let mut seen_dirnames: HashSet<String> = HashSet::new();
+    let segments: Vec<&str> = refname.split('/').filter(|s| !s.is_empty()).collect();
+    if segments.len() <= 1 {
+        // No slash-separated parent prefixes (e.g. `HEAD`).
+    } else {
+        let mut dirname = String::new();
+        for part in &segments[..segments.len() - 1] {
+            if !dirname.is_empty() {
+                dirname.push('/');
+            }
+            dirname.push_str(part);
+
+            if !seen_dirnames.insert(dirname.clone()) {
+                continue;
+            }
+
+            if skip.contains(&dirname) {
+                continue;
+            }
+
+            match read_raw_ref(&git_dir, &dirname) {
+                Ok(RawRefLookup::Exists) => {
+                    return Err(RefnameUnavailable::AncestorExists {
+                        blocking: dirname.clone(),
+                        new_ref: refname.to_owned(),
+                    });
+                }
+                // A directory at `refs/prefix` is normal when storing `refs/prefix/child`; only a
+                // real ref (loose file or packed line) blocks creating `refs/prefix/...`.
+                Ok(RawRefLookup::NotFound | RawRefLookup::IsDirectory) => {}
+                Err(_) => {}
+            }
+
+            if extras.contains(&dirname) {
+                return Err(RefnameUnavailable::SameBatch {
+                    refname: refname.to_owned(),
+                    other: dirname.clone(),
+                });
+            }
+        }
+    }
+
+    let mut leaf_dir = String::with_capacity(refname.len() + 1);
+    leaf_dir.push_str(refname);
+    leaf_dir.push('/');
+
+    let under = list_refs(&git_dir, &leaf_dir).unwrap_or_default();
+    if under.is_empty() {
+        let packed_dir = common_dir(&git_dir).unwrap_or_else(|| git_dir.clone());
+        if let Ok(Some(name)) = packed_ref_with_prefix(&packed_dir, &leaf_dir) {
+            if !skip.contains(&name) {
+                return Err(RefnameUnavailable::DescendantExists {
+                    blocking: name,
+                    new_ref: refname.to_owned(),
+                });
+            }
+        }
+        if packed_dir != git_dir {
+            if let Ok(Some(name)) = packed_ref_with_prefix(&git_dir, &leaf_dir) {
+                if !skip.contains(&name) {
+                    return Err(RefnameUnavailable::DescendantExists {
+                        blocking: name,
+                        new_ref: refname.to_owned(),
+                    });
+                }
+            }
+        }
+    }
+    if under.is_empty()
+        && fs::symlink_metadata(git_dir.join(refname))
+            .map(|m| m.is_dir())
+            .unwrap_or(false)
+    {
+        let mut blocking: Option<String> = None;
+        let dir_path = git_dir.join(refname);
+        if let Ok(read) = fs::read_dir(&dir_path) {
+            for entry in read.flatten() {
+                let path = entry.path();
+                let Ok(meta) = fs::metadata(&path) else {
+                    continue;
+                };
+                if !meta.is_file() {
+                    continue;
+                }
+                let name = entry.file_name().to_string_lossy().into_owned();
+                let full = format!("{refname}/{name}");
+                blocking = Some(full);
+                break;
+            }
+        }
+        if let Some(b) = blocking {
+            if !skip.contains(&b) {
+                return Err(RefnameUnavailable::DescendantExists {
+                    blocking: b,
+                    new_ref: refname.to_owned(),
+                });
+            }
+        }
+    }
+
+    for (existing, _) in under {
+        if skip.contains(&existing) {
+            continue;
+        }
+        return Err(RefnameUnavailable::DescendantExists {
+            blocking: existing,
+            new_ref: refname.to_owned(),
+        });
+    }
+
+    if let Some(extra) = find_descendant_in_sorted_extras(&leaf_dir, extras) {
+        if !skip.contains(&extra) {
+            return Err(RefnameUnavailable::SameBatch {
+                refname: refname.to_owned(),
+                other: extra,
+            });
+        }
+    }
+
+    Ok(())
 }
 
 fn read_raw_ref_reftable(git_dir: &Path, refname: &str) -> Result<RawRefLookup> {
@@ -337,7 +578,7 @@ pub fn write_symbolic_ref(git_dir: &Path, refname: &str, target: &str) -> Result
         fs::create_dir_all(parent)?;
     }
     let content = format!("ref: {target}\n");
-    let lock = path.with_extension("lock");
+    let lock = lock_path_for_ref(&path);
     fs::write(&lock, &content)?;
     fs::rename(&lock, &path)?;
     Ok(())
@@ -353,8 +594,7 @@ pub fn write_ref(git_dir: &Path, refname: &str, oid: &ObjectId) -> Result<()> {
         fs::create_dir_all(parent)?;
     }
     let content = format!("{oid}\n");
-    // Write via lock file for atomicity
-    let lock = path.with_extension("lock");
+    let lock = lock_path_for_ref(&path);
     fs::write(&lock, &content)?;
     fs::rename(&lock, &path)?;
     Ok(())
@@ -501,7 +741,11 @@ pub fn read_symbolic_ref(git_dir: &Path, refname: &str) -> Result<Option<String>
     match read_ref_file(&path) {
         Ok(Ref::Symbolic(target)) => Ok(Some(target)),
         Ok(Ref::Direct(_)) => Ok(None),
-        Err(Error::Io(ref e)) if e.kind() == io::ErrorKind::NotFound => {
+        Err(Error::Io(ref e))
+            if e.kind() == io::ErrorKind::NotFound
+                || e.kind() == io::ErrorKind::NotADirectory
+                || e.kind() == io::ErrorKind::IsADirectory =>
+        {
             if !notes_merge_state_ref(refname) {
                 if let Some(common) = common_dir(git_dir) {
                     if common != git_dir {
@@ -510,6 +754,8 @@ pub fn read_symbolic_ref(git_dir: &Path, refname: &str) -> Result<Option<String>
                             Ok(Ref::Symbolic(target)) => return Ok(Some(target)),
                             Ok(Ref::Direct(_)) => return Ok(None),
                             Err(Error::Io(ref e)) if e.kind() == io::ErrorKind::NotFound => {}
+                            Err(Error::Io(ref e)) if e.kind() == io::ErrorKind::NotADirectory => {}
+                            Err(Error::Io(ref e)) if e.kind() == io::ErrorKind::IsADirectory => {}
                             Err(e) => return Err(e),
                         }
                     }
@@ -894,6 +1140,139 @@ fn collect_packed_refs_into_map(
         out.insert(refname.to_string(), oid);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod refname_available_tests {
+    use super::*;
+    use std::collections::{BTreeSet, HashSet};
+    use tempfile::tempdir;
+
+    #[test]
+    fn loose_parent_blocks_child_create() {
+        let dir = tempdir().unwrap();
+        let git_dir = dir.path();
+        fs::create_dir_all(git_dir.join("refs/1l")).unwrap();
+        fs::write(
+            git_dir.join("refs/1l/c"),
+            "67bf698f3ab735e92fb011a99cff3497c44d30c1\n",
+        )
+        .unwrap();
+        assert_eq!(
+            read_raw_ref(git_dir, "refs/1l/c").unwrap(),
+            RawRefLookup::Exists
+        );
+        let extras = BTreeSet::from([
+            "refs/1l/b".to_string(),
+            "refs/1l/c/x".to_string(),
+            "refs/1l/d".to_string(),
+        ]);
+        let skip = HashSet::new();
+        let err = verify_refname_available_for_create(git_dir, "refs/1l/c/x", &extras, &skip)
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            RefnameUnavailable::AncestorExists { ref blocking, .. } if blocking == "refs/1l/c"
+        ));
+    }
+
+    #[test]
+    fn verify_sees_loose_ref_after_canonical_git_dir() {
+        let dir = tempdir().unwrap();
+        let git_dir = dir.path().join(".git");
+        fs::create_dir_all(git_dir.join("refs/1l")).unwrap();
+        fs::write(
+            git_dir.join("refs/1l/c"),
+            "67bf698f3ab735e92fb011a99cff3497c44d30c1\n",
+        )
+        .unwrap();
+        let skip = HashSet::new();
+        let extras = BTreeSet::new();
+        let err = verify_refname_available_for_create(&git_dir, "refs/1l/c/x", &extras, &skip)
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            RefnameUnavailable::AncestorExists { ref blocking, .. } if blocking == "refs/1l/c"
+        ));
+    }
+
+    #[test]
+    fn list_refs_finds_sibling_under_parent_directory() {
+        let dir = tempdir().unwrap();
+        let git_dir = dir.path();
+        fs::create_dir_all(git_dir.join("refs/ns/p")).unwrap();
+        fs::write(
+            git_dir.join("refs/ns/p/x"),
+            "67bf698f3ab735e92fb011a99cff3497c44d30c1\n",
+        )
+        .unwrap();
+        let listed = list_refs(git_dir, "refs/ns/p/").unwrap();
+        assert!(
+            listed.iter().any(|(n, _)| n == "refs/ns/p/x"),
+            "got {listed:?}"
+        );
+    }
+
+    #[test]
+    fn verify_blocks_parent_when_child_ref_exists() {
+        let dir = tempdir().unwrap();
+        let git_dir = dir.path();
+        fs::create_dir_all(git_dir.join("refs/ns/p")).unwrap();
+        fs::write(
+            git_dir.join("refs/ns/p/x"),
+            "67bf698f3ab735e92fb011a99cff3497c44d30c1\n",
+        )
+        .unwrap();
+        let extras = BTreeSet::from(["refs/ns/p".to_string()]);
+        let skip = HashSet::new();
+        let err =
+            verify_refname_available_for_create(git_dir, "refs/ns/p", &extras, &skip).unwrap_err();
+        assert!(matches!(
+            err,
+            RefnameUnavailable::DescendantExists { ref blocking, .. }
+                if blocking == "refs/ns/p/x"
+        ));
+    }
+
+    #[test]
+    fn verify_blocks_parent_git_style_nested_path() {
+        let dir = tempdir().unwrap();
+        let git_dir = dir.path();
+        fs::create_dir_all(git_dir.join("refs/3l/c")).unwrap();
+        fs::write(
+            git_dir.join("refs/3l/c/x"),
+            "67bf698f3ab735e92fb011a99cff3497c44d30c1\n",
+        )
+        .unwrap();
+        let extras = BTreeSet::from(["refs/3l/c".to_string()]);
+        let skip = HashSet::new();
+        let err =
+            verify_refname_available_for_create(git_dir, "refs/3l/c", &extras, &skip).unwrap_err();
+        assert!(matches!(
+            err,
+            RefnameUnavailable::DescendantExists { ref blocking, .. }
+                if blocking == "refs/3l/c/x"
+        ));
+    }
+
+    #[test]
+    fn intermediate_directory_does_not_block_nested_create() {
+        let dir = tempdir().unwrap();
+        let git_dir = dir.path();
+        fs::create_dir_all(git_dir.join("refs/ns")).unwrap();
+        fs::write(
+            git_dir.join("refs/ns/existing"),
+            "67bf698f3ab735e92fb011a99cff3497c44d30c1\n",
+        )
+        .unwrap();
+        assert_eq!(
+            read_raw_ref(git_dir, "refs/ns").unwrap(),
+            RawRefLookup::IsDirectory
+        );
+        let extras = BTreeSet::from(["refs/ns/newchild".to_string()]);
+        let skip = HashSet::new();
+        verify_refname_available_for_create(git_dir, "refs/ns/newchild", &extras, &skip).unwrap();
+    }
 }
 
 #[cfg(test)]

--- a/grit/src/commands/symbolic_ref.rs
+++ b/grit/src/commands/symbolic_ref.rs
@@ -249,7 +249,7 @@ fn write_symbolic_ref(git_dir: &Path, name: &str, target: &str) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
-    let lock_path = path.with_extension("lock");
+    let lock_path = grit_lib::refs::lock_path_for_ref(&path);
     fs::write(&lock_path, format!("ref: {target}\n"))?;
     fs::rename(lock_path, path)?;
     Ok(())

--- a/grit/src/commands/test_tool_ref_store.rs
+++ b/grit/src/commands/test_tool_ref_store.rs
@@ -117,7 +117,7 @@ fn cmd_create_symref(store: &RefStore, args: &[String]) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
-    let lock_path = path.with_extension("lock");
+    let lock_path = grit_lib::refs::lock_path_for_ref(&path);
     fs::write(&lock_path, format!("ref: {target}\n"))?;
     fs::rename(lock_path, path)?;
     Ok(())

--- a/grit/src/commands/update_ref.rs
+++ b/grit/src/commands/update_ref.rs
@@ -6,14 +6,15 @@ use std::fs;
 use std::io::{self, Read};
 use time::OffsetDateTime;
 
+use grit_lib::error::Error as GritError;
 use grit_lib::hooks::{run_hook, HookResult};
 use grit_lib::objects::ObjectId;
 use grit_lib::refs::{
     append_reflog, delete_ref, read_head, read_symbolic_ref, resolve_ref, should_autocreate_reflog,
-    write_ref,
+    verify_refname_available_for_create, write_ref,
 };
 use grit_lib::repo::Repository;
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 
 /// Arguments for `grit update-ref`.
 #[derive(Debug, ClapArgs)]
@@ -81,7 +82,7 @@ pub fn run(mut args: Args) -> Result<()> {
         let expected =
             parse_old_expectation(args.old_value.as_deref().or(old_from_positional.as_deref()))?;
         if let Some(exp) = expected {
-            verify_expected_old(&repo, &target_refname, exp)?;
+            verify_expected_old(&repo, refname, &target_refname, args.no_deref, exp)?;
         }
 
         let old_oid_for_reflog =
@@ -118,7 +119,7 @@ pub fn run(mut args: Args) -> Result<()> {
 
     let expected = parse_old_expectation(args.old_value.as_deref())?;
     if let Some(expected) = expected {
-        verify_expected_old(&repo, &target_refname, expected)?;
+        verify_expected_old(&repo, refname, &target_refname, args.no_deref, expected)?;
     }
 
     let old_oid_for_reflog =
@@ -200,277 +201,6 @@ fn take_batch_no_deref(args: &Args, pending_option: &mut bool) -> bool {
     nd
 }
 
-/// Process `--stdin` batch commands.
-fn run_batch(repo: &Repository, args: &Args) -> Result<()> {
-    let mut input = Vec::new();
-    io::stdin().read_to_end(&mut input)?;
-    if args.null_terminated {
-        return run_batch_nul(repo, args, &input);
-    }
-
-    let text = String::from_utf8_lossy(&input);
-    let mut transaction_active = false;
-    let mut transaction_prepared = false;
-    let mut staged: Vec<(bool, BatchOp)> = Vec::new();
-    let mut pending_option_no_deref = false;
-
-    for line in text.lines() {
-        if line.trim().is_empty() {
-            continue;
-        }
-        if line.chars().next().is_some_and(|c| c.is_whitespace()) {
-            bail!("whitespace before command: {line}");
-        }
-        let parts: Vec<&str> = line.split_whitespace().collect();
-        if parts.is_empty() {
-            continue;
-        }
-        process_batch_command(
-            repo,
-            args,
-            &parts,
-            &mut transaction_active,
-            &mut transaction_prepared,
-            &mut staged,
-            &mut pending_option_no_deref,
-        )?;
-    }
-
-    if transaction_active {
-        let hook_updates = hook_updates_for_ops(&staged)?;
-        if !hook_updates.is_empty() {
-            run_ref_transaction_aborted(repo, &hook_updates);
-        }
-    }
-
-    Ok(())
-}
-
-fn process_batch_command(
-    repo: &Repository,
-    args: &Args,
-    parts: &[&str],
-    transaction_active: &mut bool,
-    transaction_prepared: &mut bool,
-    staged: &mut Vec<(bool, BatchOp)>,
-    pending_option_no_deref: &mut bool,
-) -> Result<()> {
-    match parts[0] {
-        "update" => {
-            let nd = take_batch_no_deref(args, pending_option_no_deref);
-            if parts.len() < 3 {
-                bail!("update requires ref and new-value");
-            }
-            let op = BatchOp::UpdateOid {
-                refname: parts[1].to_owned(),
-                new_oid: resolve_oid_or_ref(repo, parts[2])?,
-                expected_old: parse_old_expectation(parts.get(3).copied())?,
-            };
-            queue_or_apply(repo, args, nd, *transaction_active, staged, op)?;
-        }
-        "create" => {
-            let nd = take_batch_no_deref(args, pending_option_no_deref);
-            if parts.len() < 3 {
-                bail!("create requires ref and new-value");
-            }
-            let op = BatchOp::CreateOid {
-                refname: parts[1].to_owned(),
-                new_oid: resolve_oid_or_ref(repo, parts[2])?,
-            };
-            queue_or_apply(repo, args, nd, *transaction_active, staged, op)?;
-        }
-        "delete" => {
-            let nd = take_batch_no_deref(args, pending_option_no_deref);
-            if parts.len() < 2 {
-                bail!("delete requires ref");
-            }
-            let op = BatchOp::DeleteOid {
-                refname: parts[1].to_owned(),
-                expected_old: parse_old_expectation(parts.get(2).copied())?,
-            };
-            queue_or_apply(repo, args, nd, *transaction_active, staged, op)?;
-        }
-        "verify" => {
-            let nd = take_batch_no_deref(args, pending_option_no_deref);
-            if parts.len() < 2 {
-                bail!("verify requires ref");
-            }
-            let op = BatchOp::VerifyOid {
-                refname: parts[1].to_owned(),
-                expected_old: parse_old_expectation(parts.get(2).copied())?,
-            };
-            queue_or_apply(repo, args, nd, *transaction_active, staged, op)?;
-        }
-        "symref-update" => {
-            let nd = take_batch_no_deref(args, pending_option_no_deref);
-            if parts.len() < 3 {
-                bail!("symref-update requires ref and new-target");
-            }
-            let expected_old = match parts.get(3).copied() {
-                None => None,
-                Some("ref") => {
-                    let Some(target) = parts.get(4) else {
-                        bail!("symref-update requires old-target after 'ref'");
-                    };
-                    Some(SymrefOldExpectation::MustTarget((*target).to_owned()))
-                }
-                Some("oid") => {
-                    let Some(oid) = parts.get(4) else {
-                        bail!("symref-update requires old-oid after 'oid'");
-                    };
-                    let parsed = oid.parse::<ObjectId>().context("invalid old-value OID")?;
-                    Some(SymrefOldExpectation::MustOid(parsed))
-                }
-                Some(other) => bail!("symref-update expected 'ref' or 'oid', got '{other}'"),
-            };
-            let op = BatchOp::UpdateSymref {
-                refname: parts[1].to_owned(),
-                new_target: parts[2].to_owned(),
-                expected_old,
-            };
-            queue_or_apply(repo, args, nd, *transaction_active, staged, op)?;
-        }
-        "symref-create" => {
-            let nd = take_batch_no_deref(args, pending_option_no_deref);
-            if parts.len() < 3 {
-                bail!("symref-create requires ref and new-target");
-            }
-            let op = BatchOp::CreateSymref {
-                refname: parts[1].to_owned(),
-                new_target: parts[2].to_owned(),
-            };
-            queue_or_apply(repo, args, nd, *transaction_active, staged, op)?;
-        }
-        "symref-delete" => {
-            let nd = take_batch_no_deref(args, pending_option_no_deref);
-            if parts.len() < 2 {
-                bail!("symref-delete requires ref");
-            }
-            let expected_old = parts
-                .get(2)
-                .map(|target| SymrefOldExpectation::MustTarget((*target).to_owned()));
-            let op = BatchOp::DeleteSymref {
-                refname: parts[1].to_owned(),
-                expected_old,
-            };
-            queue_or_apply(repo, args, nd, *transaction_active, staged, op)?;
-        }
-        "symref-verify" => {
-            let nd = take_batch_no_deref(args, pending_option_no_deref);
-            if !nd {
-                bail!("symref-verify can only be used in no-deref mode");
-            }
-            if parts.len() < 2 {
-                bail!("symref-verify requires ref");
-            }
-            let expected_old = parts
-                .get(2)
-                .map(|target| SymrefOldExpectation::MustTarget((*target).to_owned()))
-                .unwrap_or(SymrefOldExpectation::MustNotExist);
-            let op = BatchOp::VerifySymref {
-                refname: parts[1].to_owned(),
-                expected_old,
-            };
-            queue_or_apply(repo, args, nd, *transaction_active, staged, op)?;
-        }
-        "option" => {
-            if parts.len() == 2 && parts[1] == "no-deref" {
-                *pending_option_no_deref = true;
-            } else {
-                bail!("option unknown: {}", parts.get(1).copied().unwrap_or(""));
-            }
-        }
-        "start" => {
-            if *transaction_active {
-                bail!("transaction already started");
-            }
-            *transaction_active = true;
-            *transaction_prepared = false;
-            staged.clear();
-            println!("start: ok");
-        }
-        "prepare" => {
-            if !*transaction_active {
-                bail!("no transaction started");
-            }
-            let hook_updates = hook_updates_for_ops(staged)?;
-            run_ref_transaction_prepare(repo, &hook_updates)?;
-            *transaction_prepared = true;
-            println!("prepare: ok");
-        }
-        "commit" => {
-            if !*transaction_active {
-                bail!("no transaction started");
-            }
-
-            let hook_updates = hook_updates_for_ops(staged)?;
-            if !*transaction_prepared {
-                run_ref_transaction_prepare(repo, &hook_updates)?;
-            }
-            for (nd, op) in staged.drain(..) {
-                apply_batch_op(repo, args, nd, op)?;
-            }
-            run_ref_transaction_committed(repo, &hook_updates);
-            *transaction_active = false;
-            *transaction_prepared = false;
-            println!("commit: ok");
-        }
-        "abort" => {
-            if *transaction_active {
-                let hook_updates = hook_updates_for_ops(staged)?;
-                if !hook_updates.is_empty() {
-                    run_ref_transaction_aborted(repo, &hook_updates);
-                }
-            }
-            staged.clear();
-            *transaction_active = false;
-            *transaction_prepared = false;
-            println!("abort: ok");
-        }
-        other => bail!("unknown batch command: {other}"),
-    }
-    Ok(())
-}
-
-fn run_batch_nul(repo: &Repository, args: &Args, input: &[u8]) -> Result<()> {
-    let mut transaction_active = false;
-    let mut transaction_prepared = false;
-    let mut staged: Vec<(bool, BatchOp)> = Vec::new();
-    let mut pending_option_no_deref = false;
-
-    for chunk in input.split(|b| *b == 0) {
-        if chunk.is_empty() {
-            continue;
-        }
-        let line = std::str::from_utf8(chunk).context("invalid utf-8 in stdin")?;
-        if line.chars().next().is_some_and(|c| c.is_whitespace()) {
-            bail!("whitespace before command: {line}");
-        }
-        let parts: Vec<&str> = line.split_whitespace().collect();
-        if parts.is_empty() {
-            continue;
-        }
-        process_batch_command(
-            repo,
-            args,
-            &parts,
-            &mut transaction_active,
-            &mut transaction_prepared,
-            &mut staged,
-            &mut pending_option_no_deref,
-        )?;
-    }
-
-    if transaction_active {
-        let hook_updates = hook_updates_for_ops(&staged)?;
-        if !hook_updates.is_empty() {
-            run_ref_transaction_aborted(repo, &hook_updates);
-        }
-    }
-
-    Ok(())
-}
-
 fn resolve_oid_or_ref(repo: &Repository, s: &str) -> Result<ObjectId> {
     if let Ok(oid) = s.parse::<ObjectId>() {
         return Ok(oid);
@@ -511,6 +241,7 @@ enum SymrefOldExpectation {
     MustOid(ObjectId),
 }
 
+#[derive(Clone)]
 enum BatchOp {
     UpdateOid {
         refname: String,
@@ -548,6 +279,183 @@ enum BatchOp {
     },
 }
 
+fn stdin_lines_explicit_transaction(text: &str) -> bool {
+    for line in text.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.first() == Some(&"start") {
+            return true;
+        }
+    }
+    false
+}
+
+fn stdin_chunks_explicit_transaction(input: &[u8]) -> Result<bool> {
+    for chunk in input.split(|b| *b == 0) {
+        if chunk.is_empty() {
+            continue;
+        }
+        let line = std::str::from_utf8(chunk).context("invalid utf-8 in stdin")?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.first() == Some(&"start") {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+/// Process `--stdin` batch commands.
+fn run_batch(repo: &Repository, args: &Args) -> Result<()> {
+    let mut input = Vec::new();
+    io::stdin().read_to_end(&mut input)?;
+    if args.null_terminated {
+        return run_batch_nul(repo, args, &input);
+    }
+
+    let text = String::from_utf8_lossy(&input);
+    if !stdin_lines_explicit_transaction(&text) {
+        return run_implicit_stdin_batch(repo, args, &text);
+    }
+
+    let mut transaction_active = false;
+    let mut transaction_prepared = false;
+    let mut staged: Vec<(bool, BatchOp)> = Vec::new();
+    let mut pending_option_no_deref = false;
+
+    for line in text.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        if line.chars().next().is_some_and(|c| c.is_whitespace()) {
+            bail!("whitespace before command: {line}");
+        }
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.is_empty() {
+            continue;
+        }
+        process_batch_command(
+            repo,
+            args,
+            &parts,
+            &mut transaction_active,
+            &mut transaction_prepared,
+            &mut staged,
+            &mut pending_option_no_deref,
+            false,
+        )?;
+    }
+
+    if transaction_active {
+        let hook_updates = hook_updates_for_ops(&staged)?;
+        if !hook_updates.is_empty() {
+            run_ref_transaction_aborted(repo, &hook_updates);
+        }
+    }
+
+    Ok(())
+}
+
+fn run_implicit_stdin_batch(repo: &Repository, args: &Args, text: &str) -> Result<()> {
+    let mut staged: Vec<(bool, BatchOp)> = Vec::new();
+    let mut pending_option_no_deref = false;
+    let mut transaction_active = false;
+    let mut transaction_prepared = false;
+
+    for line in text.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        if line.chars().next().is_some_and(|c| c.is_whitespace()) {
+            bail!("whitespace before command: {line}");
+        }
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.is_empty() {
+            continue;
+        }
+        process_batch_command(
+            repo,
+            args,
+            &parts,
+            &mut transaction_active,
+            &mut transaction_prepared,
+            &mut staged,
+            &mut pending_option_no_deref,
+            true,
+        )?;
+    }
+
+    if staged.is_empty() {
+        return Ok(());
+    }
+    commit_batch_staged(repo, args, &staged)
+}
+
+fn storage_refname_for_op(repo: &Repository, no_deref: bool, op: &BatchOp) -> Result<String> {
+    Ok(match op {
+        BatchOp::UpdateOid { refname, .. }
+        | BatchOp::CreateOid { refname, .. }
+        | BatchOp::DeleteOid { refname, .. }
+        | BatchOp::VerifyOid { refname, .. } => effective_refname(repo, refname, no_deref)?,
+        BatchOp::UpdateSymref { refname, .. }
+        | BatchOp::CreateSymref { refname, .. }
+        | BatchOp::DeleteSymref { refname, .. }
+        | BatchOp::VerifySymref { refname, .. } => refname.clone(),
+    })
+}
+
+fn build_batch_extras(repo: &Repository, staged: &[(bool, BatchOp)]) -> Result<BTreeSet<String>> {
+    let mut extras = BTreeSet::new();
+    for (nd, op) in staged {
+        extras.insert(storage_refname_for_op(repo, *nd, op)?);
+    }
+    Ok(extras)
+}
+
+fn verify_refname_available_for_batch_create(
+    repo: &Repository,
+    staged: &[(bool, BatchOp)],
+    target_refname: &str,
+    display_refname: &str,
+) -> Result<()> {
+    let extras = build_batch_extras(repo, staged)?;
+    let skip = HashSet::<String>::new();
+    match verify_refname_available_for_create(&repo.git_dir, target_refname, &extras, &skip) {
+        Ok(()) => Ok(()),
+        Err(e) => Err(anyhow::Error::from(GritError::Message(format!(
+            "fatal: cannot lock ref '{display_refname}': {}",
+            e.lock_message_suffix()
+        )))),
+    }
+}
+
+fn commit_batch_staged(repo: &Repository, args: &Args, staged: &[(bool, BatchOp)]) -> Result<()> {
+    for (nd, op) in staged {
+        match op {
+            BatchOp::CreateOid { refname, .. } => {
+                let target = effective_refname(repo, refname, *nd)?;
+                verify_refname_available_for_batch_create(repo, staged, &target, refname)?;
+            }
+            BatchOp::CreateSymref { refname, .. } => {
+                verify_refname_available_for_batch_create(repo, staged, refname, refname)?;
+            }
+            _ => {}
+        }
+    }
+
+    let hook_updates = hook_updates_for_ops(staged)?;
+    run_ref_transaction_prepare(repo, &hook_updates)?;
+    for (nd, op) in staged {
+        apply_batch_op(repo, args, *nd, op.clone())?;
+    }
+    run_ref_transaction_committed(repo, &hook_updates);
+    Ok(())
+}
+
 fn queue_or_apply(
     repo: &Repository,
     args: &Args,
@@ -555,17 +463,350 @@ fn queue_or_apply(
     transaction_active: bool,
     staged: &mut Vec<(bool, BatchOp)>,
     op: BatchOp,
+    implicit_one_shot: bool,
 ) -> Result<()> {
     if transaction_active {
         staged.push((no_deref, op));
         Ok(())
-    } else {
-        let hook_update = hook_update_for_op(&op)?;
-        run_ref_transaction_prepare(repo, std::slice::from_ref(&hook_update))?;
-        apply_batch_op(repo, args, no_deref, op)?;
-        run_ref_transaction_committed(repo, &[hook_update]);
+    } else if implicit_one_shot {
+        staged.push((no_deref, op));
         Ok(())
+    } else {
+        commit_batch_staged(repo, args, &[(no_deref, op)])
     }
+}
+
+fn process_batch_command(
+    repo: &Repository,
+    args: &Args,
+    parts: &[&str],
+    transaction_active: &mut bool,
+    transaction_prepared: &mut bool,
+    staged: &mut Vec<(bool, BatchOp)>,
+    pending_option_no_deref: &mut bool,
+    implicit_one_shot: bool,
+) -> Result<()> {
+    match parts[0] {
+        "update" => {
+            let nd = take_batch_no_deref(args, pending_option_no_deref);
+            if parts.len() < 3 {
+                bail!("update requires ref and new-value");
+            }
+            let op = BatchOp::UpdateOid {
+                refname: parts[1].to_owned(),
+                new_oid: resolve_oid_or_ref(repo, parts[2])?,
+                expected_old: parse_old_expectation(parts.get(3).copied())?,
+            };
+            queue_or_apply(
+                repo,
+                args,
+                nd,
+                *transaction_active,
+                staged,
+                op,
+                implicit_one_shot,
+            )?;
+        }
+        "create" => {
+            let nd = take_batch_no_deref(args, pending_option_no_deref);
+            if parts.len() < 3 {
+                bail!("create requires ref and new-value");
+            }
+            let op = BatchOp::CreateOid {
+                refname: parts[1].to_owned(),
+                new_oid: resolve_oid_or_ref(repo, parts[2])?,
+            };
+            queue_or_apply(
+                repo,
+                args,
+                nd,
+                *transaction_active,
+                staged,
+                op,
+                implicit_one_shot,
+            )?;
+        }
+        "delete" => {
+            let nd = take_batch_no_deref(args, pending_option_no_deref);
+            if parts.len() < 2 {
+                bail!("delete requires ref");
+            }
+            let op = BatchOp::DeleteOid {
+                refname: parts[1].to_owned(),
+                expected_old: parse_old_expectation(parts.get(2).copied())?,
+            };
+            queue_or_apply(
+                repo,
+                args,
+                nd,
+                *transaction_active,
+                staged,
+                op,
+                implicit_one_shot,
+            )?;
+        }
+        "verify" => {
+            let nd = take_batch_no_deref(args, pending_option_no_deref);
+            if parts.len() < 2 {
+                bail!("verify requires ref");
+            }
+            let op = BatchOp::VerifyOid {
+                refname: parts[1].to_owned(),
+                expected_old: parse_old_expectation(parts.get(2).copied())?,
+            };
+            queue_or_apply(
+                repo,
+                args,
+                nd,
+                *transaction_active,
+                staged,
+                op,
+                implicit_one_shot,
+            )?;
+        }
+        "symref-update" => {
+            let nd = take_batch_no_deref(args, pending_option_no_deref);
+            if parts.len() < 3 {
+                bail!("symref-update requires ref and new-target");
+            }
+            let expected_old = match parts.get(3).copied() {
+                None => None,
+                Some("ref") => {
+                    let Some(target) = parts.get(4) else {
+                        bail!("symref-update requires old-target after 'ref'");
+                    };
+                    Some(SymrefOldExpectation::MustTarget((*target).to_owned()))
+                }
+                Some("oid") => {
+                    let Some(oid) = parts.get(4) else {
+                        bail!("symref-update requires old-oid after 'oid'");
+                    };
+                    let parsed = oid.parse::<ObjectId>().context("invalid old-value OID")?;
+                    Some(SymrefOldExpectation::MustOid(parsed))
+                }
+                Some(other) => bail!("symref-update expected 'ref' or 'oid', got '{other}'"),
+            };
+            let op = BatchOp::UpdateSymref {
+                refname: parts[1].to_owned(),
+                new_target: parts[2].to_owned(),
+                expected_old,
+            };
+            queue_or_apply(
+                repo,
+                args,
+                nd,
+                *transaction_active,
+                staged,
+                op,
+                implicit_one_shot,
+            )?;
+        }
+        "symref-create" => {
+            let nd = take_batch_no_deref(args, pending_option_no_deref);
+            if parts.len() < 3 {
+                bail!("symref-create requires ref and new-target");
+            }
+            let op = BatchOp::CreateSymref {
+                refname: parts[1].to_owned(),
+                new_target: parts[2].to_owned(),
+            };
+            queue_or_apply(
+                repo,
+                args,
+                nd,
+                *transaction_active,
+                staged,
+                op,
+                implicit_one_shot,
+            )?;
+        }
+        "symref-delete" => {
+            let nd = take_batch_no_deref(args, pending_option_no_deref);
+            if parts.len() < 2 {
+                bail!("symref-delete requires ref");
+            }
+            let expected_old = parts
+                .get(2)
+                .map(|target| SymrefOldExpectation::MustTarget((*target).to_owned()));
+            let op = BatchOp::DeleteSymref {
+                refname: parts[1].to_owned(),
+                expected_old,
+            };
+            queue_or_apply(
+                repo,
+                args,
+                nd,
+                *transaction_active,
+                staged,
+                op,
+                implicit_one_shot,
+            )?;
+        }
+        "symref-verify" => {
+            let nd = take_batch_no_deref(args, pending_option_no_deref);
+            if !nd {
+                bail!("symref-verify can only be used in no-deref mode");
+            }
+            if parts.len() < 2 {
+                bail!("symref-verify requires ref");
+            }
+            let expected_old = parts
+                .get(2)
+                .map(|target| SymrefOldExpectation::MustTarget((*target).to_owned()))
+                .unwrap_or(SymrefOldExpectation::MustNotExist);
+            let op = BatchOp::VerifySymref {
+                refname: parts[1].to_owned(),
+                expected_old,
+            };
+            queue_or_apply(
+                repo,
+                args,
+                nd,
+                *transaction_active,
+                staged,
+                op,
+                implicit_one_shot,
+            )?;
+        }
+        "option" => {
+            if parts.len() == 2 && parts[1] == "no-deref" {
+                *pending_option_no_deref = true;
+            } else {
+                bail!("option unknown: {}", parts.get(1).copied().unwrap_or(""));
+            }
+        }
+        "start" => {
+            if *transaction_active {
+                bail!("transaction already started");
+            }
+            *transaction_active = true;
+            *transaction_prepared = false;
+            staged.clear();
+            println!("start: ok");
+        }
+        "prepare" => {
+            if !*transaction_active {
+                bail!("no transaction started");
+            }
+            let hook_updates = hook_updates_for_ops(staged)?;
+            run_ref_transaction_prepare(repo, &hook_updates)?;
+            *transaction_prepared = true;
+            println!("prepare: ok");
+        }
+        "commit" => {
+            if !*transaction_active {
+                bail!("no transaction started");
+            }
+
+            let drained: Vec<(bool, BatchOp)> = staged.drain(..).collect();
+            let hook_updates = hook_updates_for_ops(&drained)?;
+            if !*transaction_prepared {
+                run_ref_transaction_prepare(repo, &hook_updates)?;
+            }
+            match commit_batch_staged(repo, args, &drained) {
+                Ok(()) => {
+                    run_ref_transaction_committed(repo, &hook_updates);
+                }
+                Err(e) => {
+                    if !hook_updates.is_empty() {
+                        run_ref_transaction_aborted(repo, &hook_updates);
+                    }
+                    return Err(e);
+                }
+            }
+            *transaction_active = false;
+            *transaction_prepared = false;
+            println!("commit: ok");
+        }
+        "abort" => {
+            if *transaction_active {
+                let hook_updates = hook_updates_for_ops(staged)?;
+                if !hook_updates.is_empty() {
+                    run_ref_transaction_aborted(repo, &hook_updates);
+                }
+            }
+            staged.clear();
+            *transaction_active = false;
+            *transaction_prepared = false;
+            println!("abort: ok");
+        }
+        other => bail!("unknown batch command: {other}"),
+    }
+    Ok(())
+}
+
+fn run_batch_nul(repo: &Repository, args: &Args, input: &[u8]) -> Result<()> {
+    if !stdin_chunks_explicit_transaction(input)? {
+        let mut staged: Vec<(bool, BatchOp)> = Vec::new();
+        let mut pending_option_no_deref = false;
+        let mut transaction_active = false;
+        let mut transaction_prepared = false;
+        for chunk in input.split(|b| *b == 0) {
+            if chunk.is_empty() {
+                continue;
+            }
+            let line = std::str::from_utf8(chunk).context("invalid utf-8 in stdin")?;
+            if line.chars().next().is_some_and(|c| c.is_whitespace()) {
+                bail!("whitespace before command: {line}");
+            }
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.is_empty() {
+                continue;
+            }
+            process_batch_command(
+                repo,
+                args,
+                &parts,
+                &mut transaction_active,
+                &mut transaction_prepared,
+                &mut staged,
+                &mut pending_option_no_deref,
+                true,
+            )?;
+        }
+        if staged.is_empty() {
+            return Ok(());
+        }
+        return commit_batch_staged(repo, args, &staged);
+    }
+
+    let mut transaction_active = false;
+    let mut transaction_prepared = false;
+    let mut staged: Vec<(bool, BatchOp)> = Vec::new();
+    let mut pending_option_no_deref = false;
+
+    for chunk in input.split(|b| *b == 0) {
+        if chunk.is_empty() {
+            continue;
+        }
+        let line = std::str::from_utf8(chunk).context("invalid utf-8 in stdin")?;
+        if line.chars().next().is_some_and(|c| c.is_whitespace()) {
+            bail!("whitespace before command: {line}");
+        }
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.is_empty() {
+            continue;
+        }
+        process_batch_command(
+            repo,
+            args,
+            &parts,
+            &mut transaction_active,
+            &mut transaction_prepared,
+            &mut staged,
+            &mut pending_option_no_deref,
+            false,
+        )?;
+    }
+
+    if transaction_active {
+        let hook_updates = hook_updates_for_ops(&staged)?;
+        if !hook_updates.is_empty() {
+            run_ref_transaction_aborted(repo, &hook_updates);
+        }
+    }
+
+    Ok(())
 }
 
 fn apply_batch_op(repo: &Repository, args: &Args, no_deref: bool, op: BatchOp) -> Result<()> {
@@ -577,7 +818,7 @@ fn apply_batch_op(repo: &Repository, args: &Args, no_deref: bool, op: BatchOp) -
         } => {
             let target_refname = effective_refname(repo, &refname, no_deref)?;
             if let Some(expected) = expected_old {
-                verify_expected_old(repo, &target_refname, expected)?;
+                verify_expected_old(repo, &refname, &target_refname, no_deref, expected)?;
             }
             let old_oid =
                 resolve_ref(&repo.git_dir, &target_refname).unwrap_or_else(|_| zero_oid());
@@ -598,7 +839,9 @@ fn apply_batch_op(repo: &Repository, args: &Args, no_deref: bool, op: BatchOp) -
         BatchOp::CreateOid { refname, new_oid } => {
             let target_refname = effective_refname(repo, &refname, no_deref)?;
             if resolve_ref(&repo.git_dir, &target_refname).is_ok() {
-                bail!("ref '{target_refname}' already exists");
+                return Err(anyhow::Error::from(GritError::Message(format!(
+                    "fatal: cannot lock ref '{refname}': reference already exists"
+                ))));
             }
             write_ref(&repo.git_dir, &target_refname, &new_oid)?;
         }
@@ -608,7 +851,7 @@ fn apply_batch_op(repo: &Repository, args: &Args, no_deref: bool, op: BatchOp) -
         } => {
             let target_refname = effective_refname(repo, &refname, no_deref)?;
             if let Some(expected) = expected_old {
-                verify_expected_old(repo, &target_refname, expected)?;
+                verify_expected_old(repo, &refname, &target_refname, no_deref, expected)?;
             }
             delete_ref(&repo.git_dir, &target_refname)?;
         }
@@ -618,7 +861,7 @@ fn apply_batch_op(repo: &Repository, args: &Args, no_deref: bool, op: BatchOp) -
         } => {
             let target_refname = effective_refname(repo, &refname, no_deref)?;
             if let Some(expected) = expected_old {
-                verify_expected_old(repo, &target_refname, expected)?;
+                verify_expected_old(repo, &refname, &target_refname, no_deref, expected)?;
             } else if resolve_ref(&repo.git_dir, &target_refname).is_err() {
                 bail!("ref '{target_refname}' does not exist");
             }
@@ -638,7 +881,9 @@ fn apply_batch_op(repo: &Repository, args: &Args, no_deref: bool, op: BatchOp) -
             new_target,
         } => {
             if ref_exists_no_deref(repo, &refname)? {
-                bail!("ref '{refname}' already exists");
+                return Err(anyhow::Error::from(GritError::Message(format!(
+                    "fatal: cannot lock ref '{refname}': reference already exists"
+                ))));
             }
             write_symbolic_ref(repo, &refname, &new_target)?;
         }
@@ -700,21 +945,40 @@ fn hook_old_value_from_expectation(expected: Option<OldExpectation>) -> String {
     }
 }
 
-fn verify_expected_old(repo: &Repository, refname: &str, expected: OldExpectation) -> Result<()> {
-    let current = resolve_ref(&repo.git_dir, refname).ok();
+fn verify_expected_old(
+    repo: &Repository,
+    display_refname: &str,
+    lock_refname: &str,
+    no_deref: bool,
+    expected: OldExpectation,
+) -> Result<()> {
+    let current = resolve_ref(&repo.git_dir, lock_refname).ok();
     match expected {
         OldExpectation::MustNotExist => {
             if current.is_some() {
-                bail!("ref '{refname}' already exists");
+                return Err(anyhow::Error::from(GritError::Message(format!(
+                    "fatal: cannot lock ref '{display_refname}': reference already exists"
+                ))));
             }
         }
         OldExpectation::MustEqual(oid) => match current {
             None => {
-                eprintln!("fatal: unable to resolve reference: {refname}");
-                std::process::exit(1);
+                if no_deref {
+                    return Err(anyhow::Error::from(GritError::Message(format!(
+                        "fatal: cannot lock ref '{display_refname}': reference is missing but expected {}",
+                        oid.to_hex()
+                    ))));
+                }
+                return Err(anyhow::Error::from(GritError::Message(format!(
+                    "fatal: cannot lock ref '{display_refname}': unable to resolve reference '{lock_refname}'"
+                ))));
             }
             Some(cur) if cur != oid => {
-                bail!("ref '{refname}' is at {cur} but expected {oid}");
+                return Err(anyhow::Error::from(GritError::Message(format!(
+                    "fatal: cannot lock ref '{display_refname}': is at {} but expected {}",
+                    cur.to_hex(),
+                    oid.to_hex()
+                ))));
             }
             _ => {}
         },
@@ -916,7 +1180,7 @@ fn write_symbolic_ref(repo: &Repository, refname: &str, target: &str) -> Result<
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
-    let lock_path = path.with_extension("lock");
+    let lock_path = grit_lib::refs::lock_path_for_ref(&path);
     fs::write(&lock_path, format!("ref: {target}\n"))?;
     fs::rename(lock_path, path)?;
     Ok(())
@@ -949,18 +1213,23 @@ fn verify_symref_expected_old(
     match expected {
         SymrefOldExpectation::MustNotExist => {
             if ref_exists_no_deref(repo, refname)? {
-                bail!("ref '{refname}' already exists");
+                return Err(anyhow::Error::from(GritError::Message(format!(
+                    "fatal: cannot lock ref '{refname}': reference already exists"
+                ))));
             }
         }
         SymrefOldExpectation::MustTarget(target) => {
             let current = read_symbolic_ref_no_deref(repo, refname)?;
             match current {
                 None => {
-                    eprintln!("fatal: unable to resolve reference: {refname}");
-                    std::process::exit(1);
+                    return Err(anyhow::Error::from(GritError::Message(format!(
+                        "fatal: cannot lock ref '{refname}': unable to resolve reference '{refname}'"
+                    ))));
                 }
                 Some(cur) if cur != target => {
-                    bail!("ref '{refname}' points to {cur} but expected {target}");
+                    return Err(anyhow::Error::from(GritError::Message(format!(
+                        "fatal: cannot lock ref '{refname}': points to {cur} but expected {target}"
+                    ))));
                 }
                 Some(_) => {}
             }
@@ -969,11 +1238,16 @@ fn verify_symref_expected_old(
             let current = resolve_ref(&repo.git_dir, refname).ok();
             match current {
                 None => {
-                    eprintln!("fatal: unable to resolve reference: {refname}");
-                    std::process::exit(1);
+                    return Err(anyhow::Error::from(GritError::Message(format!(
+                        "fatal: cannot lock ref '{refname}': unable to resolve reference '{refname}'"
+                    ))));
                 }
                 Some(cur) if cur != oid => {
-                    bail!("ref '{refname}' is at {cur} but expected {oid}");
+                    return Err(anyhow::Error::from(GritError::Message(format!(
+                        "fatal: cannot lock ref '{refname}': is at {} but expected {}",
+                        cur.to_hex(),
+                        oid.to_hex()
+                    ))));
                 }
                 Some(_) => {}
             }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-style refname availability checks and error messages for `grit update-ref --stdin`, fixes incorrect lock file paths for nested refs, and batches implicit stdin updates so validation runs before any writes (no partial application on failure).

## Key changes

- **`grit-lib`**: `verify_refname_available_for_create`, `lock_path_for_ref`, packed-prefix scan for descendants, `read_symbolic_ref` handles `ENOTDIR`/`EISDIR` like missing for path components.
- **`update-ref`**: validate all `create`/`symref-create` in a batch before hooks/apply; Git-shaped `fatal: cannot lock ref '…': …` for CAS/symref errors; do not treat pending deletes as `skip` during verification (matches Git D/F ordering).
- **Call sites**: `symbolic_ref` and `test-tool ref-store` use `lock_path_for_ref`.

## Testing

- `./scripts/run-tests.sh t1404-update-ref-errors.sh` — 38/38
- `cargo test -p grit-lib --lib` and `cargo test --workspace`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-94eecd0a-499f-4ca5-86fe-cdd1a9e035e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94eecd0a-499f-4ca5-86fe-cdd1a9e035e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

