### PR TITLE
fix: case-only git mv on case-insensitive filesystems

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -389,7 +389,7 @@ t13280-tag-list-format	t1	yes	34	34	0	true	ok	0
 t13290-commit-allow-empty-msg	t1	yes	30	30	0	true	ok	0
 t13300-add-executable-bit	t1	yes	32	32	0	true	ok	0
 t13310-rm-sparse-checkout	t1	yes	31	31	0	true	ok	0
-t13320-mv-case-sensitive	t1	yes	30	29	1	false	ok	0
+t13320-mv-case-sensitive	t1	yes	30	30	0	true	ok	0
 t13330-switch-reflog-entry	t1	yes	30	29	1	false	ok	0
 t13340-restore-merge-conflict	t1	yes	30	30	0	true	ok	0
 t13350-reset-orphan-branch	t1	yes	30	30	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,687 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,687 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T04:28:30+00:00" class="gen-time" title="2026-04-10 04:28 UTC">2026-04-10 04:28 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,687</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -197,7 +197,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">275/368 files · 8 skipped · 11,694/12,747 tests</span>
+        <span class="group-meta">276/368 files · 8 skipped · 11,695/12,747 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-green" style="width:91.7%"></div></div>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35687 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,687 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T04:28:30+00:00" class="gen-time" title="2026-04-10 04:28 UTC">2026-04-10 04:28 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,687</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -4047,14 +4047,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="30" data-passed="29">
+<tr class="" data-group="t1" data-tests="30" data-passed="30" data-full-pass="1">
   <td class="mono">t13320-mv-case-sensitive</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">30</td>
-  <td class="right">29</td>
+  <td class="right">30</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:96.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="30" data-passed="29">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit/src/commands/init.rs
+++ b/grit/src/commands/init.rs
@@ -578,6 +578,14 @@ fn create_git_dir(git_dir: &Path, opts: CreateGitDirOptions<'_>) -> Result<()> {
         fs::write(&config_path, config_content)?;
     }
 
+    // git/setup.c: if `.git/config` is visible as `CoNfIg`, the filesystem is case-insensitive.
+    if !is_reinit && !bare && fs::metadata(git_dir.join("CoNfIg")).is_ok() {
+        let content = fs::read_to_string(&config_path)?;
+        let mut cfg = ConfigFile::parse(&config_path, &content, ConfigScope::Local)?;
+        cfg.set("core.ignorecase", "true")?;
+        cfg.write()?;
+    }
+
     // Write description (only on fresh init)
     let desc_path = git_dir.join("description");
     if !desc_path.exists() {

--- a/grit/src/commands/mv.rs
+++ b/grit/src/commands/mv.rs
@@ -20,6 +20,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
+
 use crate::grit_exe;
 
 use crate::commands::sparse_advice::{emit_dirty_sparse_advice, emit_sparse_path_advice};
@@ -604,7 +607,7 @@ pub fn run(args: Args) -> Result<()> {
                 }
             }
             if src_abs.exists() {
-                fs::rename(&src_abs, &dst_abs)
+                rename_worktree_path(&src_abs, &dst_abs, ignore_case, &row.src, &row.dst)
                     .with_context(|| format!("renaming '{}' failed", row.src))?;
             }
             if row_is_gitlink {
@@ -666,8 +669,14 @@ pub fn run(args: Args) -> Result<()> {
                             fs::create_dir_all(parent)?;
                         }
                         if src_abs.exists() {
-                            fs::rename(&src_abs, &dst_abs)
-                                .with_context(|| format!("renaming '{}' failed", row.src))?;
+                            rename_worktree_path(
+                                &src_abs,
+                                &dst_abs,
+                                ignore_case,
+                                &row.src,
+                                &row.dst,
+                            )
+                            .with_context(|| format!("renaming '{}' failed", row.src))?;
                         }
                         dirty_advice.push(row.dst.clone());
                     }
@@ -979,4 +988,96 @@ fn normalise_path(path: &str) -> String {
         }
     }
     parts.join("/")
