### PR TITLE
fix: make t8360-read-tree-twoway fully pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1329,7 +1329,7 @@ t8320-config-global-local	t8	yes	34	34	0	true	ok	0
 t8330-switch-track	t8	yes	30	12	18	false	ok	0
 t8340-restore-staged	t8	yes	27	16	11	false	ok	0
 t8350-checkout-index-force	t8	yes	30	30	0	true	ok	0
-t8360-read-tree-twoway	t8	yes	25	20	5	false	ok	0
+t8360-read-tree-twoway	t8	yes	25	25	0	true	ok	0
 t8370-mktree-roundtrip	t8	yes	26	26	0	true	ok	0
 t8380-name-rev-deep	t8	yes	31	31	0	true	ok	0
 t8390-diff-tree-stat	t8	yes	37	37	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,691 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,691 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T05:08:59+00:00" class="gen-time" title="2026-04-10 05:08 UTC">2026-04-10 05:08 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,691</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,22 +263,22 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">
       <div class="group-line1">
         <span class="group-id">t8</span>
         <span class="group-desc">Porcelainish commands concerning forensics</span>
-        <span class="group-meta">81/105 files · 0 skipped · 2,866/3,116 tests</span>
+        <span class="group-meta">82/105 files · 0 skipped · 2,871/3,116 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:92.0%"></div></div>
-        <span class="group-pct pct-green">92.0%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:92.1%"></div></div>
+        <span class="group-pct pct-green">92.1%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t9">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35691 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,691 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T05:08:59+00:00" class="gen-time" title="2026-04-10 05:08 UTC">2026-04-10 05:08 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,691</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">
@@ -13447,14 +13447,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t8" data-tests="25" data-passed="20">
+<tr class="" data-group="t8" data-tests="25" data-passed="25" data-full-pass="1">
   <td class="mono">t8360-read-tree-twoway</td>
   <td>t8</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">25</td>
-  <td class="right">20</td>
+  <td class="right">25</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:80.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t8" data-tests="26" data-passed="26" data-full-pass="1">

--- a/grit/src/commands/read_tree.rs
+++ b/grit/src/commands/read_tree.rs
@@ -1029,7 +1029,7 @@ fn validate_worktree_updates(
         }
 
         match (old, new) {
-            (None, Some(_)) => {
+            (None, Some(new_entry)) => {
                 if allow_ignored_overwrite {
                     if let Some(ref mut matcher) = ignore_matcher {
                         let (ignored, _) = matcher
@@ -1057,6 +1057,11 @@ fn validate_worktree_updates(
                         }
                         continue;
                     }
+                }
+                // Untracked path on disk: allow when it already matches the blob we would
+                // materialize (e.g. `read-tree -m -u` after checkout left the same bytes).
+                if worktree_matches_entry(repo, new_entry, &abs_path)? {
+                    continue;
                 }
                 bail!(
                     "untracked working tree file '{}' would be overwritten by merge",

--- a/logs/2026-04-10_t8360-read-tree-twoway.md
+++ b/logs/2026-04-10_t8360-read-tree-twoway.md
@@ -1,0 +1,19 @@
+# t8360-read-tree-twoway
+
+## Issue
+
+Harness reported 20/25 passing. Failures split into:
+
+1. **Invalid `test_must_fail grep`**: `test_must_fail` only allows git-like commands; `grep` is rejected and the test body fails before assertions.
+2. **`read-tree -m -u`**: After `checkout-index` from the base tree, paths only in the target (e.g. `fileD`) exist on disk but are not in the old index. Validation treated them as untracked and aborted with "would be overwritten by merge" even when disk content already matched the target blob.
+
+## Fix
+
+- `tests/t8360-read-tree-twoway.sh`: use `! grep` for "must not appear in index" checks (matches upstream test-lib guidance).
+- `grit/src/commands/read_tree.rs`: in `validate_worktree_updates`, for `(old_index: None, new_index: Some)` with an existing path, skip the error when `worktree_matches_entry` agrees with the new stage-0 entry.
+
+## Verification
+
+- `./scripts/run-tests.sh t8360-read-tree-twoway.sh` → 25/25
+- `cargo test -p grit-lib --lib`
+- `cargo check -p grit-rs`

--- a/tests/t8360-read-tree-twoway.sh
+++ b/tests/t8360-read-tree-twoway.sh
@@ -39,7 +39,7 @@ test_expect_success 'two-way merge from base to target' '
 	grit ls-files --stage >out &&
 	grep "fileA" out &&
 	grep "fileD" out &&
-	test_must_fail grep "fileC" out
+	! grep "fileC" out
 '
 
 test_expect_success 'two-way merge updates fileA content in index' '
@@ -183,9 +183,9 @@ test_expect_success 'read-tree without -m replaces index entirely' '
 	rm -f .git/index &&
 	grit read-tree "$TARGET" &&
 	grit ls-files --stage >out &&
-	grep "fileA" out &&
-	grep "fileD" out &&
-	test_must_fail grep "fileC" out
+		grep "fileA" out &&
+		grep "fileD" out &&
+		! grep "fileC" out
 '
 
 test_expect_success 'read-tree single tree resets index' '


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Tests:** `t8360-read-tree-twoway.sh` used `test_must_fail grep`, which the harness rejects (`test_must_fail` only allows git-like commands). Replaced with `! grep` for the two “fileC must not appear” checks.
- **`read-tree -m -u`:** After `checkout-index` from the base tree, files that exist only in the target (e.g. `fileD`) are on disk but not in the old index. Validation treated them as untracked and failed even when the working tree already matched the target blob. We now skip that error when `worktree_matches_entry` agrees with the new stage-0 entry.

## Verification

- `./scripts/run-tests.sh t8360-read-tree-twoway.sh` → 25/25
- `cargo test -p grit-lib --lib`
- `cargo check -p grit-rs`

## Note

`cargo clippy -p grit-rs -- -D warnings` still reports many pre-existing issues in `grit-lib`; not addressed here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d060b13c-ae84-4304-bb91-c640145d52d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d060b13c-ae84-4304-bb91-c640145d52d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

