### PR TITLE
fix: MIDX groundwork, v1 pack index, config clap panic (t5319 WIP)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -681,7 +681,7 @@ commit → check it off → move on.
 - [ ] `t5572-pull-submodule` ██░░░░░░░░░░░░░░░░░░ 10/69 (59 left) — pull can handle submodules
 - [ ] `t5515-fetch-merge-logic` ░░░░░░░░░░░░░░░░░░░░ 1/65 (64 left) — Merge logic in fetch
 - [ ] `t5520-pull` ██░░░░░░░░░░░░░░░░░░ 10/80 (70 left) — pulling into void
-- [ ] `t5319-multi-pack-index` ████░░░░░░░░░░░░░░░░ 24/98 (74 left) — multi-pack-indexes
+- [~] `t5319-multi-pack-index` ███░░░░░░░░░░░░░░░░░ ~14/98 passing — multi-pack-indexes (MIDX read/write + v1 idx + config `-C` fix; verify/expire/repack/bitmap still open)
 - [ ] `t5318-commit-graph` ███░░░░░░░░░░░░░░░░░ 19/109 (90 left) — commit graph
 - [ ] `t5601-clone` ███░░░░░░░░░░░░░░░░░ 21/115 (94 left) — 
 - [ ] `t5505-remote` ██░░░░░░░░░░░░░░░░░░ 16/130 (114 left) — git remote porcelain-ish

--- a/grit-lib/src/midx.rs
+++ b/grit-lib/src/midx.rs
@@ -29,7 +29,9 @@ const MIDX_CHUNKID_PACKNAMES: u32 = 0x504e_414d;
 const MIDX_CHUNKID_OIDFANOUT: u32 = 0x4f49_4446;
 const MIDX_CHUNKID_OIDLOOKUP: u32 = 0x4f49_444c;
 const MIDX_CHUNKID_OBJECTOFFSETS: u32 = 0x4f4f_4646;
+const MIDX_CHUNKID_LARGEOFFSETS: u32 = 0x4c4f_4646;
 const MIDX_CHUNKID_REVINDEX: u32 = 0x5249_4458;
+const MIDX_CHUNK_ALIGNMENT: usize = 4;
 
 // `git midx.h` (MIDX_LARGE_OFFSET_NEEDED).
 const MIDX_LARGE_OFFSET_NEEDED: u32 = 0x8000_0000;
@@ -38,6 +40,7 @@ struct MidxEntry {
     oid: ObjectId,
     pack_id: u32,
     offset: u64,
+    pack_mtime: std::time::SystemTime,
 }
 
 /// Options for writing a multi-pack index (extension of the simple writer).
@@ -60,7 +63,7 @@ struct MidxFileHeader {
     num_chunks: u8,
 }
 
-fn parse_midx_header(data: &[u8]) -> Result<(MidxFileHeader, usize)> {
+fn parse_midx_header(data: &[u8]) -> Result<(MidxFileHeader, usize, u8)> {
     if data.len() < MIDX_HEADER_SIZE + 20 {
         return Err(Error::CorruptObject("midx file too small".to_owned()));
     }
@@ -74,15 +77,14 @@ fn parse_midx_header(data: &[u8]) -> Result<(MidxFileHeader, usize)> {
             "unsupported MIDX version {version}"
         )));
     }
-    let hash_len = data[5];
-    if hash_len != 1 {
-        return Err(Error::CorruptObject(
-            "unsupported MIDX hash version".to_owned(),
-        ));
-    }
+    let object_hash_bytes = data[5];
     let num_chunks = data[6];
     let _num_packs = u32::from_be_bytes(data[8..12].try_into().unwrap());
