### PR TITLE
fix: make t3000-ls-files-others fully pass

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -299,7 +299,7 @@ commit → check it off → move on.
 - [ ] `t3104-ls-tree-format` ██████████░░░░░░░░░░ 10/19 (9 left) — ls-tree --format
 - [ ] `t3204-branch-name-interpretation` ████████░░░░░░░░░░░░ 7/16 (9 left) — interpreting exotic branch name arguments
 
-- [ ] `t3000-ls-files-others` ████████░░░░░░░░░░░░ 6/15 (9 left) — basic tests for ls-files --others
+- [x] `t3000-ls-files-others` — basic tests for ls-files --others (15/15)
 
 - [ ] `t3508-cherry-pick-many-commits` ███████░░░░░░░░░░░░░ 5/14 (9 left) — test cherry-picking many commits
 - [x] `t3704-add-pathspec-file` ████████████████████ 11/11 (0 left) — add --pathspec-from-file

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -530,7 +530,7 @@ t2406-worktree-repair	t2	skip	24	0	0	false	ok	0
 t2407-worktree-heads	t2	skip	12	7	5	false	ok	0
 t2500-untracked-overwriting	t2	yes	8	2	6	false	ok	2
 t2501-cwd-empty	t2	yes	24	4	20	false	ok	0
-t3000-ls-files-others	t3	yes	15	6	9	false	ok	0
+t3000-ls-files-others	t3	yes	15	15	0	true	ok	0
 t3001-ls-files-others-exclude	t3	yes	27	10	17	false	ok	0
 t3002-ls-files-dashpath	t3	yes	6	6	0	true	ok	0
 t3003-ls-files-exclude	t3	yes	7	7	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,695 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,695 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T03:39:17+00:00" class="gen-time" title="2026-04-10 03:39 UTC">2026-04-10 03:39 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,695</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -219,11 +219,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">56/141 files · 2 skipped · 4,052/5,398 tests</span>
+        <span class="group-meta">57/141 files · 2 skipped · 4,061/5,398 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:75.1%"></div></div>
-        <span class="group-pct pct-blue">75.1%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:75.2%"></div></div>
+        <span class="group-pct pct-blue">75.2%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35695 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,695 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T03:39:17+00:00" class="gen-time" title="2026-04-10 03:39 UTC">2026-04-10 03:39 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,695</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -5457,14 +5457,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:16.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="15" data-passed="6">
+<tr class="" data-group="t3" data-tests="15" data-passed="15" data-full-pass="1">
   <td class="mono">t3000-ls-files-others</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">15</td>
-  <td class="right">6</td>
+  <td class="right">15</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:40.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="27" data-passed="10">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit/src/commands/ls_files.rs
+++ b/grit/src/commands/ls_files.rs
@@ -482,7 +482,13 @@ pub fn run(args: Args) -> Result<()> {
             &mut untracked,
             true,
             args.directory,
+            args.no_empty_directory,
             precompose_walk,
+            if pathspec_filter.is_empty() {
+                None
+            } else {
+                Some(pathspec_filter.as_slice())
+            },
         )?;
         untracked.sort();
 
@@ -528,7 +534,11 @@ pub fn run(args: Args) -> Result<()> {
 
             let display =
                 format_ls_display_path(args.full_name, &cwd, work_tree, path_bytes, &cwd_prefix)?;
-            filtered_untracked.push(display.into_owned());
+            let mut display = display.into_owned();
+            if path_bytes.ends_with(b"/") && !display.ends_with(b"/") {
+                display.push(b'/');
+            }
+            filtered_untracked.push(display);
         }
 
         // Collapse to directories if --directory (after making paths cwd-relative)
@@ -662,6 +672,84 @@ fn dot_git_marks_git_repository(dot_git: &std::path::Path) -> bool {
     false
 }
 
