### PR TITLE
Combined diff improvements for t4038 (WIP)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -716,7 +716,7 @@ t4034-diff-words	t4	yes	66	7	59	false	ok	0
 t4035-diff-quiet	t4	yes	23	23	0	true	ok	0
 t4036-format-patch-signer-mime	t4	yes	5	5	0	true	ok	0
 t4037-diff-r-t-dirs	t4	yes	2	2	0	true	ok	0
-t4038-diff-combined	t4	yes	25	6	19	false	ok	1
+t4038-diff-combined	t4	yes	26	8	17	false	ok	1
 t4039-diff-assume-unchanged	t4	yes	4	3	1	false	ok	0
 t4040-whitespace-status	t4	yes	11	9	2	false	ok	0
 t4041-diff-submodule-option	t4	yes	47	17	30	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,688 / 45,143).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,688 / 45,143).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,30 +148,30 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T03:44:53+00:00" class="gen-time" title="2026-04-10 03:44 UTC">2026-04-10 03:44 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,688</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">45,142</div>
+      <div class="summary-big-val">45,143</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>758 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -230,7 +230,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">73/178 files · 2 skipped · 2,862/4,438 tests</span>
+        <span class="group-meta">73/178 files · 2 skipped · 2,864/4,439 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.5%"></div></div>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35688 of 45143 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,688 / 45,143 tests · 1,405 files in scope · 758 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T03:44:53+00:00" class="gen-time" title="2026-04-10 03:44 UTC">2026-04-10 03:44 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card"><div class="n" id="sum-tests">45,143</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,688</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -7317,14 +7317,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="25" data-passed="6">
+<tr class="" data-group="t4" data-tests="26" data-passed="8">
   <td class="mono">t4038-diff-combined</td>
   <td>t4</td>
   <td></td>
-  <td class="right">25</td>
-  <td class="right">6</td>
+  <td class="right">26</td>
+  <td class="right">8</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:24.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:30.8%"></div></div></td>
   <td class="right small">1</td>
 </tr>
 <tr class="" data-group="t4" data-tests="4" data-passed="3">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/combined_diff_patch.rs
