### PR TITLE
fix: make t7507-commit-verbose pass (commit --verbose)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1229,7 +1229,7 @@ t7504-commit-msg-hook	t7	yes	29	21	8	false	ok	1
 t7505-prepare-commit-msg	t7	yes	30	29	1	false	ok	0
 t7505-prepare-commit-msg-hook	t7	yes	23	7	16	false	ok	0
 t7506-status-submodule	t7	yes	40	6	34	false	ok	0
-t7507-commit-verbose	t7	yes	45	21	24	false	ok	0
+t7507-commit-verbose	t7	yes	45	45	0	true	ok	0
 t7508-status	t7	yes	126	81	45	false	ok	0
 t7509-commit-authorship	t7	yes	12	4	8	false	ok	0
 t7510-signed-commit	t7	skip	28	0	0	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,710 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,710 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T04:39:24+00:00" class="gen-time" title="2026-04-10 04:39 UTC">2026-04-10 04:39 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,710</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">49/126 files · 11 skipped · 2,518/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.6%"></div></div>
+        <span class="group-pct pct-blue">69.6%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35710 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,710 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T04:39:24+00:00" class="gen-time" title="2026-04-10 04:39 UTC">2026-04-10 04:39 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,710</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">
@@ -12447,14 +12447,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:15.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="45" data-passed="21">
+<tr class="" data-group="t7" data-tests="45" data-passed="45" data-full-pass="1">
   <td class="mono">t7507-commit-verbose</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">45</td>
-  <td class="right">21</td>
+  <td class="right">45</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:46.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="126" data-passed="81">

