### PR TITLE
fix: make t3431-rebase-fork-point pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -618,7 +618,7 @@ t3427-rebase-subtree	t3	yes	3	0	3	false	ok	0
 t3428-rebase-signoff	t3	yes	7	1	6	false	ok	0
 t3429-rebase-edit-todo	t3	yes	7	5	2	false	ok	0
 t3430-rebase-merges	t3	yes	34	2	32	false	ok	0
-t3431-rebase-fork-point	t3	yes	26	8	18	false	ok	0
+t3431-rebase-fork-point	t3	yes	26	26	0	true	ok	0
 t3432-rebase-fast-forward	t3	yes	219	162	57	false	ok	0
 t3433-rebase-across-mode-change	t3	yes	4	4	0	true	ok	0
 t3434-rebase-i18n	t3	yes	6	3	3	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,704 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,704 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T04:18:39+00:00" class="gen-time" title="2026-04-10 04:18 UTC">2026-04-10 04:18 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,704</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -219,11 +219,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">56/141 files · 2 skipped · 4,052/5,398 tests</span>
+        <span class="group-meta">57/141 files · 2 skipped · 4,070/5,398 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:75.1%"></div></div>
-        <span class="group-pct pct-blue">75.1%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:75.4%"></div></div>
+        <span class="group-pct pct-blue">75.4%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t4">
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35704 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,704 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T04:18:39+00:00" class="gen-time" title="2026-04-10 04:18 UTC">2026-04-10 04:18 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,704</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -6337,14 +6337,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="26" data-passed="8">
+<tr class="" data-group="t3" data-tests="26" data-passed="26" data-full-pass="1">
   <td class="mono">t3431-rebase-fork-point</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">26</td>
-  <td class="right">8</td>
+  <td class="right">26</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:30.8%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="219" data-passed="162">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/merge_base.rs
+++ b/grit-lib/src/merge_base.rs
@@ -8,8 +8,12 @@ use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 
 use crate::error::{Error, Result};
 use crate::objects::{parse_commit, ObjectId, ObjectKind};
+use crate::reflog::read_reflog;
 use crate::repo::Repository;
-use crate::rev_parse::{peel_to_commit_for_merge_base, resolve_revision};
+use crate::rev_parse::{
+    peel_to_commit_for_merge_base, resolve_revision, resolve_upstream_symbolic_name,
+    upstream_suffix_info,
+};
 
 /// Resolve commit-ish command arguments to commit object IDs.
 ///
@@ -96,6 +100,120 @@ pub fn is_ancestor(repo: &Repository, ancestor: ObjectId, descendant: ObjectId) 
         return Ok(true);
     }
     Ok(cache.ancestor_closure(descendant)?.contains(&ancestor))
+}
+
+/// Returns the ref path under `logs/` used for fork-point reflog scanning for `merge-base --fork-point`
+/// and `rebase --fork-point`, matching Git's resolution order.
+///
+/// # Parameters
+///
+/// - `spec` - upstream argument as given on the command line (`main`, `refs/heads/main`, `HEAD`, …).
+pub fn resolve_fork_point_reflog_ref(repo: &Repository, spec: &str) -> String {
+    if spec == "HEAD" || spec.starts_with("refs/") {
+        return spec.to_string();
+    }
+
+    let logs_dir = repo.git_dir.join("logs");
+    let candidates = [
+        spec.to_string(),
+        format!("refs/heads/{spec}"),
+        format!("refs/remotes/{spec}"),
+    ];
+
+    for candidate in candidates {
+        if logs_dir.join(&candidate).is_file() {
+            return candidate;
+        }
+    }
+
+    format!("refs/heads/{spec}")
+}
+
+/// Picks the fork-point candidate that is not strictly dominated by another candidate in the list.
+fn select_best_fork_point(repo: &Repository, candidates: &[ObjectId]) -> Result<Option<ObjectId>> {
+    if candidates.is_empty() {
+        return Ok(None);
+    }
+
+    let mut best = HashSet::new();
+    for &candidate in candidates {
+        let mut dominated = false;
+        for &other in candidates {
+            if candidate == other {
+                continue;
+            }
+            if is_ancestor(repo, candidate, other)? {
+                dominated = true;
+                break;
+            }
+        }
+        if !dominated {
+            best.insert(candidate);
+        }
+    }
+
+    Ok(candidates.iter().copied().find(|oid| best.contains(oid)))
+}
+
+/// Computes the fork-point commit between `upstream_tip` and `head`, using the upstream ref's reflog.
+///
+/// This matches `git merge-base --fork-point` / the merge base `git rebase --fork-point` uses for
+/// selecting commits to replay.
+///
+/// # Parameters
+///
+/// - `upstream_spec` - upstream revision string (used to locate the reflog; e.g. `main`,
+///   `refs/heads/main`, or `topic@{{upstream}}`).
+/// - `upstream_tip` - resolved commit of the upstream branch tip.
+/// - `head` - commit to rebase (usually `HEAD`).
+///
+/// # Errors
+///
+/// Propagates object read, reflog, and graph walk errors.
+pub fn fork_point(
+    repo: &Repository,
+    upstream_spec: &str,
+    upstream_tip: ObjectId,
+    head: ObjectId,
+) -> Result<ObjectId> {
+    let reflog_ref = if upstream_suffix_info(upstream_spec).is_some() {
+        resolve_upstream_symbolic_name(repo, upstream_spec)?
+    } else {
+        resolve_fork_point_reflog_ref(repo, upstream_spec)
+    };
+
+    let entries = read_reflog(&repo.git_dir, &reflog_ref)
+        .map_err(|e| Error::Message(format!("failed to read reflog for '{reflog_ref}': {e}")))?;
+
+    let mut candidates = Vec::new();
+    let mut seen = HashSet::new();
+
+    for entry in entries.iter().rev() {
+        let oid = if entry.message.starts_with("checkout:") {
+            entry.old_oid
+        } else {
+            entry.new_oid
+        };
+        if !seen.insert(oid) {
+            continue;
+        }
+        if is_ancestor(repo, oid, head)? {
+            candidates.push(oid);
+        }
+    }
+
+    if let Some(fp) = select_best_fork_point(repo, &candidates)? {
+        return Ok(fp);
+    }
+
+    let mut bases = merge_bases_first_vs_rest(repo, upstream_tip, &[head])?;
+    if bases.is_empty() {
+        return Err(Error::Message(
+            "no merge base found between upstream and HEAD".to_owned(),
+        ));
+    }
+    bases.sort();
+    Ok(bases[0])
 }
 
 /// Returns every commit reachable from `tip` by walking parent links (including `tip`).