+++ b/grit-lib/src/combined_diff_patch.rs
@@ -1,0 +1,561 @@
+//! Git-style combined merge diff hunks (`diff --cc` / `diff --combined`).
+//!
+//! This approximates Git's `combine-diff.c` behaviour: per-parent Myers diffs against
+//! the merge result, lost-line lists with LCS coalescing, dense (`--cc`) hunk
+//! suppression, and `@@@` headers.
+
+use similar::{capture_diff_slices, Algorithm, DiffOp};
+
+/// Whitespace handling for combined diffs (Git `xdl_opts` subset).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CombinedDiffWsOptions {
+    pub ignore_all_space: bool,
+    pub ignore_space_change: bool,
+    pub ignore_space_at_eol: bool,
+    pub ignore_cr_at_eol: bool,
+}
+
+impl CombinedDiffWsOptions {
+    #[must_use]
+    pub fn any(self) -> bool {
+        self.ignore_all_space
+            || self.ignore_space_change
+            || self.ignore_space_at_eol
+            || self.ignore_cr_at_eol
+    }
+}
+
+#[derive(Clone)]
+struct LostSeg {
+    text: String,
+    parent_map: u32,
+}
+
+fn strip_trailing_cr(s: &str, ignore: bool) -> &str {
+    if ignore && s.ends_with('\r') {
+        &s[..s.len().saturating_sub(1)]
+    } else {
+        s
+    }
+}
+
+fn line_key(line: &str, ws: CombinedDiffWsOptions) -> String {
+    let s = strip_trailing_cr(line, ws.ignore_cr_at_eol);
+    if ws.ignore_all_space {
+        s.chars().filter(|c| !c.is_whitespace()).collect()
+    } else if ws.ignore_space_change {
+        s.split_whitespace().collect::<Vec<_>>().join(" ")
+    } else if ws.ignore_space_at_eol {
+        s.trim_end_matches(|c: char| c.is_whitespace()).to_string()
+    } else {
+        s.to_string()
+    }
+}
+
+fn lines_match(a: &str, b: &str, ws: CombinedDiffWsOptions) -> bool {
+    line_key(a, ws) == line_key(b, ws)
+}
+
+/// Coalesce `incoming` lost segments into `base` using LCS (Git `coalesce_lines`).
+fn coalesce_lost(
+    base: Vec<LostSeg>,
+    incoming: Vec<LostSeg>,
+    parent_bit: u32,
+    ws: CombinedDiffWsOptions,
+) -> Vec<LostSeg> {
+    if incoming.is_empty() {
+        return base;
+    }
+    if base.is_empty() {
+        return incoming;
+    }
+    let ob = base.len();
+    let nw = incoming.len();
+    #[derive(Clone, Copy)]
+    enum Dir {
+        Match,
+        Base,
+        New,
+    }
+    let mut lcs = vec![vec![0usize; nw + 1]; ob + 1];
+    let mut dir = vec![vec![Dir::Base; nw + 1]; ob + 1];
+    for j in 1..=nw {
+        dir[0][j] = Dir::New;
+    }
+    for i in 1..=ob {
+        dir[i][0] = Dir::Base;
+    }
+    for i in 1..=ob {
+        for j in 1..=nw {
+            if lines_match(&base[i - 1].text, &incoming[j - 1].text, ws) {
+                lcs[i][j] = lcs[i - 1][j - 1] + 1;
+                dir[i][j] = Dir::Match;
+            } else if lcs[i][j - 1] >= lcs[i - 1][j] {
+                lcs[i][j] = lcs[i][j - 1];
+                dir[i][j] = Dir::New;
+            } else {
+                lcs[i][j] = lcs[i - 1][j];
+                dir[i][j] = Dir::Base;
+            }
+        }
+    }
+    let mut out: Vec<LostSeg> = Vec::new();
+    let mut i = ob;
+    let mut j = nw;
+    while i > 0 || j > 0 {
+        match dir[i][j] {
+            Dir::Match => {
+                let mut seg = base[i - 1].clone();
+                seg.parent_map |= parent_bit;
+                out.push(seg);
+                i -= 1;
+                j -= 1;
+            }
+            Dir::New => {
+                out.push(incoming[j - 1].clone());
+                j -= 1;
+            }
+            Dir::Base => {
+                out.push(base[i - 1].clone());
+                i -= 1;
+            }
+        }
+    }
+    out.reverse();
+    out
+}
+
+struct Sline {
+    /// Lost lines shown before this result line (`-` / `--` rows).
+    lost: Vec<LostSeg>,
+    /// Pending lost lines for this result line before coalescing.
+    plost: Vec<LostSeg>,
+    /// Bitmask: parent P had this result line unchanged.
+    flag: u32,
+    bol: String,
+    p_lno: Vec<u32>,
+}
+
+fn split_lines_with_incomplete(text: &str) -> (Vec<String>, usize) {
+    if text.is_empty() {
+        return (Vec::new(), 0);
+    }
+    let lines: Vec<String> = text.lines().map(str::to_owned).collect();
+    let cnt = lines.len();
+    (lines, cnt)
+}
+
+fn combine_one_parent(
+    slines: &mut [Sline],
+    cnt: usize,
+    parent_lines: &[String],
+    n: usize,
+    _num_parent: usize,
+    ws: CombinedDiffWsOptions,
+) {
+    let nmask = 1u32 << n;
+    let old_keys: Vec<String> = parent_lines.iter().map(|l| line_key(l, ws)).collect();
+    let new_keys: Vec<String> = slines[..cnt].iter().map(|s| line_key(&s.bol, ws)).collect();
+    let ops = capture_diff_slices(Algorithm::Myers, &old_keys, &new_keys);
+
+    for op in ops {
+        match op {
+            DiffOp::Equal { .. } => {}
+            DiffOp::Delete {
+                old_index,
+                old_len,
+                new_index,
+                ..
+            } => {
+                let mut b = new_index.min(cnt);
+                if old_len > 0 && b == 0 && cnt > 0 {
+                    b = 1;
+                }
+                let b = b.min(cnt.saturating_sub(1));
+                for k in 0..old_len {
+                    slines[b].plost.push(LostSeg {
+                        text: parent_lines[old_index + k].clone(),
+                        parent_map: nmask,
+                    });
+                }
+            }
+            DiffOp::Insert {
+                new_index, new_len, ..
+            } => {
+                for k in 0..new_len {
+                    slines[new_index + k].flag |= nmask;
+                }
+            }
+            DiffOp::Replace {
+                old_index,
+                old_len,
+                new_index,
+                new_len,
+            } => {
+                let b = if new_len == 0 {
+                    let mut b = new_index.min(cnt);
+                    if old_len > 0 && b == 0 && cnt > 0 {
+                        b = 1;
+                    }
+                    b.min(cnt.saturating_sub(1))
+                } else {
+                    new_index.saturating_sub(1).min(cnt.saturating_sub(1))
+                };
+                for k in 0..old_len {
+                    slines[b].plost.push(LostSeg {
+                        text: parent_lines[old_index + k].clone(),
+                        parent_map: nmask,
+                    });
+                }
+                for k in 0..new_len {
+                    slines[new_index + k].flag |= nmask;
+                }
+            }
+        }
+    }
+
+    let mut p_lno = 1u32;
+    for lno in 0..=cnt {
+        slines[lno].p_lno[n] = p_lno;
+        if !slines[lno].plost.is_empty() {
+            let incoming = std::mem::take(&mut slines[lno].plost);
+            slines[lno].lost =
+                coalesce_lost(std::mem::take(&mut slines[lno].lost), incoming, nmask, ws);
+        }
+        for seg in &slines[lno].lost {
+            if seg.parent_map & nmask != 0 {
+                p_lno = p_lno.saturating_add(1);
+            }
+        }
+        if lno < cnt && slines[lno].flag & nmask == 0 {
+            p_lno = p_lno.saturating_add(1);
+        }
+    }
+}
+
+fn interesting(s: &Sline, all_mask: u32) -> bool {
+    (s.flag & all_mask) != 0 || !s.lost.is_empty()
+}
+
+fn find_next(slines: &[Sline], mark: u32, mut i: usize, cnt: usize, want_unmarked: bool) -> usize {
+    while i <= cnt {
+        let marked = slines[i].flag & mark != 0;
+        if want_unmarked != marked {
+            return i;
+        }
+        i += 1;
+    }
+    cnt + 1
+}
+
+fn adjust_hunk_tail(slines: &[Sline], all_mask: u32, hunk_begin: usize, mut i: usize) -> usize {
+    if hunk_begin < i && slines[i - 1].flag & all_mask == 0 {
+        i -= 1;
+    }
+    i
+}
+
+fn give_context(slines: &mut [Sline], cnt: usize, num_parent: usize, context: usize) {
+    let all_mask = (1u32 << num_parent) - 1;
+    let mark = 1u32 << num_parent;
+    let no_pre_delete = 2u32 << num_parent;
+
+    let mut i = find_next(slines, mark, 0, cnt, false);
+    if cnt < i {
+        return;
+    }
+
+    while i <= cnt {
+        let mut j = i.saturating_sub(context);
+        while j < i {
+            if slines[j].flag & mark == 0 {
+                slines[j].flag |= no_pre_delete;
+            }
+            slines[j].flag |= mark;
+            j += 1;
+        }
+
+        loop {
+            j = find_next(slines, mark, i, cnt, true);
+            if cnt < j {
+                return;
+            }
+            let k = find_next(slines, mark, j, cnt, false);
+            let j_adj = adjust_hunk_tail(slines, all_mask, i, j);
+
+            if k < j_adj + context {
+                let mut t = j;
+                while t < k {
+                    slines[t].flag |= mark;
+                    t += 1;
+                }
+                i = k;
+                continue;
+            }
+
+            i = k;
+            let k_end = (j + context).min(cnt + 1);
+            let mut t = j;
+            while t < k_end {
+                slines[t].flag |= mark;
+                t += 1;
+            }
+            break;
+        }
+    }
+}
+
+fn make_hunks(slines: &mut [Sline], cnt: usize, num_parent: usize, dense: bool, context: usize) {
+    let all_mask = (1u32 << num_parent) - 1;
+    let mark = 1u32 << num_parent;
+
+    for i in 0..=cnt {
+        if interesting(&slines[i], all_mask) {
+            slines[i].flag |= mark;
+        } else {
+            slines[i].flag &= !mark;
+        }
+    }
+
+    if dense {
+        let mut i = 0usize;
+        while i <= cnt {
+            while i <= cnt && slines[i].flag & mark == 0 {
+                i += 1;
+            }
+            if cnt < i {
+                break;
+            }
+            let hunk_begin = i;
+            let mut j = i + 1;
+            while j <= cnt {
+                if slines[j].flag & mark == 0 {
+                    let j_adj = adjust_hunk_tail(slines, all_mask, hunk_begin, j);
+                    let la = (j_adj + context).min(cnt + 1);
+                    let mut contin = false;
+                    let mut la2 = la;
+                    while la2 > j {
+                        la2 -= 1;
+                        if slines[la2].flag & mark != 0 {
+                            contin = true;
+                            break;
+                        }
+                    }
+                    if !contin {
+                        break;
+                    }
+                    j = la2;
+                }
+                j += 1;
+            }
+            let hunk_end = j;
+
+            let mut same_diff = 0u32;
+            let mut has_interesting = false;
+            let mut jj = hunk_begin;
+            while jj < hunk_end && !has_interesting {
+                let mut this_diff = slines[jj].flag & all_mask;
+                if this_diff != 0 {
+                    if same_diff == 0 {
+                        same_diff = this_diff;
+                    } else if same_diff != this_diff {
+                        has_interesting = true;
+                        break;
+                    }
+                }
+                let mut ll_iter = slines[jj].lost.iter();
+                while let Some(seg) = ll_iter.next() {
+                    if has_interesting {
+                        break;
+                    }
+                    this_diff = seg.parent_map;
+                    if same_diff == 0 {
+                        same_diff = this_diff;
+                    } else if same_diff != this_diff {
+                        has_interesting = true;
+                    }
+                }
+                jj += 1;
+            }
+            if !has_interesting && same_diff != 0 && same_diff != all_mask {
+                for k in hunk_begin..hunk_end {
+                    slines[k].flag &= !mark;
+                }
+            }
+            i = hunk_end;
+        }
+    }
+
+    give_context(slines, cnt, num_parent, context);
+}
+
+fn show_parent_lno(slines: &[Sline], l0: usize, l1: usize, n: usize, null_ctx: u32) -> String {
+    let a = slines[l0].p_lno[n];
+    let b = slines[l1].p_lno[n];
+    format!(" -{a},{}", b.saturating_sub(a).saturating_sub(null_ctx))
+}
+
+fn dump_slines(slines: &[Sline], cnt: usize, num_parent: usize, context: usize) -> String {
+    let mark = 1u32 << num_parent;
+    let no_pre_delete = 2u32 << num_parent;
+    let mut out = String::new();
+    let mut lno = 0usize;
+
+    loop {
+        while lno <= cnt && slines[lno].flag & mark == 0 {
+            lno += 1;
+        }
+        if cnt < lno {
+            break;
+        }
+        let h_start = lno;
+        let mut h_end = lno + 1;
+        while h_end <= cnt && slines[h_end].flag & mark != 0 {
+            h_end += 1;
+        }
+        let mut rlines = h_end - h_start;
+        if cnt < h_end {
+            rlines = rlines.saturating_sub(1);
+        }
+        let mut null_ctx = 0u32;
+        if context == 0 {
+            for j in h_start..h_end {
+                if slines[j].flag & (mark - 1) == 0 {
+                    null_ctx = null_ctx.saturating_add(1);
+                }
+            }
+            rlines = rlines.saturating_sub(null_ctx as usize);
+        }
+
+        out.push_str("@@@");
+        for _ in 0..=num_parent {
+            out.push('@');
+        }
+        for n in 0..num_parent {
+            out.push_str(&show_parent_lno(slines, h_start, h_end, n, null_ctx));
+        }
+        out.push_str(&format!(" +{},{} ", h_start + 1, rlines));
+        for _ in 0..=num_parent {
+            out.push('@');
+        }
+        out.push('\n');
+
+        while lno < h_end {
+            let sl = &slines[lno];
+            lno += 1;
+            let show_lost = if sl.flag & no_pre_delete == 0 {
+                sl.lost.as_slice()
+            } else {
+                &[][..]
+            };
+            for seg in show_lost {
+                out.push('-');
+                for j in 0..num_parent {
+                    if seg.parent_map & (1u32 << j) != 0 {
+                        out.push('-');
+                    } else {
+                        out.push(' ');
+                    }
+                }
+                out.push_str(&seg.text);
+                out.push('\n');
+            }
+            if cnt < lno {
+                break;
+            }
+            let sl = &slines[lno - 1];
+            if sl.flag & (mark - 1) == 0 {
+                if context == 0 {
+                    continue;
+                }
+                out.push(' ');
+            } else {
+                out.push('+');
+            }
+            let mut p_mask = 1u32;
+            for _ in 0..num_parent {
+                if p_mask & sl.flag != 0 {
+                    out.push('+');
+                } else {
+                    out.push(' ');
+                }
+                p_mask <<= 1;
+            }
+            out.push_str(&sl.bol);
+            out.push('\n');
+        }
+    }
+    out
+}
+
+fn reuse_parent(slines: &mut [Sline], cnt: usize, i: usize, j: usize) {
+    let im = 1u32 << i;
+    let jm = 1u32 << j;
+    for lno in 0..=cnt {
+        for seg in &mut slines[lno].lost {
+            if seg.parent_map & jm != 0 {
+                seg.parent_map |= im;
+            }
+        }
+        if slines[lno].flag & jm != 0 {
+            slines[lno].flag |= im;
+        }
+        slines[lno].p_lno[i] = slines[lno].p_lno[j];
+    }
+}
+
+/// Combined diff body: `@@@` hunks and parent/result lines (no `diff --cc` header).
+#[must_use]
+pub fn format_combined_diff_body(
+    parent_texts: &[String],
+    result_text: &str,
+    context: usize,
+    dense: bool,
+    ws: CombinedDiffWsOptions,
+) -> String {
+    let num_parent = parent_texts.len();
+    if num_parent == 0 {
+        return String::new();
+    }
+
+    let (res_lines, cnt) = split_lines_with_incomplete(result_text);
+    if cnt == 0 && result_text.is_empty() {
+        return String::new();
+    }
+
+    let mut slines: Vec<Sline> = (0..=cnt + 1)
+        .map(|idx| Sline {
+            lost: Vec::new(),
+            plost: Vec::new(),
+            flag: 0,
+            bol: if idx < cnt {
+                res_lines[idx].clone()
+            } else {
+                String::new()
+            },
+            p_lno: vec![0; num_parent],
+        })
+        .collect();
+
+    let parents: Vec<Vec<String>> = parent_texts
+        .iter()
+        .map(|p| p.lines().map(str::to_owned).collect())
+        .collect();
+
+    for i in 0..num_parent {
+        let mut reused = false;
+        for j in 0..i {
+            if parents[i] == parents[j] {
+                reuse_parent(&mut slines, cnt, i, j);
+                reused = true;
+                break;
+            }
+        }
+        if !reused {
+            combine_one_parent(&mut slines, cnt, &parents[i], i, num_parent, ws);
+        }
+    }
+
+    make_hunks(&mut slines, cnt, num_parent, dense, context);
+    dump_slines(&slines, cnt, num_parent, context)
+}

