### PR TITLE
fix: t7413 submodule is-active and submodule add active parity

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -836,7 +836,7 @@ commit → check it off → move on.
 - [ ] `t7525-status-rename` █████████░░░░░░░░░░░ 7/15 (8 left) — git status rename detection options
 - [ ] `t7412-submodule-absorbgitdirs` ██████░░░░░░░░░░░░░░ 4/12 (8 left) — Test submodule absorbgitdirs
 
-- [ ] `t7413-submodule-is-active` ████░░░░░░░░░░░░░░░░ 2/10 (8 left) — Test with test-tool submodule is-active
+- [x] `t7413-submodule-is-active` — Test with test-tool submodule is-active (10/10)
 
 - [x] `t7817-grep-sparse-checkout` ████████████████████ 8/8 (0 left) — grep in sparse checkout
 

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1205,7 +1205,7 @@ t7408-submodule-reference	t7	yes	16	5	11	false	ok	0
 t7409-submodule-detached-work-tree	t7	yes	3	2	1	false	ok	0
 t7411-submodule-config	t7	yes	20	4	16	false	ok	0
 t7412-submodule-absorbgitdirs	t7	yes	12	5	7	false	ok	0
-t7413-submodule-is-active	t7	yes	10	2	8	false	ok	0
+t7413-submodule-is-active	t7	yes	10	10	0	true	ok	0
 t7414-submodule-mistakes	t7	yes	5	5	0	true	ok	0
 t7416-submodule-dash-url	t7	yes	18	9	9	false	ok	0
 t7417-submodule-path-url	t7	yes	5	5	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,694 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,694 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T04:53:10+00:00" class="gen-time" title="2026-04-10 04:53 UTC">2026-04-10 04:53 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,694</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">49/126 files · 11 skipped · 2,502/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.2%"></div></div>
+        <span class="group-pct pct-blue">69.2%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35694 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,694 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T04:53:10+00:00" class="gen-time" title="2026-04-10 04:53 UTC">2026-04-10 04:53 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,694</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">
@@ -12207,14 +12207,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:41.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t7" data-tests="10" data-passed="2">
+<tr class="" data-group="t7" data-tests="10" data-passed="10" data-full-pass="1">
   <td class="mono">t7413-submodule-is-active</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">10</td>
-  <td class="right">2</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:20.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="5" data-passed="5" data-full-pass="1">

--- a/grit-lib/src/config.rs
+++ b/grit-lib/src/config.rs
@@ -1420,6 +1420,18 @@ impl ConfigSet {
             .collect()
     }
 