--- a/grit/src/commands/commit.rs
+++ b/grit/src/commands/commit.rs
@@ -27,6 +27,7 @@ use grit_lib::write_tree::{
 
 use crate::ident::{resolve_email, resolve_name, IdentRole};
 
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::fs;
 use std::io::{self, IsTerminal, Read, Write};
@@ -34,6 +35,13 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
+
+/// Environment variable set by [`preprocess_commit_argv`] with the effective `-v` count after
+/// scanning argv (Git-compatible ordering with `--no-verbose`).
+pub(crate) const GIT_GRIT_COMMIT_VERBOSE_ENV: &str = "GIT_GRIT_INTERNAL_COMMIT_VERBOSE";
+
+/// Scissors line inserted before verbose diffs in `COMMIT_EDITMSG` (matches Git's `cut_line`).
+const GIT_COMMIT_CUT_LINE: &str = "------------------------ >8 ------------------------\n";
 
 /// Arguments for `grit commit`.
 #[derive(Debug, ClapArgs)]
@@ -135,13 +143,9 @@ pub struct Args {
     #[arg(short = 'u', long = "untracked-files", value_name = "MODE", num_args = 0..=1, default_missing_value = "all")]
     pub untracked_files: Option<String>,
 
-    /// Verbose - show diff in commit message editor.
+    /// Verbose - show diff in commit message template (`-v` / `--verbose`; see argv preprocessing in `main`).
     #[arg(short = 'v', long = "verbose", action = clap::ArgAction::Count)]
     pub verbose: u8,
-
-    /// Suppress verbose output.
-    #[arg(long = "no-verbose")]
-    pub no_verbose: bool,
 
     /// Override cleanup mode.
     #[arg(long = "cleanup", value_name = "MODE")]
@@ -282,6 +286,44 @@ fn peel_message_flags_from_pathspec(args: &mut Args) {
         i += 1;
     }
     args.pathspec = out;
+}
+
+/// Git-compatible scan of `commit` argv for `-v` / `--verbose` / `--no-verbose`, sets
+/// [`GIT_GRIT_COMMIT_VERBOSE_ENV`], and strips `--no-verbose` so clap does not error on unknown long
+/// options.
+pub(crate) fn preprocess_commit_for_parse(argv: &[String]) -> Vec<String> {
+    let mut effective: Option<u32> = None;
+    for arg in argv {
+        if arg == "--no-verbose" {
+            effective = Some(0);
+            continue;
+        }
+        let inc = match arg.as_str() {
+            "-v" | "--verbose" => Some(1u32),
+            s if s.starts_with('-')
+                && !s.starts_with("--")
+                && s.len() > 1
+                && s[1..].chars().all(|c| c == 'v') =>
+            {
+                Some(s.len().saturating_sub(1) as u32)
+            }
+            _ => None,
+        };
+        if let Some(n) = inc {
+            let base = effective.unwrap_or(0);
+            effective = Some(base.saturating_add(n));
+        }
+    }
+    if let Some(v) = effective {
+        std::env::set_var(GIT_GRIT_COMMIT_VERBOSE_ENV, v.to_string());
+    } else {
+        let _ = std::env::remove_var(GIT_GRIT_COMMIT_VERBOSE_ENV);
+    }
+
+    argv.iter()
+        .filter(|a| a.as_str() != "--no-verbose")
+        .cloned()
+        .collect()
 }
 
 /// Run the `commit` command.
@@ -770,6 +812,8 @@ pub fn run(mut args: Args) -> Result<()> {
     let template_path = resolve_commit_template_path(&args, &config)?;
     let use_editor_for_message = commit_uses_editor(&args, fixup_parsed.as_ref());
 
+    let verbose_level = resolve_commit_verbose_level(&args, &config);
+    let commit_cleanup_mode = resolve_commit_cleanup_mode(&args, &config, use_editor_for_message);
     let msg_result = prepare_commit_message(
         &args,
         &repo,
@@ -778,6 +822,9 @@ pub fn run(mut args: Args) -> Result<()> {
         template_path.as_deref(),
         use_editor_for_message,
         &head,
+        &staged,
+        &unstaged,
+        verbose_level,
     )?;
     let mut message = normalize_autosquash_editor_message(
         &args,
@@ -794,7 +841,10 @@ pub fn run(mut args: Args) -> Result<()> {
     }
 
     if let Some(ref tpl) = template_for_aborted_check {
-        if template_untouched(&message, tpl) && !args.allow_empty_message {
+        let cp = comment_line_prefix_full(&config);
+        if template_untouched(&message, tpl, cp.as_ref(), commit_cleanup_mode)
+            && !args.allow_empty_message
+        {
             eprintln!("Aborting commit; you did not edit the message.");
             std::process::exit(1);
         }
@@ -962,7 +1012,13 @@ pub fn run(mut args: Args) -> Result<()> {
                 let new_raw = fs::read(&msg_file)?;
                 match String::from_utf8(new_raw.clone()) {
                     Ok(s) => {
-                        message = s;
+                        let cp = comment_line_prefix_full(&config);
+                        message = apply_cleanup_message(
+                            &s,
+                            verbose_level,
+                            cp.as_ref(),
+                            commit_cleanup_mode,
+                        );
                         raw_message = None;
                     }
                     Err(_) => {
@@ -2070,10 +2126,11 @@ pub(crate) fn launch_commit_editor(repo: &Repository, path: &Path) -> Result<()>
     Ok(())
 }
 
-/// Post-editor cleanup matching Git `strbuf_stripspace` with `comment_prefix = "#"` (default
-/// `cleanup=strip`): skip `#` lines, trim trailing whitespace per line, collapse runs of empty
-/// lines to a single blank between paragraphs, trim leading/trailing blank lines.
-pub(crate) fn cleanup_edited_commit_message(message: &str) -> String {
+/// Post-editor cleanup matching Git `strbuf_stripspace` with `comment_prefix` (from
+/// `core.commentChar` / `core.commentString`, default `#`): skip comment-prefixed lines, trim
+/// trailing whitespace per line, collapse runs of empty lines to a single blank between paragraphs,
+/// trim leading/trailing blank lines.
+pub(crate) fn cleanup_edited_commit_message(message: &str, comment_prefix: &str) -> String {
     fn line_cleanup(line: &str) -> usize {
         let mut len = line.len();
         while len > 0 {
@@ -2098,7 +2155,7 @@ pub(crate) fn cleanup_edited_commit_message(message: &str) -> String {
         };
         i += advance;
 
-        if line_with_nl.starts_with('#') {
+        if line_with_nl.starts_with(comment_prefix) {
             continue;
         }
         let content_len = line_cleanup(line_with_nl);
@@ -2140,14 +2197,29 @@ fn rest_is_empty_signedoff_only(s: &str, start: usize) -> bool {
     true
 }
 
-fn template_untouched(message: &str, template_path: &Path) -> bool {
+fn template_untouched(
+    message: &str,
+    template_path: &Path,
+    comment_prefix: &str,
+    cleanup_mode: CommitMsgCleanupMode,
+) -> bool {
     let Ok(tmpl_raw) = fs::read_to_string(template_path) else {
         return false;
     };
-    // Git runs `cleanup_message` before `template_untouched`, so `#` lines are stripped from
-    // both the editor buffer and the template file content for this comparison.
-    let tmpl = cleanup_edited_commit_message(&tmpl_raw);
-    let msg = cleanup_edited_commit_message(message);
+    let tmpl = match cleanup_mode {
+        CommitMsgCleanupMode::None => tmpl_raw,
+        CommitMsgCleanupMode::All => cleanup_edited_commit_message(&tmpl_raw, comment_prefix),
+        CommitMsgCleanupMode::Space | CommitMsgCleanupMode::Scissors => {
+            git_vertical_stripspace(&tmpl_raw)
+        }
+    };
+    let msg = match cleanup_mode {
+        CommitMsgCleanupMode::None => message.to_string(),
+        CommitMsgCleanupMode::All => cleanup_edited_commit_message(message, comment_prefix),
+        CommitMsgCleanupMode::Space | CommitMsgCleanupMode::Scissors => {
+            git_vertical_stripspace(message)
+        }
+    };
     let after_prefix = msg.strip_prefix(&tmpl).unwrap_or(msg.as_str());
     rest_is_empty_signedoff_only(msg.as_str(), msg.len().saturating_sub(after_prefix.len()))
 }
@@ -2178,6 +2250,304 @@ fn git_binary_for_status() -> PathBuf {
     PathBuf::from("git")
 }
 
+/// Full `core.commentChar` / `core.commentString` prefix (Git may use multi-character prefixes).
+pub(crate) fn comment_line_prefix_full(config: &ConfigSet) -> Cow<'_, str> {
+    let raw = config
+        .get("core.commentchar")
+        .or_else(|| config.get("core.commentChar"))
+        .or_else(|| config.get("core.commentstring"))
+        .or_else(|| config.get("core.commentString"));
+    let Some(s) = raw else {
+        return Cow::Borrowed("#");
+    };
+    let t = s.trim();
+    if t.is_empty() || t.eq_ignore_ascii_case("auto") {
+        Cow::Borrowed("#")
+    } else {
+        Cow::Owned(t.to_string())
+    }
+}
+
+/// Git `commit.verbose`: bool or integer; `-1` when unset (inherit default 0).
+fn config_commit_verbose_raw(config: &ConfigSet) -> i64 {
+    let Some(v) = config.get("commit.verbose") else {
+        return -1;
+    };
+    let t = v.trim();
+    let lower = t.to_ascii_lowercase();
+    if matches!(lower.as_str(), "true" | "yes" | "on" | "1" | "") {
+        return 1;
+    }
+    if matches!(lower.as_str(), "false" | "no" | "off" | "0") {
+        return 0;
+    }
+    t.parse::<i64>().unwrap_or(0)
+}
+
+/// Effective verbosity level after argv (`GIT_GRIT_INTERNAL_COMMIT_VERBOSE`) and `commit.verbose`.
+fn resolve_commit_verbose_level(args: &Args, config: &ConfigSet) -> i64 {
+    let cfg_v = config_commit_verbose_raw(config);
+    let scanned = std::env::var(GIT_GRIT_COMMIT_VERBOSE_ENV)
+        .ok()
+        .and_then(|s| s.parse::<u32>().ok());
+    let _ = std::env::remove_var(GIT_GRIT_COMMIT_VERBOSE_ENV);
+    let clap_v = u32::from(args.verbose);
+    let cli_count = scanned.unwrap_or(clap_v);
+    if scanned.is_some() {
+        return i64::from(cli_count);
+    }
+    if clap_v > 0 {
+        return i64::from(clap_v);
+    }
+    if cfg_v >= 0 {
+        cfg_v
+    } else {
+        0
+    }
+}
+
+/// Git `get_cleanup_mode` / `cleanup_message` modes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CommitMsgCleanupMode {
+    None,
+    Space,
+    All,
+    Scissors,
+}
+
+fn resolve_commit_cleanup_mode(
+    args: &Args,
+    config: &ConfigSet,
+    use_editor: bool,
+) -> CommitMsgCleanupMode {
+    let cleanup_cfg = config.get("commit.cleanup");
+    let cleanup = args.cleanup.as_deref().or(cleanup_cfg.as_deref());
+    match cleanup.map(|s| s.trim()) {
+        None | Some("default") => {
+            if use_editor {
+                CommitMsgCleanupMode::All
+            } else {
+                CommitMsgCleanupMode::Space
+            }
+        }
+        Some("verbatim") => CommitMsgCleanupMode::None,
+        Some("whitespace") => CommitMsgCleanupMode::Space,
+        Some("strip") => CommitMsgCleanupMode::All,
+        Some("scissors") => {
+            if use_editor {
+                CommitMsgCleanupMode::Scissors
+            } else {
+                CommitMsgCleanupMode::Space
+            }
+        }
+        Some(_) => {
+            if use_editor {
+                CommitMsgCleanupMode::All
+            } else {
+                CommitMsgCleanupMode::Space
+            }
+        }
+    }
+}
+
+/// Match Git `cleanup_message`: truncate before scissors when `verbose` or `scissors` mode; then
+/// `strbuf_stripspace` with comment prefix only for `All`.
+fn apply_cleanup_message(
+    message: &str,
+    verbose_level: i64,
+    comment_prefix: &str,
+    mode: CommitMsgCleanupMode,
+) -> String {
+    let truncate = verbose_level > 0 || mode == CommitMsgCleanupMode::Scissors;
+    let truncated = if truncate {
+        truncate_at_verbose_cutoff(message, comment_prefix)
+    } else {
+        message.to_string()
+    };
+    match mode {
+        CommitMsgCleanupMode::None => truncated,
+        CommitMsgCleanupMode::All => cleanup_edited_commit_message(&truncated, comment_prefix),
+        CommitMsgCleanupMode::Space | CommitMsgCleanupMode::Scissors => {
+            git_vertical_stripspace(&truncated)
+        }
+    }
+}
+
+/// Locate end of user message before the scissors line (Git `wt_status_locate_end`).
+fn wt_status_locate_end(message: &str, comment_prefix: &str) -> usize {
+    let cut = GIT_COMMIT_CUT_LINE;
+    let lead = format!("{comment_prefix} {cut}");
+    if message.starts_with(&lead) {
+        return 0;
+    }
+    let needle = format!("\n{comment_prefix} {cut}");
+    if let Some(pos) = message.find(&needle) {
+        return pos.saturating_add(1);
+    }
+    message.len()
+}
+
+fn truncate_at_verbose_cutoff(message: &str, comment_prefix: &str) -> String {
+    let end = wt_status_locate_end(message, comment_prefix);
+    message.get(..end).unwrap_or("").to_string()
+}
+
+fn diff_mnemonic_prefix(config: &ConfigSet) -> bool {
+    config.get("diff.mnemonicprefix").is_some_and(|v| {
+        matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "true" | "yes" | "on" | "1" | ""
+        )
+    })
+}
+
+fn append_commented_line(buf: &mut String, comment_prefix: &str, body: &str) {
+    buf.push_str(comment_prefix);
+    if !body.starts_with(['\n', '\t']) {
+        buf.push(' ');
+    }
+    buf.push_str(body);
+    if !body.ends_with('\n') {
+        buf.push('\n');
+    }
+}
+
+fn append_verbose_cut_line(buf: &mut String, comment_prefix: &str) {
+    let explanation =
+        "Do not modify or remove the line above.\nEverything below it will be ignored.\n";
+    append_commented_line(
+        buf,
+        comment_prefix,
+        GIT_COMMIT_CUT_LINE.trim_end_matches('\n'),
+    );
+    for line in explanation.split_inclusive('\n') {
+        let line = line.strip_suffix('\n').unwrap_or(line);
+        if line.is_empty() {
+            continue;
+        }
+        append_commented_line(buf, comment_prefix, line);
+    }
+}
+
+/// Append unified diffs to the commit message template (Git `wt_longstatus_print_verbose`).
+fn append_commit_verbose_diffs(
+    args: &Args,
+    repo: &Repository,
+    config: &ConfigSet,
+    head: &HeadState,
+    staged: &[DiffEntry],
+    unstaged: &[DiffEntry],
+    verbose_level: i64,
+    buf: &mut String,
+) -> Result<()> {
+    if verbose_level <= 0 {
+        return Ok(());
+    }
+    let Some(wt) = repo.work_tree.as_deref() else {
+        return Ok(());
+    };
+    let committable = !staged.is_empty();
+    let worktree_dirty = !unstaged.is_empty();
+    let mnemonic = diff_mnemonic_prefix(config);
+    let comment = comment_line_prefix_full(config).into_owned();
+    let index_file = resolved_index_path(repo);
+
+    append_verbose_cut_line(buf, &comment);
+
+    let (a1, b1) = if verbose_level > 1 && committable {
+        ("c/", "i/")
+    } else if mnemonic {
+        ("c/", "i/")
+    } else {
+        ("a/", "b/")
+    };
+
+    if verbose_level > 1 && committable {
+        buf.push('\n');
+        append_commented_line(buf, &comment, "Changes to be committed:");
+    }
+
+    // Match Git `wt_longstatus_print_verbose`: base tree is `HEAD^` when amending (index vs parent),
+    // otherwise `HEAD`. Root amend uses the empty tree.
+    let cached_base = if args.amend {
+        match head.oid() {
+            Some(oid) => {
+                let obj = repo.odb.read(oid)?;
+                let c = grit_lib::objects::parse_commit(&obj.data)?;
+                if c.parents.is_empty() {
+                    Cow::Borrowed("4b825dc642cb6eb9a060e54bf8d69288fbee4904")
+                } else {
+                    Cow::Owned(format!("{}^", oid.to_hex()))
+                }
+            }
+            None => Cow::Borrowed("HEAD"),
+        }
+    } else {
+        Cow::Borrowed("HEAD")
+    };
+
+    let out1 = Command::new(git_binary_for_status())
+        .current_dir(wt)
+        .env("GIT_DIR", &repo.git_dir)
+        .env("GIT_INDEX_FILE", &index_file)
+        .args([
+            "-c",
+            "diff.noprefix=false",
+            "-c",
+            "diff.mnemonicprefix=false",
+            "diff",
+            "--cached",
+            cached_base.as_ref(),
+            "-p",
+            "--no-color",
+            "--src-prefix",
+            a1,
+            "--dst-prefix",
+            b1,
+        ])
+        .output()
+        .context("run git diff --cached for commit template")?;
+    if out1.status.success() {
+        let patch = String::from_utf8_lossy(&out1.stdout);
+        buf.push_str(&patch);
+    }
+
+    if verbose_level > 1 && worktree_dirty {
+        buf.push('\n');
+        append_commented_line(
+            buf,
+            &comment,
+            "--------------------------------------------------",
+        );
+        append_commented_line(buf, &comment, "Changes not staged for commit:");
+        let out2 = Command::new(git_binary_for_status())
+            .current_dir(wt)
+            .env("GIT_DIR", &repo.git_dir)
+            .env("GIT_INDEX_FILE", &index_file)
+            .args([
+                "-c",
+                "diff.noprefix=false",
+                "-c",
+                "diff.mnemonicprefix=false",
+                "diff",
+                "-p",
+                "--no-color",
+                "--src-prefix",
+                "i/",
+                "--dst-prefix",
+                "w/",
+            ])
+            .output()
+            .context("run git diff for commit template")?;
+        if out2.status.success() {
+            let patch = String::from_utf8_lossy(&out2.stdout);
+            buf.push_str(&patch);
+        }
+    }
+
+    Ok(())
+}
+
 fn commit_template_status_append(
     args: &Args,
     repo: &Repository,
@@ -2185,34 +2555,41 @@ fn commit_template_status_append(
     config: &ConfigSet,
     buf: &mut String,
 ) -> Result<()> {
+    let cp = comment_line_prefix_full(config);
+    let p = cp.as_ref();
     buf.push('\n');
     if args.allow_empty_message {
-        buf.push_str(
-            "# Please enter the commit message for your changes. Lines starting\n\
-             # with '#' will be ignored.\n",
+        append_commented_line(
+            buf,
+            p,
+            "Please enter the commit message for your changes. Lines starting",
         );
+        append_commented_line(buf, p, &format!("with '{p}' will be ignored."));
     } else {
-        buf.push_str(
-            "# Please enter the commit message for your changes. Lines starting\n\
-             # with '#' will be ignored, and an empty message aborts the commit.\n",
+        append_commented_line(
+            buf,
+            p,
+            "Please enter the commit message for your changes. Lines starting",
+        );
+        append_commented_line(
+            buf,
+            p,
+            &format!("with '{p}' will be ignored, and an empty message aborts the commit."),
         );
     }
     if args.allow_empty_message {
-        buf.push_str("#\n");
+        buf.push_str(p);
+        buf.push('\n');
     }
     let author = resolve_author(args, config, repo, OffsetDateTime::now_utc())?;
-    buf.push_str("# Author:    ");
     let author_display = author
         .split_once('>')
         .map(|(a, _)| format!("{}>", a.trim()))
         .unwrap_or_else(|| author.clone());
-    buf.push_str(&author_display);
-    buf.push('\n');
-    buf.push_str("#\n");
-    buf.push_str("# On branch ");
-    buf.push_str(&branch_display_name(head));
-    buf.push('\n');
-    buf.push_str("# Changes to be committed:\n");
+    append_commented_line(buf, p, &format!("Author:    {author_display}"));
+    append_commented_line(buf, p, "");
+    append_commented_line(buf, p, &format!("On branch {}", branch_display_name(head)));
+    append_commented_line(buf, p, "Changes to be committed:");
 
     if let Some(wt) = repo.work_tree.as_deref() {
         let index_file = resolved_index_path(repo);
@@ -2255,13 +2632,17 @@ fn commit_template_status_append(
                                 Some('T') => "typechange",
                                 _ => "changed",
                             };
-                            let p = parts.get(1).copied().unwrap_or("");
-                            (lbl, p.to_string())
+                            let path_cell = parts.get(1).copied().unwrap_or("");
+                            (lbl, path_cell.to_string())
                         };
-                    buf.push_str(&format!("#\t{label}:   {display_path}\n"));
+                    buf.push_str(p);
+                    buf.push('\t');
+                    buf.push_str(&format!("{label}:   {display_path}\n"));
                 }
-                buf.push_str("#\n");
-                buf.push_str("# Untracked files not listed\n");
+                buf.push_str(p);
+                buf.push('\n');
+                buf.push_str(p);
+                buf.push_str(" Untracked files not listed\n");
                 return Ok(());
             }
         }
@@ -2283,10 +2664,14 @@ fn commit_template_status_append(
     let staged = diff_index_to_tree(&repo.odb, &index, head_tree.as_ref())?;
     for e in &staged {
         let label = status_label_staged(e.status);
-        buf.push_str(&format!("#\t{label}:   {}\n", e.display_path()));
+        buf.push_str(p);
+        buf.push('\t');
+        buf.push_str(&format!("{label}:   {}\n", e.display_path()));
     }
-    buf.push_str("#\n");
-    buf.push_str("# Untracked files not listed\n");
+    buf.push_str(p);
+    buf.push('\n');
+    buf.push_str(p);
+    buf.push_str(" Untracked files not listed\n");
     Ok(())
 }
 
@@ -2298,7 +2683,14 @@ fn prepare_commit_message(
     template_path: Option<&Path>,
     use_editor: bool,
     head: &HeadState,
+    staged: &[DiffEntry],
+    unstaged: &[DiffEntry],
+    verbose_level: i64,
 ) -> Result<MessageResult> {
+    let comment_owned = comment_line_prefix_full(config);
+    let comment_prefix = comment_owned.as_ref();
+    let cleanup_mode = resolve_commit_cleanup_mode(args, config, use_editor);
+
     if let Some(sq) = args.squash.as_deref() {
         let reuse = args
             .reuse_message
@@ -2322,10 +2714,23 @@ fn prepare_commit_message(
                 if !args.no_status {
                     commit_template_status_append(args, repo, head, config, &mut file_body)?;
                 }
+                if verbose_level > 0 {
+                    append_commit_verbose_diffs(
+                        args,
+                        repo,
+                        config,
+                        head,
+                        staged,
+                        unstaged,
+                        verbose_level,
+                        &mut file_body,
+                    )?;
+                }
                 fs::write(&edit_path, &file_body)?;
                 launch_commit_editor(repo, &edit_path)?;
                 let edited = fs::read_to_string(&edit_path)?;
-                let cleaned = cleanup_edited_commit_message(&edited);
+                let cleaned =
+                    apply_cleanup_message(&edited, verbose_level, comment_prefix, cleanup_mode);
                 return Ok(MessageResult {
                     message: ensure_trailing_newline(&cleaned),
                     raw_bytes: None,
@@ -2348,10 +2753,23 @@ fn prepare_commit_message(
             if !args.no_status {
                 commit_template_status_append(args, repo, head, config, &mut file_body)?;
             }
+            if verbose_level > 0 {
+                append_commit_verbose_diffs(
+                    args,
+                    repo,
+                    config,
+                    head,
+                    staged,
+                    unstaged,
+                    verbose_level,
+                    &mut file_body,
+                )?;
+            }
             fs::write(&edit_path, &file_body)?;
             launch_commit_editor(repo, &edit_path)?;
             let edited = fs::read_to_string(&edit_path)?;
-            let cleaned = cleanup_edited_commit_message(&edited);
+            let cleaned =
+                apply_cleanup_message(&edited, verbose_level, comment_prefix, cleanup_mode);
             return Ok(MessageResult {
                 message: ensure_trailing_newline(&cleaned),
                 raw_bytes: None,
@@ -2368,7 +2786,8 @@ fn prepare_commit_message(
 
     if !args.message.is_empty() && fixup.map(|f| matches!(f.mode, FixupMode::Fixup)) != Some(true) {
         let msg = args.message.join("\n\n");
-        let cleaned = cleanup_edited_commit_message(&msg);
+        let no_editor_cleanup = resolve_commit_cleanup_mode(args, config, false);
+        let cleaned = apply_cleanup_message(&msg, 0, comment_prefix, no_editor_cleanup);
         return Ok(MessageResult {
             message: ensure_trailing_newline(&cleaned),
             raw_bytes: None,
@@ -2391,10 +2810,23 @@ fn prepare_commit_message(
             if !args.no_status {
                 commit_template_status_append(args, repo, head, config, &mut file_body)?;
             }
+            if verbose_level > 0 {
+                append_commit_verbose_diffs(
+                    args,
+                    repo,
+                    config,
+                    head,
+                    staged,
+                    unstaged,
+                    verbose_level,
+                    &mut file_body,
+                )?;
+            }
             fs::write(&edit_path, &file_body)?;
             launch_commit_editor(repo, &edit_path)?;
             let edited = fs::read_to_string(&edit_path)?;
-            let cleaned = cleanup_edited_commit_message(&edited);
+            let cleaned =
+                apply_cleanup_message(&edited, verbose_level, comment_prefix, cleanup_mode);
             return Ok(MessageResult {
                 message: ensure_trailing_newline(&cleaned),
                 raw_bytes: None,
@@ -2438,10 +2870,22 @@ fn prepare_commit_message(
         if !args.no_status {
             commit_template_status_append(args, repo, head, config, &mut file_body)?;
         }
+        if verbose_level > 0 {
+            append_commit_verbose_diffs(
+                args,
+                repo,
+                config,
+                head,
+                staged,
+                unstaged,
+                verbose_level,
+                &mut file_body,
+            )?;
+        }
         fs::write(&edit_path, &file_body)?;
         launch_commit_editor(repo, &edit_path)?;
         let edited = fs::read_to_string(&edit_path)?;
-        let cleaned = cleanup_edited_commit_message(&edited);
+        let cleaned = apply_cleanup_message(&edited, verbose_level, comment_prefix, cleanup_mode);
         return Ok(MessageResult {
             message: ensure_trailing_newline(&cleaned),
             raw_bytes: None,
@@ -2455,7 +2899,7 @@ fn prepare_commit_message(
             .as_deref()
             .is_some_and(|m| m.eq_ignore_ascii_case("strip"))
         {
-            cleanup_edited_commit_message(&msg)
+            cleanup_edited_commit_message(&msg, comment_prefix)
         } else {
             msg
         };

--- a/grit/src/commands/history.rs
+++ b/grit/src/commands/history.rs
@@ -1,10 +1,13 @@
 //! `grit history` — history rewriting (reword, etc.).
 
-use crate::commands::commit::{cleanup_edited_commit_message, launch_commit_editor};
+use crate::commands::commit::{
+    cleanup_edited_commit_message, comment_line_prefix_full, launch_commit_editor,
+};
 use crate::commands::replay::replay_commits_onto;
 use crate::commands::update_ref::resolve_reflog_identity;
 use anyhow::{bail, Context, Result};
 use clap::{Args as ClapArgs, Parser, Subcommand};
+use grit_lib::config::ConfigSet;
 use grit_lib::diff::{diff_trees, DiffEntry, DiffStatus};
 use grit_lib::merge_base::is_ancestor;
 use grit_lib::objects::{
@@ -334,7 +337,9 @@ fn edit_reword_message(repo: &Repository, commit: &CommitData) -> Result<String>
     launch_commit_editor(repo, &edit_path)?;
 
     let edited = fs::read_to_string(&edit_path).context("reading COMMIT_EDITMSG")?;
-    Ok(cleanup_edited_commit_message(&edited))
+    let cfg = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+    let prefix = comment_line_prefix_full(&cfg);
+    Ok(cleanup_edited_commit_message(&edited, prefix.as_ref()))
 }
 
 fn append_tree_diff_status(

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -2714,16 +2714,17 @@ fn preprocess_status_argv(rest: &[String]) -> Vec<String> {
 /// - `commit -q -m <msg>` (and similar) → `-m <msg> -q` so the message is not parsed as a pathspec
 /// - `commit -m <msg> <paths>...` → `-m <msg> -- <paths>...`
 fn preprocess_commit_argv(rest: &[String]) -> Vec<String> {
+    let rest = crate::commands::commit::preprocess_commit_for_parse(rest);
     const M_STYLE: [&str; 2] = ["-m", "--message"];
     let Some(i) = rest.iter().position(|a| M_STYLE.contains(&a.as_str())) else {
-        return rest.to_vec();
+        return rest;
     };
     if i + 1 >= rest.len() {
-        return rest.to_vec();
+        return rest;
     }
     let flag = rest[i].as_str();
     if !matches!(flag, "-m" | "--message") {
-        return rest.to_vec();
+        return rest;
     }
 
     let before = &rest[..i];

--- a/logs/2026-04-10_t7507-commit-verbose.md
+++ b/logs/2026-04-10_t7507-commit-verbose.md
@@ -1,0 +1,16 @@
+# t7507-commit-verbose
+
+## Summary
+
+Implemented Git-compatible `commit --verbose` / `commit.verbose` for the commit message template:
+
+- Preprocess `commit` argv for `-v` / `--verbose` / `--no-verbose` ordering and strip `--no-verbose` before clap (`preprocess_commit_for_parse` + `GIT_GRIT_INTERNAL_COMMIT_VERBOSE`).
+- Append scissors line + unified diffs via host `git diff` (raw patch, not comment-prefixed); `--cached` base is `HEAD^` when amending (root amend uses empty tree OID).
+- `cleanup_message`-style path: truncate at scissors when verbose or `cleanup=scissors`; strip comments per `commit.cleanup` and full `core.commentChar` / `core.commentString`.
+- `commit-msg` hook re-read applies the same cleanup for UTF-8 messages.
+- `history` reword uses `comment_line_prefix_full` for cleanup.
+
+## Validation
+
+- `./scripts/run-tests.sh --timeout 120 t7507-commit-verbose.sh` — 45/45 pass.
+- `cargo test -p grit-lib --lib` — pass.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible **`git commit --verbose`** / **`commit.verbose`** for the commit message template and aligns **`cleanup_message`** behavior with Git (scissors truncation, `commit.cleanup` modes, full `core.commentChar` / `core.commentString`).

## Key changes

- **`preprocess_commit_for_parse`**: scans argv for `-v` / `--verbose` / `--no-verbose` in Git order, sets `GIT_GRIT_INTERNAL_COMMIT_VERBOSE`, strips `--no-verbose` before clap.
- **Verbose template**: scissors line + host **`git diff`** output appended **raw** (not comment-prefixed). For **`--amend`**, `git diff --cached` uses **`HEAD^`** as base (root amend → empty tree OID).
- **Cleanup**: `wt_status_locate_end`-style truncation when verbose or `cleanup=scissors`; comment stripping per cleanup mode; **`commit-msg` hook** re-read runs the same cleanup for UTF-8.
- **`history reword`**: uses `comment_line_prefix_full` when calling `cleanup_edited_commit_message`.

## Tests

- `./scripts/run-tests.sh --timeout 120 t7507-commit-verbose.sh` → **45/45**
- `cargo test -p grit-lib --lib`

## Note

Verbose diffs are generated via the real **`git`** binary (same pattern as existing `commit_template_status_append` / `git diff --cached --name-status`) to avoid reimplementing full diff-prefix / submodule behavior in this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80da7f8e-074e-4ec0-a8c6-3e6c611513ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80da7f8e-074e-4ec0-a8c6-3e6c611513ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

