### PR TITLE
fix: t9330 add -v progress on stderr

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1503,7 +1503,7 @@ t9305-fast-import-signatures	t9	skip	16	0	0	false	ok	0
 t9306-fast-import-signed-tags	t9	skip	10	0	0	false	ok	0
 t9310-tag-sort-version	t9	yes	27	27	0	true	ok	0
 t9320-commit-allow-empty	t9	yes	24	24	0	true	ok	0
-t9330-add-update-all	t9	yes	26	24	2	false	ok	0
+t9330-add-update-all	t9	yes	26	26	0	true	ok	0
 t9350-fast-export	t9	skip	73	0	0	false	ok	1
 t9351-fast-export-anonymize	t9	yes	17	13	4	false	ok	0
 t9400-for-each-ref-contains	t9	yes	25	25	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,688 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,688 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T04:25:39+00:00" class="gen-time" title="2026-04-10 04:25 UTC">2026-04-10 04:25 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,688</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">
@@ -285,11 +285,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t9</span>
         <span class="group-desc">Git tools</span>
-        <span class="group-meta">75/90 files · 127 skipped · 2,771/2,860 tests</span>
+        <span class="group-meta">76/90 files · 127 skipped · 2,773/2,860 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:96.9%"></div></div>
-        <span class="group-pct pct-green">96.9%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:97.0%"></div></div>
+        <span class="group-pct pct-green">97.0%</span>
       </div>
     </a>
 

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35688 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,688 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T04:25:39+00:00" class="gen-time" title="2026-04-10 04:25 UTC">2026-04-10 04:25 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,688</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">
@@ -15187,14 +15187,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t9" data-tests="26" data-passed="24">
+<tr class="" data-group="t9" data-tests="26" data-passed="26" data-full-pass="1">
   <td class="mono">t9330-add-update-all</td>
   <td>t9</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">26</td>
-  <td class="right">24</td>
+  <td class="right">26</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:92.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="row-skip" data-group="t9" data-tests="73" data-passed="0">

--- a/grit/src/commands/add.rs
+++ b/grit/src/commands/add.rs
@@ -897,7 +897,7 @@ fn update_tracked(
             let is_embedded_repo = abs_path.join(".git").exists();
             if is_plain_directory && !is_embedded_repo {
                 if args.verbose || args.dry_run {
-                    println!("remove '{path_str}'");
+                    eprintln!("remove '{path_str}'");
                 }
                 if !args.dry_run {
                     index.remove(raw_path);
@@ -911,7 +911,7 @@ fn update_tracked(
                     );
                     let current = index.get(raw_path, 0);
                     if current.map(|e| e.oid != oid).unwrap_or(false) {
-                        println!("add '{path_str}'");
+                        eprintln!("add '{path_str}'");
                     }
                 }
             } else {
@@ -928,7 +928,7 @@ fn update_tracked(
             }
         } else {
             if args.verbose || args.dry_run {
-                println!("remove '{path_str}'");
+                eprintln!("remove '{path_str}'");
             }
             if !args.dry_run {
                 index.remove(raw_path);
@@ -1257,7 +1257,7 @@ fn stage_gitlink(
     }
 
     if dry_run {
-        println!("add '{}'", rel_path);
+        eprintln!("add '{}'", rel_path);
         return Ok(());
     }
 
@@ -1284,7 +1284,7 @@ fn stage_gitlink(
     index.add_or_replace(entry);
 
     if verbose {
-        println!("add '{}'", rel_path);
+        eprintln!("add '{}'", rel_path);
     }
 
     Ok(())
@@ -1343,7 +1343,7 @@ pub(crate) fn stage_file(
             // Don't actually stage, just check if the file exists
             return Ok(());
         }
-        println!("add '{rel_path}'");
+        eprintln!("add '{rel_path}'");
         return Ok(());
     }
 
@@ -1414,7 +1414,7 @@ pub(crate) fn stage_file(
         entry.set_intent_to_add(true);
         index.add_or_replace(entry);
         if ctx.verbose {
-            println!("add '{rel_path}'");
+            eprintln!("add '{rel_path}'");
         }
         return Ok(());
     }
@@ -1509,7 +1509,7 @@ pub(crate) fn stage_file(
     index.stage_file(entry);
 
     if ctx.verbose {
-        println!("add '{rel_path}'");
+        eprintln!("add '{rel_path}'");
     }
 
     Ok(())

--- a/logs/2026-04-10_t9330-add-verbose-stderr.md
+++ b/logs/2026-04-10_t9330-add-verbose-stderr.md
@@ -1,0 +1,14 @@
+# t9330-add-update-all — verbose on stderr
+
+## Failure
+
+Tests 14–15: `grit add -v` / `--verbose` with `2>actual` expected non-empty stderr; progress used `println!` (stdout).
+
+## Fix
+
+`grit/src/commands/add.rs`: route dry-run and verbose `add`/`remove` progress lines through `eprintln!` (including `update_tracked`, `stage_gitlink`, `stage_file` dry-run path).
+
+## Verification
+
+- `./scripts/run-tests.sh t9330-add-update-all.sh` — 26/26
+- `cargo test -p grit-lib --lib` — pass


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t9330-add-update-all.sh` failed tests 14–15 because `grit add -v` / `--verbose` printed progress on stdout while the harness captures stderr (`2>actual`), matching real Git.

## Changes

- **`grit/src/commands/add.rs`**: Use `eprintln!` for verbose and dry-run `add` / `remove` progress (including `update_tracked`, `stage_gitlink`, and `stage_file` dry-run paths).
- **Harness metadata**: Refreshed `data/test-files.csv` and dashboard HTML/SVG after `./scripts/run-tests.sh t9330-add-update-all.sh` (26/26).
- **`logs/2026-04-10_t9330-add-verbose-stderr.md`**: Task log.

## Verification

- `./scripts/run-tests.sh t9330-add-update-all.sh` — 26/26
- `cargo test -p grit-lib --lib` — pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f14d668-d74a-4efa-aae0-500877fed0a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f14d668-d74a-4efa-aae0-500877fed0a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

