### PR TITLE
fix: make t1308-config-set fully pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -366,7 +366,7 @@ t1306-xdg-files	t1	yes	21	20	1	false	ok	0
 t13060-cherry-pick-mainline	t1	yes	31	31	0	true	ok	0
 t1307-config-blob	t1	yes	13	12	1	false	ok	0
 t13070-for-each-ref-points-at	t1	yes	32	32	0	true	ok	0
-t1308-config-set	t1	yes	39	12	27	false	ok	0
+t1308-config-set	t1	yes	39	39	0	true	ok	0
 t13080-show-ref-loose-packed	t1	yes	31	31	0	true	ok	0
 t1309-early-config	t1	yes	10	10	0	true	ok	0
 t1310-config-default	t1	yes	5	5	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,713 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,713 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T04:03:32+00:00" class="gen-time" title="2026-04-10 04:03 UTC">2026-04-10 04:03 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,713</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -197,11 +197,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">275/368 files · 8 skipped · 11,694/12,747 tests</span>
+        <span class="group-meta">276/368 files · 8 skipped · 11,721/12,747 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:91.7%"></div></div>
-        <span class="group-pct pct-green">91.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:92.0%"></div></div>
+        <span class="group-pct pct-green">92.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t2">
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35713 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,713 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T04:03:32+00:00" class="gen-time" title="2026-04-10 04:03 UTC">2026-04-10 04:03 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,713</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -3817,14 +3817,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="39" data-passed="12">
+<tr class="" data-group="t1" data-tests="39" data-passed="39" data-full-pass="1">
   <td class="mono">t1308-config-set</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">39</td>
-  <td class="right">12</td>
+  <td class="right">39</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:30.8%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="31" data-passed="31" data-full-pass="1">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/config.rs
+++ b/grit-lib/src/config.rs
@@ -226,6 +226,12 @@ pub fn canonical_key(raw: &str) -> Result<String> {
 
 // ── Parser ──────────────────────────────────────────────────────────
 
+/// Display path for config diagnostics (matches [`config_error_path_display`] for public callers).
+#[must_use]
+pub fn config_file_display_for_error(path: &Path) -> String {
+    config_error_path_display(path)
+}
+
 fn config_error_path_display(path: &Path) -> String {
     if path.file_name().and_then(|s| s.to_str()) == Some("config")
         && path
@@ -644,6 +650,14 @@ fatal: bad config variable 'fetch.negotiationalgorithm' in file '{file_disp}' at
                     file: Some(path.to_path_buf()),
                     line: start_idx + 1,
                 });
+            } else if logical_line.trim().is_empty() {
+                continue;
+            } else {
+                let file_disp = config_error_path_display(path);
+                return Err(Error::Message(format!(
+                    "fatal: bad config line {} in file {file_disp}",
+                    start_idx + 1
+                )));
             }
         }
 
@@ -674,6 +688,7 @@ fatal: bad config variable 'fetch.negotiationalgorithm' in file '{file_disp}' at
     /// headers, matching how Git injects command-line configuration.
     pub fn from_git_config_parameters(path: &Path, raw: &str) -> Result<Self> {
         let mut entries = Vec::new();
+        let pseudo_path = path.to_path_buf();
         for entry in parse_config_parameters(raw) {
             if let Some((key, val)) = entry.split_once('=') {
                 let canon = canonical_key(key.trim())?;
@@ -681,7 +696,7 @@ fatal: bad config variable 'fetch.negotiationalgorithm' in file '{file_disp}' at
                     key: canon,
                     value: Some(val.to_owned()),
                     scope: ConfigScope::Command,
-                    file: None,
+                    file: Some(pseudo_path.clone()),
                     line: 0,
                 });
             } else {
@@ -690,7 +705,7 @@ fatal: bad config variable 'fetch.negotiationalgorithm' in file '{file_disp}' at
                     key: canon,
                     value: None,
                     scope: ConfigScope::Command,
-                    file: None,
+                    file: Some(pseudo_path.clone()),
                     line: 0,
                 });
             }
@@ -1420,6 +1435,22 @@ impl ConfigSet {
             .collect()
     }
 
