### PR TITLE
fix: rev-list --exclude-hidden (t6021)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -779,7 +779,7 @@ commit → check it off → move on.
 - [ ] `t6040-tracking-info` ░░░░░░░░░░░░░░░░░░░░ 1/44 (43 left) — remote tracking stats
 - [ ] `t6002-rev-list-bisect` █░░░░░░░░░░░░░░░░░░░ 4/53 (49 left) — Tests git rev-list --bisect functionality
 - [ ] `t6302-for-each-ref-filter` ███░░░░░░░░░░░░░░░░░ 12/62 (50 left) — test for-each-refs usage of ref-filter APIs
-- [ ] `t6021-rev-list-exclude-hidden` ░░░░░░░░░░░░░░░░░░░░ 0/62 (62 left) — git rev-list --exclude-hidden test
+- [x] `t6021-rev-list-exclude-hidden` — git rev-list --exclude-hidden test (62/62)
 - [ ] `t6018-rev-list-glob` ██████░░░░░░░░░░░░░░ 30/95 (65 left) — rev-list/rev-parse --glob
 - [ ] `t6423-merge-rename-directories` ██░░░░░░░░░░░░░░░░░░ 11/82 (71 left) — recursive merge with directory renames
 - [ ] `t6120-describe` █████░░░░░░░░░░░░░░░ 27/105 (78 left) — test describe

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1060,7 +1060,7 @@ t6017-rev-list-stdin	t6	yes	37	11	26	false	ok	0
 t6018-rev-list-glob	t6	yes	95	30	65	false	ok	0
 t6019-rev-list-ancestry-path	t6	yes	18	5	13	false	ok	0
 t6020-bundle-misc	t6	yes	37	10	27	false	ok	0
