### PR TITLE
fix: make t1011-read-tree-sparse-checkout fully pass

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -130,7 +130,7 @@ commit → check it off → move on.
 - [ ] `t1002-read-tree-m-u-2way` █░░░░░░░░░░░░░░░░░░░ 2/22 (20 left) — Two way merge with read-tree -m -u $H $M
 
 - [ ] `t1301-shared-repo` █░░░░░░░░░░░░░░░░░░░ 2/22 (20 left) — Test shared repository initialization
-- [ ] `t1011-read-tree-sparse-checkout` ░░░░░░░░░░░░░░░░░░░░ 1/23 (22 left) — sparse checkout tests
+- [x] `t1011-read-tree-sparse-checkout` ████████████████████ 23/23 (0 left) — sparse checkout tests
 
 - [ ] `t0600-reffiles-backend` █████░░░░░░░░░░░░░░░ 9/33 (24 left) — Test reffiles backend
 - [ ] `t1007-hash-object` ███████░░░░░░░░░░░░░ 15/40 (25 left) — git hash-object

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -103,7 +103,7 @@ t1009-read-tree-new-index	t1	yes	3	3	0	true	ok	0
 t10090-write-tree-idempotent	t1	yes	34	34	0	true	ok	0
 t1010-mktree	t1	yes	8	8	0	true	ok	0
 t10100-ls-tree-long-format	t1	yes	36	36	0	true	ok	0
-t1011-read-tree-sparse-checkout	t1	yes	23	13	10	false	ok	0
+t1011-read-tree-sparse-checkout	t1	yes	23	23	0	true	ok	0
 t10110-ls-files-pathspec-filter	t1	yes	37	37	0	true	ok	0
 t1012-read-tree-df	t1	yes	5	5	0	true	ok	0
 t10120-config-unset-all	t1	yes	33	33	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,696 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,696 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T04:32:16+00:00" class="gen-time" title="2026-04-10 04:32 UTC">2026-04-10 04:32 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,696</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -197,11 +197,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">275/368 files · 8 skipped · 11,694/12,747 tests</span>
+        <span class="group-meta">276/368 files · 8 skipped · 11,704/12,747 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:91.7%"></div></div>
-        <span class="group-pct pct-green">91.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:91.8%"></div></div>
+        <span class="group-pct pct-green">91.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t2">
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35696 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,696 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T04:32:16+00:00" class="gen-time" title="2026-04-10 04:32 UTC">2026-04-10 04:32 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,696</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -1187,14 +1187,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="23" data-passed="13">
+<tr class="" data-group="t1" data-tests="23" data-passed="23" data-full-pass="1">
   <td class="mono">t1011-read-tree-sparse-checkout</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">23</td>
-  <td class="right">13</td>
+  <td class="right">23</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="37" data-passed="37" data-full-pass="1">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/sparse_checkout.rs
+++ b/grit-lib/src/sparse_checkout.rs
@@ -5,6 +5,7 @@
 
 use std::collections::BTreeSet;
 
+use crate::ignore::path_in_sparse_checkout as path_in_sparse_checkout_non_cone_git;
 use crate::wildmatch::{wildmatch, WM_PATHNAME};
 
 /// Parsed non-cone sparse-checkout patterns in file order (last match wins).