+    /// All raw values for a key in load order, preserving `None` for bare boolean keys.
+    ///
+    /// Matches Git's multi-value list where `NULL` means a value-less / boolean-true key.
+    #[must_use]
+    pub fn get_all_raw(&self, key: &str) -> Vec<Option<String>> {
+        let canon = match canonical_key(key) {
+            Ok(c) => c,
+            Err(_) => return Vec::new(),
+        };
+        self.entries
+            .iter()
+            .filter(|e| e.key == canon)
+            .map(|e| e.value.clone())
+            .collect()
+    }
+
     /// Get a boolean value, interpreting `true`/`yes`/`on`/`1` as true and
     /// `false`/`no`/`off`/`0` as false.
     pub fn get_bool(&self, key: &str) -> Option<std::result::Result<bool, String>> {
@@ -1506,40 +1537,52 @@ impl ConfigSet {
             let system_path = std::env::var("GIT_CONFIG_SYSTEM")
                 .map(std::path::PathBuf::from)
                 .unwrap_or_else(|_| std::path::PathBuf::from("/etc/gitconfig"));
-            if let Ok(Some(f)) = ConfigFile::from_path(&system_path, ConfigScope::System) {
-                Self::merge_with_includes(&mut set, &f, proc, 0, &ctx)?;
+            match ConfigFile::from_path(&system_path, ConfigScope::System) {
+                Ok(Some(f)) => Self::merge_with_includes(&mut set, &f, proc, 0, &ctx)?,
+                Ok(None) => {}
+                Err(e) => return Err(e),
             }
         }
 
         // Global config (Git merges every existing file: XDG then ~/.gitconfig).
         for path in global_config_paths() {
-            if let Ok(Some(f)) = ConfigFile::from_path(&path, ConfigScope::Global) {
-                Self::merge_with_includes(&mut set, &f, proc, 0, &ctx)?;
+            match ConfigFile::from_path(&path, ConfigScope::Global) {
+                Ok(Some(f)) => Self::merge_with_includes(&mut set, &f, proc, 0, &ctx)?,
+                Ok(None) => {}
+                Err(e) => return Err(e),
             }
         }
 
         // Local config
         if let Some(gd) = git_dir {
             let local_path = gd.join("config");
-            if let Ok(Some(f)) = ConfigFile::from_path(&local_path, ConfigScope::Local) {
-                Self::merge_with_includes(&mut set, &f, proc, 0, &ctx)?;
+            match ConfigFile::from_path(&local_path, ConfigScope::Local) {
+                Ok(Some(f)) => Self::merge_with_includes(&mut set, &f, proc, 0, &ctx)?,
+                Ok(None) => {}
+                Err(e) => return Err(e),
             }
 
             // Worktree config
             let wt_path = gd.join("config.worktree");
-            if let Ok(Some(f)) = ConfigFile::from_path(&wt_path, ConfigScope::Worktree) {
-                Self::merge_with_includes(&mut set, &f, proc, 0, &ctx)?;
+            match ConfigFile::from_path(&wt_path, ConfigScope::Worktree) {
+                Ok(Some(f)) => Self::merge_with_includes(&mut set, &f, proc, 0, &ctx)?,
+                Ok(None) => {}
+                Err(e) => return Err(e),
             }
         }
 
         // Environment overrides: optional file
         if let Ok(path) = std::env::var("GIT_CONFIG") {
-            if let Ok(Some(f)) = ConfigFile::from_path(Path::new(&path), ConfigScope::Command) {
-                if proc {
-                    Self::merge_with_includes(&mut set, &f, proc, 0, &ctx)?;
-                } else {
-                    set.merge(&f);
+            match ConfigFile::from_path(Path::new(&path), ConfigScope::Command) {
+                Ok(Some(f)) => {
+                    if proc {
+                        Self::merge_with_includes(&mut set, &f, proc, 0, &ctx)?;
+                    } else {
+                        set.merge(&f);
+                    }
                 }
+                Ok(None) => {}
+                Err(e) => return Err(e),
             }
         }
 

--- a/grit/src/alias.rs
+++ b/grit/src/alias.rs
@@ -42,7 +42,14 @@ pub(crate) fn lookup_alias(name: &str, config: &ConfigSet) -> Result<Option<Stri
     for k in keys {
         if let Some(e) = last_alias_entry(config, &k) {
             if e.value.is_none() {
-                bail!("missing value for '{}'", e.key);
+                if let Some(ref p) = e.file {
+                    let disp = grit_lib::config::config_file_display_for_error(p);
+                    fatal_alias(&format!(
+                        "missing value for '{}' in file {} at line {}",
+                        e.key, disp, e.line
+                    ));
+                }
+                fatal_alias(&format!("missing value for '{}'", e.key));
             }
             return Ok(e.value.clone());
         }
@@ -232,7 +239,17 @@ pub(crate) fn run_command_with_aliases(
                 .ok()
                 .map(|r| r.git_dir)
         });
-    let config = grit_lib::config::ConfigSet::load(git_dir.as_deref(), true)?;
+    let config = match grit_lib::config::ConfigSet::load(git_dir.as_deref(), true) {
+        Ok(c) => c,
+        Err(e) => {
+            let s = e.to_string();
+            if s.starts_with("fatal: bad config line ") {
+                eprintln!("{s}");
+                std::process::exit(128);
+            }
+            return Err(e.into());
+        }
+    };
 
     let mut args = vec![subcmd];
     args.extend(rest);

--- a/grit/src/commands/config.rs
+++ b/grit/src/commands/config.rs
@@ -554,6 +554,14 @@ pub fn run(args: Args) -> Result<()> {
             cmd_get(&args, &get_args, git_dir.as_deref(), None)
         }
         2 => {
+            if !args.global
+                && !args.system
+                && !args.worktree
+                && args.file.is_none()
+                && git_dir.is_none()
+            {
+                bail!("not in a git directory");
+            }
             // Legacy set: `git config key value`
             // or `git config --replace-all key value`
             let set_args = SetArgs {
@@ -581,6 +589,14 @@ pub fn run(args: Args) -> Result<()> {
                     Some(&args.positional[2]),
                 )
             } else {
+                if !args.global
+                    && !args.system
+                    && !args.worktree
+                    && args.file.is_none()
+                    && git_dir.is_none()
+                {
+                    bail!("not in a git directory");
+                }
                 // `git config key value value-pattern` (legacy with value-pattern)
                 let set_args = SetArgs {
                     key: args.positional[0].clone(),
@@ -1252,40 +1268,10 @@ fn resolve_git_dir() -> Option<PathBuf> {
         }
         return Some(p);
     }
-    // Walk up from cwd looking for .git
-    let cwd = discovery_start_dir()?;
-    let mut cur = cwd.as_path();
-    loop {
-        let dot_git = cur.join(".git");
-        if dot_git.is_dir() {
-            return Some(dot_git);
-        }
-        if dot_git.is_file() {
-            // gitfile
-            if let Ok(content) = std::fs::read_to_string(&dot_git) {
-                for line in content.lines() {
-                    if let Some(rest) = line.strip_prefix("gitdir:") {
-                        let path = rest.trim();
-                        let resolved = if Path::new(path).is_absolute() {
-                            PathBuf::from(path)
-                        } else {
-                            cur.join(path)
-                        };
-                        return Some(resolved);
-                    }
-                }
-            }
-        }
-        // Bare repository layout at `cur/`, or Git's `$GIT_DIR` shadow at `cur/.git/` when both exist.
-        if cur.join("objects").is_dir() && cur.join("HEAD").is_file() {
-            let shadow = cur.join(".git");
-            if shadow.is_dir() && shadow.join("config").is_file() {
-                return Some(shadow);
-            }
-            return Some(cur.to_path_buf());
-        }
-        cur = cur.parent()?;
-    }
+    // Use library discovery so `GIT_CEILING_DIRECTORIES` (t1308 `nongit`) matches Git.
+    grit_lib::repo::Repository::discover(None)
+        .ok()
+        .map(|r| r.git_dir)
 }
 
 /// Determine which config file to write to based on flags.

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -10,6 +10,7 @@
 use anyhow::{bail, Context, Result};
 use clap::{Args, Command, FromArgMatches, Parser};
 use std::collections::{BTreeSet, HashSet};
+use std::fs;
 use std::io::{IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
 
@@ -5364,21 +5365,146 @@ fn run_test_tool_chmtime(rest: &[String]) -> Result<()> {
     Ok(())
 }
 
+#[derive(Clone, Copy)]
+enum TestToolConfigParseKeyErr {
+    InvalidKey,
+    NoSectionOrName,
+}
+
+/// Match `git_config_parse_key` enough for `test-tool config get` (t1308).
+fn test_tool_git_config_parse_key(
+    key: &str,
+) -> std::result::Result<String, TestToolConfigParseKeyErr> {
+    let Some(last_dot) = key.rfind('.') else {
+        return Err(TestToolConfigParseKeyErr::NoSectionOrName);
+    };
+    if last_dot == 0 {
+        return Err(TestToolConfigParseKeyErr::NoSectionOrName);
+    }
+    if last_dot == key.len() - 1 {
+        return Err(TestToolConfigParseKeyErr::NoSectionOrName);
+    }
+
+    let baselen = last_dot;
+    let mut dot_seen = false;
+    let mut out: Vec<u8> = Vec::with_capacity(key.len());
+
+    for (i, c) in key.bytes().enumerate() {
+        if c == b'.' {
+            dot_seen = true;
+        }
+        if !dot_seen || i > baselen {
+            let is_first_var = i == baselen + 1;
+            let ok = c.is_ascii_alphanumeric() || c == b'-';
+            if !ok || (is_first_var && !c.is_ascii_alphabetic()) {
+                return Err(TestToolConfigParseKeyErr::InvalidKey);
+            }
+            out.push(c.to_ascii_lowercase());
+        } else if c == b'\n' {
+            return Err(TestToolConfigParseKeyErr::InvalidKey);
+        } else {
+            out.push(c.to_ascii_lowercase());
+        }
+    }
+
+    String::from_utf8(out).map_err(|_| TestToolConfigParseKeyErr::InvalidKey)
+}
+
+fn test_tool_config_display_name(path: &std::path::Path) -> String {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    if let Ok(stripped) = path.strip_prefix(&cwd) {
+        let s = stripped.to_string_lossy();
+        if s.is_empty() {
+            return ".".to_string();
+        }
+        return s.into_owned();
+    }
+    git_path::real_path_resolving(&path.display().to_string())
+        .display()
+        .to_string()
+}
+
+fn test_tool_config_origin_type(entry: &grit_lib::config::ConfigEntry) -> &'static str {
+    if matches!(entry.scope, grit_lib::config::ConfigScope::Command) {
+        return "command line";
+    }
+    "file"
+}
+
+fn test_tool_config_iterate_name(entry: &grit_lib::config::ConfigEntry) -> String {
+    match &entry.file {
+        None => String::new(),
+        Some(p) => {
+            if p.to_string_lossy() == ":GIT_CONFIG_PARAMETERS" {
+                return String::new();
+            }
+            grit_lib::config::config_file_display_for_error(p)
+        }
+    }
+}
+
+fn test_tool_config_fatal_bad_numeric(
+    name: &str,
+    value: &str,
+    entry: &grit_lib::config::ConfigEntry,
+) -> ! {
+    let v = if value.is_empty() { "''" } else { value };
+    let msg = if matches!(entry.scope, grit_lib::config::ConfigScope::Command) && entry.line == 0 {
+        format!("fatal: bad numeric config value '{v}' for '{name}': invalid unit")
+    } else if let Some(path) = &entry.file {
+        let disp = test_tool_config_display_name(path);
+        format!("fatal: bad numeric config value '{v}' for '{name}' in file {disp}: invalid unit")
+    } else {
+        format!("fatal: bad numeric config value '{v}' for '{name}': invalid unit")
+    };
+    eprintln!("{msg}");
+    std::process::exit(128);
+}
+
+fn test_tool_config_fatal_missing_string(name: &str, entry: &grit_lib::config::ConfigEntry) -> ! {
+    let msg = match &entry.file {
+        Some(path) => {
+            let disp = test_tool_config_display_name(path);
+            format!(
+                "fatal: missing value for '{name}' in file {disp} at line {}",
+                entry.line
+            )
+        }
+        None => format!("fatal: missing value for '{name}'"),
+    };
+    eprintln!("{msg}");
+    std::process::exit(128);
+}
+
+fn test_tool_parse_git_bool_strict(value: &str) -> std::result::Result<bool, ()> {
+    match value.to_ascii_lowercase().as_str() {
+        "true" | "yes" | "on" => Ok(true),
+        "false" | "no" | "off" => Ok(false),
+        "" => Ok(false),
+        _ => {
+            let Ok(n) = value.parse::<i64>() else {
+                return Err(());
+            };
+            Ok(n != 0)
+        }
+    }
+}
+
 /// Handle `test-tool config` — config API test helper.
 fn run_test_tool_config(rest: &[String]) -> Result<()> {
+    use grit_lib::config::{canonical_key, ConfigFile};
+    use grit_lib::config::{parse_git_config_int_strict, ConfigScope, ConfigSet, IncludeContext};
+
     let subcmd = rest.first().map(|s| s.as_str()).unwrap_or("");
-    let key = rest.get(1).map(|s| s.as_str()).unwrap_or("");
 
-    // Load config from current git repo
-    let repo = grit_lib::repo::Repository::discover(None).ok();
-    let git_dir = repo.as_ref().map(|r| r.git_dir.as_path());
-    let cfg = grit_lib::config::ConfigSet::load(git_dir, true).unwrap_or_default();
-
-    match subcmd {
-        "read_early_config" => match grit_lib::config::ConfigSet::read_early_config(git_dir, key) {
+    if subcmd == "read_early_config" {
+        let key = rest.get(1).map(|s| s.as_str()).unwrap_or("");
+        let repo = grit_lib::repo::Repository::discover(None).ok();
+        let git_dir = repo.as_ref().map(|r| r.git_dir.as_path());
+        return match ConfigSet::read_early_config(git_dir, key) {
             Ok(values) => {
                 if values.is_empty() {
-                    std::process::exit(0);
+                    return Ok(());
                 }
                 for v in values {
                     println!("{v}");
@@ -5386,53 +5512,320 @@ fn run_test_tool_config(rest: &[String]) -> Result<()> {
                 Ok(())
             }
             Err(e) => Err(anyhow::anyhow!("{}", e)),
-        },
-        "get_value" | "get" => match cfg.get(key) {
-            Some(val) => {
-                println!("{val}");
-                Ok(())
+        };
+    }
+
+    let repo = grit_lib::repo::Repository::discover(None).ok();
+    let git_dir = repo.as_ref().map(|r| r.git_dir.as_path());
+
+    match subcmd {
+        "get" => {
+            let key = rest.get(1).map(|s| s.as_str()).unwrap_or("");
+            let cfg = ConfigSet::load(git_dir, true).unwrap_or_default();
+            match test_tool_git_config_parse_key(key) {
+                Err(TestToolConfigParseKeyErr::InvalidKey) => {
+                    println!("Key \"{key}\" is invalid");
+                    std::process::exit(1);
+                }
+                Err(TestToolConfigParseKeyErr::NoSectionOrName) => {
+                    println!("Key \"{key}\" has no section");
+                    std::process::exit(1);
+                }
+                Ok(_) => {
+                    if cfg.get(key).is_some() {
+                        return Ok(());
+                    }
+                    println!("Value not found for \"{key}\"");
+                    std::process::exit(1);
+                }
             }
-            None => {
-                eprintln!("fatal: config {} not found", key);
-                std::process::exit(1);
-            }
-        },
-        "get_value_multi" | "get_all" => {
-            // Get all values for a key
-            let values = cfg.get_all(key);
-            if values.is_empty() {
-                eprintln!("fatal: config {} not found", key);
-                std::process::exit(1);
-            }
-            for v in values {
-                println!("{v}");
+        }
+        "get_value" => {
+            let key = rest.get(1).map(|s| s.as_str()).unwrap_or("");
+            let cfg = match ConfigSet::load(git_dir, true) {
+                Ok(c) => c,
+                Err(e) => {
+                    let es = e.to_string();
+                    if es.starts_with("fatal: bad config line ") {
+                        eprintln!("{es}");
+                        std::process::exit(128);
+                    }
+                    return Err(anyhow::anyhow!("{}", e));
+                }
+            };
+            match cfg.get_last_entry(key) {
+                Some(entry) => match &entry.value {
+                    None => println!("(NULL)"),
+                    Some(s) => println!("{s}"),
+                },
+                None => {
+                    println!("Value not found for \"{key}\"");
+                    std::process::exit(1);
+                }
             }
             Ok(())
         }
-        "get_int" => match cfg.get(key) {
-            Some(val) => match val.parse::<i64>() {
-                Ok(n) => {
-                    println!("{n}");
-                    Ok(())
+        "get_value_multi" => {
+            let key = rest.get(1).map(|s| s.as_str()).unwrap_or("");
+            let cfg = if let Some(p) = rest.get(2) {
+                let path = Path::new(p);
+                let mut set = ConfigSet::new();
+                let ctx = IncludeContext::default();
+                let file = match ConfigFile::from_path(path, ConfigScope::Local) {
+                    Ok(Some(f)) => f,
+                    Ok(None) => {
+                        println!("Value not found for \"{key}\"");
+                        std::process::exit(1);
+                    }
+                    Err(e) => return Err(anyhow::anyhow!("{}", e)),
+                };
+                set.merge_file_with_includes(&file, true, &ctx)?;
+                set
+            } else {
+                match ConfigSet::load(git_dir, true) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        let es = e.to_string();
+                        if es.starts_with("fatal: bad config line ") {
+                            eprintln!("{es}");
+                            std::process::exit(128);
+                        }
+                        return Err(anyhow::anyhow!("{}", e));
+                    }
                 }
-                Err(_) => bail!("bad numeric config value '{}'", val),
-            },
-            None => {
-                eprintln!("fatal: config {} not found", key);
+            };
+            let raw = cfg.get_all_raw(key);
+            if raw.is_empty() {
+                println!("Value not found for \"{key}\"");
                 std::process::exit(1);
             }
-        },
-        "get_bool" => match cfg.get_bool(key) {
-            Some(Ok(b)) => {
-                println!("{}", if b { "true" } else { "false" });
-                Ok(())
+            for v in raw {
+                match v {
+                    None => println!("(NULL)"),
+                    Some(s) => println!("{s}"),
+                }
             }
-            Some(Err(e)) => bail!("bad boolean config value: {}", e),
-            None => {
-                eprintln!("fatal: config {} not found", key);
+            Ok(())
+        }
+        "get_string" => {
+            let key = rest.get(1).map(|s| s.as_str()).unwrap_or("");
+            let cfg = match ConfigSet::load(git_dir, true) {
+                Ok(c) => c,
+                Err(e) => return Err(anyhow::anyhow!("{}", e)),
+            };
+            let Some(entry) = cfg.get_last_entry(key) else {
+                println!("Value not found for \"{key}\"");
                 std::process::exit(1);
+            };
+            match &entry.value {
+                None => test_tool_config_fatal_missing_string(key, &entry),
+                Some(s) => println!("{s}"),
             }
-        },
+            Ok(())
+        }
+        "get_int" => {
+            let key = rest.get(1).map(|s| s.as_str()).unwrap_or("");
+            let cfg = match ConfigSet::load(git_dir, true) {
+                Ok(c) => c,
+                Err(e) => return Err(anyhow::anyhow!("{}", e)),
+            };
+            let Some(entry) = cfg.get_last_entry(key) else {
+                println!("Value not found for \"{key}\"");
+                std::process::exit(1);
+            };
+            let value_src = entry.value.as_deref().unwrap_or("");
+            match parse_git_config_int_strict(value_src) {
+                Ok(n) => {
+                    let n32 = i32::try_from(n).unwrap_or(i32::MAX);
+                    println!("{n32}");
+                }
+                Err(_) => test_tool_config_fatal_bad_numeric(key, value_src, &entry),
+            }
+            Ok(())
+        }
+        "git_config_int" => {
+            let key = rest.get(1).map(|s| s.as_str()).unwrap_or("");
+            let cfg = match ConfigSet::load(git_dir, true) {
+                Ok(c) => c,
+                Err(e) => return Err(anyhow::anyhow!("{}", e)),
+            };
+            let canon = canonical_key(key).unwrap_or_default();
+            for entry in cfg.entries() {
+                if entry.key != canon {
+                    continue;
+                }
+                let value_src = entry.value.as_deref().unwrap_or("");
+                match parse_git_config_int_strict(value_src) {
+                    Ok(n) => {
+                        let n32 = i32::try_from(n).unwrap_or(i32::MAX);
+                        println!("{n32}");
+                    }
+                    Err(_) => test_tool_config_fatal_bad_numeric(key, value_src, entry),
+                }
+            }
+            Ok(())
+        }
+        "get_bool" => {
+            let key = rest.get(1).map(|s| s.as_str()).unwrap_or("");
+            let cfg = match ConfigSet::load(git_dir, true) {
+                Ok(c) => c,
+                Err(e) => return Err(anyhow::anyhow!("{}", e)),
+            };
+            let Some(entry) = cfg.get_last_entry(key) else {
+                println!("Value not found for \"{key}\"");
+                std::process::exit(1);
+            };
+            if entry.value.is_none() {
+                println!("1");
+                return Ok(());
+            }
+            let value_src = entry.value.as_deref().unwrap_or("");
+            match test_tool_parse_git_bool_strict(value_src) {
+                Ok(b) => println!("{}", i32::from(b)),
+                Err(_) => {
+                    eprintln!("fatal: bad boolean config value '{value_src}' for '{key}'");
+                    std::process::exit(128);
+                }
+            }
+            Ok(())
+        }
+        "configset_get_value" | "configset_get_value_multi" => {
+            let key = rest.get(1).map(|s| s.as_str()).unwrap_or("");
+            let paths: Vec<&Path> = rest.iter().skip(2).map(|s| Path::new(s.as_str())).collect();
+            if paths.is_empty() {
+                bail!("test-tool config {subcmd}: expected key and at least one file");
+            }
+            let mut set = ConfigSet::new();
+            let ctx = IncludeContext::default();
+            for path in &paths {
+                let err_line = format!(
+                    "Error (-1) reading configuration file {}.",
+                    grit_lib::config::config_file_display_for_error(path)
+                );
+                if !path.exists() {
+                    eprintln!("{err_line}");
+                    std::process::exit(2);
+                }
+                if path.is_dir() {
+                    eprintln!(
+                        "warning: unable to access '{}': Is a directory",
+                        path.display()
+                    );
+                    eprintln!("{err_line}");
+                    std::process::exit(2);
+                }
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    match fs::metadata(path) {
+                        Ok(m) if m.is_file() => {
+                            let mode = m.permissions().mode();
+                            if mode & 0o444 == 0 {
+                                eprintln!(
+                                    "warning: unable to access '{}': Permission denied",
+                                    path.display()
+                                );
+                                eprintln!("{err_line}");
+                                std::process::exit(2);
+                            }
+                        }
+                        Ok(_) => {}
+                        Err(e) => {
+                            eprintln!("warning: unable to access '{}': {e}", path.display());
+                            eprintln!("{err_line}");
+                            std::process::exit(2);
+                        }
+                    }
+                }
+                #[cfg(not(unix))]
+                {
+                    let _ = fs::metadata(path);
+                }
+                let file = match ConfigFile::from_path(path, ConfigScope::Local) {
+                    Ok(Some(f)) => f,
+                    Ok(None) => {
+                        println!("Error (-1) reading configuration file {}.", path.display());
+                        std::process::exit(2);
+                    }
+                    Err(e) => {
+                        let es = e.to_string();
+                        if let Some(rest) = es.strip_prefix("bad config line ") {
+                            if let Some((line_part, tail)) = rest.split_once(" in file ") {
+                                if let Ok(line) = line_part.parse::<usize>() {
+                                    let p = std::path::Path::new(tail);
+                                    eprintln!(
+                                        "fatal: bad config line {line} in file {}",
+                                        p.display()
+                                    );
+                                    std::process::exit(128);
+                                }
+                            }
+                        }
+                        return Err(anyhow::anyhow!("{}", e));
+                    }
+                };
+                set.merge_file_with_includes(&file, true, &ctx)?;
+            }
+            if subcmd == "configset_get_value" {
+                let raw = set.get_all_raw(key);
+                let Some(last) = raw.last() else {
+                    println!("Value not found for \"{key}\"");
+                    std::process::exit(1);
+                };
+                match last {
+                    None => println!("(NULL)"),
+                    Some(s) => println!("{s}"),
+                }
+            } else {
+                let raw = set.get_all_raw(key);
+                if raw.is_empty() {
+                    println!("Value not found for \"{key}\"");
+                    std::process::exit(1);
+                }
+                for v in raw {
+                    match v {
+                        None => println!("(NULL)"),
+                        Some(s) => println!("{s}"),
+                    }
+                }
+            }
+            Ok(())
+        }
+        "iterate" => {
+            // Upstream t1308 expects only the standard user/repo/command layers; skip system
+            // `/etc/gitconfig` so host-wide entries (e.g. git-lfs) do not appear in output.
+            std::env::set_var("GIT_CONFIG_NOSYSTEM", "1");
+            let cfg = match ConfigSet::load(git_dir, true) {
+                Ok(c) => c,
+                Err(e) => return Err(anyhow::anyhow!("{}", e)),
+            };
+            let mut first = true;
+            for entry in cfg.entries() {
+                if !first {
+                    println!();
+                }
+                first = false;
+                let value_str = match &entry.value {
+                    None => "(null)".to_string(),
+                    Some(s) => s.clone(),
+                };
+                println!("key={}", entry.key);
+                println!("value={value_str}");
+                println!("origin={}", test_tool_config_origin_type(entry));
+                println!("name={}", test_tool_config_iterate_name(entry));
+                let lno = if matches!(entry.scope, grit_lib::config::ConfigScope::Command) {
+                    -1
+                } else {
+                    i32::try_from(entry.line).unwrap_or(-1)
+                };
+                println!("lno={lno}");
+                println!("scope={}", entry.scope);
+            }
+            Ok(())
+        }
+        "get_all" => {
+            bail!("test-tool config get_all is not used by the harness; use get_value_multi");
+        }
         _ => bail!("test-tool config: unknown subcommand '{subcmd}'"),
     }
 }

--- a/logs/2026-04-10_t1308-config-set.md
+++ b/logs/2026-04-10_t1308-config-set.md
@@ -1,0 +1,14 @@
+# t1308-config-set
+
+## Goal
+Make `tests/t1308-config-set.sh` pass (39/39) against `grit` / `test-tool config`.
+
+## Changes
+- **`grit-lib` `config.rs`**: Propagate parse errors from `ConfigSet::load_with_options` (no silent skip on bad system/global/local files). Reject non-empty lines that are not section headers or key lines (`fatal: bad config line N in file …`). Expose `config_file_display_for_error`. Add `ConfigSet::get_all_raw` for NULL multi-values. `from_git_config_parameters` stores pseudo path on entries for diagnostics.
+- **`grit` `main.rs`**: Reimplement `test-tool config` to match upstream C helper: `get_value`/`get`/`get_string`/`get_int`/`get_bool`/`git_config_int`/`get_value_multi`/`configset_*`/`iterate`, correct exit codes and stderr/stdout split, `GIT_CONFIG_NOSYSTEM` for iterate, `lno=-1` for command scope.
+- **`grit` `config.rs`**: `resolve_git_dir` uses `Repository::discover` so `GIT_CEILING_DIRECTORIES` + `nongit` works; reject legacy `config key value` without repo when not `--global`/`--system`/etc.
+- **`grit` `alias.rs`**: Bare alias entries die with `fatal: missing value for 'alias.br' in file … at line …`; load failures with `fatal: bad config line` exit 128.
+
+## Validation
+- `./scripts/run-tests.sh t1308-config-set.sh` → 39/39 pass
+- `cargo test -p grit-lib --lib`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible `test-tool config` behavior and related config plumbing so `tests/t1308-config-set.sh` passes 39/39.

## Key changes

- **test-tool config** (`grit/src/main.rs`): Full subcommand surface matching upstream `git/t/helper/test-config.c` — correct stdout/stderr, exit codes, `(NULL)` handling, `configset_*` file errors on stderr, `iterate` metadata (`lno=-1` for command scope, skip system layer via `GIT_CONFIG_NOSYSTEM` for stable output).
- **ConfigSet::load_with_options** (`grit-lib/src/config.rs`): Propagate parse failures from system/global/local files instead of ignoring them.
- **Config parser**: Reject stray non-empty lines as `fatal: bad config line N in file …`; expose `config_file_display_for_error`; `get_all_raw` for multi-value NULLs; pseudo path on `GIT_CONFIG_PARAMETERS` entries.
- **git config** (`grit/src/commands/config.rs`): Use `Repository::discover` for `resolve_git_dir` so `GIT_CEILING_DIRECTORIES` / `nongit` works; reject legacy `config key value` outside a repo without explicit file scope.
- **Aliases** (`grit/src/alias.rs`): Bare `alias.*` keys exit 128 with `fatal: missing value for 'alias.X' in file … at line …`; fatal parse errors from config load.

## Validation

- `./scripts/run-tests.sh t1308-config-set.sh`
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd6494a3-2bcb-4f15-9640-723ecd40931e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd6494a3-2bcb-4f15-9640-723ecd40931e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