+    /// True if any config entry uses `key` (after canonicalization), including bare boolean keys.
+    ///
+    /// Unlike [`Self::get`], this does not treat a missing value as `"true"` — it reports whether
+    /// the key appears in the merged config at all (Git `repo_config_get` / `git_configset_get`).
+    #[must_use]
+    pub fn has_key(&self, key: &str) -> bool {
+        let Ok(canon) = canonical_key(key) else {
+            return false;
+        };
+        self.entries.iter().any(|e| e.key == canon)
+    }
+
     /// Get a boolean value, interpreting `true`/`yes`/`on`/`1` as true and
     /// `false`/`no`/`off`/`0` as false.
     pub fn get_bool(&self, key: &str) -> Option<std::result::Result<bool, String>> {

--- a/grit-lib/src/lib.rs
+++ b/grit-lib/src/lib.rs
@@ -99,6 +99,7 @@ pub mod simple_ipc {
 }
 pub mod state;
 pub mod stripspace;
+pub mod submodule_active;
 pub mod submodule_gitdir;
 pub mod test_tool_progress;
 pub mod textconv_cache;

--- a/grit-lib/src/submodule_active.rs
+++ b/grit-lib/src/submodule_active.rs
@@ -1,0 +1,246 @@
+//! Submodule "active" state (`submodule.c` `is_submodule_active` parity).
+//!
+//! Used by `test-tool submodule is-active` and `git submodule add` when deciding
+//! whether to write `submodule.<name>.active`.
+
+use std::path::Path;
+
+use crate::config::{ConfigFile, ConfigScope, ConfigSet};
+use crate::index::{Index, MODE_GITLINK};
+use crate::objects::ObjectKind;
+use crate::pathspec::{matches_pathspec_with_context, PathspecMatchContext};
+use crate::repo::Repository;
+use crate::wildmatch::wildmatch;
+
+/// Returns `true` when `submodule.active` is configured (any `submodule.active` entry exists).
+fn config_has_submodule_active_key(cfg: &ConfigSet) -> bool {
+    cfg.has_key("submodule.active")
+}
+
+/// Reads `submodule.active` patterns for [`submodule_add_should_set_active`].
+///
+/// Returns `Ok(None)` when the key is absent. Returns `Err` when a value is missing (bare key),
+/// matching Git's `repo_config_get_string_multi` error path.
+fn submodule_active_pattern_values(
+    cfg: &ConfigSet,
+) -> std::result::Result<Option<Vec<String>>, String> {
+    if !config_has_submodule_active_key(cfg) {
+        return Ok(None);
+    }
+    let values = cfg.get_all("submodule.active");
+    if values.is_empty() {
+        return Ok(Some(Vec::new()));
+    }
+    for v in &values {
+        if v.is_empty() {
+            return Err("missing value for 'submodule.active'".to_string());
+        }
+    }
+    Ok(Some(values))
+}
+
+/// Whether `git submodule add` should write `submodule.<name>.active=true` to the local config.
+///
+/// Mirrors `submodule--helper.c` after registering `.gitmodules`: when `submodule.active` is
+/// absent, or multi-string read fails, always set active; otherwise set active only when no
+/// configured pattern [`wildmatch`]s the submodule path (flags `0`, matching Git).
+#[must_use]
+pub fn submodule_add_should_set_active(repo: &Repository, sm_path: &str) -> bool {
+    let Ok(cfg) = ConfigSet::load(Some(&repo.git_dir), true) else {
+        return true;
+    };
+    let path = sm_path.replace('\\', "/");
+    match submodule_active_pattern_values(&cfg) {
+        Ok(None) => true,
+        Err(_) => true,
+        Ok(Some(patterns)) => {
+            let matched = patterns
+                .iter()
+                .any(|p| wildmatch(p.trim().as_bytes(), path.as_bytes(), 0));
+            !matched
+        }
+    }
+}
+
+fn read_gitmodules_text(
+    repo: &Repository,
+    work_tree: &Path,
+) -> crate::error::Result<Option<String>> {
+    let gitmodules_path = work_tree.join(".gitmodules");
+    if gitmodules_path.exists() {
+        let content = std::fs::read_to_string(&gitmodules_path).map_err(crate::error::Error::Io)?;
+        return Ok(Some(content));
+    }
+    let index = repo.load_index()?;
+    let Some(ie) = index.get(b".gitmodules", 0) else {
+        return Ok(None);
+    };
+    let obj = repo.odb.read(&ie.oid)?;
+    if obj.kind != ObjectKind::Blob {
+        return Ok(None);
+    }
+    String::from_utf8(obj.data)
+        .map(Some)
+        .map_err(|e| crate::error::Error::ConfigError(format!("invalid .gitmodules utf-8: {e}")))
+}
+
+/// Resolve the submodule **logical name** for an index path (`.gitmodules` `submodule.<name>.path`).
+///
+/// Returns `None` when the path is not listed as a submodule in `.gitmodules` (work tree file or
+/// index blob), matching Git's `submodule_from_path` failure.
+pub fn submodule_name_for_path(
+    repo: &Repository,
+    path: &str,
+) -> crate::error::Result<Option<String>> {
+    let Some(wt) = repo.work_tree.as_ref() else {
+        return Ok(None);
+    };
+    let Some(content) = read_gitmodules_text(repo, wt)? else {
+        return Ok(None);
+    };
+    let config = ConfigFile::parse(&wt.join(".gitmodules"), &content, ConfigScope::Local)?;
+    let path_norm = path.replace('\\', "/");
+
+    #[derive(Default)]
+    struct ModuleFields {
+        path: Option<String>,
+    }
+    let mut modules: std::collections::BTreeMap<String, ModuleFields> =
+        std::collections::BTreeMap::new();
+
+    for entry in &config.entries {
+        let key = &entry.key;
+        if !key.starts_with("submodule.") {
+            continue;
+        }
+        let rest = &key["submodule.".len()..];
+        let Some(last_dot) = rest.rfind('.') else {
+            continue;
+        };
+        let name = &rest[..last_dot];
+        let var = &rest[last_dot + 1..];
+        if var == "path" {
+            modules.entry(name.to_string()).or_default().path = entry.value.clone();
+        }
+    }
+
+    for (name, f) in modules {
+        if let Some(p) = f.path {
+            let p_norm = p.replace('\\', "/");
+            if p_norm == path_norm {
+                return Ok(Some(name));
+            }
+        }
+    }
+    Ok(None)
+}
+
+fn parse_pathspec_exclude(spec: &str) -> (bool, &str) {
+    let s = spec.trim();
+    if let Some(rest) = s.strip_prefix(":!") {
+        return (true, rest);
+    }
+    if let Some(rest) = s.strip_prefix(":^") {
+        return (true, rest);
+    }
+    if let Some(inner) = s.strip_prefix(":(exclude)") {
+        return (true, inner);
+    }
+    if let Some(inner) = s.strip_prefix(":(exclude,") {
+        if let Some(close) = inner.find(')') {
+            return (true, &inner[close + 1..]);
+        }
+    }
+    (false, s)
+}
+
+fn index_gitlink_match_for_path(index: &Index, path: &str) -> Option<PathspecMatchContext> {
+    for e in &index.entries {
+        if e.stage() != 0 {
+            continue;
+        }
+        if e.mode != MODE_GITLINK {
+            continue;
+        }
+        let name = String::from_utf8_lossy(&e.path);
+        let name = name.replace('\\', "/");
+        if name == path {
+            return Some(PathspecMatchContext {
+                is_directory: false,
+                is_git_submodule: true,
+            });
+        }
+    }
+    None
+}
+
+fn spec_matches_submodule_path(
+    _index: &Index,
+    spec: &str,
+    path: &str,
+    ctx: PathspecMatchContext,
+) -> bool {
+    let (is_exclude, pattern_src) = parse_pathspec_exclude(spec);
+    let pattern = pattern_src.trim();
+    if pattern.is_empty() && !is_exclude {
+        return false;
+    }
+    matches_pathspec_with_context(pattern, path, ctx)
+}
+
+/// Whether `path` matches `submodule.active` pathspecs using the given index (Git `match_pathspec`).
+///
+/// On missing string values (bare `submodule.active`), returns an error message suitable for stderr.
+pub fn submodule_active_pathspec_match(
+    index: &Index,
+    specs: &[String],
+    path: &str,
+) -> std::result::Result<bool, String> {
+    for v in specs {
+        if v.is_empty() {
+            return Err("error: missing value for 'submodule.active'".to_string());
+        }
+    }
+    let ctx = index_gitlink_match_for_path(index, path).unwrap_or(PathspecMatchContext {
+        is_directory: false,
+        is_git_submodule: true,
+    });
+
+    let positive = specs
+        .iter()
+        .any(|s| !parse_pathspec_exclude(s).0 && spec_matches_submodule_path(index, s, path, ctx));
+    if !positive {
+        return Ok(false);
+    }
+    let excluded = specs
+        .iter()
+        .any(|s| parse_pathspec_exclude(s).0 && spec_matches_submodule_path(index, s, path, ctx));
+    Ok(!excluded)
+}
+
+/// Git `is_submodule_active` for the current repository and index (`HEAD` + `.gitmodules` mapping).
+///
+/// Returns `Ok(true)` / `Ok(false)` for normal checks, or `Err` when `submodule.active` has a bare
+/// entry (Git `config_error_nonbool`).
+pub fn is_submodule_active(repo: &Repository, path: &str) -> std::result::Result<bool, String> {
+    let path_norm = path.replace('\\', "/");
+    let Some(name) = submodule_name_for_path(repo, &path_norm).map_err(|e| e.to_string())? else {
+        return Ok(false);
+    };
+
+    let cfg = ConfigSet::load(Some(&repo.git_dir), true).map_err(|e| e.to_string())?;
+    let per_key = format!("submodule.{name}.active");
+    if let Some(res) = cfg.get_bool(&per_key) {
+        let b = res.map_err(|_| format!("invalid boolean for '{per_key}'"))?;
+        return Ok(b);
+    }
+
+    if config_has_submodule_active_key(&cfg) {
+        let values = cfg.get_all("submodule.active");
+        let index = repo.load_index().map_err(|e| e.to_string())?;
+        return submodule_active_pathspec_match(&index, &values, &path_norm);
+    }
+
+    let url_key = format!("submodule.{name}.url");
+    Ok(cfg.get(&url_key).is_some())
+}

--- a/grit/src/commands/submodule.rs
+++ b/grit/src/commands/submodule.rs
@@ -1983,7 +1983,9 @@ fn run_add(args: &AddArgs) -> Result<()> {
         ConfigFile::parse(&local_config_path, "", ConfigScope::Local)?
     };
     local_config.set(&format!("submodule.{name}.url"), &args.url)?;
-    local_config.set(&format!("submodule.{name}.active"), "true")?;
+    if grit_lib::submodule_active::submodule_add_should_set_active(&repo, &path) {
+        local_config.set(&format!("submodule.{name}.active"), "true")?;
+    }
     local_config.write()?;
 
     // Add the submodule path to the index.

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -5153,6 +5153,23 @@ fn run_test_tool_submodule(rest: &[String]) -> Result<()> {
                 bail!(".gitmodules is not writable in this state");
             }
         }