--- a/grit/src/commands/branch.rs
+++ b/grit/src/commands/branch.rs
@@ -1208,6 +1208,18 @@ fn create_branch(
 
     grit_lib::refs::write_ref(&repo.git_dir, &refname, &oid).map_err(|e| anyhow::anyhow!("{e}"))?;
 
+    if start_point.is_none() && args.track.is_some() {
+        if let Some(tracked_short) = head.branch_name() {
+            let merge_ref = format!("refs/heads/{tracked_short}");
+            let config_path = repo.git_dir.join("config");
+            let mut cfg = std::fs::read_to_string(&config_path).unwrap_or_default();
+            cfg.push_str(&format!("\n[branch \"{name}\"]"));
+            cfg.push_str("\n\tremote = .");
+            cfg.push_str(&format!("\n\tmerge = {merge_ref}\n"));
+            std::fs::write(&config_path, cfg)?;
+        }
+    }
+
     // Create reflog when explicitly requested or when core.logAllRefUpdates
     // enables branch reflogs for this repository.
     if args.create_reflog || should_log_ref_updates(repo) {

--- a/grit/src/commands/merge_base.rs
+++ b/grit/src/commands/merge_base.rs
@@ -2,13 +2,12 @@
 
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
+use grit_lib::error::Error as GritError;
 use grit_lib::merge_base::{
-    independent_commits, is_ancestor, merge_bases_first_vs_rest, merge_bases_octopus,
+    fork_point, independent_commits, is_ancestor, merge_bases_first_vs_rest, merge_bases_octopus,
     resolve_commit_specs,
 };
-use grit_lib::reflog::read_reflog;
 use grit_lib::repo::Repository;
-use std::collections::HashSet;
 
 /// Arguments for `grit merge-base`.
 #[derive(Debug, ClapArgs)]
@@ -139,87 +138,20 @@ fn run_fork_point(repo: &Repository, show_all: bool, revisions: Vec<String>) -> 
     let upstream_oid = commits[0];
     let commit_oid = commits[1];
 
-    let reflog_ref = resolve_fork_point_reflog_ref(repo, &upstream_spec);
-    let entries = read_reflog(&repo.git_dir, &reflog_ref)
-        .map_err(|e| anyhow::anyhow!("failed to read reflog for '{upstream_spec}': {e}"))?;
-    let mut candidates = Vec::new();
-    let mut seen = HashSet::new();
-
-    for entry in entries.iter().rev() {
-        let oid = if entry.message.starts_with("checkout:") {
-            entry.old_oid
-        } else {
-            entry.new_oid
-        };
-        if !seen.insert(oid) {
-            continue;
+    match fork_point(repo, &upstream_spec, upstream_oid, commit_oid) {
+        Ok(oid) => {
+            println!("{oid}");
+            Ok(())
         }
-        if is_ancestor(repo, oid, commit_oid)? {
-            candidates.push(oid);
-        }
-    }
-
-    if let Some(fork_point) = select_best_fork_point(repo, &candidates)? {
-        println!("{fork_point}");
-        return Ok(());
-    }
-
-    let mut bases = merge_bases_first_vs_rest(repo, upstream_oid, &[commit_oid])?;
-    if bases.is_empty() {
-        std::process::exit(1);
-    }
-    bases.sort();
-    println!("{}", bases[0]);
-    Ok(())
-}
-
-fn resolve_fork_point_reflog_ref(repo: &Repository, spec: &str) -> String {
-    if spec == "HEAD" || spec.starts_with("refs/") {
-        return spec.to_string();
-    }
-
-    let logs_dir = repo.git_dir.join("logs");
-    let candidates = [
-        spec.to_string(),
-        format!("refs/heads/{spec}"),
-        format!("refs/remotes/{spec}"),
-    ];
-
-    for candidate in candidates {
-        if logs_dir.join(&candidate).is_file() {
-            return candidate;
-        }
-    }
-
-    format!("refs/heads/{spec}")
-}
-
-fn select_best_fork_point(
-    repo: &Repository,
-    candidates: &[grit_lib::objects::ObjectId],
-) -> Result<Option<grit_lib::objects::ObjectId>> {
-    if candidates.is_empty() {
-        return Ok(None);
-    }
-
-    let mut best = HashSet::new();
-    for &candidate in candidates {
-        let mut dominated = false;
-        for &other in candidates {
-            if candidate == other {
-                continue;
+        Err(e) => {
+            if let GritError::Message(msg) = &e {
+                if msg.contains("no merge base") {
+                    std::process::exit(1);
+                }
             }
-            if is_ancestor(repo, candidate, other)? {
-                dominated = true;
-                break;
-            }
-        }
-        if !dominated {
-            best.insert(candidate);
+            Err(e.into())
         }
     }
-
-    Ok(candidates.iter().copied().find(|oid| best.contains(oid)))
 }
 
 fn print_result(mut oids: Vec<grit_lib::objects::ObjectId>, show_all: bool) {

--- a/grit/src/commands/rebase.rs
+++ b/grit/src/commands/rebase.rs
@@ -22,7 +22,7 @@ use grit_lib::config::ConfigSet;
 use grit_lib::diff::{self, count_changes, diff_index_to_tree, DiffEntry};
 use grit_lib::hooks::{run_hook, HookResult};
 use grit_lib::index::{Index, IndexEntry, MODE_EXECUTABLE, MODE_SYMLINK};
-use grit_lib::merge_base::{ancestor_closure, is_ancestor, merge_bases_first_vs_rest};
+use grit_lib::merge_base::{ancestor_closure, fork_point, is_ancestor, merge_bases_first_vs_rest};
 use grit_lib::merge_file::{merge, ConflictStyle, MergeInput};
 use grit_lib::objects::{
     parse_commit, parse_tree, serialize_commit, CommitData, ObjectId, ObjectKind,
@@ -31,7 +31,10 @@ use grit_lib::patch_ids::compute_patch_id;
 use grit_lib::refs::append_reflog;
 use grit_lib::repo::Repository;
 use grit_lib::rev_list::{rev_list, split_revision_token, OrderingMode, RevListOptions};
-use grit_lib::rev_parse::{abbreviate_object_id, resolve_revision};
+use grit_lib::rev_parse::{
+    abbreviate_object_id, resolve_revision, resolve_revision_without_index_dwim,
+    upstream_suffix_info,
+};
 use grit_lib::state::{resolve_head, HeadState};
 use grit_lib::whitespace_rule::{fix_blob_bytes, parse_whitespace_rule, WS_DEFAULT_RULE};
 use grit_lib::write_tree::write_tree_from_index;
@@ -276,11 +279,9 @@ pub fn run(mut args: Args) -> Result<()> {
         if args.keep_base {
             bail!("options '--keep-base' and '--root' cannot be used together");
         }
+        // `rebase.forkPoint` may be true in config; Git only rejects the explicit CLI combination.
         if args.fork_point {
             bail!("options '--root' and '--fork-point' cannot be used together");
-        }
-        if args.onto.is_none() {
-            bail!("a base commit must be provided with --onto when using --root");
         }
         if args.upstream.is_some() && args.branch.is_some() {
             bail!("git rebase: too many arguments");
@@ -311,7 +312,7 @@ pub fn run(mut args: Args) -> Result<()> {
     if args.branch.is_some() {
         let repo = Repository::discover(None).context("not a git repository")?;
         let uspec = args.upstream.as_deref().unwrap_or("HEAD");
-        let uoid = resolve_revision(&repo, uspec)
+        let uoid = resolve_revision_without_index_dwim(&repo, uspec)
             .with_context(|| format!("bad revision '{uspec}'"))?
             .to_hex();
         args.upstream = Some(uoid);
@@ -356,24 +357,27 @@ pub fn run(mut args: Args) -> Result<()> {
         args.branch = None;
     }
 
-    // If no upstream specified and no --onto, try to find the upstream tracking branch.
-    if args.upstream.is_none() && args.onto.is_none() && !args.root {
+    // Default upstream to the current branch's @{upstream} whenever it is omitted (including
+    // `rebase --onto <newbase>` — Git still uses the configured upstream for fork-point / merge
+    // base logic; t3431).
+    if args.upstream.is_none() && !args.root {
         let repo = Repository::discover(None).context("not a git repository")?;
         let head = resolve_head(&repo.git_dir)?;
         let branch_name = match &head {
             HeadState::Branch { short_name, .. } => short_name.clone(),
             _ => bail!("no upstream configured for the current branch"),
         };
-        // Try to resolve @{upstream}
         match resolve_revision(&repo, &format!("{}@{{upstream}}", branch_name)) {
             Ok(_) => {
                 args.upstream = Some(format!("{}@{{upstream}}", branch_name));
             }
             Err(_) => {
-                bail!(
-                    "There is no tracking information for the current branch.\n\
-                     Please specify which branch you want to rebase against."
-                );
+                if args.onto.is_none() {
+                    bail!(
+                        "There is no tracking information for the current branch.\n\
+                         Please specify which branch you want to rebase against."
+                    );
+                }
             }
         }
     }
@@ -1879,6 +1883,26 @@ fn apply_autostash_after_ff(repo: &Repository, autostash_oid: &ObjectId) -> Resu
 
 // ── Main rebase flow ────────────────────────────────────────────────
 
+/// True when `name` is both a local branch and a tag pointing at different commits.
+///
+/// `git rebase --fork-point` fails in this case (t3431) while a plain revision parse would pick
+/// the branch and warn.
+fn fork_point_upstream_name_is_ambiguous(repo: &Repository, name: &str) -> Result<bool> {
+    if name.contains('@')
+        || name.starts_with("refs/")
+        || name == "HEAD"
+        || name.contains('*')
+        || name.contains(':')
+    {
+        return Ok(false);
+    }
+    let head_ref = format!("refs/heads/{name}");
+    let tag_ref = format!("refs/tags/{name}");
+    let head_oid = grit_lib::refs::resolve_ref(&repo.git_dir, &head_ref).ok();
+    let tag_oid = grit_lib::refs::resolve_ref(&repo.git_dir, &tag_ref).ok();
+    Ok(matches!((head_oid, tag_oid), (Some(h), Some(t)) if h != t))
+}
+
 fn do_rebase(args: Args, pre_rebase_hook_second: Option<String>) -> Result<()> {
     let repo = Repository::discover(None).context("not a git repository")?;
     let git_dir = &repo.git_dir;
@@ -1960,42 +1984,106 @@ fn do_rebase(args: Args, pre_rebase_hook_second: Option<String>) -> Result<()> {
         .ok_or_else(|| anyhow::anyhow!("cannot rebase: HEAD is unborn"))?
         .to_owned();
 
-    let (upstream_spec, upstream_oid, onto_oid, onto_name_for_state) = if args.root {
-        let onto_spec = args
-            .onto
-            .as_deref()
-            .ok_or_else(|| anyhow::anyhow!("internal: --root without --onto"))?;
-        let onto = resolve_revision(&repo, onto_spec)
-            .with_context(|| format!("bad revision '{onto_spec}'"))?;
-        ("--root".to_owned(), onto, onto, onto_spec.to_owned())
+    // Git applies fork-point for the default upstream (`@{upstream}`) when `rebase.forkPoint` is
+    // true, but not when the user names the upstream explicitly (`rebase main`), unless
+    // `--fork-point` is passed (t3431).
+    let fork_point_effective = if args.root {
+        false
+    } else if args.fork_point {
+        true
+    } else if args.no_fork_point {
+        false
     } else {
-        let upstream_spec = args.upstream.as_deref().unwrap_or("HEAD").to_owned();
-        let up_oid = resolve_revision(&repo, &upstream_spec)
-            .with_context(|| format!("bad revision '{upstream_spec}'"))?;
-        let (onto, onto_label) = if let Some(ref onto_spec) = args.onto {
-            let oid = resolve_revision(&repo, onto_spec)
-                .with_context(|| format!("bad revision '{onto_spec}'"))?;
-            (oid, onto_spec.clone())
-        } else if args.keep_base {
-            let oid = find_merge_base(&repo, up_oid, head_oid_early).unwrap_or(up_oid);
-            (oid, upstream_spec.clone())
-        } else {
-            (up_oid, upstream_spec.clone())
-        };
-        (upstream_spec, up_oid, onto, onto_label)
+        let cfg_default = config
+            .get_bool("rebase.forkPoint")
+            .and_then(|r| r.ok())
+            .unwrap_or(true);
+        let upstream_arg = args.upstream.as_deref().unwrap_or("HEAD");
+        let implicit_upstream = upstream_suffix_info(upstream_arg).is_some();
+        cfg_default && implicit_upstream
     };
+
+    // Fork-point scans the upstream ref's reflog. The spec string is the same as the upstream
+    // argument (`side@{upstream}` when implicit, or `main` / `refs/heads/main` when explicit).
+    let fork_point_reflog_spec: Option<String> = if fork_point_effective {
+        Some(args.upstream.as_deref().unwrap_or("HEAD").to_owned())
+    } else {
+        None
+    };
+
+    if !args.root {
+        let us = args.upstream.as_deref().unwrap_or("HEAD");
+        if args.fork_point && fork_point_upstream_name_is_ambiguous(&repo, us)? {
+            bail!(
+                "fatal: ambiguous argument '{us}': unknown revision or path not in the working tree.\n\
+Use '--' to separate paths from revisions, like this:\n\
+'git <command> [<revision>...] -- [<file>...]'"
+            );
+        }
+    }
+
+    let (upstream_spec, upstream_oid, upstream_tip_oid, onto_oid, onto_name_for_state) =
+        if args.root {
+            let (onto, onto_label) = if let Some(ref onto_spec) = args.onto {
+                let oid = resolve_revision_without_index_dwim(&repo, onto_spec)
+                    .with_context(|| format!("bad revision '{onto_spec}'"))?;
+                (oid, onto_spec.clone())
+            } else {
+                (ObjectId::zero(), "root".to_owned())
+            };
+            ("--root".to_owned(), onto, onto, onto, onto_label)
+        } else {
+            let upstream_spec = args.upstream.as_deref().unwrap_or("HEAD").to_owned();
+            let up_oid = resolve_revision_without_index_dwim(&repo, &upstream_spec)
+                .with_context(|| format!("bad revision '{upstream_spec}'"))?;
+            let upstream_tip_oid = up_oid;
+
+            let mut effective_upstream_for_range = up_oid;
+            if let Some(ref fp_spec) = fork_point_reflog_spec {
+                let fp_oid = fork_point(&repo, fp_spec, up_oid, head_oid_early)
+                    .with_context(|| format!("fork-point resolution failed for '{fp_spec}'"))?;
+                effective_upstream_for_range = fp_oid;
+            }
+
+            let (onto, onto_label) = if let Some(ref onto_spec) = args.onto {
+                let oid = resolve_revision_without_index_dwim(&repo, onto_spec)
+                    .with_context(|| format!("bad revision '{onto_spec}'"))?;
+                (oid, onto_spec.clone())
+            } else if args.keep_base {
+                // Replay onto merge-base(upstream-tip, HEAD). Fork-point only narrows which commits
+                // are replayed, not this base (t3431 `--fork-point --keep-base` → onto B).
+                let oid = find_merge_base(&repo, upstream_tip_oid, head_oid_early)
+                    .unwrap_or(upstream_tip_oid);
+                (oid, upstream_spec.clone())
+            } else {
+                (up_oid, upstream_spec.clone())
+            };
+            (
+                upstream_spec,
+                effective_upstream_for_range,
+                upstream_tip_oid,
+                onto,
+                onto_label,
+            )
+        };
 
     let head = head_state;
     let head_oid = head_oid_early;
 
+    let root_rebase_no_onto = args.root && args.onto.is_none();
+
     let want_stat =
         args.stat || (config.get("rebase.stat").as_deref() == Some("true") && !args.no_stat);
 
-    let branch_base_merge = merge_bases_first_vs_rest(&repo, onto_oid, &[head_oid])?;
-    let branch_base = if branch_base_merge.len() == 1 {
-        Some(branch_base_merge[0])
-    } else {
+    let branch_base = if root_rebase_no_onto {
         None
+    } else {
+        let branch_base_merge = merge_bases_first_vs_rest(&repo, onto_oid, &[head_oid])?;
+        if branch_base_merge.len() == 1 {
+            Some(branch_base_merge[0])
+        } else {
+            None
+        }
     };
 
     let whitespace_forces_replay = args
@@ -2005,7 +2093,17 @@ fn do_rebase(args: Args, pre_rebase_hook_second: Option<String>) -> Result<()> {
     let allow_preemptive_ff =
         !args.interactive && args.exec.is_none() && !whitespace_forces_replay && !args.autosquash;
 
-    if allow_preemptive_ff && rebase_can_preemptive_ff(&repo, onto_oid, upstream_oid, head_oid)? {
+    // `rebase --keep-base` with fork-point uses a different upstream OID for the replay list than
+    // the branch tip; preemptive fast-forward detection wrongly treats the branch as up-to-date
+    // (t3431 `--fork-point --keep-base`).
+    let skip_preemptive_ff_for_keep_base_fork_point =
+        args.keep_base && upstream_tip_oid != upstream_oid;
+
+    if allow_preemptive_ff
+        && !root_rebase_no_onto
+        && !skip_preemptive_ff_for_keep_base_fork_point
+        && rebase_can_preemptive_ff(&repo, onto_oid, upstream_tip_oid, head_oid)?
+    {
         if !args.no_ff {
             print_branch_up_to_date(&head);
             if let Some(ref oid) = autostash_oid {
@@ -2031,7 +2129,9 @@ fn do_rebase(args: Args, pre_rebase_hook_second: Option<String>) -> Result<()> {
                 None => println!("Changes to {}:", onto_oid.to_hex()),
             }
         }
-        print_rebase_diffstat(&repo, branch_base, onto_oid)?;
+        if !root_rebase_no_onto {
+            print_rebase_diffstat(&repo, branch_base, onto_oid)?;
+        }
     }
 
     let reapply_cherry_picks = if args.reapply_cherry_picks {
@@ -2042,10 +2142,22 @@ fn do_rebase(args: Args, pre_rebase_hook_second: Option<String>) -> Result<()> {
         args.keep_base
     };
     let filter_cherry_equivalents = !reapply_cherry_picks && !args.interactive;
+    // `--keep-base` commit selection: default (config fork-point only) still uses the upstream
+    // *tip* for the replay list so `rebase --keep-base` includes commits like C (t3431.4). Explicit
+    // `--fork-point --keep-base` uses the fork-point commit so only F..G replay onto B (t3431.12).
+    let commits_upstream = if args.keep_base {
+        if fork_point_effective && args.fork_point {
+            upstream_oid
+        } else {
+            upstream_tip_oid
+        }
+    } else {
+        upstream_oid
+    };
     let mut commits = if args.root {
         collect_commits_for_root_rebase(&repo, head_oid, onto_oid)?
     } else {
-        collect_rebase_todo_commits(&repo, head_oid, upstream_oid, filter_cherry_equivalents)?
+        collect_rebase_todo_commits(&repo, head_oid, commits_upstream, filter_cherry_equivalents)?
     };
 
     if !args.keep_empty && !args.interactive {
@@ -2112,14 +2224,14 @@ fn do_rebase(args: Args, pre_rebase_hook_second: Option<String>) -> Result<()> {
     };
 
     if !args.no_ff && rebase_todo_lines.is_empty() {
-        if head_oid == onto_oid {
+        if !onto_oid.is_zero() && head_oid == onto_oid {
             print_branch_up_to_date(&head);
             if let Some(ref oid) = autostash_oid {
                 apply_autostash_after_ff(&repo, oid)?;
             }
             return Ok(());
         }
-        if can_fast_forward(&repo, head_oid, onto_oid)? {
+        if !onto_oid.is_zero() && can_fast_forward(&repo, head_oid, onto_oid)? {
             let ff_base = merge_bases_first_vs_rest(&repo, onto_oid, &[head_oid])?
                 .into_iter()
                 .next();
@@ -2214,15 +2326,34 @@ fn do_rebase(args: Args, pre_rebase_hook_second: Option<String>) -> Result<()> {
     let ident = reflog_identity(&repo);
     let ra = rebase_reflog_action();
     let start_msg = format!("{ra} (start): checkout {onto_name_for_state}");
+    let checkout_target_oid = if args.root && args.onto.is_none() {
+        ObjectId::zero()
+    } else {
+        onto_oid
+    };
     // Git records `(start)` on HEAD only; the branch ref keeps its pre-rebase tip until `(finish)`.
     let _ = append_reflog(
-        git_dir, "HEAD", &head_oid, &onto_oid, &ident, &start_msg, false,
+        git_dir,
+        "HEAD",
+        &head_oid,
+        &checkout_target_oid,
+        &ident,
+        &start_msg,
+        false,
     );
 
     let checkout_onto = || -> Result<()> {
-        let onto_obj = repo.odb.read(&onto_oid)?;
-        let onto_commit = parse_commit(&onto_obj.data)?;
-        let entries = tree_to_index_entries(&repo, &onto_commit.tree, "")?;
+        let empty_tree: ObjectId = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+            .parse()
+            .map_err(|_| anyhow::anyhow!("internal: empty tree object id"))?;
+        let tree_oid = if args.root && args.onto.is_none() {
+            empty_tree
+        } else {
+            let onto_obj = repo.odb.read(&onto_oid)?;
+            let onto_commit = parse_commit(&onto_obj.data)?;
+            onto_commit.tree
+        };
+        let entries = tree_to_index_entries(&repo, &tree_oid, "")?;
         let mut idx = Index::new();
         idx.entries = entries;
         idx.sort();
@@ -2231,7 +2362,15 @@ fn do_rebase(args: Args, pre_rebase_hook_second: Option<String>) -> Result<()> {
             check_dirty_worktree(&repo, &old_index, &idx, wt, &head)?;
         }
 
-        fs::write(git_dir.join("HEAD"), format!("{}\n", onto_oid.to_hex()))?;
+        let head_after_checkout = if args.root && args.onto.is_none() {
+            ObjectId::zero()
+        } else {
+            onto_oid
+        };
+        fs::write(
+            git_dir.join("HEAD"),
+            format!("{}\n", head_after_checkout.to_hex()),
+        )?;
         fs::write(
             git_dir.join("ORIG_HEAD"),
             format!("{}\n", head_oid.to_hex()),
@@ -2241,7 +2380,7 @@ fn do_rebase(args: Args, pre_rebase_hook_second: Option<String>) -> Result<()> {
         if let Some(wt) = &repo.work_tree {
             checkout_merged_index(&repo, wt, &old_index, &idx)?;
         }
-        run_post_checkout_hook(&repo, &head_oid, &onto_oid)?;
+        run_post_checkout_hook(&repo, &head_oid, &head_after_checkout)?;
         Ok(())
     };
 
@@ -2253,11 +2392,12 @@ fn do_rebase(args: Args, pre_rebase_hook_second: Option<String>) -> Result<()> {
         return Err(e);
     }
 
-    eprintln!(
-        "rebasing {} commits onto {}",
-        total,
-        &onto_oid.to_hex()[..7]
-    );
+    let onto_display = if args.root && args.onto.is_none() {
+        "root".to_owned()
+    } else {
+        onto_oid.to_hex()[..7].to_string()
+    };
+    eprintln!("rebasing {} commits onto {}", total, onto_display);
 
     replay_remaining(&repo, &rb_dir, autostash_oid, backend, had_rebase_autostash)?;
 
@@ -2433,13 +2573,19 @@ fn collect_commits_for_root_rebase(
     head: ObjectId,
     onto: ObjectId,
 ) -> Result<Vec<ObjectId>> {
-    let range = format!("{}..{}", onto.to_hex(), head.to_hex());
-    let (positive, negative) = split_revision_token(&range);
     let mut opts = RevListOptions::default();
     opts.first_parent = true;
     opts.ordering = OrderingMode::Default;
     opts.reverse = true;
-    let listed = rev_list(repo, &positive, &negative, &opts).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let listed = if onto.is_zero() {
+        // `rebase --root` without `--onto`: replay the full first-parent chain from the branch tip
+        // (Git uses an empty lower bound; we cannot pass the null OID through rev-list).
+        rev_list(repo, &[head.to_hex()], &[], &opts).map_err(|e| anyhow::anyhow!("{e}"))?
+    } else {
+        let range = format!("{}..{}", onto.to_hex(), head.to_hex());
+        let (positive, negative) = split_revision_token(&range);
+        rev_list(repo, &positive, &negative, &opts).map_err(|e| anyhow::anyhow!("{e}"))?
+    };
     filter_redundant_patch_commits(repo, onto, &listed.commits)
 }
 
@@ -2452,23 +2598,25 @@ fn filter_redundant_patch_commits(
     ordered: &[ObjectId],
 ) -> Result<Vec<ObjectId>> {
     let mut seen_patch_ids: HashSet<ObjectId> = HashSet::new();
-    for oid in ancestor_closure(repo, onto)? {
-        let obj = match repo.odb.read(&oid) {
-            Ok(o) => o,
-            Err(_) => continue,
-        };
-        if obj.kind != ObjectKind::Commit {
-            continue;
-        }
-        let commit = match parse_commit(&obj.data) {
-            Ok(c) => c,
-            Err(_) => continue,
-        };
-        if commit.parents.len() > 1 {
-            continue;
-        }
-        if let Some(pid) = compute_patch_id(&repo.odb, &oid)? {
-            seen_patch_ids.insert(pid);
+    if !onto.is_zero() {
+        for oid in ancestor_closure(repo, onto)? {
+            let obj = match repo.odb.read(&oid) {
+                Ok(o) => o,
+                Err(_) => continue,
+            };
+            if obj.kind != ObjectKind::Commit {
+                continue;
+            }
+            let commit = match parse_commit(&obj.data) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            if commit.parents.len() > 1 {
+                continue;
+            }
+            if let Some(pid) = compute_patch_id(&repo.odb, &oid)? {
+                seen_patch_ids.insert(pid);
+            }
         }
     }
 
@@ -2556,9 +2704,17 @@ fn print_rebase_diffstat(
     } else {
         None
     };
-    let new_obj = repo.odb.read(&onto_oid)?;
-    let new_commit = parse_commit(&new_obj.data)?;
-    let entries = diff::diff_trees(&repo.odb, old_tree.as_ref(), Some(&new_commit.tree), "")?;
+    let empty_tree: ObjectId = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+        .parse()
+        .map_err(|_| anyhow::anyhow!("internal: empty tree object id"))?;
+    let new_tree = if onto_oid.is_zero() {
+        empty_tree
+    } else {
+        let new_obj = repo.odb.read(&onto_oid)?;
+        let new_commit = parse_commit(&new_obj.data)?;
+        new_commit.tree
+    };
+    let entries = diff::diff_trees(&repo.odb, old_tree.as_ref(), Some(&new_tree), "")?;
     print_diffstat_from_entries(repo, &entries);
     Ok(())
 }
@@ -3072,9 +3228,16 @@ fn cherry_pick_for_rebase(
         .oid()
         .ok_or_else(|| anyhow::anyhow!("HEAD is unborn during rebase"))?
         .to_owned();
+    const GIT_EMPTY_TREE_HEX: &str = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+    let empty_tree_oid = ObjectId::from_hex(GIT_EMPTY_TREE_HEX)
+        .map_err(|e| anyhow::anyhow!("invalid empty tree oid: {e}"))?;
+    let head_at_empty_tree = head_oid.is_zero();
 
     if keep_empty && todo_cmd == RebaseTodoCmd::Pick && is_commit_tree_unchanged(repo, commit_oid)?
     {
+        if head_at_empty_tree {
+            bail!("internal: keep-empty pick with null HEAD during rebase");
+        }
         let head_obj = repo.odb.read(&head_oid)?;
         let head_commit = parse_commit(&head_obj.data)?;
         let now = time::OffsetDateTime::now_utc();
@@ -3101,7 +3264,6 @@ fn cherry_pick_for_rebase(
     }
 
     // Parent tree (base for the cherry-pick). Root commits use Git's empty tree as base.
-    const GIT_EMPTY_TREE_HEX: &str = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
     let parent_tree_oid = if let Some(parent_oid) = commit.parents.first() {
         let parent_obj = repo.odb.read(parent_oid)?;
         let parent_commit = parse_commit(&parent_obj.data)?;
@@ -3114,10 +3276,15 @@ fn cherry_pick_for_rebase(
     // Commit's tree (theirs — the changes we want)
     let commit_tree_oid = commit.tree;
 
-    // HEAD tree (ours — the current state)
-    let head_obj = repo.odb.read(&head_oid)?;
-    let head_commit = parse_commit(&head_obj.data)?;
-    let head_tree_oid = head_commit.tree;
+    // HEAD tree (ours — the current state). `rebase --root` without `--onto` leaves HEAD at the
+    // null OID until the first replayed commit exists (Git-compatible).
+    let head_tree_oid = if head_at_empty_tree {
+        empty_tree_oid
+    } else {
+        let head_obj = repo.odb.read(&head_oid)?;
+        let head_commit = parse_commit(&head_obj.data)?;
+        head_commit.tree
+    };
     let root_rebase = rb_dir.join("root").exists();
     let ws_fix_rule = load_ws_fix_rule_from_rebase_state(git_dir);
 

--- a/grit/src/commands/reset.rs
+++ b/grit/src/commands/reset.rs
@@ -126,7 +126,9 @@ pub struct Args {
     pub patch: bool,
 
     /// Remaining positional arguments: `[<commit>] [--] [<path>…]`.
-    #[arg(trailing_var_arg = true, allow_hyphen_values = false)]
+    ///
+    /// Hyphen values must be allowed so `HEAD^` / `HEAD~1` are not dropped by clap (t3431 setup).
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     pub rest: Vec<String>,
 
     /// When true, `reset --merge` does not remove `CHERRY_PICK_HEAD` / `REVERT_HEAD` (sequencer abort).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible **rebase fork-point** behavior (reflog-based merge base), `rebase.forkPoint` config semantics, default `@{upstream}` when `--onto` is used, and **`rebase --root`** without `--onto` (including `rebase.forkPoint true`).

Also fixes **`git branch -t <name>`** without a start point to set local tracking, **`reset --hard HEAD^`** argument parsing (clap `allow_hyphen_values`), and factors **`merge_base::fork_point`** for shared use with `grit merge-base --fork-point`.

## Test

- `./scripts/run-tests.sh t3431-rebase-fork-point.sh` → **26/26** pass (CSV + dashboards refreshed).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb0b7d7f-c6fe-487c-a1ff-a0f64a450d02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb0b7d7f-c6fe-487c-a1ff-a0f64a450d02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

