### PR TITLE
docs: refresh test dashboards (t3701 harness run)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,686 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,686 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T04:26:42+00:00" class="gen-time" title="2026-04-10 04:26 UTC">2026-04-10 04:26 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,686</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>758 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35686 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,686 / 45,142 tests · 1,405 files in scope · 758 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T04:26:42+00:00" class="gen-time" title="2026-04-10 04:26 UTC">2026-04-10 04:26 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,686</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit/src/commands/add.rs
+++ b/grit/src/commands/add.rs
@@ -25,7 +25,7 @@ use std::io::Read;
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 
-fn resolved_env_index_path(repo: &Repository) -> PathBuf {
+pub(crate) fn resolved_env_index_path(repo: &Repository) -> PathBuf {
     if let Ok(raw) = std::env::var("GIT_INDEX_FILE") {
         let p = PathBuf::from(raw);
         if p.is_absolute() {
@@ -189,24 +189,6 @@ pub fn run(mut args: Args) -> Result<()> {
         bail!("options '--dry-run' and '--interactive'/'--patch' cannot be used together");
     }
 
-    // Stubs for unsupported interactive modes — accept the flags
-    // gracefully so scripts that pass them don't hard-fail.
-    if args.patch || args.interactive || args.edit {
-        // Real git would enter interactive mode; we just warn and succeed.
-        let mode_name = if args.patch {
-            "-p/--patch"
-        } else if args.interactive {
-            "-i/--interactive"
-        } else {
-            "-e/--edit"
-        };
-        eprintln!(
-            "warning: {} mode is not yet implemented; doing nothing",
-            mode_name
-        );
-        return Ok(());
-    }
-
     let repo = Repository::discover(None).context("not a git repository")?;
     let work_tree = repo
         .work_tree
@@ -243,6 +225,37 @@ pub fn run(mut args: Args) -> Result<()> {
         }
     }
 
+    let conv = ConversionConfig::from_config(&config);
+    let attrs = crlf::load_gitattributes(work_tree);
+    let add_cfg = AddConfig {
+        core_filemode,
+        precompose_unicode,
+        ignore_errors: args.ignore_errors
+            || config
+                .get_bool("add.ignore-errors")
+                .and_then(|r| r.ok())
+                .unwrap_or(false),
+        conv,
+        attrs,
+        config: config.clone(),
+    };
+
+    if args.patch {
+        return super::add_patch::run_add_patch(&repo, &args.pathspec, &add_cfg);
+    }
+    if args.interactive || args.edit {
+        let mode_name = if args.interactive {
+            "-i/--interactive"
+        } else {
+            "-e/--edit"
+        };
+        eprintln!(
+            "warning: {} mode is not yet implemented; doing nothing",
+            mode_name
+        );
+        return Ok(());
+    }
+
     // "git add" with no pathspecs and no flags: give advice
     if args.pathspec.is_empty()
         && !args.all
@@ -276,22 +289,6 @@ pub fn run(mut args: Args) -> Result<()> {
         Some(IgnoreMatcher::from_repository(&repo)?)
     } else {
         None
-    };
-
-    let conv = ConversionConfig::from_config(&config);
-    let attrs = crlf::load_gitattributes(work_tree);
-
-    let add_cfg = AddConfig {
-        core_filemode,
-        precompose_unicode,
-        ignore_errors: args.ignore_errors
-            || config
-                .get_bool("add.ignore-errors")
-                .and_then(|r| r.ok())
-                .unwrap_or(false),
-        conv,
-        attrs,
-        config: config.clone(),
     };
 
     // --renormalize: re-apply clean conversion to tracked files

--- a/grit/src/commands/add_patch.rs
+++ b/grit/src/commands/add_patch.rs
@@ -1,0 +1,577 @@
+//! Interactive `git add -p` — stage selected hunks from the index↔worktree diff.
+//!
+//! Uses the same Myers line-diff and hunk-splitting approach as [`crate::commands::stash`] patch
+//! mode, then writes blended blob content and updated modes into the index.
+
+use anyhow::{bail, Context, Result};
+use grit_lib::crlf::{self, ConvertToGitOpts};
+use grit_lib::diff::{diff_index_to_worktree, mode_from_metadata, DiffStatus};
+use grit_lib::index::{Index, IndexEntry};
+use grit_lib::merge_file::is_binary;
+use grit_lib::objects::{ObjectId, ObjectKind};
+use grit_lib::odb::Odb;
+use grit_lib::repo::Repository;
+use similar::{Algorithm, TextDiff};
+use std::fs;
+use std::io::{self, BufRead, Write};
+use std::path::Path;
+
+use crate::commands::add::{resolved_env_index_path, AddConfig};
+use crate::commands::checkout::{patch_path_filter_matches, resolve_pathspec};
+use crate::commands::stash::{partial_unified_for_op_range, split_hunk_at_first_gap};
+use grit_lib::index::entry_from_metadata;
+
+/// Blend index and worktree bytes for **staging** (`git add -p`).
+///
+/// [`checkout::blend_line_diff_by_hunk_ranges`] uses `accepted` with **revert/checkout** semantics
+/// (accepted ⇒ keep the index/source side). For `add -p`, user `y` means take the **worktree**
+/// side, so we invert the boolean vector.
+fn blend_for_stage_hunks(
+    index_bytes: &[u8],
+    work_bytes: &[u8],
+    ranges: &[(usize, usize)],
+    stage_yes: &[bool],
+) -> String {
+    let revert_accepted: Vec<bool> = stage_yes.iter().map(|a| !*a).collect();
+    crate::commands::checkout::blend_line_diff_by_hunk_ranges(
+        index_bytes,
+        work_bytes,
+        ranges,
+        &revert_accepted,
+    )
+}
+
+/// Run `git add -p` / `git add --patch`.
+pub(crate) fn run_add_patch(
+    repo: &Repository,
+    pathspecs: &[String],
+    add_cfg: &AddConfig,
+) -> Result<()> {
+    let work_tree = repo
+        .work_tree
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("this operation must be run in a work tree"))?;
+
+    let cwd = std::env::current_dir().context("resolving cwd")?;
+    let filter_paths: Vec<String> = pathspecs
+        .iter()
+        .map(|p| resolve_pathspec(p, work_tree, &cwd))
+        .collect();
+
+    let index_path = resolved_env_index_path(repo);
+    let mut index = repo.load_index_at(&index_path).context("loading index")?;
+
+    let mut entries = diff_index_to_worktree(&repo.odb, &index, work_tree)?;
+    entries.retain(|e| {
+        if e.status == DiffStatus::Unmerged {
+            return false;
+        }
+        patch_path_filter_matches(e.path(), &filter_paths)
+    });
+    entries.sort_by(|a, b| a.path().cmp(b.path()));
+
+    if entries.is_empty() {
+        println!("No changes.");
+        return Ok(());
+    }
+
+    let stdin = io::stdin();
+    let mut reader = stdin.lock();
+    let mut out = io::stdout();
+
+    let odb = &repo.odb;
+    let conv = &add_cfg.conv;
+    let attrs = &add_cfg.attrs;
+
+    for entry in entries {
+        let path_str = entry.path().to_owned();
+        let path_bytes = path_str.as_bytes();
+
+        let Some(ie) = index.get(path_bytes, 0).cloned() else {
+            continue;
+        };
+
+        if ie.mode == 0o160000 {
+            continue;
+        }
+
+        let abs_path = work_tree.join(&path_str);
+        let meta = match fs::symlink_metadata(&abs_path) {
+            Ok(m) => m,
+            Err(e)
+                if e.kind() == std::io::ErrorKind::NotFound
+                    || e.raw_os_error() == Some(20) /* ENOTDIR */ =>
+            {
+                if entry.status != DiffStatus::Deleted {
+                    continue;
+                }
+                handle_deleted_file(
+                    repo,
+                    &mut index,
+                    index_path.as_path(),
+                    &path_str,
+                    &ie,
+                    &mut reader,
+                    &mut out,
+                    odb,
+                )?;
+                continue;
+            }
+            Err(_) => continue,
+        };
+
+        let file_attrs = crlf::get_file_attrs(attrs, &path_str, false, &add_cfg.config);
+
+        let index_blob = if ie.oid == ObjectId::zero() {
+            Vec::new()
+        } else {
+            let obj = match odb.read(&ie.oid) {
+                Ok(o) if o.kind == ObjectKind::Blob => o.data,
+                _ => continue,
+            };
+            obj
+        };
+
+        let work_blob = if meta.file_type().is_symlink() {
+            let target = fs::read_link(&abs_path)?;
+            target.to_string_lossy().into_owned().into_bytes()
+        } else {
+            let raw = fs::read(&abs_path).unwrap_or_default();
+            let prior_blob = if ie.oid != ObjectId::zero() {
+                Some(index_blob.clone())
+            } else {
+                None
+            };
+            let opts = ConvertToGitOpts {
+                index_blob: prior_blob.as_deref(),
+                renormalize: false,
+                check_safecrlf: true,
+            };
+            match crlf::convert_to_git_with_opts(&raw, &path_str, conv, &file_attrs, opts) {
+                Ok(c) => c,
+                Err(msg) => {
+                    eprintln!("{msg}");
+                    continue;
+                }
+            }
+        };
+
+        if is_binary(&index_blob) || is_binary(&work_blob) {
+            continue;
+        }
+
+        let mode_differs = parse_mode_u32(&entry.old_mode) != parse_mode_u32(&entry.new_mode);
+        let content_differs = index_blob != work_blob;
+
+        let mut effective_mode = ie.mode;
+        let index_side_bytes = index_blob.clone();
+
+        if mode_differs {
+            write!(out, "(1/1) Stage mode change [y,n,q,a,d,s,e,p,P,?]? ").ok();
+            out.flush().ok();
+            match read_one_command(&mut reader, &mut out)? {
+                ReadCmd::Eof => {
+                    repo.write_index_at(&index_path, &mut index)?;
+                    return Ok(());
+                }
+                ReadCmd::Invalid => {}
+                ReadCmd::Char(c) => match c {
+                    'y' => effective_mode = mode_from_metadata(&meta),
+                    'q' => {
+                        repo.write_index_at(&index_path, &mut index)?;
+                        return Ok(());
+                    }
+                    _ => {}
+                },
+            }
+        }
+
+        if !content_differs {
+            if mode_differs && effective_mode != ie.mode {
+                write_index_blob_and_mode(
+                    odb,
+                    &mut index,
+                    &path_str,
+                    &abs_path,
+                    &index_side_bytes,
+                    effective_mode,
+                )?;
+            }
+            continue;
+        }
+
+        let mut cur_work = work_blob;
+
+        'rediff: loop {
+            let index_str = String::from_utf8_lossy(&index_side_bytes);
+            let work_str = String::from_utf8_lossy(&cur_work);
+            let text_diff = TextDiff::configure()
+                .algorithm(Algorithm::Myers)
+                .diff_lines(index_str.as_ref(), work_str.as_ref());
+            let ops: Vec<_> = text_diff.ops().to_vec();
+            let has_change = ops
+                .iter()
+                .any(|o| !matches!(o, similar::DiffOp::Equal { .. }));
+            if !has_change {
+                if mode_differs && effective_mode != ie.mode {
+                    write_index_blob_and_mode(
+                        odb,
+                        &mut index,
+                        &path_str,
+                        &abs_path,
+                        &index_side_bytes,
+                        effective_mode,
+                    )?;
+                }
+                break 'rediff;
+            }
+
+            let n_ops = ops.len();
+            let mut hunk_ranges: Vec<(usize, usize)> = vec![(0, n_ops)];
+            let mut accepted = vec![false; hunk_ranges.len()];
+            let mut hunk_cursor = 0usize;
+
+            'hunk_loop: loop {
+                let n_hunks = hunk_ranges.len();
+                if hunk_cursor >= n_hunks {
+                    break;
+                }
+
+                let display_idx = hunk_cursor + 1;
+                let (s, e) = hunk_ranges[hunk_cursor];
+                let hunk_only = partial_unified_for_op_range(
+                    path_str.as_str(),
+                    &index_side_bytes,
+                    &cur_work,
+                    &ops[s..e],
+                    3,
+                );
+
+                writeln!(out, "diff --git a/{path_str} b/{path_str}").ok();
+                write!(out, "--- a/{path_str}\n+++ b/{path_str}\n").ok();
+                write!(out, "{hunk_only}").ok();
+                write!(
+                    out,
+                    "({display_idx}/{n_hunks}) Stage this hunk [y,n,q,a,d,s,e,p,P,?]? "
+                )
+                .ok();
+                out.flush().ok();
+
+                match read_one_command(&mut reader, &mut out)? {
+                    ReadCmd::Eof => {
+                        let blended = blend_for_stage_hunks(
+                            &index_side_bytes,
+                            &cur_work,
+                            &hunk_ranges,
+                            &accepted,
+                        );
+                        write_index_blob_and_mode(
+                            odb,
+                            &mut index,
+                            &path_str,
+                            &abs_path,
+                            blended.as_bytes(),
+                            effective_mode,
+                        )?;
+                        repo.write_index_at(&index_path, &mut index)?;
+                        return Ok(());
+                    }
+                    ReadCmd::Invalid => continue 'hunk_loop,
+                    ReadCmd::Char(c) => match c {
+                        'y' => {
+                            accepted[hunk_cursor] = true;
+                            hunk_cursor += 1;
+                        }
+                        'n' => {
+                            hunk_cursor += 1;
+                        }
+                        'a' => {
+                            for j in hunk_cursor..n_hunks {
+                                accepted[j] = true;
+                            }
+                            break 'hunk_loop;
+                        }
+                        'd' => break 'hunk_loop,
+                        'q' => {
+                            let blended = blend_for_stage_hunks(
+                                &index_side_bytes,
+                                &cur_work,
+                                &hunk_ranges,
+                                &accepted,
+                            );
+                            write_index_blob_and_mode(
+                                odb,
+                                &mut index,
+                                &path_str,
+                                &abs_path,
+                                blended.as_bytes(),
+                                effective_mode,
+                            )?;
+                            repo.write_index_at(&index_path, &mut index)?;
+                            return Ok(());
+                        }
+                        's' => {
+                            if !split_hunk_at_first_gap(&mut hunk_ranges, hunk_cursor, &ops) {
+                                writeln!(out, "Sorry, cannot split this hunk").ok();
+                                continue 'hunk_loop;
+                            }
+                            let n = hunk_ranges.len();
+                            accepted.resize(n, false);
+                            continue 'hunk_loop;
+                        }
+                        'e' => match edit_worktree_via_editor(&cur_work) {
+                            Ok(edited) => {
+                                cur_work = edited;
+                                continue 'rediff;
+                            }
+                            Err(_) => continue 'hunk_loop,
+                        },
+                        '?' => {
+                            writeln!(
+                                out,
+                                "y - stage this hunk\n\
+                                 n - do not stage this hunk\n\
+                                 q - quit; do not stage this hunk or any of the remaining ones\n\
+                                 a - stage this hunk and all later hunks in the file\n\
+                                 d - do not stage this hunk or any of the later hunks in the file\n\
+                                 s - split the current hunk into smaller hunks\n\
+                                 e - manually edit the current hunk\n"
+                            )
+                            .ok();
+                            continue 'hunk_loop;
+                        }
+                        _ => continue 'hunk_loop,
+                    },
+                }
+            }
+
+            let blended =
+                blend_for_stage_hunks(&index_side_bytes, &cur_work, &hunk_ranges, &accepted);
+
+            if accepted.iter().any(|&a| a) || (mode_differs && effective_mode != ie.mode) {
+                write_index_blob_and_mode(
+                    odb,
+                    &mut index,
+                    &path_str,
+                    &abs_path,
+                    blended.as_bytes(),
+                    effective_mode,
+                )?;
+            }
+            break 'rediff;
+        }
+    }
+
+    repo.write_index_at(&index_path, &mut index)
+        .context("writing index")?;
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReadCmd {
+    Eof,
+    Invalid,
+    Char(char),
+}
+
+fn read_one_command(reader: &mut impl BufRead, out: &mut impl Write) -> Result<ReadCmd> {
+    let mut line = String::new();
+    if reader.read_line(&mut line)? == 0 {
+        return Ok(ReadCmd::Eof);
+    }
+    let trimmed = line.trim_end_matches(['\n', '\r']);
+    let t = trimmed.trim();
+    if t.is_empty() {
+        return Ok(ReadCmd::Char(' '));
+    }
+    if t.len() > 1 {
+        writeln!(out, "Sorry, only one letter is expected, got '{t}'")?;
+        return Ok(ReadCmd::Invalid);
+    }
+    let c = t.chars().next().unwrap_or(' ');
+    Ok(ReadCmd::Char(c.to_ascii_lowercase()))
+}
+
+fn parse_mode_u32(m: &str) -> u32 {
+    u32::from_str_radix(m, 8).unwrap_or(0)
+}
+
+fn handle_deleted_file(
+    repo: &Repository,
+    index: &mut Index,
+    index_path: &Path,
+    path_str: &str,
+    ie: &IndexEntry,
+    reader: &mut impl BufRead,
+    out: &mut impl Write,
+    odb: &Odb,
+) -> Result<()> {
+    let index_blob = if ie.oid == ObjectId::zero() {
+        Vec::new()
+    } else {
+        let obj = odb.read(&ie.oid)?;
+        if obj.kind != ObjectKind::Blob {
+            return Ok(());
+        }
+        obj.data
+    };
+    if is_binary(&index_blob) {
+        return Ok(());
+    }
+
+    let work_blob = Vec::<u8>::new();
+    let index_str = String::from_utf8_lossy(&index_blob);
+    let work_str = String::from_utf8_lossy(&work_blob);
+    let text_diff = TextDiff::configure()
+        .algorithm(Algorithm::Myers)
+        .diff_lines(index_str.as_ref(), work_str.as_ref());
+    let ops: Vec<_> = text_diff.ops().to_vec();
+    let n_ops = ops.len();
+    let mut hunk_ranges = vec![(0, n_ops)];
+    let mut accepted = vec![false; 1];
+    let mut hunk_cursor = 0usize;
+
+    loop {
+        if hunk_cursor >= hunk_ranges.len() {
+            break;
+        }
+        let display_idx = hunk_cursor + 1;
+        let n_hunks = hunk_ranges.len();
+        let (s, e) = hunk_ranges[hunk_cursor];
+        let hunk_only =
+            partial_unified_for_op_range(path_str, &index_blob, &work_blob, &ops[s..e], 3);
+        writeln!(out, "diff --git a/{path_str} b/{path_str}").ok();
+        write!(out, "--- a/{path_str}\n+++ b/{path_str}\n").ok();
+        write!(out, "{hunk_only}").ok();
+        write!(
+            out,
+            "({display_idx}/{n_hunks}) Stage deletion [y,n,q,a,d,s,e,p,P,?]? "
+        )
+        .ok();
+        out.flush().ok();
+
+        match read_one_command(reader, out)? {
+            ReadCmd::Eof => {
+                repo.write_index_at(index_path, index)?;
+                return Ok(());
+            }
+            ReadCmd::Invalid => continue,
+            ReadCmd::Char(c) => match c {
+                'y' => {
+                    accepted[hunk_cursor] = true;
+                    hunk_cursor += 1;
+                }
+                'n' => {
+                    hunk_cursor += 1;
+                }
+                'a' => {
+                    for j in hunk_cursor..n_hunks {
+                        accepted[j] = true;
+                    }
+                    break;
+                }
+                'd' => break,
+                'q' => {
+                    repo.write_index_at(index_path, index)?;
+                    return Ok(());
+                }
+                's' => {
+                    if !split_hunk_at_first_gap(&mut hunk_ranges, hunk_cursor, &ops) {
+                        writeln!(out, "Sorry, cannot split this hunk").ok();
+                        continue;
+                    }
+                    let n = hunk_ranges.len();
+                    accepted.resize(n, false);
+                }
+                '?' => {
+                    writeln!(
+                        out,
+                        "y - stage this hunk for deletion\n\
+                         n - do not stage this hunk\n\
+                         q - quit\n\
+                         a - stage this and all later hunks\n\
+                         d - skip remaining hunks in this file\n\
+                         s - split hunk\n"
+                    )
+                    .ok();
+                }
+                _ => {}
+            },
+        }
+    }
+
+    if accepted.iter().any(|&a| a) {
+        let blended = blend_for_stage_hunks(&index_blob, &work_blob, &hunk_ranges, &accepted);
+        if blended.is_empty() {
+            index.remove(path_str.as_bytes());
+        } else {
+            let oid = odb.write(ObjectKind::Blob, blended.as_bytes())?;
+            if let Some(ent) = index.get_mut(path_str.as_bytes(), 0) {
+                ent.oid = oid;
+                ent.size = blended.len() as u32;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn write_index_blob_and_mode(
+    odb: &Odb,
+    index: &mut Index,
+    path_str: &str,
+    abs_path: &Path,
+    blob_data: &[u8],
+    mode: u32,
+) -> Result<()> {
+    let oid = odb.write(ObjectKind::Blob, blob_data)?;
+    let meta = fs::symlink_metadata(abs_path).ok();
+    let mut new_ent = if let Some(m) = meta.as_ref() {
+        let mut e = entry_from_metadata(m, path_str.as_bytes(), oid, mode);
+        e.mode = mode;
+        e
+    } else {
+        IndexEntry {
+            ctime_sec: 0,
+            ctime_nsec: 0,
+            mtime_sec: 0,
+            mtime_nsec: 0,
+            dev: 0,
+            ino: 0,
+            mode,
+            uid: 0,
+            gid: 0,
+            size: blob_data.len() as u32,
+            oid,
+            flags: path_str.len().min(0xFFF) as u16,
+            flags_extended: None,
+            path: path_str.as_bytes().to_vec(),
+        }
+    };
+    new_ent.set_intent_to_add(false);
+    new_ent.set_assume_unchanged(false);
+    new_ent.set_skip_worktree(false);
+    index.stage_file(new_ent);
+    Ok(())
+}
+
+fn edit_worktree_via_editor(content: &[u8]) -> Result<Vec<u8>> {
+    use std::io::Write;
+    let mut f = tempfile::NamedTempFile::new().context("temp file for add -p edit")?;
+    f.as_file_mut().write_all(content)?;
+    f.flush()?;
+    let path = f.path().to_owned();
+    let editor = std::env::var("VISUAL")
+        .or_else(|_| std::env::var("EDITOR"))
+        .unwrap_or_else(|_| "vi".to_string());
+    let status = std::process::Command::new("sh")
+        .arg("-c")
+        .arg(format!("{} \"$1\"", editor))
+        .arg("sh")
+        .arg(&path)
+        .status()
+        .context("running editor")?;
+    if !status.success() {
+        bail!("editor failed");
+    }
+    fs::read(&path).context("reading edited file")
+}

--- a/grit/src/commands/mod.rs
+++ b/grit/src/commands/mod.rs
@@ -3,6 +3,7 @@
 //! Each submodule corresponds to one plumbing subcommand.
 
 pub mod add;
+mod add_patch;
 pub mod am;
 pub mod annotate;
 pub mod apply;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Implements **`git add -p` / `git add --patch`**: index↔worktree diff via `diff_index_to_worktree`, Myers line diff, hunk display with `partial_unified_for_op_range`, split (`s`), basic prompts (`y`/`n`/`a`/`d`/`q`/`e`/`?`), and index updates (blob OID + mode).
- **`blend_for_stage_hunks`** inverts the boolean vector passed to `checkout::blend_line_diff_by_hunk_ranges` so user **y** stages the **worktree** side (that helper is defined for revert/checkout semantics).
- **`add -p` with no pathspec** is dispatched before the “Nothing specified” advice (matches Git: patch all dirty tracked paths).
- **`resolved_env_index_path`** is `pub(crate)` so `add_patch` respects `GIT_INDEX_FILE`.

`-i` / `-e` remain stubbed with a warning.

## Test plan

- [ ] `cargo build --release -p grit-rs`
- [ ] `cargo test -p grit-lib --lib`
- [ ] Manual: repo with modified tracked file, `printf 'y\n' | grit add -p`, `grit diff --cached` shows staged hunk

(No full t3701 pass yet — many tests need Git-parity extras: navigation, colors, diffFilter, `--no-auto-advance`, etc.)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eebdc104-30ee-45d5-898a-5eff3e69f0fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eebdc104-30ee-45d5-898a-5eff3e69f0fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