--- a/grit-lib/src/combined_tree_diff.rs
+++ b/grit-lib/src/combined_tree_diff.rs
@@ -9,6 +9,57 @@ use crate::error::Result;
 use crate::objects::{parse_commit, parse_tree, tree_entry_cmp, ObjectId, ObjectKind, TreeEntry};
 use crate::odb::Odb;
 
+/// One character per parent for raw / name-status combined output (`A`/`M`/`D`).
+#[must_use]
+pub fn combined_parent_status_char(s: CombinedParentStatus) -> char {
+    match s {
+        CombinedParentStatus::Added => 'A',
+        CombinedParentStatus::Modified => 'M',
+        CombinedParentStatus::Deleted => 'D',
+    }
+}
+
+/// Git raw combined line (`::::modes... oids... MM\tpath`).
+#[must_use]
+pub fn format_combined_raw_line(p: &CombinedDiffPath, abbrev_len: Option<usize>) -> String {
+    let n = p.parents.len();
+    let mut colons = String::with_capacity(n);
+    for _ in 0..n {
+        colons.push(':');
+    }
+    let mut modes = String::new();
+    for side in &p.parents {
+        modes.push_str(&format!("{:06o} ", side.mode));
+    }
+    modes.push_str(&format!("{:06o}", p.merge_mode));
+    let mut oids = String::new();
+    for side in &p.parents {
+        let h = format!("{}", side.oid);
+        let disp = if let Some(len) = abbrev_len {
+            &h[..len.min(h.len())]
+        } else {
+            h.as_str()
+        };
+        oids.push(' ');
+        oids.push_str(disp);
+    }
+    let rh = format!("{}", p.merge_oid);
+    let rdisp = if let Some(len) = abbrev_len {
+        &rh[..len.min(rh.len())]
+    } else {
+        rh.as_str()
+    };
+    oids.push(' ');
+    oids.push_str(rdisp);
+    oids.push(' ');
+    let status: String = p
+        .parents
+        .iter()
+        .map(|s| combined_parent_status_char(s.status))
+        .collect();
+    format!("{colons}{modes}{oids}{status}\t{}", p.path)
+}
+
 /// Per-parent coarse status in a combined diff (`A` / `M` / `D`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CombinedParentStatus {
@@ -408,14 +459,28 @@ pub fn combined_diff_paths_filtered(
         parent_trees.push(Some(c.tree));
     }
     let parent_opts: Vec<Option<ObjectId>> = parent_trees;
