### PR TITLE
fix: make t4030-diff-textconv pass (textconv porcelain)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -708,7 +708,7 @@ t4026-color	t4	yes	34	34	0	true	ok	0
 t4027-diff-submodule	t4	yes	20	6	14	false	ok	0
 t4028-format-patch-mime-headers	t4	yes	3	3	0	true	ok	0
 t4029-diff-trailing-space	t4	yes	1	1	0	true	ok	0
-t4030-diff-textconv	t4	yes	19	10	9	false	ok	0
+t4030-diff-textconv	t4	yes	19	19	0	true	ok	0
 t4031-diff-rewrite-binary	t4	yes	8	3	5	false	ok	0
 t4032-diff-inter-hunk-context	t4	yes	37	29	8	false	ok	0
 t4033-diff-patience	t4	yes	11	9	2	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,695 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,695 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T05:09:53+00:00" class="gen-time" title="2026-04-10 05:09 UTC">2026-04-10 05:09 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,695</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -230,22 +230,22 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">73/178 files · 2 skipped · 2,862/4,438 tests</span>
+        <span class="group-meta">74/178 files · 2 skipped · 2,871/4,438 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.5%"></div></div>
-        <span class="group-pct pct-blue">64.5%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.7%"></div></div>
+        <span class="group-pct pct-blue">64.7%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35695 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,695 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T05:09:53+00:00" class="gen-time" title="2026-04-10 05:09 UTC">2026-04-10 05:09 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,695</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -7237,14 +7237,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="19" data-passed="10">
+<tr class="" data-group="t4" data-tests="19" data-passed="19" data-full-pass="1">
   <td class="mono">t4030-diff-textconv</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">19</td>
-  <td class="right">10</td>
+  <td class="right">19</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:52.6%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="8" data-passed="3">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit/src/commands/format_patch.rs
+++ b/grit/src/commands/format_patch.rs
@@ -7,11 +7,12 @@
 use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
 use grit_lib::config::ConfigSet;
-use grit_lib::diff::{count_changes, diff_trees, unified_diff, zero_oid};
+use grit_lib::diff::{count_changes, diff_trees, unified_diff, zero_oid, DiffStatus};
 use grit_lib::diffstat::{
     write_diffstat_block, DiffstatOptions, FileStatInput, FORMAT_PATCH_STAT_WIDTH,
 };
 use grit_lib::merge_base::merge_bases_first_vs_rest;
+use grit_lib::merge_diff::{blob_text_for_diff_with_oid, diff_textconv_active, is_binary_for_diff};
 use grit_lib::objects::{parse_commit, CommitData, ObjectId};
 use grit_lib::odb::Odb;
 use grit_lib::repo::Repository;