-t6021-rev-list-exclude-hidden	t6	yes	62	1	61	false	ok	0
+t6021-rev-list-exclude-hidden	t6	yes	62	62	0	true	ok	0
 t6022-rev-list-missing	t6	yes	40	4	36	false	ok	0
 t6030-bisect-porcelain	t6	yes	96	66	30	false	ok	0
 t6040-tracking-info	t6	yes	44	35	9	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.2% of harness tests passing (35,747 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.2% of harness tests passing (35,747 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T03:59:26+00:00" class="gen-time" title="2026-04-10 03:59 UTC">2026-04-10 03:59 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.2%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,747</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.2%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,33 +241,33 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
       <div class="group-line1">
         <span class="group-id">t6</span>
         <span class="group-desc">Revision tree commands (e.g. merge-base)</span>
-        <span class="group-meta">47/105 files · 3 skipped · 1,830/2,822 tests</span>
+        <span class="group-meta">48/105 files · 3 skipped · 1,891/2,822 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.8%"></div></div>
-        <span class="group-pct pct-blue">64.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:67.0%"></div></div>
+        <span class="group-pct pct-blue">67.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t7">
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35747 of 45142 tests passing across 1405 harness files (79.2% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.2% pass rate · 35,747 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T03:59:26+00:00" class="gen-time" title="2026-04-10 03:59 UTC">2026-04-10 03:59 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,747</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.2%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -10757,14 +10757,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:27.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t6" data-tests="62" data-passed="1">
+<tr class="" data-group="t6" data-tests="62" data-passed="62" data-full-pass="1">
   <td class="mono">t6021-rev-list-exclude-hidden</td>
   <td>t6</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">62</td>
-  <td class="right">1</td>
+  <td class="right">62</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:1.6%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t6" data-tests="40" data-passed="4">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/lib.rs
+++ b/grit-lib/src/lib.rs
@@ -71,6 +71,7 @@ pub mod promisor;
 pub mod prune_packed;
 pub mod push_submodules;
 pub mod quote_path;
+pub mod ref_exclusions;
 pub mod reflog;
 pub mod refs;
 pub mod reftable;

--- a/grit-lib/src/ref_exclusions.rs
+++ b/grit-lib/src/ref_exclusions.rs
@@ -1,0 +1,204 @@
+//! Reference exclusion rules for `rev-list` / `rev-parse` (`--exclude`, `--exclude-hidden`).
+//!
+//! Mirrors Git's `ref_exclusions` / `parse_hide_refs_config` / `ref_is_hidden` in `revision.c`
+//! and `refs.c`.
+
+use crate::config::ConfigSet;
+use crate::wildmatch::{wildmatch, WM_PATHNAME};
+
+/// One `transfer.hideRefs` / `<section>.hideRefs` prefix rule (after normalization).
+#[derive(Debug, Clone)]
+struct HideRefRule {
+    /// Pattern without leading `!` or `^`.
+    pattern: String,
+    /// If true, the rule negates a previous hide (Git `!` prefix).
+    negated: bool,
+    /// If true, match against the full ref name (`^` prefix in config).
+    full_ref: bool,
+}
+
+/// Patterns that exclude refs from `--all` / glob expansion, including hidden-ref config.
+#[derive(Debug, Clone, Default)]
+pub struct RefExclusions {
+    /// `wildmatch` patterns from `--exclude=<pat>` (full ref names).
+    excluded_refs: Vec<String>,
+    /// Rules from config when `--exclude-hidden=<section>` is active.
+    hidden_rules: Vec<HideRefRule>,
+    /// Set after `--exclude-hidden=` is parsed; cleared by [`RefExclusions::clear`].
+    /// Used to reject a second `--exclude-hidden` before the next pseudo-ref clears state.
+    pub hidden_configured: bool,
+}
+
+impl RefExclusions {
+    /// Reset exclusions after `--all` / `--glob` / `--branches` / … (matches Git `clear_ref_exclusions`).
+    pub fn clear(&mut self) {
+        self.excluded_refs.clear();
+        self.hidden_rules.clear();
+        self.hidden_configured = false;
+    }
+
+    /// Append a `--exclude=<pattern>` entry (Git wildmatch on the ref name).
+    pub fn add_excluded_ref(&mut self, pattern: impl Into<String>) {
+        self.excluded_refs.push(pattern.into());
+    }
+
+    /// Load `transfer.hideRefs` and `<section>.hideRefs` into this set.
+    ///
+    /// `section` must be one of `fetch`, `receive`, or `uploadpack`.
+    pub fn load_hidden_refs_from_config(&mut self, config: &ConfigSet, section: &str) {
+        self.hidden_configured = true;
+        let section_key = format!("{section}.hiderefs");
+        for e in config.entries() {
+            if e.key == "transfer.hiderefs" || e.key == section_key {
+                if let Some(v) = e.value.as_deref() {
+                    self.hidden_rules.push(parse_hide_refs_value(v));
+                }
+            }
+        }
+    }
+
+    /// Whether this ref should be omitted from ref listing (exclude + hidden rules).
+    ///
+    /// - `stripped_name` — ref name with `GIT_NAMESPACE` prefix removed, when applicable.
+    /// - `full_name` — storage path of the ref (e.g. `refs/heads/main`).
+    pub fn ref_excluded(&self, stripped_name: Option<&str>, full_name: &str) -> bool {
+        for pat in &self.excluded_refs {
+            if wildmatch(pat.as_bytes(), full_name.as_bytes(), WM_PATHNAME) {
+                return true;
+            }
+        }
+        ref_is_hidden(stripped_name, full_name, &self.hidden_rules)
+    }
+}
+
+fn trim_trailing_slashes(mut s: String) -> String {
+    while s.ends_with('/') {
+        s.pop();
+    }
+    s
+}
+
+fn parse_hide_refs_value(raw: &str) -> HideRefRule {
+    let mut rest = raw;
+    let mut negated = false;
+    if let Some(stripped) = rest.strip_prefix('!') {
+        negated = true;
+        rest = stripped;
+    }
+    let mut full_ref = false;
+    if let Some(stripped) = rest.strip_prefix('^') {
+        full_ref = true;
+        rest = stripped;
+    }
+    HideRefRule {
+        pattern: trim_trailing_slashes(rest.to_owned()),
+        negated,
+        full_ref,
+    }
+}
+
+fn ref_is_hidden(stripped_name: Option<&str>, full_name: &str, rules: &[HideRefRule]) -> bool {
+    for rule in rules.iter().rev() {
+        let subject = if rule.full_ref {
+            full_name
+        } else {
+            match stripped_name {
+                Some(s) => s,
+                None => continue,
+            }
+        };
+        if subject.is_empty() {
+            continue;
+        }
+        let pat = rule.pattern.as_str();
+        if pat.is_empty() {
+            continue;
+        }
+        if skip_prefix_git(subject, pat)
+            .is_some_and(|tail| tail.is_empty() || tail.starts_with('/'))
+        {
+            return !rule.negated;
+        }
+    }
+    false
+}
+
+/// Git `skip_prefix` semantics: `subject` must begin with `prefix` byte-for-byte; returns the tail.
+fn skip_prefix_git<'a>(subject: &'a str, prefix: &str) -> Option<&'a str> {
+    let b = subject.as_bytes();
+    let p = prefix.as_bytes();
+    if p.is_empty() {
+        return Some(subject);
+    }
+    if b.len() < p.len() {
+        return None;
+    }
+    if &b[..p.len()] == p {
+        subject.get(p.len()..)
+    } else {
+        None
+    }
+}
+
+/// `GIT_NAMESPACE` value (e.g. `namespace` / `a/b`) expanded to the `refs/namespaces/.../`
+/// prefix, or empty string when unset.
+pub fn git_namespace_prefix() -> String {
+    let raw = std::env::var("GIT_NAMESPACE").unwrap_or_default();
+    if raw.is_empty() {
+        return String::new();
+    }
+    let mut out = String::new();
+    for comp in raw.split('/') {
+        if comp.is_empty() {
+            continue;
+        }
+        out.push_str("refs/namespaces/");
+        out.push_str(comp);
+        out.push('/');
+    }
+    while out.ends_with('/') {
+        out.pop();
+    }
+    if !out.is_empty() {
+        out.push('/');
+    }
+    out
+}
+
+/// Strip a leading namespace prefix from `refname`, returning `None` when not under the namespace.
+pub fn strip_git_namespace<'a>(refname: &'a str, namespace_prefix: &str) -> Option<&'a str> {
+    if namespace_prefix.is_empty() {
+        return Some(refname);
+    }
+    refname.strip_prefix(namespace_prefix)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hide_refs_prefix_match() {
+        let rules = vec![parse_hide_refs_value("refs/hidden/")];
+        assert!(ref_is_hidden(
+            Some("refs/hidden/foo"),
+            "refs/hidden/foo",
+            &rules
+        ));
+        assert!(!ref_is_hidden(
+            Some("refs/heads/main"),
+            "refs/heads/main",
+            &rules
+        ));
+    }
+
+    #[test]
+    fn hide_refs_negation() {
+        let rules = vec![
+            parse_hide_refs_value("refs/foo/"),
+            parse_hide_refs_value("!refs/foo/bar"),
+        ];
+        assert!(!ref_is_hidden(Some("refs/foo/bar"), "refs/foo/bar", &rules));
+        assert!(ref_is_hidden(Some("refs/foo/baz"), "refs/foo/baz", &rules));
+    }
+}