+}
+
+/// When the work tree is on a case-insensitive volume, `rename("a", "A")` can fail or no-op because
+/// both paths resolve to the same directory entry. Git relies on `core.ignorecase` plus a
+/// two-step rename via a temporary name (see `t13320-mv-case-sensitive` on macOS/Windows).
+fn rename_worktree_path(
+    src: &Path,
+    dst: &Path,
+    ignore_case_config: bool,
+    src_rel: &str,
+    dst_rel: &str,
+) -> std::io::Result<()> {
+    if needs_case_only_two_step_rename(src, dst, ignore_case_config, src_rel, dst_rel)? {
+        rename_via_intermediate_temp(src, dst)
+    } else {
+        fs::rename(src, dst)
+    }
+}
+
+fn needs_case_only_two_step_rename(
+    src: &Path,
+    dst: &Path,
+    ignore_case_config: bool,
+    src_rel: &str,
+    dst_rel: &str,
+) -> std::io::Result<bool> {
+    if src_rel == dst_rel {
+        return Ok(false);
+    }
+    if !src_rel.eq_ignore_ascii_case(dst_rel) {
+        return Ok(false);
+    }
+    if ignore_case_config {
+        return Ok(true);
+    }
+    same_filesystem_identity(src, dst)
+}
+
+#[cfg(unix)]
+fn same_filesystem_identity(a: &Path, b: &Path) -> std::io::Result<bool> {
+    let ma = match fs::metadata(a) {
+        Ok(m) => m,
+        Err(_) => return Ok(false),
+    };
+    let mb = match fs::metadata(b) {
+        Ok(m) => m,
+        Err(_) => return Ok(false),
+    };
+    Ok(ma.dev() == mb.dev() && ma.ino() == mb.ino())
+}
+
+#[cfg(not(unix))]
+fn same_filesystem_identity(_a: &Path, _b: &Path) -> std::io::Result<bool> {
+    Ok(false)
+}
+
+fn rename_via_intermediate_temp(src: &Path, dst: &Path) -> std::io::Result<()> {
+    let parent = dst
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let stem = dst
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let pid = std::process::id();
+    for n in 0u64..10_000 {
+        let inter = parent.join(format!(".grit-mv-case-{pid}-{n}-{stem}"));
+        if inter == src || inter == dst {
+            continue;
+        }
+        match fs::rename(src, &inter) {
+            Ok(()) => match fs::rename(&inter, dst) {
+                Ok(()) => return Ok(()),
+                Err(e) => {
+                    let _ = fs::rename(&inter, src);
+                    return Err(e);
+                }
+            },
+            Err(e)
+                if e.kind() == std::io::ErrorKind::AlreadyExists
+                    || e.kind() == std::io::ErrorKind::NotFound =>
+            {
+                continue;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    Err(std::io::Error::new(
+        std::io::ErrorKind::AlreadyExists,
+        "could not allocate a unique intermediate path for case-only rename",
+    ))
 }

--- a/logs/2026-04-10_t13320-mv-case-sensitive.md
+++ b/logs/2026-04-10_t13320-mv-case-sensitive.md
@@ -1,0 +1,15 @@
+# t13320-mv-case-sensitive
+
+## Context
+
+Harness was already 30/30 on Linux; hardened behavior for case-insensitive filesystems (macOS/Windows) where `rename(a, A)` can fail when source and destination are the same directory entry.
+
+## Changes
+
+- **`grit init`**: After creating `config`, if `.git/CoNfIg` is accessible (Git’s probe), set `core.ignorecase = true` (matches `git/setup.c`).
+- **`grit mv`**: For ASCII case-only renames, when `core.ignorecase` is true or Unix metadata shows `src` and `dst` are the same inode, rename via a unique intermediate path under the destination parent.
+
+## Validation
+
+- `cargo test -p grit-lib --lib`
+- `./scripts/run-tests.sh t13320-mv-case-sensitive.sh` → 30/30


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t13320-mv-case-sensitive` was already passing on Linux; this hardens `grit mv` for **case-insensitive** volumes (typical macOS/APFS and Windows) where a single `rename()` for an ASCII case-only change can fail because source and destination resolve to the same directory entry.

## Changes

- **`grit init`**: After writing the initial `config`, probe whether `.git/CoNfIg` is visible (Git’s `setup.c` check) and set `core.ignorecase = true` when it is.
- **`grit mv`**: When the relative paths differ only by ASCII case and either `core.ignorecase` is true or (on Unix) `src` and `dst` metadata show the same device/inode, perform a **two-step rename** via a unique intermediate filename next to the destination.

## Testing

- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t13320-mv-case-sensitive.sh` (30/30)

## Log

See `logs/2026-04-10_t13320-mv-case-sensitive.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9efeac49-78f6-42af-adb5-c89f5c3772f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9efeac49-78f6-42af-adb5-c89f5c3772f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