-    Ok((MidxFileHeader { num_chunks }, MIDX_HEADER_SIZE))
+    Ok((
+        MidxFileHeader { num_chunks },
+        MIDX_HEADER_SIZE,
+        object_hash_bytes,
+    ))
 }
 
 fn parse_pack_names_blob(pn: &[u8]) -> Result<Vec<String>> {
@@ -178,7 +180,7 @@ fn load_midx_file(path: &Path) -> Result<Vec<u8>> {
 }
 
 fn oids_and_packs_from_midx_data(data: &[u8]) -> Result<(HashSet<ObjectId>, Vec<String>)> {
-    let (_, hdr_end) = parse_midx_header(data)?;
+    let (_, hdr_end, _) = parse_midx_header(data)?;
     let (pn_off, pn_len) = find_chunk(data, hdr_end, MIDX_CHUNKID_PACKNAMES)?;
     let pack_names = parse_pack_names_blob(&data[pn_off..pn_off + pn_len])?;
     let (_ooff_off, ooff_len) = find_chunk(data, hdr_end, MIDX_CHUNKID_OBJECTOFFSETS)?;
@@ -284,6 +286,40 @@ fn clear_stale_split_layers(pack_dir: &Path, keep: &[String]) -> Result<()> {
     Ok(())
 }
 
+fn pack_mtime_for_midx(idx: &PackIndex) -> std::time::SystemTime {
+    fs::metadata(&idx.pack_path)
+        .and_then(|m| m.modified())
+        .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
+}
+
+fn midx_pick_better_entry(
+    cur: &MidxEntry,
+    cand_pack: u32,
+    cand_offset: u64,
+    cand_mtime: std::time::SystemTime,
+    preferred_pack: Option<u32>,
+) -> bool {
+    let cur_pref = preferred_pack == Some(cur.pack_id);
+    let new_pref = preferred_pack == Some(cand_pack);
+    if new_pref && !cur_pref {
+        return true;
+    }
+    if cur_pref && !new_pref {
+        return false;
+    }
+    match cand_mtime.cmp(&cur.pack_mtime) {
+        std::cmp::Ordering::Greater => true,
+        std::cmp::Ordering::Less => false,
+        std::cmp::Ordering::Equal => {
+            if cand_pack != cur.pack_id {
+                cand_pack < cur.pack_id
+            } else {
+                cand_offset < cur.offset
+            }
+        }
+    }
+}
+
 fn build_midx_bytes(
     idx_names: &[String],
     indexes: &[PackIndex],
@@ -291,51 +327,42 @@ fn build_midx_bytes(
     write_bitmap_placeholders: bool,
 ) -> Result<Vec<u8>> {
     let preferred_pack_idx = preferred_idx.map(|p| p as u32);
+    let pack_mtimes: Vec<std::time::SystemTime> = indexes.iter().map(pack_mtime_for_midx).collect();
 
-    let mut best: HashMap<ObjectId, (u32, u64)> = HashMap::new();
+    let mut best: HashMap<ObjectId, MidxEntry> = HashMap::new();
     for (pack_id, idx) in indexes.iter().enumerate() {
         let pack_id = u32::try_from(pack_id).map_err(|_| {
             Error::CorruptObject("too many pack files for multi-pack-index".to_owned())
         })?;
+        let mtime = pack_mtimes[pack_id as usize];
         for e in &idx.entries {
-            let replace = match best.get(&e.oid) {
-                None => true,
-                Some((old_pack, _)) => match preferred_idx {
-                    Some(pref) => {
-                        let old_pref = (*old_pack as usize) == pref;
-                        let new_pref = (pack_id as usize) == pref;
-                        if new_pref && !old_pref {
-                            true
-                        } else if old_pref && !new_pref {
-                            false
-                        } else {
-                            pack_id > *old_pack
-                        }
-                    }
-                    None => pack_id > *old_pack,
-                },
+            let cand = MidxEntry {
+                oid: e.oid,
+                pack_id,
+                offset: e.offset,
+                pack_mtime: mtime,
             };
-            if replace {
-                best.insert(e.oid, (pack_id, e.offset));
+            match best.get(&e.oid) {
+                None => {
+                    best.insert(e.oid, cand);
+                }
+                Some(cur) => {
+                    if midx_pick_better_entry(cur, pack_id, e.offset, mtime, preferred_pack_idx) {
+                        best.insert(e.oid, cand);
+                    }
+                }
             }
         }
     }
 
-    let mut entries: Vec<MidxEntry> = best
-        .into_iter()
-        .map(|(oid, (pack_id, offset))| MidxEntry {
-            oid,
-            pack_id,
-            offset,
-        })
-        .collect();
+    let mut entries: Vec<MidxEntry> = best.into_values().collect();
     entries.sort_by(|a, b| a.oid.cmp(&b.oid));
 
+    let mut large_offsets: Vec<u64> = Vec::new();
     for e in &entries {
-        if e.offset >= u64::from(MIDX_LARGE_OFFSET_NEEDED) {
+        if e.offset > u64::from(u32::MAX) {
             return Err(Error::CorruptObject(
-                "object offset too large for simple multi-pack-index writer (need LOFF chunk)"
-                    .to_owned(),
+                "object offset does not fit in multi-pack-index".to_owned(),
             ));
         }
     }
@@ -347,9 +374,9 @@ fn build_midx_bytes(
         pack_names_blob.extend_from_slice(name.as_bytes());
         pack_names_blob.push(0);
     }
-    while pack_names_blob.len() % 4 != 0 {
-        pack_names_blob.push(0);
-    }
+    let pad = (MIDX_CHUNK_ALIGNMENT - (pack_names_blob.len() % MIDX_CHUNK_ALIGNMENT))
+        % MIDX_CHUNK_ALIGNMENT;
+    pack_names_blob.extend(std::iter::repeat_n(0u8, pad));
     let chunk_pnam = pack_names_blob;
 
     let mut chunk_oidf = vec![0u8; 256 * 4];
@@ -369,11 +396,30 @@ fn build_midx_bytes(
     let mut chunk_ooff = Vec::with_capacity(entries.len() * 8);
     for e in &entries {
         chunk_ooff.extend_from_slice(&e.pack_id.to_be_bytes());
-        let off32 = u32::try_from(e.offset).map_err(|_| {
-            Error::CorruptObject("object offset overflow in multi-pack-index".to_owned())
-        })?;
-        chunk_ooff.extend_from_slice(&off32.to_be_bytes());
+        let needs_large = e.offset >= u64::from(MIDX_LARGE_OFFSET_NEEDED);
+        let encoded = if needs_large {
+            let slot = u32::try_from(large_offsets.len()).map_err(|_| {
+                Error::CorruptObject("too many large offsets in multi-pack-index".to_owned())
+            })?;
+            large_offsets.push(e.offset);
+            MIDX_LARGE_OFFSET_NEEDED | slot
+        } else {
+            u32::try_from(e.offset).map_err(|_| {
+                Error::CorruptObject("object offset overflow in multi-pack-index".to_owned())
+            })?
+        };
+        chunk_ooff.extend_from_slice(&encoded.to_be_bytes());
     }
+
+    let chunk_loff: Vec<u8> = if large_offsets.is_empty() {
+        Vec::new()
+    } else {
+        let mut v = Vec::with_capacity(large_offsets.len() * 8);
+        for off in &large_offsets {
+            v.extend_from_slice(&off.to_be_bytes());
+        }
+        v
+    };
 
     let pref = preferred_pack_idx;
     let mut order: Vec<u32> = (0..entries.len() as u32).collect();
@@ -401,9 +447,8 @@ fn build_midx_bytes(
             v.extend_from_slice(&0u32.to_be_bytes());
             v.extend_from_slice(&0u32.to_be_bytes());
         }
-        while v.len() % 4 != 0 {
-            v.push(0);
-        }
+        let pad = (MIDX_CHUNK_ALIGNMENT - (v.len() % MIDX_CHUNK_ALIGNMENT)) % MIDX_CHUNK_ALIGNMENT;
+        v.extend(std::iter::repeat_n(0u8, pad));
         v
     } else {
         Vec::new()
@@ -415,6 +460,9 @@ fn build_midx_bytes(
         (MIDX_CHUNKID_OIDLOOKUP, chunk_oidl),
         (MIDX_CHUNKID_OBJECTOFFSETS, chunk_ooff),
     ];
+    if !chunk_loff.is_empty() {
+        chunks.push((MIDX_CHUNKID_LARGEOFFSETS, chunk_loff));
+    }
     if pref.is_some() || write_bitmap_placeholders {
         chunks.push((MIDX_CHUNKID_REVINDEX, chunk_ridx));
     }
@@ -461,7 +509,7 @@ fn build_midx_bytes(
 }
 
 fn find_chunk(data: &[u8], header_end: usize, chunk_id: u32) -> Result<(usize, usize)> {
-    let (hdr, _) = parse_midx_header(data)?;
+    let (hdr, _, _) = parse_midx_header(data)?;
     let n = hdr.num_chunks as usize;
     let pos = header_end;
     let toc_end = pos + (n + 1) * CHUNK_TOC_ENTRY_SIZE;
@@ -501,7 +549,7 @@ pub fn read_midx_pack_idx_names(objects_dir: &Path) -> Result<Vec<String>> {
     let path = resolve_tip_midx_path(&pack_dir)
         .ok_or_else(|| Error::CorruptObject("no multi-pack-index found".to_owned()))?;
     let data = fs::read(&path).map_err(Error::Io)?;
-    let (_, hdr_end) = parse_midx_header(&data)?;
+    let (_, hdr_end, _) = parse_midx_header(&data)?;
     let (pn_off, pn_len) = find_chunk(&data, hdr_end, MIDX_CHUNKID_PACKNAMES)?;
     parse_pack_names_blob(&data[pn_off..pn_off + pn_len])
 }
@@ -520,7 +568,7 @@ pub fn format_midx_dump(objects_dir: &Path) -> Result<String> {
     let path = resolve_tip_midx_path(&pack_dir)
         .ok_or_else(|| Error::CorruptObject("no multi-pack-index found".to_owned()))?;
     let data = fs::read(&path).map_err(Error::Io)?;
-    let (hdr, hdr_end) = parse_midx_header(&data)?;
+    let (hdr, hdr_end, _) = parse_midx_header(&data)?;
     let sig = u32::from_be_bytes(data[0..4].try_into().unwrap());
     let version = data[4];
     let hash_len = data[5];
@@ -551,7 +599,7 @@ pub fn format_midx_dump(objects_dir: &Path) -> Result<String> {
         chunk_tags.push(tag);
     }
 
-    let (ooff_off, ooff_len) = find_chunk(&data, hdr_end, MIDX_CHUNKID_OBJECTOFFSETS)?;
+    let (_ooff_off, ooff_len) = find_chunk(&data, hdr_end, MIDX_CHUNKID_OBJECTOFFSETS)?;
     let num_objects = ooff_len / 8;
 
     let pack_names = read_midx_pack_idx_names(objects_dir)?;
@@ -574,8 +622,223 @@ pub fn format_midx_dump(objects_dir: &Path) -> Result<String> {
         out.push('\n');
     }
     out.push_str(&format!("object-dir: {}\n", objects_dir.display()));
-    let _ = ooff_off;
     Ok(out)
+}
+
+/// Returns whether `oid` appears in the active MIDX OID table for `objects_dir`.
+///
+/// [`None`] means there is no MIDX at the pack tip. [`Some`] is the lookup result when a MIDX exists.
+pub fn midx_oid_listed_in_tip(objects_dir: &Path, oid: &ObjectId) -> Result<Option<bool>> {
+    let pack_dir = objects_dir.join("pack");
+    let Some(midx_path) = resolve_tip_midx_path(&pack_dir) else {
+        return Ok(None);
+    };
+    let data = fs::read(&midx_path).map_err(Error::Io)?;
+    let (_, hdr_end, hash_bytes) = parse_midx_header(&data)?;
+    if hash_bytes != 1 {
+        eprintln!(
+            "error: multi-pack-index hash version {} does not match version 1",
+            hash_bytes
+        );
+        return Err(Error::CorruptObject(
+            "multi-pack-index hash version mismatch".to_owned(),
+        ));
+    }
+    let (oidf_off, oidf_len) = find_chunk(&data, hdr_end, MIDX_CHUNKID_OIDFANOUT)?;
+    if oidf_len != 256 * 4 {
+        eprintln!("error: multi-pack-index OID fanout is of the wrong size");
+        return Err(Error::CorruptObject(
+            "multi-pack-index OID fanout is of the wrong size".to_owned(),
+        ));
+    }
+    let (oidl_off, oidl_len) = find_chunk(&data, hdr_end, MIDX_CHUNKID_OIDLOOKUP)?;
+    let (_ooff_off, ooff_len) = find_chunk(&data, hdr_end, MIDX_CHUNKID_OBJECTOFFSETS)?;
+    let num_objects = ooff_len / 8;
+    if oidl_len != num_objects * 20 || ooff_len != num_objects * 8 {
+        if oidl_len != num_objects * 20 {
+            eprintln!("error: multi-pack-index OID lookup chunk is the wrong size");
+        } else {
+            eprintln!("error: multi-pack-index object offset chunk is the wrong size");
+        }
+        return Err(Error::CorruptObject("midx chunk size mismatch".to_owned()));
+    }
+
+    let first = oid.as_bytes()[0] as usize;
+    let lo = if first == 0 {
+        0u32
+    } else {
+        u32::from_be_bytes(
+            data[oidf_off + (first - 1) * 4..oidf_off + first * 4]
+                .try_into()
+                .unwrap(),
+        )
+    };
+    let hi = u32::from_be_bytes(
+        data[oidf_off + first * 4..oidf_off + (first + 1) * 4]
+            .try_into()
+            .unwrap(),
+    );
+    if lo > hi || hi as usize > num_objects {
+        eprintln!(
+            "error: oid fanout out of order: fanout[{}] = {:08x} > {:08x} = fanout[{}]",
+            first.saturating_sub(1),
+            lo,
+            hi,
+            first
+        );
+        return Err(Error::CorruptObject("oid fanout out of order".to_owned()));
+    }
+
+    let mut i = lo as usize;
+    while i < hi as usize {
+        let o = ObjectId::from_bytes(&data[oidl_off + i * 20..oidl_off + (i + 1) * 20])?;
+        match o.cmp(oid) {
+            std::cmp::Ordering::Equal => return Ok(Some(true)),
+            std::cmp::Ordering::Greater => return Ok(Some(false)),
+            std::cmp::Ordering::Less => i += 1,
+        }
+    }
+    Ok(Some(false))
+}
+
+/// When `core.multiPackIndex` is enabled, try to read `oid` from the active MIDX in `objects_dir`.
+///
+/// Returns [`None`] when no MIDX exists or `oid` is not listed. Returns [`Some(Err(..))`] when the
+/// MIDX is present but malformed (callers surface Git-style `error:` / `fatal:` messages).
+pub fn try_read_object_via_midx(
+    objects_dir: &Path,
+    oid: &ObjectId,
+) -> Result<Option<crate::objects::Object>> {
+    let pack_dir = objects_dir.join("pack");
+    let Some(midx_path) = resolve_tip_midx_path(&pack_dir) else {
+        return Ok(None);
+    };
+    let data = fs::read(&midx_path).map_err(Error::Io)?;
+    let (_, hdr_end, hash_bytes) = parse_midx_header(&data)?;
+    let num_packs_hdr = u32::from_be_bytes(data[8..12].try_into().unwrap());
+    if hash_bytes != 1 {
+        eprintln!(
+            "error: multi-pack-index hash version {} does not match version 1",
+            hash_bytes
+        );
+        return Err(Error::CorruptObject(
+            "multi-pack-index hash version mismatch".to_owned(),
+        ));
+    }
+    let (pn_off, pn_len) = find_chunk(&data, hdr_end, MIDX_CHUNKID_PACKNAMES)?;
+    let pack_names = parse_pack_names_blob(&data[pn_off..pn_off + pn_len])?;
+    if pack_names.len() != num_packs_hdr as usize {
+        return Err(Error::CorruptObject(
+            "multi-pack-index pack-name chunk is too short".to_owned(),
+        ));
+    }
+    let (oidf_off, oidf_len) = find_chunk(&data, hdr_end, MIDX_CHUNKID_OIDFANOUT)?;
+    if oidf_len != 256 * 4 {
+        eprintln!("error: multi-pack-index OID fanout is of the wrong size");
+        return Err(Error::CorruptObject(
+            "multi-pack-index OID fanout is of the wrong size".to_owned(),
+        ));
+    }
+    let (oidl_off, oidl_len) = find_chunk(&data, hdr_end, MIDX_CHUNKID_OIDLOOKUP)?;
+    let (ooff_off, ooff_len) = find_chunk(&data, hdr_end, MIDX_CHUNKID_OBJECTOFFSETS)?;
+    let num_objects = ooff_len / 8;
+    if oidl_len != num_objects * 20 {
+        eprintln!("error: multi-pack-index OID lookup chunk is the wrong size");
+        return Err(Error::CorruptObject(
+            "multi-pack-index OID lookup chunk is the wrong size".to_owned(),
+        ));
+    }
+    if ooff_len != num_objects * 8 {
+        eprintln!("error: multi-pack-index object offset chunk is the wrong size");
+        return Err(Error::CorruptObject(
+            "multi-pack-index object offset chunk is the wrong size".to_owned(),
+        ));
+    }
+    let loff = find_chunk(&data, hdr_end, MIDX_CHUNKID_LARGEOFFSETS).ok();
+    let ridx = find_chunk(&data, hdr_end, MIDX_CHUNKID_REVINDEX).ok();
+
+    if let Some((_, rlen)) = ridx {
+        if rlen != num_objects * 4 {
+            eprintln!("error: multi-pack-index reverse-index chunk is the wrong size");
+            eprintln!("warning: multi-pack bitmap is missing required reverse index");
+        }
+    }
+
+    let first = oid.as_bytes()[0] as usize;
+    let lo = if first == 0 {
+        0u32
+    } else {
+        u32::from_be_bytes(
+            data[oidf_off + (first - 1) * 4..oidf_off + first * 4]
+                .try_into()
+                .unwrap(),
+        )
+    };
+    let hi = u32::from_be_bytes(
+        data[oidf_off + first * 4..oidf_off + (first + 1) * 4]
+            .try_into()
+            .unwrap(),
+    );
+    if lo > hi || hi as usize > num_objects {
+        eprintln!(
+            "error: oid fanout out of order: fanout[{}] = {:08x} > {:08x} = fanout[{}]",
+            first.saturating_sub(1),
+            lo,
+            hi,
+            first
+        );
+        return Err(Error::CorruptObject("oid fanout out of order".to_owned()));
+    }
+
+    let mut pos = None;
+    let mut i = lo as usize;
+    while i < hi as usize {
+        let o = ObjectId::from_bytes(&data[oidl_off + i * 20..oidl_off + (i + 1) * 20])?;
+        let c = o.cmp(oid);
+        if c == std::cmp::Ordering::Equal {
+            pos = Some(i);
+            break;
+        }
+        if c == std::cmp::Ordering::Greater {
+            break;
+        }
+        i += 1;
+    }
+    let Some(pos) = pos else {
+        return Ok(None);
+    };
+
+    let obase = ooff_off + pos * 8;
+    let pack_id = u32::from_be_bytes(data[obase..obase + 4].try_into().unwrap());
+    let raw_off = u32::from_be_bytes(data[obase + 4..obase + 8].try_into().unwrap());
+    let _offset = if (raw_off & MIDX_LARGE_OFFSET_NEEDED) != 0 {
+        let Some((loff_off, loff_len)) = loff else {
+            return Err(Error::CorruptObject(
+                "multi-pack-index large offset missing LOFF chunk".to_owned(),
+            ));
+        };
+        let idx = (raw_off & !MIDX_LARGE_OFFSET_NEEDED) as usize;
+        let need = (idx + 1) * 8;
+        if loff_len < need {
+            return Err(Error::CorruptObject(
+                "multi-pack-index large offset out of bounds".to_owned(),
+            ));
+        }
+        u64::from_be_bytes(
+            data[loff_off + idx * 8..loff_off + (idx + 1) * 8]
+                .try_into()
+                .unwrap(),
+        )
+    } else {
+        raw_off as u64
+    };
+
+    let idx_name = pack_names
+        .get(pack_id as usize)
+        .ok_or_else(|| Error::CorruptObject("bad pack-int-id".to_owned()))?;
+    let idx_path = pack_dir.join(idx_name);
+    let idx = crate::pack::read_pack_index(&idx_path)?;
+    crate::pack::read_object_from_pack(&idx, oid).map(Some)
 }
 
 pub fn read_midx_preferred_idx_name(objects_dir: &Path) -> Result<String> {
@@ -583,7 +846,7 @@ pub fn read_midx_preferred_idx_name(objects_dir: &Path) -> Result<String> {
     let path = resolve_tip_midx_path(&pack_dir)
         .ok_or_else(|| Error::CorruptObject("no multi-pack-index found".to_owned()))?;
     let data = fs::read(&path).map_err(Error::Io)?;
-    let (_, hdr_end) = parse_midx_header(&data)?;
+    let (_, hdr_end, _) = parse_midx_header(&data)?;
     let (pn_off, pn_len) = find_chunk(&data, hdr_end, MIDX_CHUNKID_PACKNAMES)?;
     let names = parse_pack_names_blob(&data[pn_off..pn_off + pn_len])?;
     let (ooff_off, ooff_len) = find_chunk(&data, hdr_end, MIDX_CHUNKID_OBJECTOFFSETS)?;
@@ -702,34 +965,35 @@ pub fn write_multi_pack_index_with_options(
         indexes.push(read_pack_index(&path)?);
     }
 
-    let mut best: HashMap<ObjectId, (u32, u64)> = HashMap::new();
+    let pack_mtimes_layer: Vec<std::time::SystemTime> =
+        indexes.iter().map(pack_mtime_for_midx).collect();
+    let preferred_u32 = preferred_idx.map(|p| p as u32);
+
+    let mut best: HashMap<ObjectId, MidxEntry> = HashMap::new();
     for (pack_id, idx) in indexes.iter().enumerate() {
         let pack_id = u32::try_from(pack_id).map_err(|_| {
             Error::CorruptObject("too many pack files for multi-pack-index".to_owned())
         })?;
+        let mtime = pack_mtimes_layer[pack_id as usize];
         for e in &idx.entries {
             if opts.incremental && base_oids.contains(&e.oid) {
                 continue;
             }
-            let replace = match best.get(&e.oid) {
-                None => true,
-                Some((old_pack, _)) => match preferred_idx {
-                    Some(pref) => {
-                        let old_pref = (*old_pack as usize) == pref;
-                        let new_pref = (pack_id as usize) == pref;
-                        if new_pref && !old_pref {
-                            true
-                        } else if old_pref && !new_pref {
-                            false
-                        } else {
-                            pack_id > *old_pack
-                        }
-                    }
-                    None => pack_id > *old_pack,
-                },
+            let cand = MidxEntry {
+                oid: e.oid,
+                pack_id,
+                offset: e.offset,
+                pack_mtime: mtime,
             };
-            if replace {
-                best.insert(e.oid, (pack_id, e.offset));
+            match best.get(&e.oid) {
+                None => {
+                    best.insert(e.oid, cand);
+                }
+                Some(cur) => {
+                    if midx_pick_better_entry(cur, pack_id, e.offset, mtime, preferred_u32) {
+                        best.insert(e.oid, cand);
+                    }
+                }
             }
         }
     }

--- a/grit-lib/src/odb.rs
+++ b/grit-lib/src/odb.rs
@@ -27,7 +27,9 @@ use flate2::write::ZlibEncoder;
 use flate2::Compression;
 use sha1::{Digest, Sha1};
 
+use crate::config::ConfigSet;
 use crate::error::{Error, Result};
+use crate::midx::{midx_oid_listed_in_tip, try_read_object_via_midx};
 use crate::objects::{Object, ObjectId, ObjectKind};
 use crate::pack;
 
@@ -62,6 +64,8 @@ pub struct Odb {
     objects_dir: PathBuf,
     /// Work tree root for resolving relative alternate env paths.
     work_tree: Option<PathBuf>,
+    /// When set, used to read `core.multiPackIndex` (and related) for MIDX-backed object reads.
+    config_git_dir: Option<PathBuf>,
 }
 
 impl Odb {
@@ -74,6 +78,7 @@ impl Odb {
         Self {
             objects_dir: objects_dir.to_path_buf(),
             work_tree: None,
+            config_git_dir: None,
         }
     }
 
@@ -83,6 +88,26 @@ impl Odb {
         Self {
             objects_dir: objects_dir.to_path_buf(),
             work_tree: Some(work_tree.to_path_buf()),
+            config_git_dir: None,
+        }
+    }
+
+    /// Attach a git directory so [`Self::read`] can honor `core.multiPackIndex` when resolving packed objects.
+    #[must_use]
+    pub fn with_config_git_dir(mut self, git_dir: PathBuf) -> Self {
+        self.config_git_dir = Some(git_dir);
+        self
+    }
+
+    fn core_multi_pack_index_enabled(&self) -> bool {
+        let Some(git_dir) = &self.config_git_dir else {
+            return false;
+        };
+        let cfg = ConfigSet::load(Some(git_dir), true).unwrap_or_default();
+        match cfg.get_bool("core.multiPackIndex") {
+            Some(Ok(b)) => b,
+            Some(Err(_)) => true,
+            None => true,
         }
     }
 
@@ -161,6 +186,16 @@ impl Odb {
                 if idx.entries.iter().any(|e| e.oid == *oid) {
                     return true;
                 }
+            }
+        }
+        if objects_dir == self.objects_dir.as_path()
+            && self.config_git_dir.is_some()
+            && self.core_multi_pack_index_enabled()
+        {
+            match midx_oid_listed_in_tip(objects_dir, oid) {
+                Ok(Some(true)) => return true,
+                Ok(Some(false)) | Ok(None) => {}
+                Err(_) => return false,
             }
         }
         false
@@ -261,15 +296,21 @@ impl Odb {
             }
         }
 
+        if self.config_git_dir.is_some() && self.core_multi_pack_index_enabled() {
+            if let Some(obj) = try_read_object_via_midx(&self.objects_dir, oid)? { return Ok(obj) }
+        }
+
         // Fall back to pack files.
         if let Ok(obj) = pack::read_object_from_packs(&self.objects_dir, oid) {
             return Ok(obj);
         }
 
+        let midx_alt = self.config_git_dir.is_some() && self.core_multi_pack_index_enabled();
+
         // Check alternates from info/alternates file.
         if let Ok(alts) = pack::read_alternates_recursive(&self.objects_dir) {
             for alt_dir in &alts {
-                if let Ok(obj) = Self::read_from_dir(alt_dir, oid) {
+                if let Ok(obj) = Self::read_from_dir(alt_dir, oid, midx_alt) {
                     return Ok(obj);
                 }
             }
@@ -277,7 +318,7 @@ impl Odb {
 
         // Check GIT_ALTERNATE_OBJECT_DIRECTORIES env var.
         for alt_dir in env_alternate_dirs(self.work_tree.as_deref()) {
-            if let Ok(obj) = Self::read_from_dir(&alt_dir, oid) {
+            if let Ok(obj) = Self::read_from_dir(&alt_dir, oid, midx_alt) {
                 return Ok(obj);
             }
         }
@@ -286,13 +327,18 @@ impl Odb {
     }
 
     /// Try to read an object from a specific objects directory (loose or pack).
-    fn read_from_dir(objects_dir: &Path, oid: &ObjectId) -> Result<Object> {
+    fn read_from_dir(objects_dir: &Path, oid: &ObjectId, use_midx: bool) -> Result<Object> {
         let loose = objects_dir
             .join(oid.loose_prefix())
             .join(oid.loose_suffix());
         if let Ok(file) = fs::File::open(&loose) {
             let raw = read_zlib_loose_payload(file)?;
             return parse_object_bytes(&raw);
+        }
+        if use_midx {
+            if let Some(obj) = try_read_object_via_midx(objects_dir, oid)? {
+                return Ok(obj);
+            }
         }
         pack::read_object_from_packs(objects_dir, oid)
     }

--- a/grit-lib/src/pack.rs
+++ b/grit-lib/src/pack.rs
@@ -279,13 +279,76 @@ pub fn collect_local_pack_info(objects_dir: &Path) -> Result<LocalPackInfo> {
     Ok(info)
 }
 
-/// Parse a version-2 pack index file.
-///
-/// # Errors
-///
-/// Returns [`Error::CorruptObject`] when format checks fail.
-pub fn read_pack_index(idx_path: &Path) -> Result<PackIndex> {
-    let bytes = fs::read(idx_path).map_err(Error::Io)?;
+fn verify_idx_trailing_checksum(idx_path: &Path, bytes: &[u8]) -> Result<()> {
+    if bytes.len() < 20 {
+        return Err(Error::CorruptObject(format!(
+            "index file {} missing checksum",
+            idx_path.display()
+        )));
+    }
+    let idx_body_end = bytes.len() - 20;
+    let mut h = Sha1::new();
+    h.update(&bytes[..idx_body_end]);
+    let digest = h.finalize();
+    if digest.as_slice() != &bytes[idx_body_end..] {
+        return Err(Error::CorruptObject(format!(
+            "index checksum mismatch for {}",
+            idx_path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn read_pack_index_v1(idx_path: &Path, bytes: &[u8]) -> Result<PackIndex> {
+    let mut pos = 0usize;
+    if bytes.len() < 256 * 4 + 20 {
+        return Err(Error::CorruptObject(format!(
+            "index file {} is too small",
+            idx_path.display()
+        )));
+    }
+    let mut fanout = [0u32; 256];
+    for slot in &mut fanout {
+        *slot = read_u32_be(bytes, &mut pos)?;
+    }
+    let object_count = fanout[255] as usize;
+    let need = pos
+        .saturating_add(object_count.saturating_mul(24))
+        .saturating_add(20);
+    if bytes.len() < need {
+        return Err(Error::CorruptObject(format!(
+            "truncated idx file {}",
+            idx_path.display()
+        )));
+    }
+
+    let mut entries: Vec<PackIndexEntry> = Vec::with_capacity(object_count);
+    for i in 0..object_count {
+        let offset = read_u32_be(bytes, &mut pos)? as u64;
+        let oid = ObjectId::from_bytes(&bytes[pos..pos + 20])?;
+        pos += 20;
+        if i > 0 && entries[i - 1].oid >= oid {
+            return Err(Error::CorruptObject(format!(
+                "oid lookup out of order in {}",
+                idx_path.display()
+            )));
+        }
+        entries.push(PackIndexEntry { oid, offset });
+    }
+
+    verify_idx_trailing_checksum(idx_path, bytes)?;
+
+    let mut pack_path = idx_path.to_path_buf();
+    pack_path.set_extension("pack");
+
+    Ok(PackIndex {
+        idx_path: idx_path.to_path_buf(),
+        pack_path,
+        entries,
+    })
+}
+
+fn read_pack_index_v2(idx_path: &Path, bytes: &[u8]) -> Result<PackIndex> {
     if bytes.len() < 8 + 256 * 4 + 40 {
         return Err(Error::CorruptObject(format!(
             "index file {} is too small",
@@ -294,15 +357,8 @@ pub fn read_pack_index(idx_path: &Path) -> Result<PackIndex> {
     }
 
     let mut pos = 0usize;
-    let magic = &bytes[pos..pos + 4];
     pos += 4;
-    if magic != [0xff, b't', b'O', b'c'] {
-        return Err(Error::CorruptObject(format!(
-            "unsupported idx signature in {}",
-            idx_path.display()
-        )));
-    }
-    let version = read_u32_be(&bytes, &mut pos)?;
+    let version = read_u32_be(bytes, &mut pos)?;
     if version != 2 {
         return Err(Error::CorruptObject(format!(
             "unsupported idx version {} in {}",
@@ -313,7 +369,7 @@ pub fn read_pack_index(idx_path: &Path) -> Result<PackIndex> {
 
     let mut fanout = [0u32; 256];
     for slot in &mut fanout {
-        *slot = read_u32_be(&bytes, &mut pos)?;
+        *slot = read_u32_be(bytes, &mut pos)?;
     }
     let object_count = fanout[255] as usize;
 
@@ -336,13 +392,12 @@ pub fn read_pack_index(idx_path: &Path) -> Result<PackIndex> {
         oids.push(oid);
     }
 
-    // Skip CRC table.
     pos += object_count * 4;
 
     let mut offsets32 = Vec::with_capacity(object_count);
     let mut large_count = 0usize;
     for _ in 0..object_count {
-        let v = read_u32_be(&bytes, &mut pos)?;
+        let v = read_u32_be(bytes, &mut pos)?;
         if (v & 0x8000_0000) != 0 {
             large_count += 1;
         }
@@ -357,7 +412,7 @@ pub fn read_pack_index(idx_path: &Path) -> Result<PackIndex> {
     }
     let mut large_offsets = Vec::with_capacity(large_count);
     for _ in 0..large_count {
-        large_offsets.push(read_u64_be(&bytes, &mut pos)?);
+        large_offsets.push(read_u64_be(bytes, &mut pos)?);
     }
 
     let mut next_large = 0usize;
@@ -379,29 +434,34 @@ pub fn read_pack_index(idx_path: &Path) -> Result<PackIndex> {
     let mut pack_path = idx_path.to_path_buf();
     pack_path.set_extension("pack");
 
-    // Trailing 20 bytes are SHA-1 over all preceding index bytes (Git format).
-    if bytes.len() < 20 {
-        return Err(Error::CorruptObject(format!(
-            "index file {} missing checksum",
-            idx_path.display()
-        )));
-    }
-    let idx_body_end = bytes.len() - 20;
-    let mut h = Sha1::new();
-    h.update(&bytes[..idx_body_end]);
-    let digest = h.finalize();
-    if digest.as_slice() != &bytes[idx_body_end..] {
-        return Err(Error::CorruptObject(format!(
-            "index checksum mismatch for {}",
-            idx_path.display()
-        )));
-    }
+    verify_idx_trailing_checksum(idx_path, bytes)?;
 
     Ok(PackIndex {
         idx_path: idx_path.to_path_buf(),
         pack_path,
         entries,
     })
+}
+
+/// Parse a pack index file (version 1 legacy or version 2).
+///
+/// # Errors
+///
+/// Returns [`Error::CorruptObject`] when format checks fail.
+pub fn read_pack_index(idx_path: &Path) -> Result<PackIndex> {
+    let bytes = fs::read(idx_path).map_err(Error::Io)?;
+    if bytes.len() < 8 {
+        return Err(Error::CorruptObject(format!(
+            "index file {} is too small",
+            idx_path.display()
+        )));
+    }
+    let magic = &bytes[0..4];
+    if magic == [0xff, b't', b'O', b'c'] {
+        read_pack_index_v2(idx_path, &bytes)
+    } else {
+        read_pack_index_v1(idx_path, &bytes)
+    }
 }
 
 /// A pack object type as encoded in the packed stream header.

--- a/grit-lib/src/repo.rs
+++ b/grit-lib/src/repo.rs
@@ -108,9 +108,9 @@ impl Repository {
         };
 
         let odb = if let Some(ref wt) = work_tree {
-            Odb::with_work_tree(&objects_dir, wt)
+            Odb::with_work_tree(&objects_dir, wt).with_config_git_dir(git_dir.clone())
         } else {
-            Odb::new(&objects_dir)
+            Odb::new(&objects_dir).with_config_git_dir(git_dir.clone())
         };
 
         Ok(Self {

--- a/grit/src/commands/config.rs
+++ b/grit/src/commands/config.rs
@@ -41,8 +41,8 @@ pub struct Args {
     #[arg(long, global = true)]
     pub global: bool,
 
-    /// Run as if started in the given path (affects repo discovery for local config).
-    #[arg(short = 'C', value_name = "PATH", global = true)]
+    /// Use the given git directory (affects repo discovery for local config).
+    #[arg(long = "git-dir", value_name = "PATH", global = true)]
     pub git_dir_path: Option<PathBuf>,
 
     /// Use the repository-local config file.

--- a/logs/2026-04-10_t5319-midx-progress.md
+++ b/logs/2026-04-10_t5319-midx-progress.md
@@ -1,0 +1,22 @@
+# t5319 multi-pack-index progress
+
+## Fixes shipped
+
+- **Clap panic**: Removed duplicate global `-C` on `git config` (`git_dir_path` now uses `--git-dir` only). Debug builds were panicking on every `grit` invocation.
+- **Pack index v1**: `read_pack_index` now parses legacy v1 `.idx` (required for `pack-objects --index-version=1` in t5319).
+- **MIDX write**: Include all `*.idx` under `pack/` (not only `pack-*.idx`); duplicate resolution matches Git (preferred pack, then newer mtime, then lower pack id); emit **LOFF** when offsets need the high bit; pad PNAM/BTMP per 4-byte alignment.
+- **MIDX read path**: `try_read_object_via_midx` + `midx_oid_listed_in_tip`; `Odb` attaches `config_git_dir` and when `core.multiPackIndex` is true prefers MIDX for packed reads (and alternates when enabled).
+
+## Still failing (major gaps)
+
+t5319 still reports **~84/98** failures. Remaining work includes:
+
+- `multi-pack-index` CLI: `--stdin-packs`, `--preferred-pack`, `--progress` / `--no-progress`, full **verify** (checksum, chunk validation, progress messages), **expire**, **repack** (`--batch-size`, delta islands), **bitmap** / `test-tool read-midx --show-objects` / `--bitmap` BTMP semantics.
+- Error strings must match Git (`fatal: multi-pack-index …`) in many reader tests; current midx reader only covers a subset.
+- `rev-list` / `count-objects` may need explicit MIDX-aware enumeration where they bypass `Odb::read`.
+
+## Commands
+
+```bash
+cd tests && GUST_BIN=../target/debug/grit sh ./t5319-multi-pack-index.sh
+```

--- a/progress.md
+++ b/progress.md
@@ -1,17 +1,21 @@
 # Progress — Grit Test Coverage
 
-**Updated:** 2026-04-09
+**Updated:** 2026-04-10
 
 ## Counts (derived from plan.md)
 
 | Status      | Count |
 |-------------|-------|
 | Completed   |   325 |
-| In progress |     5 |
-| Remaining   |   441 |
+| In progress |     6 |
+| Remaining   |   440 |
 | **Total**   |   771 |
 
-Task lines in `PLAN.md`: 325 completed (`[x]`), 5 in progress (`[~]`), 441 remaining (`[ ]`).
+Task lines in `PLAN.md`: 325 completed (`[x]`), 6 in progress (`[~]`), 440 remaining (`[ ]`).
+
+## In progress
+
+- `t5319-multi-pack-index` (~14/98): MIDX read/write groundwork + `Odb` integration; CLI verify/expire/repack/bitmap still open (see `logs/2026-04-10_t5319-midx-progress.md`).
 
 ## Recently completed
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This branch fixes a **debug-build clap panic** that prevented `grit` from running at all (duplicate global `-C` on `git config`), adds **legacy pack index v1** parsing, improves **multi-pack-index writing** (all `*.idx` packs, Git-style duplicate resolution, LOFF chunk, alignment), and wires **MIDX-backed object reads** into `Odb` when `core.multiPackIndex` is enabled.

`t5319-multi-pack-index.sh` is **not** fully passing yet (~14/98); remaining work is mostly `multi-pack-index` subcommands (verify/expire/repack), `--stdin-packs` / `--preferred-pack`, progress flags, and bitmap/test-tool parity.

## Details

- `grit/src/commands/config.rs`: second `-C` removed; use `--git-dir` for git-dir path (Git-compatible long form).
- `grit-lib/src/pack.rs`: `read_pack_index` supports v1 and v2.
- `grit-lib/src/midx.rs`: writer + `try_read_object_via_midx` / `midx_oid_listed_in_tip`.
- `grit-lib/src/odb.rs` + `repo.rs`: optional `config_git_dir` on `Odb` for MIDX + config.

## Testing

- `cargo test -p grit-lib --lib`
- `cd tests && GUST_BIN=../target/debug/grit sh ./t5319-multi-pack-index.sh` (still many failures)

## Log

See `logs/2026-04-10_t5319-midx-progress.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32dfa7c2-3204-430a-afb0-8a96d292db0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32dfa7c2-3204-430a-afb0-8a96d292db0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