--- a/grit-lib/src/rev_list.rs
+++ b/grit-lib/src/rev_list.rs
@@ -20,6 +20,7 @@ use crate::index::Index;
 use crate::objects::{parse_commit, parse_tag, parse_tree, ObjectId, ObjectKind};
 use crate::pack;
 use crate::patch_ids::compute_patch_id;
+use crate::ref_exclusions::{git_namespace_prefix, strip_git_namespace, RefExclusions};
 use crate::reflog::{list_reflog_refs, read_reflog};
 use crate::refs;
 use crate::repo::Repository;
@@ -325,8 +326,10 @@ pub enum OrderingMode {
 /// Parsed and normalized options for rev-list traversal.
 #[derive(Debug, Clone)]
 pub struct RevListOptions {
-    /// Include all refs (`--all`) as positive tips.
+    /// Include all refs (`--all`) as positive tips (legacy single-pass; see [`Self::all_refs_passes`]).
     pub all_refs: bool,
+    /// Each `--all` in argv order: `(negated, exclusions snapshot)` — negated tips join the exclude set.
+    pub all_refs_passes: Vec<(bool, RefExclusions)>,
     /// Follow only first parent when walking merges.
     pub first_parent: bool,
     /// Enable ancestry-path filtering.
@@ -414,12 +417,15 @@ pub struct RevListOptions {
     pub commit_graph_changed_paths_version: i32,
     /// Optional trace counters for `GIT_TRACE2_PERF` Bloom statistics.
     pub bloom_stats: Option<BloomWalkStatsHandle>,
+    /// `--exclude` / `--exclude-hidden` ref filtering for `--all` and similar tips.
+    pub ref_exclusions: RefExclusions,
 }
 
 impl Default for RevListOptions {
     fn default() -> Self {
         Self {
             all_refs: false,
+            all_refs_passes: Vec::new(),
             first_parent: false,
             ancestry_path: false,
             ancestry_path_bottoms: Vec::new(),
@@ -463,6 +469,7 @@ impl Default for RevListOptions {
             commit_graph_read_changed_paths: true,
             commit_graph_changed_paths_version: -1,
             bloom_stats: None,
+            ref_exclusions: RefExclusions::default(),
         }
     }
 }
@@ -501,6 +508,26 @@ pub struct RevListResult {
     pub bitmap_object_format: bool,
 }
 
+fn empty_rev_list_result(options: &RevListOptions) -> RevListResult {
+    let bitmap_object_format = options.objects
+        && options.use_bitmap_index
+        && (options.bitmap_oid_only_objects || options.unpacked_only);
+    RevListResult {
+        commits: Vec::new(),
+        objects: Vec::new(),
+        omitted_objects: Vec::new(),
+        missing_objects: Vec::new(),
+        boundary_commits: Vec::new(),
+        left_right_map: HashMap::new(),
+        cherry_equivalent: HashSet::new(),
+        per_commit_object_counts: Vec::new(),
+        object_walk_tips: Vec::new(),
+        objects_print_commit: Vec::new(),
+        object_segments: Vec::new(),
+        bitmap_object_format,
+    }
+}
+
 /// Resolve and walk revisions for the requested options.
 ///
 /// # Parameters
@@ -527,10 +554,19 @@ pub fn rev_list(
     } else {
         (resolve_specs(repo, positive_specs)?, Vec::new())
     };
-    let exclude = resolve_specs(repo, negative_specs)?;
+    let mut exclude = resolve_specs(repo, negative_specs)?;
 
-    if options.all_refs {
-        include.extend(all_ref_tips(repo)?);
+    if !options.all_refs_passes.is_empty() {
+        for (negated, snap) in &options.all_refs_passes {
+            let tips = all_ref_tips(repo, snap)?;
+            if *negated {
+                exclude.extend(tips);
+            } else {
+                include.extend(tips);
+            }
+        }
+    } else if options.all_refs {
+        include.extend(all_ref_tips(repo, &options.ref_exclusions)?);
     }
 
     if options.objects && options.include_reflog_entries {
@@ -565,7 +601,10 @@ pub fn rev_list(
         merged
     };
 
-    if include.is_empty() && object_roots.is_empty() {
+    if include.is_empty() && object_roots.is_empty() && exclude.is_empty() {
+        if !options.all_refs_passes.is_empty() {
+            return Ok(empty_rev_list_result(options));
+        }
         return Err(Error::InvalidRef("no revisions specified".to_owned()));
     }
 
@@ -588,7 +627,7 @@ pub fn rev_list(
     included.retain(|oid| !excluded.contains(oid));
 
     if options.simplify_by_decoration {
-        let decorated = all_ref_tips(repo)?;
+        let decorated = all_ref_tips(repo, &RefExclusions::default())?;
         included.retain(|oid| decorated.contains(oid));
     }
 
@@ -2151,28 +2190,52 @@ fn reflog_commit_tips(repo: &Repository) -> Result<Vec<ObjectId>> {
     Ok(out)
 }
 
-fn all_ref_tips(repo: &Repository) -> Result<Vec<ObjectId>> {
+fn commit_tips_from_ref_pairs(
+    repo: &Repository,
+    pairs: &[(String, ObjectId)],
+    exclusions: &RefExclusions,
+) -> Result<Vec<ObjectId>> {
+    let namespace_prefix = git_namespace_prefix();
     let mut raw = Vec::new();
-    if let Ok(head) = refs::resolve_ref(&repo.git_dir, "HEAD") {
-        raw.push(head);
+    for (refname, oid) in pairs {
+        if exclusions.ref_excluded(strip_git_namespace(refname, &namespace_prefix), refname) {
+            continue;
+        }
+        raw.push(*oid);
     }
-    raw.extend(
-        refs::list_refs(&repo.git_dir, "refs/")?
-            .into_iter()
-            .map(|(_, oid)| oid),
-    );
-    // Peel tags to commits; skip non-commit objects (e.g. tags of blobs/trees)
+    peel_ref_oids_to_unique_commits(repo, raw)
+}
+
+fn peel_ref_oids_to_unique_commits(repo: &Repository, raw: Vec<ObjectId>) -> Result<Vec<ObjectId>> {
     let mut out = Vec::new();
     let mut seen = HashSet::new();
     for oid in raw {
         match peel_to_commit(repo, oid) {
             Ok(commit_oid) if seen.insert(commit_oid) => out.push(commit_oid),
-            Err(_) => {} // skip non-commit refs
+            Err(_) => {}
             _ => {}
         }
     }
     out.sort();
     Ok(out)
+}
+
+fn all_ref_tips(repo: &Repository, exclusions: &RefExclusions) -> Result<Vec<ObjectId>> {
+    let mut pairs = Vec::new();
+    if let Ok(head) = refs::resolve_ref(&repo.git_dir, "HEAD") {
+        pairs.push(("HEAD".to_owned(), head));
+    }
+    pairs.extend(refs::list_refs(&repo.git_dir, "refs/")?);
+    commit_tips_from_ref_pairs(repo, &pairs, exclusions)
+}
+
+/// Expand named refs to peeled unique commit tips, applying `--exclude` / `--exclude-hidden` rules.
+pub fn commit_tips_from_named_refs(
+    repo: &Repository,
+    pairs: &[(String, ObjectId)],
+    exclusions: &RefExclusions,
+) -> Result<Vec<ObjectId>> {
+    commit_tips_from_ref_pairs(repo, pairs, exclusions)
 }
 
 fn walk_closure(graph: &mut CommitGraph<'_>, starts: &[ObjectId]) -> Result<HashSet<ObjectId>> {

--- a/grit/src/commands/rev_list.rs
+++ b/grit/src/commands/rev_list.rs
@@ -1,17 +1,20 @@
 //! `grit rev-list` command.
 
+use crate::explicit_exit::ExplicitExit;
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::config::ConfigSet;
+use grit_lib::error::Error as LibError;
 use grit_lib::git_date::parse::parse_date_basic;
 use grit_lib::objects::{parse_commit, parse_tree, ObjectId};
 use grit_lib::pack;
 use grit_lib::promisor::read_promisor_missing_oids;
+use grit_lib::ref_exclusions::RefExclusions;
 use grit_lib::repo::Repository;
 use grit_lib::rev_list::{
-    collect_revision_specs_with_stdin, is_symmetric_diff, merge_bases, render_commit,
-    render_commit_with_color, rev_list, split_symmetric_diff, tag_targets, FilterObjectKind,
-    MissingAction, ObjectFilter, OrderingMode, OutputMode, RevListOptions,
+    collect_revision_specs_with_stdin, commit_tips_from_named_refs, is_symmetric_diff, merge_bases,
+    render_commit, render_commit_with_color, rev_list, split_symmetric_diff, tag_targets,
+    FilterObjectKind, MissingAction, ObjectFilter, OrderingMode, OutputMode, RevListOptions,
 };
 use std::collections::{HashMap, HashSet};
 use std::io::Write;
@@ -54,6 +57,18 @@ fn resolve_max_tree_depth(config: &ConfigSet) -> Result<usize> {
         DEFAULT_MAX_TREE_DEPTH
     };
     Ok(depth)
+}
+
+fn reject_exclude_hidden_with_pseudo_ref(hidden: bool, other: &str) -> Result<()> {
+    if hidden {
+        return Err(anyhow::Error::new(ExplicitExit {
+            code: 129,
+            message: format!(
+                "error: options '--exclude-hidden' and '{other}' cannot be used together"
+            ),
+        }));
+    }
+    Ok(())
 }
 
 fn filter_mentions_tree_depth(f: &ObjectFilter) -> bool {
@@ -100,6 +115,8 @@ pub fn run(args: Args) -> Result<()> {
     let mut use_bitmap_index = false;
     let mut unpacked_only = false;
     let mut test_bitmap = false;
+    let mut ref_exclusions = RefExclusions::default();
+    let mut all_refs_passes: Vec<(bool, RefExclusions)> = Vec::new();
 
     let mut i = 0usize;
     while i < args.args.len() {
@@ -117,7 +134,10 @@ pub fn run(args: Args) -> Result<()> {
         }
         if !end_of_options && arg.starts_with('-') {
             match arg.as_str() {
-                "--all" => options.all_refs = true,
+                "--all" => {
+                    all_refs_passes.push((not_mode, ref_exclusions.clone()));
+                    ref_exclusions.clear();
+                }
                 "--first-parent" => options.first_parent = true,
                 "--ancestry-path" => options.ancestry_path = true,
                 "--simplify-by-decoration" => options.simplify_by_decoration = true,
@@ -247,68 +267,115 @@ pub fn run(args: Args) -> Result<()> {
                     let pattern = arg.trim_start_matches("--glob=");
                     let matching = grit_lib::refs::list_refs_glob(&repo.git_dir, pattern)
                         .context("failed to list glob refs")?;
-                    for (_, oid) in matching {
+                    let tips = commit_tips_from_named_refs(&repo, &matching, &ref_exclusions)
+                        .context("failed to expand glob refs")?;
+                    for oid in tips {
                         revision_specs.push(oid.to_hex());
                     }
+                    ref_exclusions.clear();
                 }
                 "--glob" => {
-                    // Detached option: next arg is the pattern.
                     i += 1;
                     if let Some(next) = args.args.get(i) {
                         let matching = grit_lib::refs::list_refs_glob(&repo.git_dir, next)
                             .context("failed to list glob refs")?;
-                        for (_, oid) in matching {
+                        let tips = commit_tips_from_named_refs(&repo, &matching, &ref_exclusions)
+                            .context("failed to expand glob refs")?;
+                        for oid in tips {
                             revision_specs.push(oid.to_hex());
                         }
                     }
+                    ref_exclusions.clear();
                 }
                 "--branches" => {
+                    reject_exclude_hidden_with_pseudo_ref(
+                        ref_exclusions.hidden_configured,
+                        "--branches",
+                    )?;
                     let matching = grit_lib::refs::list_refs(&repo.git_dir, "refs/heads/")
                         .context("failed to list branch refs")?;
-                    for (_, oid) in matching {
+                    let tips = commit_tips_from_named_refs(&repo, &matching, &ref_exclusions)
+                        .context("failed to expand branch refs")?;
+                    for oid in tips {
                         revision_specs.push(oid.to_hex());
                     }
+                    ref_exclusions.clear();
                 }
                 _ if arg.starts_with("--branches=") => {
+                    reject_exclude_hidden_with_pseudo_ref(
+                        ref_exclusions.hidden_configured,
+                        "--branches",
+                    )?;
                     let pattern = arg.trim_start_matches("--branches=");
                     let full_pattern = format!("refs/heads/{pattern}");
                     let matching = grit_lib::refs::list_refs_glob(&repo.git_dir, &full_pattern)
                         .context("failed to list branch refs")?;
-                    for (_, oid) in matching {
+                    let tips = commit_tips_from_named_refs(&repo, &matching, &ref_exclusions)
+                        .context("failed to expand branch refs")?;
+                    for oid in tips {
                         revision_specs.push(oid.to_hex());
                     }
+                    ref_exclusions.clear();
                 }
                 "--tags" => {
+                    reject_exclude_hidden_with_pseudo_ref(
+                        ref_exclusions.hidden_configured,
+                        "--tags",
+                    )?;
                     let matching = grit_lib::refs::list_refs(&repo.git_dir, "refs/tags/")
                         .context("failed to list tag refs")?;
-                    for (_, oid) in matching {
+                    let tips = commit_tips_from_named_refs(&repo, &matching, &ref_exclusions)
+                        .context("failed to expand tag refs")?;
+                    for oid in tips {
                         revision_specs.push(oid.to_hex());
                     }
+                    ref_exclusions.clear();
                 }
                 _ if arg.starts_with("--tags=") => {
+                    reject_exclude_hidden_with_pseudo_ref(
+                        ref_exclusions.hidden_configured,
+                        "--tags",
+                    )?;
                     let pattern = arg.trim_start_matches("--tags=");
                     let full_pattern = format!("refs/tags/{pattern}");
                     let matching = grit_lib::refs::list_refs_glob(&repo.git_dir, &full_pattern)
                         .context("failed to list tag refs")?;
-                    for (_, oid) in matching {
+                    let tips = commit_tips_from_named_refs(&repo, &matching, &ref_exclusions)
+                        .context("failed to expand tag refs")?;
+                    for oid in tips {
                         revision_specs.push(oid.to_hex());
                     }
+                    ref_exclusions.clear();
                 }
                 "--remotes" => {
+                    reject_exclude_hidden_with_pseudo_ref(
+                        ref_exclusions.hidden_configured,
+                        "--remotes",
+                    )?;
                     let matching = grit_lib::refs::list_refs(&repo.git_dir, "refs/remotes/")
                         .context("failed to list remote refs")?;
-                    for (_, oid) in matching {
+                    let tips = commit_tips_from_named_refs(&repo, &matching, &ref_exclusions)
+                        .context("failed to expand remote refs")?;
+                    for oid in tips {
                         revision_specs.push(oid.to_hex());
                     }
+                    ref_exclusions.clear();
                 }
                 _ if arg.starts_with("--remotes=") => {
+                    reject_exclude_hidden_with_pseudo_ref(
+                        ref_exclusions.hidden_configured,
+                        "--remotes",
+                    )?;
                     let pattern = arg.trim_start_matches("--remotes=");
                     let full_pattern = format!("refs/remotes/{pattern}");
                     let matching = grit_lib::refs::list_refs_glob(&repo.git_dir, &full_pattern)
                         .context("failed to list remote refs")?;
-                    for (_, oid) in matching {
+                    let tips = commit_tips_from_named_refs(&repo, &matching, &ref_exclusions)
+                        .context("failed to expand remote refs")?;
+                    for oid in tips {
                         revision_specs.push(oid.to_hex());
                     }
+                    ref_exclusions.clear();
                 }
                 "--alternate-refs" => {
                     // List refs from alternate object directories
@@ -436,6 +503,35 @@ pub fn run(args: Args) -> Result<()> {
                     let val = arg.split_once('=').map(|(_, v)| v).unwrap_or_default();
                     options.since_cutoff = Some(parse_rev_list_date(val)?);
                 }
+                _ if arg.starts_with("--exclude=") => {
+                    let pat = arg.trim_start_matches("--exclude=");
+                    ref_exclusions.add_excluded_ref(pat);
+                }
+                "--exclude" => {
+                    i += 1;
+                    let Some(pat) = args.args.get(i) else {
+                        bail!("--exclude requires a value");
+                    };
+                    ref_exclusions.add_excluded_ref(pat.clone());
+                }
+                _ if arg.starts_with("--exclude-hidden=") => {
+                    let section = arg.trim_start_matches("--exclude-hidden=");
+                    if ref_exclusions.hidden_configured {
+                        return Err(anyhow::Error::new(LibError::Message(
+                            "fatal: --exclude-hidden= passed more than once".to_owned(),
+                        )));
+                    }
+                    match section {
+                        "fetch" | "receive" | "uploadpack" => {
+                            ref_exclusions.load_hidden_refs_from_config(&config, section);
+                        }
+                        other => {
+                            return Err(anyhow::Error::new(LibError::Message(format!(
+                                "fatal: unsupported section for hidden refs: {other}"
+                            ))));
+                        }
+                    }
+                }
                 _ => bail!("unsupported option: {arg}"),
             }
             i += 1;
@@ -492,7 +588,11 @@ pub fn run(args: Args) -> Result<()> {
     }
 
     if options.paths.is_empty() {
-        let keep_at_least = if options.all_refs { 0 } else { 1 };
+        let keep_at_least = if !options.all_refs_passes.is_empty() || options.all_refs {
+            0
+        } else {
+            1
+        };
         let (revs, trailing_paths) =
             split_trailing_pathspecs(&repo, &revision_specs, keep_at_least);
         revision_specs = revs;
@@ -555,8 +655,11 @@ pub fn run(args: Args) -> Result<()> {
         collect_revision_specs_with_stdin(&processed_specs, read_stdin)
             .context("failed to parse revision arguments")?;
     if stdin_all_refs {
-        options.all_refs = true;
+        all_refs_passes.push((not_mode, ref_exclusions.clone()));
     }
+
+    options.ref_exclusions = ref_exclusions;
+    options.all_refs_passes = all_refs_passes;
 
     // If symmetric diff, resolve merge bases and set up positive/negative
     if let (Some(ref lhs), Some(ref rhs)) = (&symmetric_left, &symmetric_right) {

--- a/logs/2026-04-10-rev-list-exclude-hidden.md
+++ b/logs/2026-04-10-rev-list-exclude-hidden.md
@@ -1,0 +1,17 @@
+# t6021 rev-list --exclude-hidden
+
+## Goal
+
+Make `tests/t6021-rev-list-exclude-hidden.sh` pass (Git parity for `rev-list --exclude-hidden`).
+
+## Changes
+
+- Added `grit-lib::ref_exclusions`: `transfer.hideRefs` + `<section>.hideRefs` parsing (canonical `hiderefs` keys), Git-style `ref_is_hidden` prefix rules (`!`, `^`), `GIT_NAMESPACE` → `refs/namespaces/.../` prefix for stripped matching.
+- `RevListOptions`: `ref_exclusions`, `all_refs_passes: Vec<(bool, RefExclusions)>` so each `--all` records current `--not` mode and exclusion snapshot (matches Git argument order).
+- `rev_list`: merge tips from passes into include vs exclude; allow empty result when `--all` yields no tips after hiding; `commit_tips_from_named_refs` for `--glob` / pseudo-refs.
+- `grit rev-list`: `--exclude`, `--exclude-hidden`, conflict errors with pseudo-refs (exit 129), fatal messages via `LibError::Message` for verbatim stderr.
+
+## Validation
+
+- `./scripts/run-tests.sh t6021-rev-list-exclude-hidden.sh` — 62/62
+- `cargo test -p grit-lib --lib`

--- a/progress.md
+++ b/progress.md
@@ -1,20 +1,21 @@
 # Progress — Grit Test Coverage
 
-**Updated:** 2026-04-09
+**Updated:** 2026-04-10
 
 ## Counts (derived from plan.md)
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   325 |
+| Completed   |   326 |
 | In progress |     5 |
-| Remaining   |   441 |
+| Remaining   |   440 |
 | **Total**   |   771 |
 
-Task lines in `PLAN.md`: 325 completed (`[x]`), 5 in progress (`[~]`), 441 remaining (`[ ]`).
+Task lines in `PLAN.md`: 326 completed (`[x]`), 5 in progress (`[~]`), 440 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t6021-rev-list-exclude-hidden` — 62/62 tests pass (`rev-list`: `--exclude-hidden` + `transfer.hideRefs` / section `hideRefs`, `--exclude` wildmatch, `GIT_NAMESPACE` strip vs `^` full-name rules, per-`--all` exclusion snapshots and `--not` ordering, conflict with `--branches`/`--tags`/`--remotes`, empty walk when all refs hidden)
 - `t3309-notes-merge-auto-resolve` — 31/31 tests pass (`notes merge`: `union` / `cat_sort_uniq` blob combine like Git; successful merge commits use two parents; `notes.mergeStrategy` config errors match upstream expectations)
 - `t4063-diff-blobs` — 18/18 tests pass (`diff`: blob↔blob and `rev:path` pairs without treating blobs as trees; `HEAD:one..HEAD:two` range split; `rev:path` vs worktree file uses tree path + modes + `write_patch_with_prefix`; raw blob OID vs existing file uses filename as old path; `rev_parse::resolve_treeish_blob_at_path` for tree walks)
 - `t5524-pull-msg` — 3/3 tests pass (`git pull --no-rebase --log` merge message preserves `$` in subject lines; `--log=1` limits shortlog; harness CSV/dashboards refreshed; `PLAN.md` marked complete)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible `git rev-list --exclude-hidden` and related ref exclusion behavior so `t6021-rev-list-exclude-hidden` passes (62/62).

## Details

- New `grit_lib::ref_exclusions`: reads `transfer.hideRefs` and `<fetch|receive|uploadpack>.hideRefs` from merged config, applies Git-style prefix rules (`!`, `^`), and matches `--exclude` patterns with `wildmatch` + `WM_PATHNAME`.
- `GIT_NAMESPACE` expands to `refs/namespaces/.../` for stripped-name matching vs full ref names for `^` rules.
- `rev-list` records each `--all` as a snapshot of the current ref-exclusion state and whether `--not` is active, so ordering like `--all --exclude-hidden … --not --all` matches Git.
- Pseudo-refs (`--glob`, `--branches`, `--tags`, `--remotes`) apply exclusions then clear state; `--exclude-hidden` with those pseudo-refs errors with exit 129.
- Empty traversal when every ref is hidden (e.g. double `--all` with `hideRefs=refs/`) returns success with no output.

## Validation

- `./scripts/run-tests.sh t6021-rev-list-exclude-hidden.sh`
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d04709d-6c7a-4cf3-8429-b1723016fc3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d04709d-6c7a-4cf3-8429-b1723016fc3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

