### PR TITLE
fix: make t7403-submodule-sync fully pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1198,7 +1198,7 @@ t7301-clean-interactive	t7	yes	23	8	15	false	ok	0
 t7400-submodule-basic	t7	yes	124	51	73	false	ok	0
 t7401-submodule-summary	t7	yes	25	6	19	false	ok	0
 t7402-submodule-rebase	t7	yes	6	1	5	false	ok	0
-t7403-submodule-sync	t7	yes	18	5	13	false	ok	0
+t7403-submodule-sync	t7	yes	18	18	0	true	ok	0
 t7406-submodule-update	t7	yes	70	15	55	false	ok	0
 t7407-submodule-foreach	t7	yes	23	19	4	false	ok	0
 t7408-submodule-reference	t7	yes	16	5	11	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,699 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,699 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T03:46:57+00:00" class="gen-time" title="2026-04-10 03:46 UTC">2026-04-10 03:46 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,699</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">49/126 files · 11 skipped · 2,507/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.3%"></div></div>
+        <span class="group-pct pct-blue">69.3%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35699 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,699 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T03:46:57+00:00" class="gen-time" title="2026-04-10 03:46 UTC">2026-04-10 03:46 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,699</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">
@@ -12137,14 +12137,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:16.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="5">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7403-submodule-sync</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">5</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:27.8%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="70" data-passed="15">

--- a/grit/src/commands/pack_objects.rs
+++ b/grit/src/commands/pack_objects.rs
@@ -1015,9 +1015,21 @@ fn walk_reachable(repo: &Repository, oid: &ObjectId, oids: &mut BTreeSet<ObjectI
                 if nul + 21 > data.len() {
                     break;
                 }
+                let mode_end = data[pos..nul]
+                    .iter()
+                    .position(|&b| b == b' ')
+                    .map(|i| pos + i)
+                    .ok_or_else(|| anyhow::anyhow!("corrupt tree object"))?;
+                let mode = std::str::from_utf8(&data[pos..mode_end])
+                    .map_err(|_| anyhow::anyhow!("corrupt tree object"))?;
                 let entry_oid = ObjectId::from_bytes(&data[nul + 1..nul + 21])
                     .map_err(|e| anyhow::anyhow!("{e}"))?;
-                walk_reachable(repo, &entry_oid, oids)?;
+                // Git submodules are tree entries with mode 160000 (commit gitlink). The
+                // referenced commit lives in the submodule's object store, not the superproject;
+                // `git pack-objects` must not traverse into it (matches Git; fixes fetch/pull).
+                if mode != "160000" {
+                    walk_reachable(repo, &entry_oid, oids)?;
+                }
                 pos = nul + 21;
             }
         }

--- a/grit/src/commands/submodule.rs
+++ b/grit/src/commands/submodule.rs
@@ -551,6 +551,10 @@ pub struct SyncArgs {
     #[arg(long)]
     pub recursive: bool,
 
+    /// Prefix for nested submodule paths in status output (internal; matches `git submodule--helper sync`).
+    #[arg(long = "super-prefix", value_name = "PREFIX")]
+    pub super_prefix: Option<String>,
+
     /// Restrict to specific submodule paths.
     #[arg(value_name = "PATH")]
     pub paths: Vec<String>,
@@ -2153,21 +2157,19 @@ fn resolve_submodule_super_url(
         return Ok(raw_url.to_string());
     }
 
-    let super_git = superproject_git_dir_for_nested_modules(repo_git_dir)
+    // Use this repository's git dir for `remote.*.url` (matches Git's `resolve_relative_url`: it
+    // reads `the_repository`, not the outer superproject). Nested sync runs with `git_dir` under
+    // `.git/modules/<name>/` and must use that config—using only the top-level `.git` breaks
+    // recursive sync (t7403).
+    let outer_git = superproject_git_dir_for_nested_modules(repo_git_dir)
         .unwrap_or_else(|| repo_git_dir.to_path_buf());
-    let super_wt = super_git
+    let outer_wt = outer_git
         .parent()
         .map(Path::to_path_buf)
         .unwrap_or_else(|| work_tree.to_path_buf());
 
-    let mut base = default_remote_url_raw(&super_git)
-        .unwrap_or_else(|| super_wt.to_string_lossy().into_owned());
-    if url_is_local_not_ssh(&base)
-        && !is_absolute_path_url(&base)
-        && (base.starts_with("./") || base.starts_with("../"))
-    {
-        base = canonicalize_local_remote_url_base(&super_wt, &super_git, &base);
-    }
+    let base = default_remote_url_raw(repo_git_dir)
+        .unwrap_or_else(|| outer_wt.to_string_lossy().into_owned());
     git_relative_url(&base, raw_url, None)
 }
 