+        "is-active" => {
+            let path = rest
+                .get(1)
+                .map(|s| s.as_str())
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("usage: test-tool submodule is-active <path>"))?;
+            let repo =
+                grit_lib::repo::Repository::discover(None).context("not a git repository")?;
+            match grit_lib::submodule_active::is_submodule_active(&repo, path) {
+                Ok(true) => Ok(()),
+                Ok(false) => std::process::exit(1),
+                Err(msg) => {
+                    eprintln!("{msg}");
+                    Ok(())
+                }
+            }
+        }
         other => bail!("test-tool submodule: unknown subcommand '{other}'"),
     }
 }

--- a/logs/2026-04-10_t7413-submodule-is-active.md
+++ b/logs/2026-04-10_t7413-submodule-is-active.md
@@ -1,0 +1,22 @@
+# t7413-submodule-is-active
+
+## Goal
+
+Make `tests/t7413-submodule-is-active.sh` pass (10/10).
+
+## Changes
+
+- Added `grit-lib/src/submodule_active.rs`: map worktree path → submodule name via `.gitmodules` (work tree or index blob); `is_submodule_active` matching Git `submodule.c` order (`submodule.<name>.active`, then `submodule.active` pathspecs with exclude handling, then URL fallback); `submodule_add_should_set_active` mirroring `submodule--helper.c` wildmatch on `submodule.active` patterns.
+- `ConfigSet::has_key` in `config.rs` for “key present” without coercing bare keys to `"true"`.
+- `test-tool submodule is-active` in `grit/src/main.rs`: exit 1 when inactive, print error and exit 0 when bare `submodule.active` (matches Git test expectations).
+- `git submodule add`: only set `submodule.<name>.active` when `submodule_add_should_set_active` returns true.
+
+## Validation
+
+- `cargo build --release -p grit-rs`
+- `cargo test -p grit-lib --lib`
+- `./scripts/run-tests.sh t7413-submodule-is-active.sh` → 10/10
+
+## Note
+
+Full-workspace `cargo clippy -- -D warnings` still reports many pre-existing issues unrelated to this change.