+    combined_diff_paths_trees(odb, commit_tree, &parent_opts, walk, find_object)
+}
+
+/// Combined diff paths when `parents` are already tree OIDs (plumbing `git diff --cc` with N+1 trees).
+pub fn combined_diff_paths_trees(
+    odb: &Odb,
+    merge_tree: &ObjectId,
+    parent_trees: &[Option<ObjectId>],
+    walk: &CombinedTreeDiffOptions,
+    find_object: Option<&ObjectId>,
+) -> Result<Vec<CombinedDiffPath>> {
+    if parent_trees.is_empty() {
+        return Ok(Vec::new());
+    }
     let mut out = Vec::new();
     ll_diff_tree_paths(
         odb,
         &mut out,
         "",
         walk,
-        Some(commit_tree),
-        &parent_opts,
+        Some(merge_tree),
+        parent_trees,
         find_object,
     )?;
     Ok(out)

--- a/grit-lib/src/lib.rs
+++ b/grit-lib/src/lib.rs
@@ -18,6 +18,7 @@
 pub mod attributes;
 pub mod bloom;
 pub mod check_ref_format;
+pub mod combined_diff_patch;
 pub mod combined_tree_diff;
 pub mod commit_encoding;
 pub mod commit_graph_file;

--- a/grit-lib/src/merge_diff.rs
+++ b/grit-lib/src/merge_diff.rs
@@ -9,11 +9,14 @@ use std::process::{Command, Stdio};
 
 use tempfile::NamedTempFile;
 
+use crate::combined_diff_patch::{format_combined_diff_body, CombinedDiffWsOptions};
+use crate::combined_tree_diff::CombinedParentSide;
 use crate::config::ConfigSet;
 use crate::crlf::{get_file_attrs, load_gitattributes, DiffAttr, FileAttrs};
-use crate::diff::{diff_trees, DiffStatus};
+use crate::diff::{detect_renames, diff_trees, DiffStatus};
 use crate::objects::{parse_commit, parse_tree, ObjectId, ObjectKind};
 use crate::odb::Odb;
+use crate::quote_path::format_diff_path_with_prefix;
 use crate::textconv_cache::{read_textconv_cache, write_textconv_cache};
 
 /// Paths that differ between the merge result tree and **every** parent tree.
@@ -48,6 +51,61 @@ pub fn combined_diff_paths(odb: &Odb, commit_tree: &ObjectId, parents: &[ObjectI
         return Vec::new();
     }
     paths_in_tree_order(odb, commit_tree, "", &common)
+}
+
+/// Per-parent blob paths for a combined merge path when rename detection is enabled.
+///
+/// Returns `None` when no special mapping is needed (each parent reads `merge_path`).
+#[must_use]
+pub fn combined_merge_parent_blob_paths(
+    odb: &Odb,
+    merge_path: &str,
+    parent_trees: &[ObjectId],
+    rename_threshold: u32,
+) -> Option<Vec<String>> {
+    if parent_trees.len() < 2 {
+        return None;
+    }
+    let mut per_parent: Vec<String> = Vec::with_capacity(parent_trees.len());
+    for t in parent_trees {
+        if blob_oid_at_path(odb, t, merge_path).is_some() {
+            per_parent.push(merge_path.to_string());
+        } else {
+            per_parent.push(String::new());
+        }
+    }
+    if per_parent.iter().all(|p| !p.is_empty()) {
+        return None;
+    }
+    let mut any_rename = false;
+    for (i, t) in parent_trees.iter().enumerate() {
+        if !per_parent[i].is_empty() {
+            continue;
+        }
+        let entries = diff_trees(odb, Some(t), None, merge_path).ok()?;
+        let with_rn = detect_renames(odb, entries, rename_threshold);
+        let mut found: Option<String> = None;
+        for e in with_rn {
+            if e.status != DiffStatus::Renamed {
+                continue;
+            }
+            let new_p = e.new_path.as_deref().unwrap_or("");
+            if new_p != merge_path {
+                continue;
+            }
+            let old_p = e.old_path.clone()?;
+            if blob_oid_at_path(odb, t, &old_p).is_some() {
+                if found.is_some() {
+                    return None;
+                }
+                found = Some(old_p);
+            }
+        }
+        let p = found?;
+        per_parent[i] = p;
+        any_rename = true;
+    }
+    any_rename.then_some(per_parent)
 }
 
 /// All blob paths in `tree_oid`, depth-first in Git tree entry order (for `diff` / `log`
@@ -457,11 +515,25 @@ pub fn format_combined_binary_header(
     abbrev: usize,
     use_cc_word: bool,
 ) -> String {
-    let p1 = abbrev_hex(&parent_oids[0], abbrev);
-    let p2 = abbrev_hex(&parent_oids[1], abbrev);
+    format_combined_binary_header_n(path, parent_oids, result_oid, abbrev, use_cc_word)
+}
+
+/// `index` line for N-parent combined/binary diffs (`p1,p2,...pn..result`).
+#[must_use]
+pub fn format_combined_binary_header_n(
+    path: &str,
+    parent_oids: &[ObjectId],
+    result_oid: &ObjectId,
+    abbrev: usize,
+    use_cc_word: bool,
+) -> String {
+    let idx: Vec<String> = parent_oids.iter().map(|o| abbrev_hex(o, abbrev)).collect();
     let res = abbrev_hex(result_oid, abbrev);
     let kind = if use_cc_word { "cc" } else { "combined" };
-    format!("diff --{kind} {path}\nindex {p1},{p2}..{res}\nBinary files differ\n")
+    format!(
+        "diff --{kind} {path}\nindex {}..{res}\nBinary files differ\n",
+        idx.join(",")
+    )
 }
 
 /// Full combined diff for a binary path (two parents).
@@ -472,10 +544,54 @@ pub fn format_combined_binary(
     abbrev: usize,
     use_cc_word: bool,
 ) -> String {
-    format_combined_binary_header(path, parent_oids, result_oid, abbrev, use_cc_word)
+    format_combined_binary_header_n(path, parent_oids, result_oid, abbrev, use_cc_word)
 }
 
-/// Combined text diff with textconv (two parents, single-file focus).
+fn push_combined_file_headers(
+    out: &mut String,
+    merge_path: &str,
+    parent_paths: &[String],
+    parent_sides: &[CombinedParentSide],
+    combined_all_paths: bool,
+    quote_path_fully: bool,
+) {
+    let a_prefix = "a/";
+    let b_prefix = "b/";
+    if combined_all_paths {
+        for (i, p) in parent_paths.iter().enumerate() {
+            if parent_sides
+                .get(i)
+                .is_some_and(|s| s.status == crate::combined_tree_diff::CombinedParentStatus::Added)
+            {
+                out.push_str("--- /dev/null\n");
+            } else {
+                let line = format_diff_path_with_prefix(a_prefix, p, quote_path_fully);
+                out.push_str("--- ");
+                out.push_str(&line);
+                out.push('\n');
+            }
+        }
+        let line = format_diff_path_with_prefix(b_prefix, merge_path, quote_path_fully);
+        out.push_str("+++ ");
+        out.push_str(&line);
+        out.push('\n');
+    } else {
+        let la = format_diff_path_with_prefix(a_prefix, merge_path, quote_path_fully);
+        let lb = format_diff_path_with_prefix(b_prefix, merge_path, quote_path_fully);
+        out.push_str("--- ");
+        out.push_str(&la);
+        out.push('\n');
+        out.push_str("+++ ");
+        out.push_str(&lb);
+        out.push('\n');
+    }
+}
+
+/// Combined text diff with optional textconv (N parents, single merge path).
+///
+/// `parent_blob_paths` — when set, length must match `parent_trees`; each entry is the path
+/// used to read that parent's blob (for `--combined-all-paths` rename cases). When `None`,
+/// every parent uses `path`.
 #[allow(clippy::too_many_arguments)]
 pub fn format_combined_textconv_patch(
     git_dir: &Path,
@@ -488,19 +604,34 @@ pub fn format_combined_textconv_patch(
     context: usize,
     use_cc_word: bool,
     use_textconv: bool,
+    ws: CombinedDiffWsOptions,
+    combined_all_paths: bool,
+    parent_blob_paths: Option<&[String]>,
+    parent_sides: &[CombinedParentSide],
+    quote_path_fully: bool,
 ) -> Option<String> {
-    if parent_trees.len() != 2 {
+    if parent_trees.len() < 2 {
         return None;
     }
-    let mut parent_blobs = Vec::new();
-    for t in parent_trees {
-        let b = read_blob_at_path(odb, t, path)?;
+    let parent_paths: Vec<&str> = if let Some(ps) = parent_blob_paths {
+        if ps.len() != parent_trees.len() {
+            return None;
+        }
+        ps.iter().map(|s| s.as_str()).collect()
+    } else {
+        vec![path; parent_trees.len()]
+    };
+
+    let mut parent_blobs = Vec::with_capacity(parent_trees.len());
+    let mut parent_oids = Vec::with_capacity(parent_trees.len());
+    for (i, t) in parent_trees.iter().enumerate() {
+        let p = parent_paths[i];
+        let b = read_blob_at_path(odb, t, p)?;
+        let oid = blob_oid_at_path(odb, t, p)?;
         parent_blobs.push(b);
+        parent_oids.push(oid);
     }
     let result_blob = read_blob_at_path(odb, result_tree, path)?;
-
-    let p0oid = blob_oid_at_path(odb, &parent_trees[0], path)?;
-    let p1oid = blob_oid_at_path(odb, &parent_trees[1], path)?;
     let roid = blob_oid_at_path(odb, result_tree, path)?;
 
     let textconv_for_patch = use_textconv && diff_textconv_active(git_dir, config, path);
@@ -512,40 +643,62 @@ pub fn format_combined_textconv_patch(
     {
         return Some(format_combined_binary(
             path,
-            &[p0oid, p1oid],
+            &parent_oids,
             &roid,
             abbrev,
             use_cc_word,
         ));
     }
 
-    let t0 = if textconv_for_patch {
-        blob_text_for_diff_with_oid(odb, git_dir, config, path, &parent_blobs[0], &p0oid, true)
-    } else {
-        blob_text_for_diff(git_dir, config, path, &parent_blobs[0], use_textconv)
-    };
-    let t1 = if textconv_for_patch {
-        blob_text_for_diff_with_oid(odb, git_dir, config, path, &parent_blobs[1], &p1oid, true)
-    } else {
-        blob_text_for_diff(git_dir, config, path, &parent_blobs[1], use_textconv)
-    };
+    let mut parent_texts = Vec::with_capacity(parent_trees.len());
+    for (i, blob) in parent_blobs.iter().enumerate() {
+        let p = parent_paths[i];
+        let oid = &parent_oids[i];
+        let t = if textconv_for_patch {
+            blob_text_for_diff_with_oid(odb, git_dir, config, p, blob, oid, true)
+        } else {
+            blob_text_for_diff(git_dir, config, p, blob, use_textconv)
+        };
+        parent_texts.push(t);
+    }
     let tr = if textconv_for_patch {
         blob_text_for_diff_with_oid(odb, git_dir, config, path, &result_blob, &roid, true)
     } else {
         blob_text_for_diff(git_dir, config, path, &result_blob, use_textconv)
     };
-    let p1a = abbrev_hex(&p0oid, abbrev);
-    let p2a = abbrev_hex(&p1oid, abbrev);
+
+    let idx: Vec<String> = parent_oids.iter().map(|o| abbrev_hex(o, abbrev)).collect();
     let ra = abbrev_hex(&roid, abbrev);
     let kind = if use_cc_word { "cc" } else { "combined" };
 
+    let header_paths: Vec<String> = if combined_all_paths {
+        parent_paths.iter().map(|s| (*s).to_string()).collect()
+    } else {
+        Vec::new()
+    };
+
     let mut out = String::new();
     out.push_str(&format!("diff --{kind} {path}\n"));
-    out.push_str(&format!("index {p1a},{p2a}..{ra}\n"));
-    out.push_str(&format!("--- a/{path}\n"));
-    out.push_str(&format!("+++ b/{path}\n"));
-    let _ = context;
-    out.push_str(&combined_hunk_two_parents(&t0, &t1, &tr));
+    out.push_str(&format!("index {}..{ra}\n", idx.join(",")));
+    if combined_all_paths {
+        push_combined_file_headers(
+            &mut out,
+            path,
+            &header_paths,
+            parent_sides,
+            true,
+            quote_path_fully,
+        );
+    } else {
+        push_combined_file_headers(&mut out, path, &[], parent_sides, false, quote_path_fully);
+    }
+    out.push_str(&format_combined_diff_body(
+        &parent_texts,
+        &tr,
+        context,
+        use_cc_word,
+        ws,
+    ));
     Some(out)
 }
 
@@ -599,7 +752,13 @@ pub fn format_worktree_conflict_combined(
     if wt_text.contains("<<<<<<<") && wt_text.contains(">>>>>>>") {
         out.push_str(&conflict_combined_body(&wt_for_conflict));
     } else {
-        out.push_str(&combined_hunk_two_parents(&t_ours, &t_theirs, &wt_text));
+        out.push_str(&format_combined_diff_body(
+            &[t_ours, t_theirs],
+            &wt_text,
+            3,
+            true,
+            CombinedDiffWsOptions::default(),
+        ));
     }
     out
 }
@@ -651,35 +810,6 @@ fn conflict_combined_body(wt: &str) -> String {
         i += 1;
     }
     body
-}
-
-fn combined_hunk_two_parents(a: &str, b: &str, result: &str) -> String {
-    let la: Vec<&str> = a.lines().collect();
-    let lb: Vec<&str> = b.lines().collect();
-    let lr: Vec<&str> = result.lines().collect();
-    let n = lr.len().max(la.len()).max(lb.len()).max(1);
-
-    let old_a = la.len().max(1) as u32;
-    let old_b = lb.len().max(1) as u32;
-    let new_c = lr.len().max(1) as u32;
-
-    let mut body = String::new();
-    for idx in 0..n {
-        let ra = la.get(idx).copied().unwrap_or("");
-        let rb = lb.get(idx).copied().unwrap_or("");
-        let rr = lr.get(idx).copied().unwrap_or("");
-        if ra != rr {
-            body.push_str(&format!("- {ra}\n"));
-        }
-        if rb != rr {
-            body.push_str(&format!(" -{rb}\n"));
-        }
-        if ra != rr || rb != rr {
-            body.push_str(&format!("++{rr}\n"));
-        }
-    }
-
-    format!("@@@ -1,{old_a} -1,{old_b} +1,{new_c} @@@\n{body}")
 }
 
 fn read_blob(odb: &Odb, oid: &ObjectId) -> Vec<u8> {

--- a/grit/src/commands/commit.rs
+++ b/grit/src/commands/commit.rs
@@ -1643,17 +1643,24 @@ fn auto_stage_tracked(repo: &Repository, work_tree: &Path) -> Result<()> {
                 fs::read(&abs_path)?
             };
             let oid = repo.odb.write(ObjectKind::Blob, &data)?;
-            if index
+            let has_unmerged = index
                 .entries
                 .iter()
-                .find(|e| e.path == *raw_path)
-                .is_some_and(|e| !e.intent_to_add() && e.oid == oid)
+                .any(|e| e.path == *raw_path && e.stage() != 0);
+            if !has_unmerged
+                && index
+                    .entries
+                    .iter()
+                    .find(|e| e.path == *raw_path)
+                    .is_some_and(|e| !e.intent_to_add() && e.oid == oid)
             {
                 continue;
             }
             let mode = grit_lib::index::normalize_mode(meta.mode());
             let entry = grit_lib::index::entry_from_stat(&abs_path, raw_path, oid, mode)?;
-            index.add_or_replace(entry);
+            // Use `stage_file` so conflict stages (1/2/3) are cleared when `commit -a`
+            // re-stages the resolved worktree file (t4038 merge conflict resolution).
+            index.stage_file(entry);
             changed = true;
         } else {
             index.remove(raw_path);

--- a/grit/src/commands/diff.rs
+++ b/grit/src/commands/diff.rs
@@ -17,6 +17,10 @@ use crate::pathspec::resolve_pathspec;
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::attributes::{collect_attrs_for_path, load_gitattributes_for_diff, AttrValue};
+use grit_lib::combined_diff_patch::CombinedDiffWsOptions;
+use grit_lib::combined_tree_diff::{
+    combined_diff_paths_trees, format_combined_raw_line, CombinedTreeDiffOptions,
+};
 use grit_lib::config::ConfigSet;
 use grit_lib::crlf::{
     get_file_attrs, load_gitattributes, parse_gitattributes_content, AttrRule, DiffAttr,
@@ -32,8 +36,9 @@ use grit_lib::diffstat::{terminal_columns, write_diffstat_block, DiffstatOptions
 use grit_lib::error::Error;
 use grit_lib::index::Index;
 use grit_lib::merge_diff::{
-    blob_text_for_diff_with_oid, combined_diff_paths, diff_textconv_active,
-    format_worktree_conflict_combined, run_textconv,
+    blob_text_for_diff_with_oid, combined_diff_paths, combined_merge_parent_blob_paths,
+    diff_textconv_active, format_combined_textconv_patch, format_worktree_conflict_combined,
+    run_textconv,
 };
 use grit_lib::objects::{parse_commit, ObjectId, ObjectKind};
 use grit_lib::odb::Odb;
@@ -1207,6 +1212,7 @@ pub fn run(mut args: Args) -> Result<()> {
     // trailing_var_arg may capture flags like --name-only into args.
     // Move them back into the flags struct so they take effect.
     let mut want_combined_diff = false;
+    let mut combined_diff_dense = false;
     let mut extra_revs = Vec::new();
     let mut rev_idx = 0;
     while rev_idx < revs.len() {
@@ -1216,6 +1222,7 @@ pub fn run(mut args: Args) -> Result<()> {
             match r.as_str() {
                 "-c" => {
                     want_combined_diff = true;
+                    combined_diff_dense = false;
                 }
                 "--name-only" => args.name_only = true,
                 "--name-status" => args.name_status = true,
@@ -1372,6 +1379,7 @@ pub fn run(mut args: Args) -> Result<()> {
                 }
                 "--cc" => {
                     want_combined_diff = true;
+                    combined_diff_dense = true;
                 }
                 "--find-copies-harder" => {
                     args.find_copies_harder = true;
@@ -1474,6 +1482,88 @@ pub fn run(mut args: Args) -> Result<()> {
             revs = vec![left.to_owned(), right.to_owned()];
         }
     }
+
+    if want_combined_diff && revs.len() >= 3 && !args.cached {
+        fn tree_oid_for_diff_spec(repo: &Repository, spec: &str) -> Result<ObjectId> {
+            commit_or_tree_oid(repo, spec)
+        }
+        let merge_tree = tree_oid_for_diff_spec(&repo, revs.last().unwrap())?;
+        let mut parent_trees = Vec::with_capacity(revs.len() - 1);
+        for s in &revs[..revs.len() - 1] {
+            parent_trees.push(tree_oid_for_diff_spec(&repo, s)?);
+        }
+        let walk = CombinedTreeDiffOptions {
+            recursive: true,
+            tree_in_recursive: false,
+        };
+        let parent_opts: Vec<Option<ObjectId>> = parent_trees.iter().copied().map(Some).collect();
+        let mut cpaths =
+            combined_diff_paths_trees(&repo.odb, &merge_tree, &parent_opts, &walk, None)?;
+        cpaths = filter_combined_paths(cpaths, &paths);
+        let has_diff = !cpaths.is_empty();
+        let abbrev_opt = if args.full_index || args.no_abbrev {
+            None
+        } else {
+            Some(args.abbrev.map(|n| n.max(4).min(40)).unwrap_or(7))
+        };
+        let mut stdout = io::stdout().lock();
+        if args.raw {
+            for p in &cpaths {
+                writeln!(stdout, "{}", format_combined_raw_line(p, abbrev_opt))?;
+            }
+        } else if emit_unified_patch && !args.no_patch {
+            let ws = CombinedDiffWsOptions {
+                ignore_all_space: args.ignore_all_space,
+                ignore_space_change: args.ignore_space_change,
+                ignore_space_at_eol: args.ignore_space_at_eol,
+                ignore_cr_at_eol: args.ignore_cr_at_eol,
+            };
+            let rename_thresh = args
+                .find_renames
+                .as_deref()
+                .map(parse_diff_rename_threshold)
+                .unwrap_or(50);
+            let patch_abbrev = abbrev_opt.unwrap_or(40);
+            for p in &cpaths {
+                let parent_blob_paths = if args.find_renames.is_some() {
+                    combined_merge_parent_blob_paths(
+                        &repo.odb,
+                        &p.path,
+                        &parent_trees,
+                        rename_thresh,
+                    )
+                } else {
+                    None
+                };
+                if let Some(patch) = format_combined_textconv_patch(
+                    &repo.git_dir,
+                    &diff_config,
+                    &repo.odb,
+                    &p.path,
+                    &parent_trees,
+                    &merge_tree,
+                    patch_abbrev,
+                    patch_context,
+                    combined_diff_dense,
+                    !args.no_textconv,
+                    ws,
+                    false,
+                    parent_blob_paths.as_deref(),
+                    &p.parents,
+                    quote_path_fully,
+                ) {
+                    write!(stdout, "{patch}")?;
+                }
+            }
+        }
+        if args.exit_code || args.quiet {
+            if has_diff {
+                std::process::exit(1);
+            }
+        }
+        return Ok(());
+    }
+
     let work_tree = repo.work_tree.as_deref();
 
     // Load index (empty if not found)
@@ -3906,6 +3996,44 @@ fn commit_or_tree_oid(repo: &Repository, spec: &str) -> Result<ObjectId> {
             _ => bail!("object '{}' does not name a tree or commit", oid),
         }
     }
+}
+
+/// Filter combined-diff paths like [`filter_by_paths`].
+fn filter_combined_paths(
+    entries: Vec<grit_lib::combined_tree_diff::CombinedDiffPath>,
+    paths: &[String],
+) -> Vec<grit_lib::combined_tree_diff::CombinedDiffPath> {
+    if paths.is_empty() {
+        return entries;
+    }
+    let mut include_specs: Vec<&str> = Vec::new();
+    let mut exclude_inners: Vec<&str> = Vec::new();
+    for spec in paths {
+        if let Some(inner) = spec.strip_prefix(":!").or_else(|| spec.strip_prefix(":^")) {
+            exclude_inners.push(inner);
+        } else {
+            include_specs.push(spec.as_str());
+        }
+    }
+    if include_specs.is_empty() && !exclude_inners.is_empty() {
+        include_specs.push(".");
+    }
+    entries
+        .into_iter()
+        .filter(|e| {
+            let path = e.path.as_str();
+            let included = include_specs.iter().any(|spec| {
+                if spec == &"." || spec.is_empty() {
+                    return true;
+                }
+                crate::pathspec::pathspec_matches(spec, path)
+            });
+            let excluded = exclude_inners
+                .iter()
+                .any(|inner| crate::pathspec::pathspec_matches(inner, path));
+            included && !excluded
+        })
+        .collect()
 }
 
 /// Filter diff entries to only those matching the given pathspecs.

--- a/grit/src/commands/diff_index.rs
+++ b/grit/src/commands/diff_index.rs
@@ -902,6 +902,9 @@ fn diff_tree_vs_index(
         let new = index_map.get(&path).copied();
         match (old, new) {
             (Some(old), Some(new)) if old == new => {}
+            // Same blob OID with only mode noise: Git does not treat this as blocking
+            // `git merge` / `git checkout` (see t4038 tree-sorting merge scenario).
+            (Some(old), Some(new)) if old.oid == new.oid => {}
             (Some(old), Some(new)) => changes.push(RawChange {
                 path,
                 status: 'M',

--- a/grit/src/commands/diff_tree.rs
+++ b/grit/src/commands/diff_tree.rs
@@ -9,8 +9,10 @@
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use encoding_rs::Encoding;
+use grit_lib::combined_diff_patch::CombinedDiffWsOptions;
 use grit_lib::combined_tree_diff::{
-    combined_diff_paths_filtered, CombinedDiffPath, CombinedParentStatus, CombinedTreeDiffOptions,
+    combined_diff_paths_filtered, combined_diff_paths_trees, format_combined_raw_line,
+    CombinedDiffPath, CombinedParentStatus, CombinedTreeDiffOptions,
 };
 use grit_lib::config::ConfigSet;
 use grit_lib::diff::{
@@ -20,7 +22,7 @@ use grit_lib::diff::{
 };
 use grit_lib::merge_base::merge_bases_first_vs_rest;
 use grit_lib::merge_diff::{
-    combined_diff_paths, format_combined_textconv_patch, is_binary_for_diff,
+    combined_merge_parent_blob_paths, format_combined_textconv_patch, is_binary_for_diff,
 };
 use grit_lib::objects::{parse_commit, parse_tree, ObjectId, ObjectKind};
 use grit_lib::odb::Odb;
@@ -141,6 +143,13 @@ struct Options {
     submodule_mode: Option<String>,
     /// Object id spec for `--find-object` (resolved against the repo before the walk).
     find_object: Option<String>,
+    /// List old paths per parent on renames (`--combined-all-paths`).
+    combined_all_paths: bool,
+    /// Whitespace options for combined patch hunks.
+    ignore_space_at_eol: bool,
+    ignore_space_change: bool,
+    ignore_all_space: bool,
+    ignore_cr_at_eol: bool,
 }
 
 impl Default for Options {
@@ -184,6 +193,11 @@ impl Default for Options {
             pickaxe_all: false,
             submodule_mode: None,
             find_object: None,
+            combined_all_paths: false,
+            ignore_space_at_eol: false,
+            ignore_space_change: false,
+            ignore_all_space: false,
+            ignore_cr_at_eol: false,
         }
     }
 }
@@ -302,6 +316,11 @@ fn parse_options(repo: &Repository, argv: &[String]) -> Result<Options> {
                             .with_context(|| format!("invalid -U value: `{val}`"))?;
                     }
                 }
+                "--combined-all-paths" => opts.combined_all_paths = true,
+                "--ignore-space-at-eol" => opts.ignore_space_at_eol = true,
+                "-b" | "--ignore-space-change" => opts.ignore_space_change = true,
+                "-w" | "--ignore-all-space" => opts.ignore_all_space = true,
+                "--ignore-cr-at-eol" => opts.ignore_cr_at_eol = true,
                 "-M" | "--find-renames" => opts.find_renames = Some(50),
                 "-C" | "--find-copies" => {
                     opts.find_copies = Some(50);
@@ -469,7 +488,95 @@ pub fn run(mut args: Args) -> Result<()> {
 
 // ── Two-tree mode ────────────────────────────────────────────────────
 
+fn run_multi_tree_combined(
+    repo: &Repository,
+    opts: &Options,
+    out: &mut impl Write,
+    merge_tree: &ObjectId,
+    parent_trees: &[ObjectId],
+) -> Result<bool> {
+    let odb = &repo.odb;
+    let walk = CombinedTreeDiffOptions {
+        recursive: true,
+        tree_in_recursive: false,
+    };
+    let parent_opts: Vec<Option<ObjectId>> = parent_trees.iter().copied().map(Some).collect();
+    let paths = combined_diff_paths_trees(odb, merge_tree, &parent_opts, &walk, None)?;
+    let has_diff = !paths.is_empty();
+    if opts.quiet || !has_diff {
+        return Ok(has_diff);
+    }
+
+    let config = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+    let quote_fully = config.quote_path_fully();
+    let abbrev_len = if opts.full_index {
+        40usize
+    } else {
+        opts.abbrev.unwrap_or(7)
+    };
+    let ws = CombinedDiffWsOptions {
+        ignore_all_space: opts.ignore_all_space,
+        ignore_space_change: opts.ignore_space_change,
+        ignore_space_at_eol: opts.ignore_space_at_eol,
+        ignore_cr_at_eol: opts.ignore_cr_at_eol,
+    };
+    let rename_thresh = opts.find_renames.unwrap_or(50);
+
+    for p in &paths {
+        match opts.format {
+            OutputFormat::Raw => {
+                if opts.nul_terminated {
+                    write_combined_raw_z(out, None, p, opts.abbrev)?;
+                } else {
+                    writeln!(out, "{}", format_combined_raw_line(p, opts.abbrev))?;
+                }
+            }
+            OutputFormat::NameOnly | OutputFormat::NameStatus => {
+                print_combined_paths(out, std::slice::from_ref(p), opts)?;
+            }
+            OutputFormat::Patch => {
+                let parent_blob_paths = if opts.combined_all_paths && opts.find_renames.is_some() {
+                    combined_merge_parent_blob_paths(odb, &p.path, parent_trees, rename_thresh)
+                } else {
+                    None
+                };
+                let ps_ref = parent_blob_paths.as_deref();
+                if let Some(patch) = format_combined_textconv_patch(
+                    &repo.git_dir,
+                    &config,
+                    odb,
+                    &p.path,
+                    parent_trees,
+                    merge_tree,
+                    abbrev_len,
+                    opts.context_lines,
+                    opts.combined_use_cc_word,
+                    false,
+                    ws,
+                    opts.combined_all_paths,
+                    ps_ref,
+                    &p.parents,
+                    quote_fully,
+                ) {
+                    write!(out, "{patch}")?;
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(has_diff)
+}
+
 fn run_two_trees(repo: &Repository, opts: &Options, out: &mut impl Write) -> Result<bool> {
+    if opts.combined_patch && opts.objects.len() >= 3 {
+        let merge = resolve_to_tree(repo, opts.objects.last().unwrap())?;
+        let mut parents = Vec::with_capacity(opts.objects.len() - 1);
+        for s in &opts.objects[..opts.objects.len() - 1] {
+            parents.push(resolve_to_tree(repo, s)?);
+        }
+        return run_multi_tree_combined(repo, opts, out, &merge, &parents);
+    }
+
     let (spec_a, spec_b) = if opts.reverse {
         (&opts.objects[1], &opts.objects[0])
     } else {
@@ -552,7 +659,7 @@ fn run_one_commit(repo: &Repository, opts: &Options, out: &mut impl Write) -> Re
                 && opts.combined_patch
                 && matches!(
                     opts.format,
-                    OutputFormat::NameStatus | OutputFormat::NameOnly
+                    OutputFormat::NameStatus | OutputFormat::NameOnly | OutputFormat::Raw
                 )
             {
                 let find_oid = if let Some(ref spec) = opts.find_object {
@@ -564,8 +671,8 @@ fn run_one_commit(repo: &Repository, opts: &Options, out: &mut impl Write) -> Re
                     None
                 };
                 let walk = CombinedTreeDiffOptions {
-                    recursive: opts.recursive,
-                    tree_in_recursive: find_oid.is_some(),
+                    recursive: true,
+                    tree_in_recursive: opts.show_trees || find_oid.is_some(),
                 };
                 let paths = combined_diff_paths_filtered(
                     &repo.odb,
@@ -578,7 +685,27 @@ fn run_one_commit(repo: &Repository, opts: &Options, out: &mut impl Write) -> Re
                 if !opts.quiet && (has_diff || opts.pretty.is_some()) {
                     write_commit_header(out, &oid, &obj.data, opts)?;
                     if has_diff {
-                        print_combined_paths(out, &paths, opts)?;
+                        match opts.format {
+                            OutputFormat::Raw => {
+                                for p in &paths {
+                                    if opts.nul_terminated {
+                                        write_combined_raw_z(
+                                            out,
+                                            Some(&oid.to_hex()),
+                                            p,
+                                            opts.abbrev,
+                                        )?;
+                                    } else {
+                                        writeln!(
+                                            out,
+                                            "{}",
+                                            format_combined_raw_line(p, opts.abbrev)
+                                        )?;
+                                    }
+                                }
+                            }
+                            _ => print_combined_paths(out, &paths, opts)?,
+                        }
                     }
                 }
             } else if commit.parents.len() > 1
@@ -586,12 +713,38 @@ fn run_one_commit(repo: &Repository, opts: &Options, out: &mut impl Write) -> Re
                 && opts.format == OutputFormat::Patch
             {
                 let config = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+                let quote_fully = config.quote_path_fully();
                 let abbrev_len = if opts.full_index {
                     40usize
                 } else {
                     opts.abbrev.unwrap_or(7)
                 };
-                let paths = combined_diff_paths(&repo.odb, &commit.tree, &commit.parents);
+                let ws = CombinedDiffWsOptions {
+                    ignore_all_space: opts.ignore_all_space,
+                    ignore_space_change: opts.ignore_space_change,
+                    ignore_space_at_eol: opts.ignore_space_at_eol,
+                    ignore_cr_at_eol: opts.ignore_cr_at_eol,
+                };
+                let rename_thresh = opts.find_renames.unwrap_or(50);
+                let find_oid = if let Some(ref spec) = opts.find_object {
+                    Some(
+                        resolve_revision(repo, spec)
+                            .with_context(|| format!("unable to resolve '{spec}'"))?,
+                    )
+                } else {
+                    None
+                };
+                let walk = CombinedTreeDiffOptions {
+                    recursive: true,
+                    tree_in_recursive: opts.show_trees || find_oid.is_some(),
+                };
+                let paths = combined_diff_paths_filtered(
+                    &repo.odb,
+                    &commit.tree,
+                    &commit.parents,
+                    &walk,
+                    find_oid.as_ref(),
+                )?;
                 has_diff = !paths.is_empty();
                 if !opts.quiet && (has_diff || opts.pretty.is_some()) {
                     write_commit_header(out, &oid, &obj.data, opts)?;
@@ -599,19 +752,36 @@ fn run_one_commit(repo: &Repository, opts: &Options, out: &mut impl Write) -> Re
                     for p in &commit.parents {
                         parent_trees.push(commit_tree(&repo.odb, p)?);
                     }
-                    if parent_trees.len() == 2 {
-                        for path in paths {
+                    if parent_trees.len() >= 2 {
+                        for p in paths {
+                            let parent_blob_paths =
+                                if opts.combined_all_paths && opts.find_renames.is_some() {
+                                    combined_merge_parent_blob_paths(
+                                        &repo.odb,
+                                        &p.path,
+                                        &parent_trees,
+                                        rename_thresh,
+                                    )
+                                } else {
+                                    None
+                                };
+                            let ps_ref = parent_blob_paths.as_deref();
                             if let Some(patch) = format_combined_textconv_patch(
                                 &repo.git_dir,
                                 &config,
                                 &repo.odb,
-                                &path,
+                                &p.path,
                                 &parent_trees,
                                 &commit.tree,
                                 abbrev_len,
                                 opts.context_lines,
                                 opts.combined_use_cc_word,
                                 false,
+                                ws,
+                                opts.combined_all_paths,
+                                ps_ref,
+                                &p.parents,
+                                quote_fully,
                             ) {
                                 write!(out, "{patch}")?;
                             }
@@ -1263,6 +1433,22 @@ fn print_submodule_log_for_entry(
         }
     }
 
+    Ok(())
+}
+
+fn write_combined_raw_z(
+    out: &mut impl Write,
+    commit_hex: Option<&str>,
+    p: &CombinedDiffPath,
+    abbrev_len: Option<usize>,
+) -> Result<()> {
+    if let Some(h) = commit_hex {
+        out.write_all(h.as_bytes())?;
+        out.write_all(b"\0")?;
+    }
+    let line = format_combined_raw_line(p, abbrev_len);
+    out.write_all(line.as_bytes())?;
+    out.write_all(b"\0")?;
     Ok(())
 }
 

--- a/grit/src/commands/show.rs
+++ b/grit/src/commands/show.rs
@@ -10,6 +10,8 @@
 
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
+use grit_lib::combined_diff_patch::CombinedDiffWsOptions;
+use grit_lib::combined_tree_diff::{combined_diff_paths_filtered, CombinedTreeDiffOptions};
 use grit_lib::config::ConfigSet;
 use grit_lib::diff::{
     anchored_unified_diff, detect_copies, detect_renames, diff_trees, unified_diff, zero_oid,
@@ -18,8 +20,8 @@ use grit_lib::diff::{
 use grit_lib::diffstat::{terminal_columns, write_diffstat_block, DiffstatOptions, FileStatInput};
 use grit_lib::merge_base::merge_bases_first_vs_rest;
 use grit_lib::merge_diff::{
-    blob_oid_at_path, blob_text_for_diff, combined_diff_paths, format_combined_binary,
-    format_combined_textconv_patch, format_parent_patch, is_binary_for_diff, read_blob_at_path,
+    blob_oid_at_path, blob_text_for_diff, format_combined_binary, format_combined_textconv_patch,
+    format_parent_patch, is_binary_for_diff, read_blob_at_path,
 };
 use grit_lib::objects::{parse_commit, parse_tag, parse_tree, ObjectId, ObjectKind};
 use grit_lib::odb::Odb;
@@ -199,6 +201,22 @@ pub struct Args {
     /// Disable textconv.
     #[arg(long = "no-textconv")]
     pub no_textconv: bool,
+
+    /// Ignore whitespace at end of line in combined diffs.
+    #[arg(long = "ignore-space-at-eol")]
+    pub ignore_space_at_eol: bool,
+
+    /// Ignore changes in amount of whitespace in combined diffs.
+    #[arg(short = 'b', long = "ignore-space-change")]
+    pub ignore_space_change: bool,
+
+    /// Ignore all whitespace in combined diffs.
+    #[arg(short = 'w', long = "ignore-all-space")]
+    pub ignore_all_space: bool,
+
+    /// Ignore carriage return at end of line in combined diffs.
+    #[arg(long = "ignore-cr-at-eol")]
+    pub ignore_cr_at_eol: bool,
 
     /// Show binary diff in git binary format.
     #[arg(long = "binary")]
@@ -1157,50 +1175,78 @@ fn show_commit(
             return Ok(());
         }
 
-        if use_combined_format && parent_trees.len() == 2 {
-            let paths = combined_diff_paths(odb, &commit.tree, &commit.parents);
-            let ptrees = [parent_trees[0], parent_trees[1]];
-            for path in paths {
-                let Some(o0) = read_blob_at_path(odb, &ptrees[0], &path) else {
-                    continue;
-                };
-                let Some(o1) = read_blob_at_path(odb, &ptrees[1], &path) else {
-                    continue;
-                };
-                let Some(nr) = read_blob_at_path(odb, &commit.tree, &path) else {
-                    continue;
-                };
-                let binary = is_binary_for_diff(git_dir, &path, &o0)
-                    || is_binary_for_diff(git_dir, &path, &o1)
-                    || is_binary_for_diff(git_dir, &path, &nr);
-                if binary {
-                    let oid0 = blob_oid_at_path(odb, &ptrees[0], &path);
-                    let oid1 = blob_oid_at_path(odb, &ptrees[1], &path);
-                    let oidr = blob_oid_at_path(odb, &commit.tree, &path);
-                    if let (Some(a), Some(b), Some(c)) = (oid0, oid1, oidr) {
-                        write!(
-                            out,
-                            "{}",
-                            format_combined_binary(
-                                &path,
-                                &[a, b],
-                                &c,
-                                abbrev_len,
-                                combined_use_cc_word
-                            )
-                        )?;
+        if use_combined_format && parent_trees.len() >= 2 {
+            let walk = CombinedTreeDiffOptions {
+                recursive: true,
+                tree_in_recursive: false,
+            };
+            let paths =
+                combined_diff_paths_filtered(odb, &commit.tree, &commit.parents, &walk, None)
+                    .unwrap_or_default();
+            let quote_fully = config.quote_path_fully();
+            let ws = CombinedDiffWsOptions {
+                ignore_all_space: args.ignore_all_space,
+                ignore_space_change: args.ignore_space_change,
+                ignore_space_at_eol: args.ignore_space_at_eol,
+                ignore_cr_at_eol: args.ignore_cr_at_eol,
+            };
+            for p in paths {
+                let mut any_blob = false;
+                let mut binary = false;
+                for (i, _side) in p.parents.iter().enumerate() {
+                    if let Some(b) = read_blob_at_path(odb, &parent_trees[i], &p.path) {
+                        any_blob = true;
+                        if is_binary_for_diff(git_dir, &p.path, &b) {
+                            binary = true;
+                        }
                     }
+                }
+                if let Some(nr) = read_blob_at_path(odb, &commit.tree, &p.path) {
+                    any_blob = true;
+                    if is_binary_for_diff(git_dir, &p.path, &nr) {
+                        binary = true;
+                    }
+                }
+                if !any_blob {
+                    continue;
+                }
+                if binary {
+                    let mut po = Vec::with_capacity(p.parents.len());
+                    for (i, _side) in p.parents.iter().enumerate() {
+                        po.push(
+                            blob_oid_at_path(odb, &parent_trees[i], &p.path)
+                                .unwrap_or_else(zero_oid),
+                        );
+                    }
+                    let roid =
+                        blob_oid_at_path(odb, &commit.tree, &p.path).unwrap_or_else(zero_oid);
+                    write!(
+                        out,
+                        "{}",
+                        format_combined_binary(
+                            &p.path,
+                            &po,
+                            &roid,
+                            abbrev_len,
+                            combined_use_cc_word
+                        )
+                    )?;
                 } else if let Some(patch) = format_combined_textconv_patch(
                     git_dir,
                     &config,
                     odb,
-                    &path,
-                    &ptrees,
+                    &p.path,
+                    &parent_trees,
                     &commit.tree,
                     abbrev_len,
                     context,
                     combined_use_cc_word,
                     use_textconv,
+                    ws,
+                    false,
+                    None,
+                    &p.parents,
+                    quote_fully,
                 ) {
                     write!(out, "{patch}")?;
                 }

--- a/tests/test-lib.sh
+++ b/tests/test-lib.sh
@@ -90,10 +90,10 @@ else
 	_test_output_base="$TEST_DIRECTORY"
 fi
 TRASH_DIRECTORY="${TRASH_DIRECTORY:-$_test_output_base/trash.$_test_basename}"
-# BIN_DIRECTORY lives *outside* the working tree so that `git clean -x`
-# (used in pristine_detach and similar helpers) cannot remove the wrapper
-# scripts.  Using a sibling directory keeps things self-contained.
-BIN_DIRECTORY="${TEST_DIRECTORY}/bin.${_test_basename}"
+# Wrapper scripts must survive `git clean` and must not live under
+# `$TEST_DIRECTORY` (some tests remove sibling paths). Use a per-host temp dir.
+_tmpbase="${TMPDIR:-/tmp}"
+BIN_DIRECTORY="${_tmpbase}/gust-test-bin.${_test_basename}.$$"
 TEST_RESULTS_DIR="${TEST_DIRECTORY}/test-results"
 
 . "$TEST_DIRECTORY"/test-lib-harness.sh
@@ -148,6 +148,9 @@ setup_trash () {
 	mkdir -p "$TRASH_DIRECTORY"
 	# BIN_DIRECTORY is outside the working tree so git clean -x cannot remove it
 	mkdir -p "$BIN_DIRECTORY"
+	# Remove stale wrappers before rewrite: avoids Linux ETXTBSY when replacing a
+	# running executable and restores wrappers if a prior run left BIN_DIRECTORY empty.
+	rm -f "$BIN_DIRECTORY/git" "$BIN_DIRECTORY/grit" "$BIN_DIRECTORY/test-tool" "$BIN_DIRECTORY/scalar" 2>/dev/null || true
 	# Write a 'git' wrapper script that calls grit (GUST_BIN is absolute path)
 	cat >"$BIN_DIRECTORY/git" <<EOF
 #!/bin/sh


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds combined-diff (`--cc` / `-c`) plumbing and harness fixes toward `t4038-diff-combined`:

- `grit-lib`: `combined_diff_patch` (Git-style combined hunks), `combined_diff_paths_trees`, `format_combined_raw_line`.
- `diff-tree` / `show` / `diff`: N-parent combined patches, `--combined-all-paths`, whitespace flags, multi-tree `git diff --cc --raw`.
- `merge_diff`: N-parent headers/patches; rename-aware parent paths for combined-all-paths.
- `commit -a`: clear unmerged stages when resolving conflicts even if OID matches stage 0.
- `diff_index`: same OID index vs HEAD not treated as blocking merge.
- Tests: `BIN_DIRECTORY` under `TMPDIR`; unlink wrappers before rewrite.

## Status

`t4038-diff-combined` not fully passing yet.

## Validation

- `cargo build --release -p grit-rs`
- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t4038-diff-combined.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83273e6b-6e2c-476c-b02b-91f80f6df35e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83273e6b-6e2c-476c-b02b-91f80f6df35e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