@@ -415,10 +416,17 @@ pub fn path_in_sparse_checkout(
 ///
 /// - `git_dir` — repository git directory (reads `config` and `info/sparse-checkout`).
 /// - `index` — index to update in place; bumped to version 3 when any entry is marked skip-worktree.
+/// - `skip_sparse_checkout` — when true (e.g. `read-tree --no-sparse-checkout`), do not set
+///   `skip-worktree` bits even if sparse checkout is enabled.
 pub fn apply_sparse_checkout_skip_worktree(
     git_dir: &std::path::Path,
     index: &mut crate::index::Index,
+    skip_sparse_checkout: bool,
 ) {
+    if skip_sparse_checkout {
+        return;
+    }
+
     let config = crate::config::ConfigSet::load(Some(git_dir), true)
         .unwrap_or_else(|_| crate::config::ConfigSet::new());
     let sparse_enabled = config
@@ -435,21 +443,23 @@ pub fn apply_sparse_checkout_skip_worktree(
         .map(|v| v.eq_ignore_ascii_case("true"))
         .unwrap_or(true);
 
-    let mut warnings = Vec::new();
-    let (_cone_ok, _cone_loaded, non_cone) =
-        load_sparse_checkout_with_warnings(git_dir, cone_config, &mut warnings);
-    for line in warnings {
-        eprintln!("{line}");
-    }
-
     let sparse_path = git_dir.join("info").join("sparse-checkout");
     let file_content = std::fs::read_to_string(&sparse_path).unwrap_or_default();
+    let sparse_lines = parse_sparse_checkout_file(&file_content);
+
+    // Use silent cone parsing here: non-cone files like `sub` are normal and should not emit
+    // "disabling cone pattern matching" on every index update (t1011 checkout noise).
     let cone_struct = if cone_config {
         ConePatterns::try_parse(&file_content)
     } else {
         None
     };
-    let effective_cone = cone_config && cone_struct.is_some();
+
+    // Git: an on-disk sparse-checkout file with no effective patterns (e.g. a file that only
+    // contains blank lines) still enables sparse mode and excludes every path (`pl->nr == 0`
+    // yields UNDECIDED → rejected at repo root in `path_in_sparse_checkout_1`).
+    let sparse_file_exists = sparse_path.is_file();
+    let exclude_all = sparse_file_exists && sparse_lines.is_empty();
 
     let mut any_skip = false;
     for entry in &mut index.entries {
@@ -457,12 +467,13 @@ pub fn apply_sparse_checkout_skip_worktree(
             continue;
         }
         let path_str = String::from_utf8_lossy(&entry.path);
-        let included = path_in_sparse_checkout(
-            path_str.as_ref(),
-            effective_cone,
-            cone_struct.as_ref(),
-            &non_cone,
-        );
+        let included = if exclude_all {
+            false
+        } else if let Some(cone) = cone_struct.as_ref() {
+            cone.path_included(path_str.as_ref())
+        } else {
+            path_in_sparse_checkout_non_cone_git(path_str.as_ref(), &sparse_lines)
+        };
         entry.set_skip_worktree(!included);
         if !included {
             any_skip = true;

--- a/grit/src/commands/checkout.rs
+++ b/grit/src/commands/checkout.rs
@@ -848,6 +848,7 @@ pub fn run(mut args: Args) -> Result<()> {
             args.force,
             args.ours,
             args.theirs,
+            args.ignore_skip_worktree_bits,
             &merge_cli,
         );
     }
@@ -866,6 +867,7 @@ pub fn run(mut args: Args) -> Result<()> {
                     args.force,
                     args.ours,
                     args.theirs,
+                    args.ignore_skip_worktree_bits,
                     &merge_cli,
                 );
             }
@@ -875,6 +877,24 @@ pub fn run(mut args: Args) -> Result<()> {
     // Case: checkout -f (no args) — force reset working tree to HEAD
     if args.force && target.is_none() && paths.is_empty() {
         return force_reset_to_head(&repo);
+    }
+
+    // Bare `git checkout` with no positional arguments: Git's `switch_branches` defaults the
+    // "new" branch to HEAD and merges the working tree (re-applies sparse-checkout when enabled).
+    if paths.is_empty() && !args.detach && target.is_none() {
+        let head = resolve_head(&repo.git_dir)?;
+        let tree_oid = match &head {
+            HeadState::Branch { oid: Some(oid), .. } | HeadState::Detached { oid } => {
+                commit_to_tree(&repo, oid)?
+            }
+            HeadState::Branch { oid: None, .. } | HeadState::Invalid => return Ok(()),
+        };
+        let sparse_on = sparse_checkout_config_enabled(&repo.git_dir);
+        if sparse_on {
+            let recurse = RECURSE_SUBMODULES.with(|r| r.get());
+            switch_to_tree(&repo, &head, &tree_oid, switch_force, recurse)?;
+        }
+        return Ok(());
     }
 
     // Case 3: checkout -- (with no paths and no target) is a no-op
@@ -1153,6 +1173,7 @@ pub fn run(mut args: Args) -> Result<()> {
                 args.force,
                 args.ours,
                 args.theirs,
+                args.ignore_skip_worktree_bits,
                 &merge_cli,
             ) {
                 Ok(()) => Ok(()),
@@ -2525,11 +2546,13 @@ fn switch_to_tree(
         new_index.sort();
     }
 
-    apply_sparse_checkout_skip_worktree(&repo.git_dir, &mut new_index);
+    apply_sparse_checkout_skip_worktree(&repo.git_dir, &mut new_index, false);
 
     // Perform the actual working tree update.
     // When force, write all entries even if OID matches (to restore dirty files).
     checkout_index_to_worktree(repo, &old_index, &new_index, &work_tree, force)?;
+
+    warn_sparse_paths_already_present(repo, &old_index, &new_index, &work_tree);
 
     // Update stat info in the new index to match the freshly checked-out files
     for entry in &mut new_index.entries {
@@ -3210,6 +3233,7 @@ fn checkout_paths(
     force_paths: bool,
     ours: bool,
     theirs: bool,
+    ignore_skip_worktree_bits: bool,
     merge_cli: &CheckoutMergeCli,
 ) -> Result<()> {
     if source.is_some() && merge_mode {
@@ -3235,6 +3259,9 @@ checking out of the index."
     // `GIT_TRACE2` parallel worker count: full index restore may only increment `updated_paths` for
     // paths actually written; nested submodule checkouts strip trace — use index size (t2080).
     let mut trace_parallel_units_from_index = 0usize;
+
+    let skip_for_sparse =
+        |entry: &IndexEntry| -> bool { entry.skip_worktree() && !ignore_skip_worktree_bits };
 
     match source {
         None => {
@@ -3291,6 +3318,9 @@ checking out of the index."
                         if ie.stage() != 0 {
                             continue;
                         }
+                        if skip_for_sparse(ie) {
+                            continue;
+                        }
                         let p = String::from_utf8_lossy(&ie.path).to_string();
                         if glob_matches(&rel, &p) {
                             let w = write_blob_to_worktree(
@@ -3333,14 +3363,16 @@ checking out of the index."
                                     // `checkout -f`: only refresh paths that have stage 0; leave
                                     // purely unmerged paths untouched (t7201).
                                     if let Some(entry) = index.get(pb.as_slice(), 0) {
-                                        checkout_record_path_result(
-                                            write_blob_to_worktree(
-                                                repo, work_tree, &p, &entry.oid, entry.mode,
-                                                &index, false,
-                                            ),
-                                            &mut updated_paths,
-                                            &mut path_errors,
-                                        );
+                                        if !skip_for_sparse(entry) {
+                                            checkout_record_path_result(
+                                                write_blob_to_worktree(
+                                                    repo, work_tree, &p, &entry.oid, entry.mode,
+                                                    &index, false,
+                                                ),
+                                                &mut updated_paths,
+                                                &mut path_errors,
+                                            );
+                                        }
                                     }
                                     continue;
                                 } else if !ours && !theirs && !merge_mode {
@@ -3370,14 +3402,16 @@ checking out of the index."
                                         &mut path_errors,
                                     );
                                 } else if let Some(entry) = index.get(pb.as_slice(), 0) {
-                                    checkout_record_path_result(
-                                        write_blob_to_worktree(
-                                            repo, work_tree, &p, &entry.oid, entry.mode, &index,
-                                            false,
-                                        ),
-                                        &mut updated_paths,
-                                        &mut path_errors,
-                                    );
+                                    if !skip_for_sparse(entry) {
+                                        checkout_record_path_result(
+                                            write_blob_to_worktree(
+                                                repo, work_tree, &p, &entry.oid, entry.mode,
+                                                &index, false,
+                                            ),
+                                            &mut updated_paths,
+                                            &mut path_errors,
+                                        );
+                                    }
                                 }
                             } else if merge_mode {
                                 let stage1 = index.get(pb.as_slice(), 1).cloned();
@@ -3400,14 +3434,16 @@ checking out of the index."
                                         Err(e) => path_errors.push(e),
                                     }
                                 } else if let Some(entry) = index.get(pb.as_slice(), 0) {
-                                    checkout_record_path_result(
-                                        write_blob_to_worktree(
-                                            repo, work_tree, &p, &entry.oid, entry.mode, &index,
-                                            false,
-                                        ),
-                                        &mut updated_paths,
-                                        &mut path_errors,
-                                    );
+                                    if !skip_for_sparse(entry) {
+                                        checkout_record_path_result(
+                                            write_blob_to_worktree(
+                                                repo, work_tree, &p, &entry.oid, entry.mode,
+                                                &index, false,
+                                            ),
+                                            &mut updated_paths,
+                                            &mut path_errors,
+                                        );
+                                    }
                                 }
                             }
                         }
@@ -3416,9 +3452,26 @@ checking out of the index."
                         // toward parallel checkout tests even though nested grit runs strip GIT_TRACE2).
                         let n = index.entries.iter().filter(|e| e.stage() == 0).count();
                         trace_parallel_units_from_index = trace_parallel_units_from_index.max(n);
+                        let mut sparse_skip_paths: Vec<Vec<u8>> = Vec::new();
+                        for ie in &index.entries {
+                            if ie.stage() == 0 && ie.skip_worktree() {
+                                sparse_skip_paths.push(ie.path.clone());
+                            }
+                        }
+                        for pb in sparse_skip_paths {
+                            let p = String::from_utf8_lossy(&pb).into_owned();
+                            let abs = work_tree.join(&p);
+                            if abs.is_file() || abs.is_symlink() {
+                                let _ = std::fs::remove_file(&abs);
+                            }
+                            remove_empty_parent_dirs(work_tree, &abs);
+                        }
                         // Restore ALL index entries
                         for ie in &index.entries {
                             if ie.stage() != 0 {
+                                continue;
+                            }
+                            if skip_for_sparse(ie) {
                                 continue;
                             }
                             let p = String::from_utf8_lossy(&ie.path).to_string();
@@ -3431,15 +3484,17 @@ checking out of the index."
                             );
                         }
                     }
-                } else if let Some(entry) = index.get(path_bytes, 0) {
+                } else if let Some(entry) = index.get(path_bytes, 0).cloned() {
                     // Exact file match
-                    checkout_record_path_result(
-                        write_blob_to_worktree(
-                            repo, work_tree, &rel, &entry.oid, entry.mode, &index, false,
-                        ),
-                        &mut updated_paths,
-                        &mut path_errors,
-                    );
+                    if !skip_for_sparse(&entry) {
+                        checkout_record_path_result(
+                            write_blob_to_worktree(
+                                repo, work_tree, &rel, &entry.oid, entry.mode, &index, false,
+                            ),
+                            &mut updated_paths,
+                            &mut path_errors,
+                        );
+                    }
                 } else if ours || theirs {
                     let stage2 = index.get(path_bytes, 2).cloned();
                     let stage3 = index.get(path_bytes, 3).cloned();
@@ -3499,6 +3554,9 @@ checking out of the index."
                     let mut matched = false;
                     for ie in &index.entries {
                         if ie.stage() != 0 {
+                            continue;
+                        }
+                        if skip_for_sparse(ie) {
                             continue;
                         }
                         let p = String::from_utf8_lossy(&ie.path).to_string();
@@ -4628,6 +4686,64 @@ fn find_recursive(
 // ---------------------------------------------------------------------------
 // Working tree helpers
 // ---------------------------------------------------------------------------
+
+/// After a branch/tree checkout with sparse checkout enabled, warn when paths
+/// transition from non-sparse to sparse in the index but already exist on disk
+/// (Git `WARNING_SPARSE_ORPHANED_NOT_OVERWRITTEN` / unpack-trees).
+fn warn_sparse_paths_already_present(
+    repo: &Repository,
+    old_index: &Index,
+    new_index: &Index,
+    work_tree: &Path,
+) {
+    let cfg = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+    let sparse_on = cfg
+        .get("core.sparsecheckout")
+        .map(|v| v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+    if !sparse_on {
+        return;
+    }
+
+    if !repo.git_dir.join("info").join("sparse-checkout").is_file() {
+        return;
+    }
+
+    let old_stage0: HashMap<&[u8], &IndexEntry> = old_index
+        .entries
+        .iter()
+        .filter(|e| e.stage() == 0)
+        .map(|e| (e.path.as_slice(), e))
+        .collect();
+
+    let mut warned: Vec<String> = Vec::new();
+    for entry in &new_index.entries {
+        if entry.stage() != 0 || entry.skip_worktree() {
+            continue;
+        }
+        let rel = String::from_utf8_lossy(&entry.path);
+        let old_entry = old_stage0.get(entry.path.as_slice());
+        let materializing = old_entry.map_or(true, |e| e.skip_worktree());
+        if !materializing {
+            continue;
+        }
+        let abs = work_tree.join(rel.as_ref());
+        if abs.is_file() || abs.is_symlink() {
+            warned.push(rel.into_owned());
+        }
+    }
+
+    if warned.is_empty() {
+        return;
+    }
+    warned.sort();
+    eprintln!("warning: The following paths were already present and thus not updated despite sparse patterns:");
+    for p in &warned {
+        eprintln!("\t{p}");
+    }
+    eprintln!();
+    eprintln!("After fixing the above paths, you may want to run `git sparse-checkout reapply`.");
+}
 
 /// Update the working tree from old_index to new_index: remove deleted files,
 /// add new files, update modified files.

--- a/grit/src/commands/merge.rs
+++ b/grit/src/commands/merge.rs
@@ -989,7 +989,7 @@ fn merge_unborn(repo: &Repository, head: &HeadState, args: &Args) -> Result<()> 
     let mut index = Index::new();
     index.entries = entries;
     index.sort();
-    apply_sparse_checkout_skip_worktree(&repo.git_dir, &mut index);
+    apply_sparse_checkout_skip_worktree(&repo.git_dir, &mut index, false);
 
     if let Some(ref wt) = repo.work_tree {
         checkout_entries(
@@ -1033,7 +1033,7 @@ fn do_fast_forward(
     let current_index = repo.load_index()?;
     let old_tree = commit_tree(repo, head_oid)?;
     let mut new_index = compose_fast_forward_index(repo, commit.tree, old_tree, &current_index)?;
-    apply_sparse_checkout_skip_worktree(&repo.git_dir, &mut new_index);
+    apply_sparse_checkout_skip_worktree(&repo.git_dir, &mut new_index, false);
     let old_entries = tree_to_map(tree_to_index_entries(repo, &old_tree, "")?);
     let index_dirty_vs_head = diff_index::index_cached_differs_from_head(repo)?;
     let index_already_at_target = index_matches_commit_tree(repo, merge_oid)?;
@@ -1542,7 +1542,7 @@ Aborting"
         None,
         None,
     )?;
-    apply_sparse_checkout_skip_worktree(&repo.git_dir, &mut merge_result.index);
+    apply_sparse_checkout_skip_worktree(&repo.git_dir, &mut merge_result.index, false);
 
     let append_strategy_failed = std::env::var("GIT_MERGE_VERBOSITY")
         .ok()
@@ -2561,7 +2561,7 @@ fn do_octopus_merge(
     final_index.entries = current_tree_entries;
     final_index.sort();
     compose_octopus_final_index(&pre_merge_index, &mut final_index);
-    apply_sparse_checkout_skip_worktree(&repo.git_dir, &mut final_index);
+    apply_sparse_checkout_skip_worktree(&repo.git_dir, &mut final_index, false);
     repo.write_index(&mut final_index)?;
 
     let sparse_on = sparse_checkout_enabled(&repo.git_dir);
@@ -2882,7 +2882,7 @@ fn do_strategy_theirs(
     let mut new_index = Index::new();
     new_index.entries = entries;
     new_index.sort();
-    apply_sparse_checkout_skip_worktree(&repo.git_dir, &mut new_index);
+    apply_sparse_checkout_skip_worktree(&repo.git_dir, &mut new_index, false);
 
     if let Some(ref wt) = repo.work_tree {
         let old_tree = commit_tree(repo, head_oid)?;
@@ -3097,7 +3097,7 @@ fn do_squash(
     let mut new_index = Index::new();
     new_index.entries = entries;
     new_index.sort();
-    apply_sparse_checkout_skip_worktree(&repo.git_dir, &mut new_index);
+    apply_sparse_checkout_skip_worktree(&repo.git_dir, &mut new_index, false);
 
     if let Some(ref wt) = repo.work_tree {
         checkout_entries(
@@ -3175,7 +3175,7 @@ fn merge_abort() -> Result<()> {
     let mut index = Index::new();
     index.entries = entries;
     index.sort();
-    apply_sparse_checkout_skip_worktree(&repo.git_dir, &mut index);
+    apply_sparse_checkout_skip_worktree(&repo.git_dir, &mut index, false);
 
     if let Some(ref wt) = repo.work_tree {
         checkout_entries(

--- a/grit/src/commands/merge_resolve.rs
+++ b/grit/src/commands/merge_resolve.rs
@@ -34,6 +34,7 @@ pub fn run(args: Args) -> Result<()> {
         empty: false,
         super_prefix: None,
         recurse_submodules: false,
+        no_sparse_checkout: false,
         trees: vec![base, head, remote],
     })?;
 

--- a/grit/src/commands/read_tree.rs
+++ b/grit/src/commands/read_tree.rs
@@ -63,6 +63,10 @@ pub struct Args {
     #[arg(long = "recurse-submodules", alias = "recursive")]
     pub recurse_submodules: bool,
 
+    /// Skip applying sparse-checkout skip-worktree bits (matches `git read-tree --no-sparse-checkout`).
+    #[arg(long = "no-sparse-checkout")]
+    pub no_sparse_checkout: bool,
+
     /// Tree-ish arguments (1 for reset, 2 for 2-way merge, 3 for 3-way merge).
     pub trees: Vec<String>,
 }
@@ -241,6 +245,9 @@ pub fn run(args: Args) -> Result<()> {
         new_index.entries =
             tree_to_index_entries(&repo, &tree_oids[tree_oids.len() - 1], "", prot)?;
         new_index.sort();
+        if !dry_run {
+            apply_sparse_checkout(&repo.git_dir, &mut new_index, args.no_sparse_checkout)?;
+        }
         if !dry_run && args.update {
             checkout_index_entries(&repo, &old_index, &new_index)?;
         }
@@ -314,7 +321,7 @@ pub fn run(args: Args) -> Result<()> {
     }
 
     // Apply sparse checkout: set skip-worktree on entries not matching patterns
-    apply_sparse_checkout(&repo.git_dir, &mut new_index)?;
+    apply_sparse_checkout(&repo.git_dir, &mut new_index, args.no_sparse_checkout)?;
 
     if args.update {
         validate_worktree_updates(
@@ -325,6 +332,8 @@ pub fn run(args: Args) -> Result<()> {
             args.super_prefix.as_deref(),
         )?;
     }
+
+    sparse_refresh_skip_worktree_for_dirty_paths(&repo, &old_index, &mut new_index)?;
     if !dry_run && args.update {
         checkout_index_entries(&repo, &old_index, &new_index)?;
     }
@@ -816,8 +825,52 @@ fn stage_entry(index: &mut Index, src: &IndexEntry, stage: u8) {
 }
 
 /// Check if `core.sparseCheckout` is enabled and apply skip-worktree bits.
-fn apply_sparse_checkout(git_dir: &Path, index: &mut Index) -> Result<()> {
-    apply_sparse_checkout_skip_worktree(git_dir, index);
+fn apply_sparse_checkout(
+    git_dir: &Path,
+    index: &mut Index,
+    skip_sparse_checkout: bool,
+) -> Result<()> {
+    apply_sparse_checkout_skip_worktree(git_dir, index, skip_sparse_checkout);
+    Ok(())
+}
+
+/// When sparse checkout would mark a path `skip-worktree` but the work tree already differs
+/// from the index entry, clear `skip-worktree` so `read-tree -u` can materialize or report
+/// conflicts (Git `verify_uptodate_sparse` / `apply_sparse_checkout`).
+fn sparse_refresh_skip_worktree_for_dirty_paths(
+    repo: &Repository,
+    _old_index: &Index,
+    new_index: &mut Index,
+) -> Result<()> {
+    let Some(wt) = repo.work_tree.as_deref() else {
+        return Ok(());
+    };
+    let config = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+    let sparse_on = config
+        .get("core.sparsecheckout")
+        .map(|v| v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+    if !sparse_on {
+        return Ok(());
+    }
+
+    for entry in new_index.entries.iter_mut() {
+        if entry.stage() != 0 || !entry.skip_worktree() {
+            continue;
+        }
+        let was_sparse = _old_index
+            .get(&entry.path, 0)
+            .is_some_and(|e| e.skip_worktree());
+        if was_sparse {
+            continue;
+        }
+        let rel = String::from_utf8_lossy(&entry.path);
+        let abs = wt.join(rel.as_ref());
+        let exists = std::fs::symlink_metadata(&abs).is_ok();
+        if exists && !worktree_matches_entry(repo, entry, &abs)? {
+            entry.set_skip_worktree(false);
+        }
+    }
     Ok(())
 }
 
@@ -920,6 +973,16 @@ fn checkout_index_entries(repo: &Repository, old_index: &Index, new_index: &Inde
                 .get(&entry.path)
                 .is_some_and(|old_entry| same_blob(old_entry, entry))
             && checkout_entry_present_on_disk(&abs_path, entry.mode)
+        {
+            continue;
+        }
+
+        // Sparse checkout: when `skip-worktree` was cleared because the work tree did not match
+        // the index (Git `verify_uptodate_sparse`), do not overwrite the on-disk file with the
+        // index blob (t1011 read-tree dirty case outside sparse cone).
+        if entry.mode != MODE_GITLINK
+            && checkout_entry_present_on_disk(&abs_path, entry.mode)
+            && !worktree_matches_entry(repo, entry, &abs_path)?
         {
             continue;
         }
@@ -1029,6 +1092,11 @@ fn validate_worktree_updates(
         }
 
         match (old, new) {
+            (None, Some(new_entry)) if new_entry.skip_worktree() => {
+                // Sparse checkout: new paths outside the cone are not materialized; Git skips
+                // `verify_absent` for `CE_NEW_SKIP_WORKTREE` entries (t1011 dirty case).
+                continue;
+            }
             (None, Some(_)) => {
                 if allow_ignored_overwrite {
                     if let Some(ref mut matcher) = ignore_matcher {
@@ -1255,7 +1323,7 @@ pub fn am_clean_index(
     let orig_map = tree_to_map(tree_to_index_entries(repo, &orig_tree_oid, "", prot)?);
     let mut phase2 = two_way_merge(repo, &phase1, &head_map, &orig_map)?;
 
-    apply_sparse_checkout(&repo.git_dir, &mut phase2)?;
+    apply_sparse_checkout(&repo.git_dir, &mut phase2, false)?;
 
     if repo.work_tree.is_some() {
         checkout_index_entries(repo, &phase1, &phase2)?;

--- a/logs/2026-04-10_t1011-read-tree-sparse-checkout.md
+++ b/logs/2026-04-10_t1011-read-tree-sparse-checkout.md
@@ -1,0 +1,17 @@
+# t1011-read-tree-sparse-checkout
+
+## Summary
+
+Made `tests/t1011-read-tree-sparse-checkout.sh` pass (23/23).
+
+## Changes
+
+- **`grit-lib` `sparse_checkout`**: `apply_sparse_checkout_skip_worktree` now takes `skip_sparse_checkout`; uses Git-style non-cone rules via `ignore::path_in_sparse_checkout`; cone mode uses silent `ConePatterns::try_parse` (no spam on raw patterns); empty on-disk sparse file with no patterns excludes all paths.
+- **`read-tree`**: `--no-sparse-checkout`; apply sparse after merge; validate worktree before clearing skip-worktree for dirty paths; skip untracked-overwrite check for new skip-worktree entries; `checkout_index_entries` skips checkout when disk differs from index for materialized paths; `--reset` applies sparse before checkout.
+- **`checkout`**: bare `git checkout` with sparse enabled calls `switch_to_tree` (re-apply patterns); `warn_sparse_paths_already_present` for materializing paths with existing files; `checkout .` removes skip-worktree paths from disk then restores; `--ignore-skip-worktree-bits` honored in path checkout.
+- **`merge` / `merge_resolve`**: pass new `apply_sparse_checkout_skip_worktree` flag.
+
+## Validation
+
+- `./scripts/run-tests.sh t1011-read-tree-sparse-checkout.sh` → 23/23
+- `cargo fmt`, `cargo clippy --fix --allow-dirty`, `cargo test -p grit-lib --lib`

--- a/progress.md
+++ b/progress.md
@@ -1,20 +1,21 @@
 # Progress — Grit Test Coverage
 
-**Updated:** 2026-04-09
+**Updated:** 2026-04-10
 
 ## Counts (derived from plan.md)
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   325 |
+| Completed   |   326 |
 | In progress |     5 |
-| Remaining   |   441 |
+| Remaining   |   440 |
 | **Total**   |   771 |
 
-Task lines in `PLAN.md`: 325 completed (`[x]`), 5 in progress (`[~]`), 441 remaining (`[ ]`).
+Task lines in `PLAN.md`: 326 completed (`[x]`), 5 in progress (`[~]`), 440 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t1011-read-tree-sparse-checkout` — 23/23 tests pass (`read-tree --no-sparse-checkout`; empty sparse file excludes all paths; non-cone matching via `ignore::path_in_sparse_checkout`; sparse refresh + checkout skips overwriting dirty out-of-cone files; bare `checkout` reapplies sparse when enabled; path checkout removes skip-worktree paths before restore; sparse “already present” warnings on materialize)
 - `t3309-notes-merge-auto-resolve` — 31/31 tests pass (`notes merge`: `union` / `cat_sort_uniq` blob combine like Git; successful merge commits use two parents; `notes.mergeStrategy` config errors match upstream expectations)
 - `t4063-diff-blobs` — 18/18 tests pass (`diff`: blob↔blob and `rev:path` pairs without treating blobs as trees; `HEAD:one..HEAD:two` range split; `rev:path` vs worktree file uses tree path + modes + `write_patch_with_prefix`; raw blob OID vs existing file uses filename as old path; `rev_parse::resolve_treeish_blob_at_path` for tree walks)
 - `t5524-pull-msg` — 3/3 tests pass (`git pull --no-rebase --log` merge message preserves `$` in subject lines; `--log=1` limits shortlog; harness CSV/dashboards refreshed; `PLAN.md` marked complete)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible sparse-checkout behavior for `read-tree` and `checkout` so `t1011-read-tree-sparse-checkout` passes all 23 tests.

## Key changes

- **`apply_sparse_checkout_skip_worktree`**: optional `skip_sparse_checkout` flag; non-cone matching via `ignore::path_in_sparse_checkout`; empty `info/sparse-checkout` excludes all paths; silent cone parse (no warning spam for raw patterns like `sub`).
- **`read-tree`**: `--no-sparse-checkout`; ordering of validate vs sparse refresh; skip untracked-overwrite validation for new `skip-worktree` entries; do not overwrite worktree when disk content disagrees with index after sparse materialization; sparse on `--reset`.
- **`checkout`**: bare `checkout` reapplies sparse when enabled; warnings when materializing paths that already exist on disk; `checkout .` removes `skip-worktree` paths from disk before restore; `--ignore-skip-worktree-bits` for path checkout.

## Test

`./scripts/run-tests.sh t1011-read-tree-sparse-checkout.sh` → 23/23

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3bd5922b-d515-4b4c-b924-bdfc99c02cb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3bd5922b-d515-4b4c-b924-bdfc99c02cb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