--- a/progress.md
+++ b/progress.md
@@ -1,20 +1,21 @@
 # Progress — Grit Test Coverage
 
-**Updated:** 2026-04-09
+**Updated:** 2026-04-10
 
 ## Counts (derived from plan.md)
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   325 |
+| Completed   |   326 |
 | In progress |     5 |
-| Remaining   |   441 |
+| Remaining   |   440 |
 | **Total**   |   771 |
 
-Task lines in `PLAN.md`: 325 completed (`[x]`), 5 in progress (`[~]`), 441 remaining (`[ ]`).
+Task lines in `PLAN.md`: 326 completed (`[x]`), 5 in progress (`[~]`), 440 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t7413-submodule-is-active` — 10/10 tests pass (`test-tool submodule is-active`: `is_submodule_active` parity; `submodule.active` pathspec + `:(exclude)`; bare `submodule.active` stderr; `submodule add` skips `submodule.<name>.active` when path matches `submodule.active` wildmatch; `ConfigSet::has_key`)
 - `t3309-notes-merge-auto-resolve` — 31/31 tests pass (`notes merge`: `union` / `cat_sort_uniq` blob combine like Git; successful merge commits use two parents; `notes.mergeStrategy` config errors match upstream expectations)
 - `t4063-diff-blobs` — 18/18 tests pass (`diff`: blob↔blob and `rev:path` pairs without treating blobs as trees; `HEAD:one..HEAD:two` range split; `rev:path` vs worktree file uses tree path + modes + `write_patch_with_prefix`; raw blob OID vs existing file uses filename as old path; `rev_parse::resolve_treeish_blob_at_path` for tree walks)
 - `t5524-pull-msg` — 3/3 tests pass (`git pull --no-rebase --log` merge message preserves `$` in subject lines; `--log=1` limits shortlog; harness CSV/dashboards refreshed; `PLAN.md` marked complete)

--- a/test-results.md
+++ b/test-results.md
@@ -1,5 +1,10 @@
 # Test results
 
+**2026-04-10 (t7413 / submodule is-active)**
+
+- `cargo test -p grit-lib --lib`: 160 passed
+- `./scripts/run-tests.sh t7413-submodule-is-active.sh`: 10/10 passed
+
 **2026-04-09 (t4063 / diff blobs)**
 
 - `cargo test -p grit-lib --lib`: 155 passed


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git `is_submodule_active` behavior for `test-tool submodule is-active` and aligns `git submodule add` with Git when `submodule.active` pathspecs already cover the new path (skip writing redundant `submodule.<name>.active`).

## Changes

- New `grit_lib::submodule_active`: resolve submodule name from `.gitmodules` (work tree or index blob), evaluate `submodule.<name>.active`, `submodule.active` pathspecs (including `:(exclude)`), URL fallback; wildmatch-based check for add.
- `ConfigSet::has_key` so "key present" does not treat bare keys as string `"true"`.
- Wire `test-tool submodule is-active` in the binary (exit 1 inactive; bare `submodule.active` prints error to stderr and exits 0 per upstream test).

## Testing

- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t7413-submodule-is-active.sh` (10/10)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe52aaa9-6bde-4ff0-96c8-e94a24f92353"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe52aaa9-6bde-4ff0-96c8-e94a24f92353"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