@@ -2181,21 +2183,15 @@ fn resolve_submodule_sub_origin_url(
     if !raw_url.starts_with("./") && !raw_url.starts_with("../") {
         return Ok(raw_url.to_string());
     }
-    let super_git = superproject_git_dir_for_nested_modules(repo_git_dir)
+    let outer_git = superproject_git_dir_for_nested_modules(repo_git_dir)
         .unwrap_or_else(|| repo_git_dir.to_path_buf());
-    let super_wt = super_git
+    let outer_wt = outer_git
         .parent()
         .map(Path::to_path_buf)
         .unwrap_or_else(|| work_tree.to_path_buf());
 
-    let mut base = default_remote_url_raw(&super_git)
-        .unwrap_or_else(|| super_wt.to_string_lossy().into_owned());
-    if url_is_local_not_ssh(&base)
-        && !is_absolute_path_url(&base)
-        && (base.starts_with("./") || base.starts_with("../"))
-    {
-        base = canonicalize_local_remote_url_base(&super_wt, &super_git, &base);
-    }
+    let base = default_remote_url_raw(repo_git_dir)
+        .unwrap_or_else(|| outer_wt.to_string_lossy().into_owned());
     let up = submodule_up_path(submodule_path);
     let up_ref = (!up.is_empty()).then_some(up.as_str());
     git_relative_url(&base, raw_url, up_ref)
@@ -2213,32 +2209,6 @@ fn superproject_git_dir_for_nested_modules(git_dir: &Path) -> Option<PathBuf> {
         p = parent.to_path_buf();
     }
     None
-}
-
-/// Superproject work tree when `git_dir` is under `.git/modules/<name>/` (else `None`).
-fn superproject_work_tree_for_nested_git_dir(git_dir: &Path) -> Option<PathBuf> {
-    superproject_git_dir_for_nested_modules(git_dir).and_then(|g| g.parent().map(Path::to_path_buf))
-}
-
-/// Join and canonicalize a possibly-relative remote URL; uses the submodule's work tree, or the
-/// outer superproject tree for paths under `.git/modules/` (so `../sub` matches Git).
-fn canonicalize_local_remote_url_base(work_tree: &Path, git_dir: &Path, url: &str) -> String {
-    if !url_is_local_not_ssh(url)
-        || is_absolute_path_url(url)
-        || (!url.starts_with("./") && !url.starts_with("../"))
-    {
-        return url.to_string();
-    }
-    let base_dir = superproject_work_tree_for_nested_git_dir(git_dir)
-        .unwrap_or_else(|| work_tree.to_path_buf());
-    let joined = base_dir.join(url);
-    let joined_s = joined.to_string_lossy().into_owned();
-    joined
-        .canonicalize()
-        .map(|p| p.to_string_lossy().into_owned())
-        .unwrap_or_else(|_| {
-            crate::git_path::normalize_path_copy(&joined_s).unwrap_or_else(|_| url.to_string())
-        })
 }
 
 /// Raw `remote.<default>.url` from config (may be `../sub`); matches Git's
@@ -2272,8 +2242,14 @@ fn count_slashes_in_submodule_path(path: &str) -> usize {
     path.bytes().filter(|&b| b == b'/').count()
 }
 