+/// Whether traversal must recurse into `dir_rel` (no trailing `/`) instead of
+/// emitting `dir_rel/` as a single `--directory` line (Git
+/// `MATCHED_RECURSIVELY_LEADING_PATHSPEC` in `treat_directory`).
+fn pathspec_requires_recurse_into_dir(dir_rel: &[u8], specs: &[Pathspec]) -> bool {
+    if dir_rel.is_empty() {
+        return false;
+    }
+    for spec in specs {
+        match spec {
+            Pathspec::Literal(spec_bytes) => {
+                if literal_pathspec_recurses_into_dir(dir_rel, spec_bytes.as_slice()) {
+                    return true;
+                }
+            }
+            Pathspec::Glob(pattern) => {
+                let pb = pattern.as_bytes();
+                let nw = simple_glob_prefix(pb).len();
+                if nw == pb.len() {
+                    if literal_pathspec_recurses_into_dir(dir_rel, pb) {
+                        return true;
+                    }
+                } else if nw < pb.len() {
+                    // Wildcards in pattern: Git recurses when still under the literal prefix
+                    // (see `match_pathspec_item` glob case in `dir.c`).
+                    let lit = pb[..nw].strip_suffix(b"/").unwrap_or(&pb[..nw]);
+                    if lit.is_empty() {
+                        return true;
+                    }
+                    if dir_rel == lit {
+                        return true;
+                    }
+                    if dir_rel.len() > lit.len()
+                        && dir_rel.starts_with(lit)
+                        && dir_rel.get(lit.len()) == Some(&b'/')
+                    {
+                        return true;
+                    }
+                }
+            }
+            Pathspec::Magic(_) => {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn literal_pathspec_recurses_into_dir(dir_rel: &[u8], spec: &[u8]) -> bool {
+    if !spec.starts_with(dir_rel) {
+        return false;
+    }
+    if spec.len() <= dir_rel.len() {
+        return false;
+    }
+    if spec.get(dir_rel.len()) != Some(&b'/') {
+        return false;
+    }
+    // Git `match_pathspec_item` with `DO_MATCH_LEADING_PATHSPEC`: recurse only when the
+    // pathspec extends *past* `dir_rel/` (not when it is exactly `dir/`).
+    spec.len() > dir_rel.len() + 1
+}
+
+/// Length of the pattern's literal prefix before the first glob metacharacter.
+fn simple_glob_prefix(pat: &[u8]) -> &[u8] {
+    if grit_lib::pathspec::literal_pathspecs_enabled() {
+        return pat;
+    }
+    let mut i = 0;
+    while i < pat.len() {
+        match pat[i] {
+            b'*' | b'?' | b'[' => break,
+            b'\\' if i + 1 < pat.len() => i += 2,
+            _ => i += 1,
+        }
+    }
+    &pat[..i]
+}
+
 /// Walk the worktree and collect paths of untracked files.
 ///
 /// Returns whether any path was recorded under `dir` (files, nested repo markers, or when
@@ -670,6 +758,9 @@ fn dot_git_marks_git_repository(dot_git: &std::path::Path) -> bool {
 ///
 /// `emit_empty_directories` matches Git: plain `ls-files --others` does not list empty
 /// untracked directories; `--directory` adds `name/` markers for empty dirs (used by completion).
+///
+/// When `pathspecs` is set, directory boundaries follow Git `dir.c` `treat_directory`:
+/// untracked dirs are emitted as `name/` unless a pathspec can still match deeper paths inside.
 fn walk_worktree(
     root: &std::path::Path,
     dir: &std::path::Path,
@@ -677,7 +768,9 @@ fn walk_worktree(
     out: &mut Vec<Vec<u8>>,
     is_root: bool,
     emit_empty_directories: bool,
+    hide_empty_directories: bool,
     precompose_unicode: bool,
+    pathspecs: Option<&[Pathspec]>,
 ) -> Result<bool> {
     let mut rel_bytes = path_to_bytes(dir.strip_prefix(root).unwrap_or(dir));
     if precompose_unicode {
@@ -752,6 +845,19 @@ fn walk_worktree(
                 }
                 continue;
             }
+            let prefix_slash: Vec<u8> = [rel_bytes.as_slice(), b"/"].concat();
+            let has_tracked_under = indexed.iter().any(|t| t.starts_with(&prefix_slash));
+            let must_recurse = !emit_empty_directories
+                || hide_empty_directories
+                || has_tracked_under
+                || pathspecs.is_some_and(|ps| pathspec_requires_recurse_into_dir(&rel_bytes, ps));
+            if emit_empty_directories && !must_recurse {
+                let mut dir_entry = rel_bytes.clone();
+                dir_entry.push(b'/');
+                out.push(dir_entry);
+                added = true;
+                continue;
+            }
             if walk_worktree(
                 root,
                 &path,
@@ -759,7 +865,9 @@ fn walk_worktree(
                 out,
                 false,
                 emit_empty_directories,
+                hide_empty_directories,
                 precompose_unicode,
+                pathspecs,
             )? {
                 added = true;
             }
@@ -1202,22 +1310,99 @@ fn path_to_bytes(path: &std::path::Path) -> Vec<u8> {
     path.as_os_str().as_bytes().to_vec()
 }
 
-/// Collapse file paths into unique top-level directory entries.
-/// E.g., ["dir/a", "dir/b", "file"] → ["dir/", "file"]
+/// Collapse paths for `ls-files --directory`: group by top-level segment, then
+/// collapse untracked files under the same immediate subdirectory to `top/sub/`.
 fn collapse_to_directories(paths: &[Vec<u8>]) -> Vec<Vec<u8>> {
-    let mut dirs = BTreeSet::new();
-    let mut result = Vec::new();
+    use std::collections::BTreeMap;
+
+    #[derive(Default)]
+    struct TopBucket {
+        /// Files directly under `top/` (single path component, no further `/`).
+        direct: Vec<Vec<u8>>,
+        /// Deeper paths `top/sub/...`
+        subs: BTreeMap<Vec<u8>, Subdir>,
+    }
+
+    #[derive(Default)]
+    struct Subdir {
+        files: Vec<Vec<u8>>,
+        empty_dir: bool,
+    }
+
+    let mut tops: BTreeMap<Vec<u8>, TopBucket> = BTreeMap::new();
+    let mut root_level_dirs: Vec<Vec<u8>> = Vec::new();
+
     for p in paths {
-        if let Some(pos) = p.iter().position(|&b| b == b'/') {
-            let dir = p[..=pos].to_vec();
-            if dirs.insert(dir.clone()) {
-                result.push(dir);
+        if p.ends_with(b"/") && !p[..p.len() - 1].contains(&b'/') {
+            root_level_dirs.push(p.clone());
+            continue;
+        }
+        let Some(pos) = p.iter().position(|&b| b == b'/') else {
+            tops.entry(p.clone()).or_default();
+            continue;
+        };
+        let top = p[..pos].to_vec();
+        let tail = &p[pos + 1..];
+        let b = tops.entry(top).or_default();
+
+        if tail.is_empty() {
+            continue;
+        }
+        if tail.ends_with(b"/") && !tail[..tail.len() - 1].contains(&b'/') {
+            let name = tail[..tail.len() - 1].to_vec();
+            b.subs.entry(name).or_default().empty_dir = true;
+            continue;
+        }
+        if let Some(sp) = tail.iter().position(|&b| b == b'/') {
+            let sub = tail[..sp].to_vec();
+            let file = tail[sp + 1..].to_vec();
+            let e = b.subs.entry(sub).or_default();
+            if !file.is_empty() {
+                e.files.push(file);
             }
         } else {
-            result.push(p.clone());
+            b.direct.push(tail.to_vec());
         }
     }
-    result
+
+    let mut out = Vec::new();
+    out.extend(root_level_dirs);
+    for (top, b) in tops {
+        if b.subs.is_empty() && b.direct.is_empty() {
+            out.push(top);
+            continue;
+        }
+        if b.subs.is_empty() {
+            // Only `top/file` paths: always collapse to `top/` (matches Git).
+            let mut line = top;
+            line.push(b'/');
+            out.push(line);
+            continue;
+        }
+        if !b.direct.is_empty() {
+            let mut line = top.clone();
+            line.push(b'/');
+            out.push(line);
+        }
+        for (sub, info) in b.subs {
+            let mut prefix = top.clone();
+            prefix.push(b'/');
+            prefix.extend_from_slice(&sub);
+            if info.files.is_empty() {
+                prefix.push(b'/');
+                out.push(prefix);
+            } else if info.files.len() == 1 {
+                prefix.push(b'/');
+                prefix.extend_from_slice(&info.files[0]);
+                out.push(prefix);
+            } else {
+                prefix.push(b'/');
+                out.push(prefix);
+            }
+        }
+    }
+    out.sort();
+    out
 }
 
 /// Check whether an index entry's file has been modified on disk.

--- a/logs/2026-04-10_t3000-ls-files-others.md
+++ b/logs/2026-04-10_t3000-ls-files-others.md
@@ -1,0 +1,23 @@
+# t3000-ls-files-others
+
+## Goal
+
+Make `tests/t3000-ls-files-others.sh` pass (15/15) — `git ls-files --others` with `--directory`, `--no-empty-directory`, pathspecs, and glob interaction.
+
+## Changes (grit `ls_files.rs`)
+
+1. **Trailing `/` on directory output** — `format_ls_display_path` / pathdiff dropped the slash; re-append when the repo-relative path ended with `/`.
+2. **`--no-empty-directory` + short-circuit** — When `--directory` emitted a dir without recursing, files under that dir were never collected, so `path2/` vanished under `--no-empty-directory`. Pass `hide_empty_directories` into `walk_worktree` and recurse whenever it is set (Git always walks to classify emptiness).
+3. **Pathspec-aware `--directory` walk** — Mirror Git `dir.c` `treat_directory`: emit `dir/` without recursing only when no pathspec requires deeper matches and the directory has no tracked descendants; glob pathspecs with wildcards force recurse under the literal prefix.
+4. **`collapse_to_directories`** — Replaced first-segment-only collapse with grouping by top-level name: `path2/file2` + `path2-junk` → `path2/`; nested cases like `partially_tracked/untracked_dir/` + `untracked/deep/` stay distinct.
+
+## Validation
+
+- `cargo build --release -p grit-rs`
+- `cargo check -p grit-rs`
+- `cargo test -p grit-lib --lib`
+- `./scripts/run-tests.sh t3000-ls-files-others.sh`
+
+## Note
+
+Workspace `cargo clippy -- -D warnings` fails on pre-existing grit-lib lints; used `cargo check` for this change set.

--- a/progress.md
+++ b/progress.md
@@ -1,20 +1,21 @@
 # Progress — Grit Test Coverage
 
-**Updated:** 2026-04-09
+**Updated:** 2026-04-10
 
 ## Counts (derived from plan.md)
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   325 |
+| Completed   |   326 |
 | In progress |     5 |
-| Remaining   |   441 |
+| Remaining   |   440 |
 | **Total**   |   771 |
 
-Task lines in `PLAN.md`: 325 completed (`[x]`), 5 in progress (`[~]`), 441 remaining (`[ ]`).
+Task lines in `PLAN.md`: 326 completed (`[x]`), 5 in progress (`[~]`), 440 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t3000-ls-files-others` — 15/15 tests pass (`ls-files --others --directory`: pathspec-aware directory short-circuit like Git `treat_directory`, preserve trailing `/` through cwd-relative display, `--no-empty-directory` still recurses to find files under collapsed dirs, smarter `--directory` aggregation for mixed depths)
 - `t3309-notes-merge-auto-resolve` — 31/31 tests pass (`notes merge`: `union` / `cat_sort_uniq` blob combine like Git; successful merge commits use two parents; `notes.mergeStrategy` config errors match upstream expectations)
 - `t4063-diff-blobs` — 18/18 tests pass (`diff`: blob↔blob and `rev:path` pairs without treating blobs as trees; `HEAD:one..HEAD:two` range split; `rev:path` vs worktree file uses tree path + modes + `write_patch_with_prefix`; raw blob OID vs existing file uses filename as old path; `rev_parse::resolve_treeish_blob_at_path` for tree walks)
 - `t5524-pull-msg` — 3/3 tests pass (`git pull --no-rebase --log` merge message preserves `$` in subject lines; `--log=1` limits shortlog; harness CSV/dashboards refreshed; `PLAN.md` marked complete)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible `ls-files --others` behavior for `--directory`, `--no-empty-directory`, and pathspec/glob combinations covered by `t3000-ls-files-others.sh` (15/15).

## Key changes

- **Path-aware directory walk**: When `--directory` is set, untracked directories are emitted as `name/` without recursing only when Git would stop early (no tracked descendants under the dir, and no pathspec implies deeper matches). Literal pathspecs that extend past `dir/` and glob pathspecs with wildcard segments force recursion under the literal prefix (mirrors `dir.c` `treat_directory` / `MATCHED_RECURSIVELY_LEADING_PATHSPEC`).
- **Trailing slash in output**: Cwd-relative display via pathdiff dropped the `/` on synthetic directory entries; re-append when the repo-relative path ended with `/`.
- **`--no-empty-directory`**: Pass the flag into the walk so we still recurse and collect files under directories that collapse to `top/` in output (fixes missing `path2/` when `path2/file2` exists alongside sibling files).
- **`collapse_to_directories`**: Group by top-level path segment so mixed layouts (e.g. `path2/file2` + `path2-junk`, or nested `partially_tracked/...` + `untracked/...`) match Git’s aggregation.

## Validation

- `cargo build --release -p grit-rs`
- `cargo check -p grit-rs`
- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t3000-ls-files-others.sh` → 15/15

## Notes

Workspace `cargo clippy -p grit-rs -- -D warnings` currently fails due to pre-existing `grit-lib` lints unrelated to this change; `cargo check` was used for verification.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f342f3d3-b172-4321-ae0f-428aad0ac400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f342f3d3-b172-4321-ae0f-428aad0ac400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