@@ -152,6 +153,10 @@ pub struct Args {
     /// Include binary diffs (accepted for compatibility).
     #[arg(long = "binary")]
     pub binary: bool,
+
+    /// Do not run textconv in the patch body (emit `Binary files differ` like plumbing).
+    #[arg(long = "no-binary")]
+    pub no_binary: bool,
 
     /// Do not use a/b/ prefix in diff output.
     #[arg(long = "no-prefix")]
@@ -518,12 +523,14 @@ pub fn run(mut args: Args) -> Result<()> {
         let include_base = is_last_patch(idx);
         let patch = format_single_patch(
             &repo.odb,
+            repo.git_dir.as_path(),
             oid,
             commit,
             &subject,
             &opts,
             include_base,
             &log_output_encoding,
+            args.no_binary,
         )?;
 
         if args.stdout {
@@ -958,12 +965,14 @@ fn extract_email(ident: &str) -> Option<&str> {
 /// Format a single commit as an email-style patch.
 fn format_single_patch(
     odb: &Odb,
+    git_dir: &std::path::Path,
     oid: &ObjectId,
     commit: &CommitData,
     subject: &str,
     opts: &PatchOptions,
     include_base: bool,
     log_output_encoding: &str,
+    no_binary: bool,
 ) -> Result<String> {
     let mut out = String::new();
     let charset_label = rfc2047_charset_label(log_output_encoding);
@@ -991,6 +1000,7 @@ fn format_single_patch(
     } else {
         diff_entries_raw
     };
+    let config = ConfigSet::load(Some(git_dir), true).unwrap_or_default();
 
     // Build stat + full diff into separate string
     let mut diff_text = String::new();
@@ -1001,8 +1011,56 @@ fn format_single_patch(
         let old_path = entry.old_path.as_deref().unwrap_or("/dev/null");
         let new_path = entry.new_path.as_deref().unwrap_or("/dev/null");
         write_diff_header_to_string(&mut diff_text, entry);
-        let old_content = read_blob_content(odb, &entry.old_oid);
-        let new_content = read_blob_content(odb, &entry.new_oid);
+        let path_for_attrs = entry.path();
+        let use_textconv = !no_binary;
+        let textconv_patch = use_textconv && diff_textconv_active(git_dir, &config, path_for_attrs);
+        let old_raw = read_blob_bytes(odb, &entry.old_oid);
+        let new_raw = read_blob_bytes(odb, &entry.new_oid);
+        if !textconv_patch
+            && (is_binary_for_diff(git_dir, path_for_attrs, &old_raw)
+                || is_binary_for_diff(git_dir, path_for_attrs, &new_raw))
+        {
+            if entry.status == DiffStatus::Deleted {
+                diff_text.push_str(&format!("Binary files a/{old_path} and /dev/null differ\n"));
+            } else if entry.status == DiffStatus::Added {
+                diff_text.push_str(&format!("Binary files /dev/null and b/{new_path} differ\n"));
+            } else {
+                diff_text.push_str(&format!(
+                    "Binary files a/{old_path} and b/{new_path} differ\n"
+                ));
+            }
+            continue;
+        }
+        let old_content = if entry.old_oid == zero_oid() {
+            String::new()
+        } else if use_textconv {
+            blob_text_for_diff_with_oid(
+                odb,
+                git_dir,
+                &config,
+                path_for_attrs,
+                &old_raw,
+                &entry.old_oid,
+                true,
+            )
+        } else {
+            read_blob_content(odb, &entry.old_oid)
+        };
+        let new_content = if entry.new_oid == zero_oid() {
+            String::new()
+        } else if use_textconv {
+            blob_text_for_diff_with_oid(
+                odb,
+                git_dir,
+                &config,
+                path_for_attrs,
+                &new_raw,
+                &entry.new_oid,
+                true,
+            )
+        } else {
+            read_blob_content(odb, &entry.new_oid)
+        };
         let patch = unified_diff(&old_content, &new_content, old_path, new_path, 3);
         diff_text.push_str(&patch);
     }
@@ -1174,6 +1232,13 @@ fn format_single_patch(
     out.push('\n');
 
     Ok(out)
+}
+
+fn read_blob_bytes(odb: &Odb, oid: &ObjectId) -> Vec<u8> {
+    if *oid == zero_oid() {
+        return Vec::new();
+    }
+    odb.read(oid).map(|o| o.data).unwrap_or_default()
 }
 
 /// Read blob content as UTF-8 string (empty for zero OID).

--- a/grit/src/commands/log.rs
+++ b/grit/src/commands/log.rs
@@ -26,7 +26,9 @@ use grit_lib::line_log::{
     format_line_log_diff, line_log_filter_commits, parse_line_log_ranges, rewritten_first_parent,
 };
 use grit_lib::merge_base::is_ancestor;
-use grit_lib::merge_diff::{blob_text_for_diff, is_binary_for_diff};
+use grit_lib::merge_diff::{
+    blob_text_for_diff, blob_text_for_diff_with_oid, diff_textconv_active, is_binary_for_diff,
+};
 use grit_lib::objects::{parse_commit, parse_tag, ObjectId, ObjectKind};
 use grit_lib::odb::Odb;
 use grit_lib::reflog::read_reflog;
@@ -4897,6 +4899,24 @@ fn validate_log_pickaxe_options(repo: &Repository, args: &Args) -> Result<()> {
     Ok(())
 }
 
+/// First executable token of `diff.<driver>.textconv`, matching Git's shell concatenation for
+/// values like `"/abs/cwd"/hexdump` (t4030-diff-textconv).
+fn pickaxe_textconv_cmd_first_token(cmd_line: &str) -> Option<String> {
+    let s = cmd_line.trim();
+    if s.is_empty() {
+        return None;
+    }
+    if let Some(rest) = s.strip_prefix('"') {
+        let end = rest.find('"')?;
+        let prefix = &rest[..end];
+        let tail = rest[end + 1..].trim_start();
+        let suffix = tail.split_whitespace().next().unwrap_or("");
+        return Some(format!("{prefix}{suffix}"));
+    }
+    let first = s.split_whitespace().next()?;
+    Some(first.trim_matches(|c| c == '"' || c == '\'').to_string())
+}
+
 fn path_has_textconv_driver(git_dir: &Path, config: &ConfigSet, path: &str) -> bool {
     let work_tree = git_dir.parent().unwrap_or(git_dir);
     let rules = load_gitattributes(work_tree);
@@ -4927,11 +4947,11 @@ fn validate_pickaxe_textconv_drivers(git_dir: &Path, work_tree: Option<&Path>) -
         if cmd_line.ends_with('<') {
             cmd_line = cmd_line.trim_end_matches('<').trim_end().to_string();
         }
-        let Some(first_word) = cmd_line.split_whitespace().next() else {
+        let Some(first_word) = pickaxe_textconv_cmd_first_token(&cmd_line) else {
             continue;
         };
         if first_word.starts_with('/') || first_word.contains('/') {
-            if !Path::new(first_word).is_file() {
+            if !Path::new(&first_word).is_file() {
                 return Err(anyhow::Error::new(ExplicitExit {
                     code: 128,
                     message: format!(
@@ -6840,8 +6860,9 @@ fn write_commit_diff_body(
     }
 
     if show_patch {
+        let config = ConfigSet::load(Some(git_dir), true).unwrap_or_default();
         for entry in list_patch {
-            log_write_patch_entry(out, odb, entry, args, patch_context)?;
+            log_write_patch_entry(out, odb, git_dir, &config, entry, args, patch_context)?;
         }
     }
 
@@ -6852,6 +6873,8 @@ fn write_commit_diff_body(
 fn log_write_patch_entry(
     out: &mut impl Write,
     odb: &Odb,
+    git_dir: &std::path::Path,
+    config: &ConfigSet,
     entry: &DiffEntry,
     args: &Args,
     context_lines: usize,
@@ -6929,7 +6952,57 @@ fn log_write_patch_entry(
         DiffStatus::Unmerged => {}
     }
 
-    let (old_content, new_content) = log_read_blob_pair(odb, entry)?;
+    let path_for_attrs = entry.path();
+    let use_textconv = !args.no_textconv;
+    let textconv_patch = use_textconv && diff_textconv_active(git_dir, config, path_for_attrs);
+    let old_raw = read_blob_bytes(odb, &entry.old_oid);
+    let new_raw = read_blob_bytes(odb, &entry.new_oid);
+    if !textconv_patch
+        && (is_binary_for_diff(git_dir, path_for_attrs, &old_raw)
+            || is_binary_for_diff(git_dir, path_for_attrs, &new_raw))
+    {
+        let (src_pfx, dst_pfx) = if args.no_prefix {
+            ("", "")
+        } else {
+            ("a/", "b/")
+        };
+        writeln!(
+            out,
+            "Binary files {src_pfx}{old_path} and {dst_pfx}{new_path} differ"
+        )?;
+        return Ok(());
+    }
+
+    let old_content = if entry.old_oid == zero_oid() {
+        String::new()
+    } else if use_textconv {
+        blob_text_for_diff_with_oid(
+            odb,
+            git_dir,
+            config,
+            path_for_attrs,
+            &old_raw,
+            &entry.old_oid,
+            true,
+        )
+    } else {
+        String::from_utf8_lossy(&old_raw).into_owned()
+    };
+    let new_content = if entry.new_oid == zero_oid() {
+        String::new()
+    } else if use_textconv {
+        blob_text_for_diff_with_oid(
+            odb,
+            git_dir,
+            config,
+            path_for_attrs,
+            &new_raw,
+            &entry.new_oid,
+            true,
+        )
+    } else {
+        String::from_utf8_lossy(&new_raw).into_owned()
+    };
     let display_old = if entry.status == DiffStatus::Added {
         "/dev/null"
     } else {

--- a/grit/src/commands/show.rs
+++ b/grit/src/commands/show.rs
@@ -13,13 +13,14 @@ use clap::Args as ClapArgs;
 use grit_lib::config::ConfigSet;
 use grit_lib::diff::{
     anchored_unified_diff, detect_copies, detect_renames, diff_trees, unified_diff, zero_oid,
-    DiffEntry,
+    DiffEntry, DiffStatus,
 };
 use grit_lib::diffstat::{terminal_columns, write_diffstat_block, DiffstatOptions, FileStatInput};
 use grit_lib::merge_base::merge_bases_first_vs_rest;
 use grit_lib::merge_diff::{
-    blob_oid_at_path, blob_text_for_diff, combined_diff_paths, format_combined_binary,
-    format_combined_textconv_patch, format_parent_patch, is_binary_for_diff, read_blob_at_path,
+    blob_oid_at_path, blob_text_for_diff, blob_text_for_diff_with_oid, combined_diff_paths,
+    diff_textconv_active, format_combined_binary, format_combined_textconv_patch,
+    format_parent_patch, is_binary_for_diff, read_blob_at_path,
 };
 use grit_lib::objects::{parse_commit, parse_tag, parse_tree, ObjectId, ObjectKind};
 use grit_lib::odb::Odb;
@@ -30,6 +31,7 @@ use grit_lib::rev_list::{
 };
 use grit_lib::rev_parse::{
     peel_to_tree, resolve_revision, resolve_revision_without_index_dwim, split_double_dot_range,
+    split_treeish_colon,
 };
 use std::collections::{BTreeSet, HashMap};
 use std::io::{self, Write};
@@ -200,6 +202,10 @@ pub struct Args {
     #[arg(long = "no-textconv")]
     pub no_textconv: bool,
 
+    /// Run `diff.<driver>.textconv` for `rev:path` blob output (Git default is raw blob).
+    #[arg(long = "textconv", hide = true)]
+    pub textconv: bool,
+
     /// Show binary diff in git binary format.
     #[arg(long = "binary")]
     pub binary: bool,
@@ -290,7 +296,8 @@ pub fn run(mut args: Args) -> Result<()> {
         for s in &raw_objects {
             let looks_like_rev_spec = s.starts_with('^')
                 || split_double_dot_range(s).is_some()
-                || (s.contains("...") && !s.contains("...."));
+                || (s.contains("...") && !s.contains("...."))
+                || split_treeish_colon(s).is_some_and(|(b, a)| !b.is_empty() && !a.is_empty());
             // Do not use index DWIM alone: a tracked filename like `numbers` must be a pathspec
             // (`git show rev -- numbers`), not mis-parsed as an extra revision (t4069.15).
             if looks_like_rev_spec || resolve_revision_without_index_dwim(&repo, s).is_ok() {
@@ -572,6 +579,25 @@ pub fn run(mut args: Args) -> Result<()> {
                 show_tree_named(&mut out, &repo, spec, oid)?;
             }
             ObjectKind::Blob => {
+                if args.textconv && !args.no_textconv {
+                    if let Some((_rev, path_after)) = split_treeish_colon(spec) {
+                        if !path_after.is_empty() {
+                            let config =
+                                ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+                            let text = blob_text_for_diff_with_oid(
+                                &repo.odb,
+                                repo.git_dir.as_path(),
+                                &config,
+                                path_after,
+                                &obj.data,
+                                &oid,
+                                true,
+                            );
+                            out.write_all(text.as_bytes())?;
+                            continue;
+                        }
+                    }
+                }
                 out.write_all(&obj.data)?;
             }
         }
@@ -699,6 +725,40 @@ fn write_formatted_line(out: &mut impl Write, formatted: &str) -> Result<()> {
         writeln!(out, "{formatted}")?;
     }
     Ok(())
+}
+
+/// Git porcelain (`show`, `log -p`) splits a blob↔symlink type change into a delete hunk plus an add
+/// hunk so textconv applies only to the deleted regular file (t4030-diff-textconv).
+fn expand_typechange_entries_for_porcelain(entries: Vec<DiffEntry>) -> Vec<DiffEntry> {
+    let mut out = Vec::with_capacity(entries.len() + 4);
+    for e in entries {
+        if e.status == DiffStatus::TypeChanged {
+            let path = e.path().to_string();
+            out.push(DiffEntry {
+                status: DiffStatus::Deleted,
+                old_path: Some(path.clone()),
+                new_path: None,
+                old_mode: e.old_mode.clone(),
+                new_mode: "000000".to_owned(),
+                old_oid: e.old_oid,
+                new_oid: zero_oid(),
+                score: None,
+            });
+            out.push(DiffEntry {
+                status: DiffStatus::Added,
+                old_path: None,
+                new_path: Some(path),
+                old_mode: "000000".to_owned(),
+                new_mode: e.new_mode.clone(),
+                old_oid: zero_oid(),
+                new_oid: e.new_oid,
+                score: None,
+            });
+        } else {
+            out.push(e);
+        }
+    }
+    out
 }
 
 /// Show a commit object: header + diff.
@@ -952,9 +1012,11 @@ fn show_commit(
             let old_tree_oid = old_tree.flatten();
             let diff_entries =
                 diff_trees(odb, old_tree_oid.as_ref(), new_tree, "").context("computing diff")?;
+            let diff_entries =
+                apply_rename_copy_detection(odb, diff_entries, args, old_tree_oid.as_ref());
             (
                 old_tree_oid,
-                apply_rename_copy_detection(odb, diff_entries, args, old_tree_oid.as_ref()),
+                expand_typechange_entries_for_porcelain(diff_entries),
             )
         }
     } else {
@@ -968,9 +1030,11 @@ fn show_commit(
         let old_tree_oid = old_tree.flatten();
         let diff_entries =
             diff_trees(odb, old_tree_oid.as_ref(), new_tree, "").context("computing diff")?;
+        let diff_entries =
+            apply_rename_copy_detection(odb, diff_entries, args, old_tree_oid.as_ref());
         (
             old_tree_oid,
-            apply_rename_copy_detection(odb, diff_entries, args, old_tree_oid.as_ref()),
+            expand_typechange_entries_for_porcelain(diff_entries),
         )
     };
 
@@ -1241,17 +1305,45 @@ fn show_commit(
         };
 
         let path_for_attrs = entry.path();
-        if is_binary_for_diff(git_dir, path_for_attrs, &old_raw)
-            || is_binary_for_diff(git_dir, path_for_attrs, &new_raw)
+        let textconv_patch = use_textconv && diff_textconv_active(git_dir, &config, path_for_attrs);
+        if !textconv_patch
+            && (is_binary_for_diff(git_dir, path_for_attrs, &old_raw)
+                || is_binary_for_diff(git_dir, path_for_attrs, &new_raw))
         {
             writeln!(out, "Binary files a/{new_path} and b/{new_path} differ")?;
             continue;
         }
 
-        let old_content =
-            blob_text_for_diff(git_dir, &config, path_for_attrs, &old_raw, use_textconv);
-        let new_content =
-            blob_text_for_diff(git_dir, &config, path_for_attrs, &new_raw, use_textconv);
+        let old_content = if entry.old_oid == grit_lib::diff::zero_oid() {
+            String::new()
+        } else if use_textconv {
+            blob_text_for_diff_with_oid(
+                odb,
+                git_dir,
+                &config,
+                path_for_attrs,
+                &old_raw,
+                &entry.old_oid,
+                true,
+            )
+        } else {
+            blob_text_for_diff(git_dir, &config, path_for_attrs, &old_raw, false)
+        };
+        let new_content = if entry.new_oid == grit_lib::diff::zero_oid() {
+            String::new()
+        } else if use_textconv {
+            blob_text_for_diff_with_oid(
+                odb,
+                git_dir,
+                &config,
+                path_for_attrs,
+                &new_raw,
+                &entry.new_oid,
+                true,
+            )
+        } else {
+            blob_text_for_diff(git_dir, &config, path_for_attrs, &new_raw, false)
+        };
 
         let patch = if !args.anchored.is_empty() {
             let line_algo = if args.patience {

--- a/logs/2026-04-10_t4030-diff-textconv.md
+++ b/logs/2026-04-10_t4030-diff-textconv.md
@@ -1,0 +1,19 @@
+# t4030-diff-textconv
+
+## Goal
+
+Make `tests/t4030-diff-textconv.sh` pass (19/19).
+
+## Fixes
+
+1. **`git show` commit diff** — Use the same textconv/binary gate as `git diff` (`diff_textconv_active` + `blob_text_for_diff_with_oid`) instead of bailing on NUL before textconv.
+2. **Type change (blob → symlink)** — Expand `TypeChanged` into delete + add entries for porcelain `show` output so the deleted regular file still runs textconv; symlinks stay raw (matches upstream Git).
+3. **`git log -p`** — Same textconv/binary handling as diff; emit `Binary files … differ` when appropriate.
+4. **`git format-patch --no-binary`** — New flag; patch body skips textconv and emits binary placeholders (plumbing-style).
+5. **Pickaxe textconv driver check** — Parse first token of `diff.*.textconv` like shell concatenation (`"/path"/script`) so validation matches runnable commands.
+6. **`git show rev:path`** — Treat `rev:path` as a single revision token in argv splitting; raw blob by default; **`--textconv`** runs textconv for blob output only (matches Git).
+
+## Validation
+
+- `./scripts/run-tests.sh t4030-diff-textconv.sh` → 19/19
+- `cargo fmt`, `cargo check`, `cargo clippy -p grit-rs --fix --allow-dirty`, `cargo test -p grit-lib --lib`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible `diff.*.textconv` behavior for porcelain commands exercised by `t4030-diff-textconv.sh` (19/19).

## Changes

- **`git show`**: Commit patches use the same textconv vs binary gate as `git diff` (`diff_textconv_active` + `blob_text_for_diff_with_oid`). Blob↔symlink type changes are expanded into delete + add hunks so textconv applies only to the deleted regular file.
- **`git log -p`**: Patch hunks honor textconv and emit `Binary files … differ` when textconv is not active, matching Git.
- **`git format-patch`**: Add `--no-binary` to suppress textconv in the patch body (plumbing-style binary lines).
- **Pickaxe validation**: Parse the first token of `diff.<driver>.textconv` like shell concatenation for values such as `"/cwd"/script`.
- **`git show rev:path`**: Parse `rev:path` as a single revision in argv splitting; raw blob by default; **`--textconv`** applies textconv for blob output only.

## Test plan

- `./scripts/run-tests.sh t4030-diff-textconv.sh`
- `cargo fmt`, `cargo check`, `cargo clippy -p grit-rs`, `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fcd3d935-9a14-4eca-a99f-9e22790d47d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fcd3d935-9a14-4eca-a99f-9e22790d47d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