+/// Strip a leading `./` so `./dir/sub` matches Git's cache path `dir/sub` for `get_up_path`.
+fn submodule_path_for_up_path(path: &str) -> &str {
+    path.strip_prefix("./").unwrap_or(path)
+}
+
 /// Git's `get_up_path(path)` for submodule URL resolution (`relative_url` `up_path`).
 fn submodule_up_path(path: &str) -> String {
+    let path = submodule_path_for_up_path(path);
     let mut s = String::new();
     for _ in 0..count_slashes_in_submodule_path(path) {
         s.push_str("../");
@@ -2407,9 +2383,29 @@ fn resolve_path_components(base_path: &str, relative: &str) -> String {
     format!("/{}", parts.join("/"))
 }
 
+/// Display path for `submodule sync` messages (`get_submodule_displaypath` in Git).
+fn submodule_sync_display_path(
+    work_tree: &Path,
+    cwd: &Path,
+    super_prefix: Option<&str>,
+    submodule_path: &str,
+) -> String {
+    if let Some(sp) = super_prefix {
+        let base = sp.trim_end_matches('/');
+        if base.is_empty() {
+            submodule_path.to_string()
+        } else {
+            format!("{base}/{submodule_path}")
+        }
+    } else {
+        rev_parse::to_relative_path(&work_tree.join(submodule_path), cwd).replace('\\', "/")
+    }
+}
+
 fn run_sync(args: &SyncArgs, quiet: bool) -> Result<()> {
     let repo = Repository::discover(None).context("not a git repository")?;
     let work_tree = repo.work_tree.as_ref().context("bare repository")?;
+    let cwd = std::env::current_dir().context("failed to read current directory")?;
     let modules = parse_gitmodules(work_tree)?;
     let selected = filter_submodules(&modules, &args.paths);
 
@@ -2433,7 +2429,9 @@ fn run_sync(args: &SyncArgs, quiet: bool) -> Result<()> {
         let super_url = resolve_submodule_super_url(work_tree, &repo.git_dir, &m.url)?;
         config.set(&url_key, &super_url)?;
         if !quiet {
-            eprintln!("Synchronizing submodule url for '{}'", m.path);
+            let display_path =
+                submodule_sync_display_path(work_tree, &cwd, args.super_prefix.as_deref(), &m.path);
+            println!("Synchronizing submodule url for '{display_path}'");
         }
 
         // Submodule working tree remote: relative_url with get_up_path (see git submodule sync).
@@ -2464,15 +2462,25 @@ fn run_sync(args: &SyncArgs, quiet: bool) -> Result<()> {
             if sub_path.join(".git").exists() {
                 let nested = parse_gitmodules(&sub_path).unwrap_or_default();
                 if !nested.is_empty() {
-                    // Use the grit binary for recursive sync in nested submodules.
+                    let parent_display = submodule_sync_display_path(
+                        work_tree,
+                        &cwd,
+                        args.super_prefix.as_deref(),
+                        &m.path,
+                    );
+                    let child_super = format!("{}/", parent_display.trim_end_matches('/'));
                     let grit_bin =
                         std::env::current_exe().unwrap_or_else(|_| PathBuf::from("grit"));
-                    let _status = grit_subprocess(&grit_bin)
-                        .arg("submodule")
+                    let mut cmd = grit_subprocess(&grit_bin);
+                    cmd.arg("submodule")
                         .arg("sync")
                         .arg("--recursive")
-                        .current_dir(&sub_path)
-                        .status();
+                        .arg(format!("--super-prefix={child_super}"))
+                        .current_dir(&sub_path);
+                    if quiet {
+                        cmd.arg("--quiet");
+                    }
+                    let _status = cmd.status();
                 }
             }
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR fixes `git submodule sync` behavior and a related `pack-objects` bug so **t7403-submodule-sync** passes all 18 harness tests.

## Changes

- **`pack-objects`**: When walking trees for reachability, skip entries with mode `160000` (submodule gitlinks). Those commits live in the submodule object database, not the superproject; traversing them caused `missing object in non-promisor repository` and broke `git pull` in the test setup.
- **`submodule sync`**:
  - Print the “Synchronizing submodule url for …” line on **stdout** (tests redirect stdout).
  - Compute the display path relative to the current working directory (matches Git’s `get_submodule_displaypath` with a prefix).
  - Add **`--super-prefix`** and pass it through recursive child invocations so nested sync output matches Git (e.g. `../submodule/sub-submodule`).
  - Resolve relative URLs using **`default_remote_url_raw` from the current repository’s git dir** (not only the outer superproject `.git`), matching Git’s `resolve_relative_url`.
  - Remove filesystem canonicalization of relative `remote.*.url` before `relative_url`; Git operates on path strings, and canonicalizing broke nested recursive sync.
  - Strip a leading `./` from submodule paths when computing `get_up_path`, matching Git’s slash count for paths like `./a/b/c`.

## Validation

- `./scripts/run-tests.sh t7403-submodule-sync.sh` — 18/18 pass
- `cargo test -p grit-lib --lib` — pass
- `cargo check -p grit-rs` — pass

Dashboard / `data/test-files.csv` updated by the harness run.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e17a3b28-0b09-4f90-8c77-295ffdc89d46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e17a3b28-0b09-4f90-8c77-295ffdc89d46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

