### PR TITLE
fix(diffstat): pad --stat name column by display width (t4073)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -758,7 +758,7 @@ t4070-diff-submodule	t4	yes	31	31	0	true	ok	0
 t4071-diff-empty-tree	t4	yes	32	29	3	false	ok	0
 t4071-diff-minimal	t4	yes	1	1	0	true	ok	0
 t4072-diff-max-depth	t4	yes	50	47	3	false	ok	0
-t4073-diff-stat-name-width	t4	yes	6	2	4	false	ok	0
+t4073-diff-stat-name-width	t4	yes	6	6	0	true	ok	0
 t4074-diff-shifted-matched-group	t4	yes	4	4	0	true	ok	0
 t4075-diff-full-index-abbrev	t4	yes	7	7	0	true	ok	0
 t4076-diff-ignore-submodules	t4	yes	4	4	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,690 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,690 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T05:11:04+00:00" class="gen-time" title="2026-04-10 05:11 UTC">2026-04-10 05:11 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,690</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -230,22 +230,22 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">73/178 files · 2 skipped · 2,862/4,438 tests</span>
+        <span class="group-meta">74/178 files · 2 skipped · 2,866/4,438 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.5%"></div></div>
-        <span class="group-pct pct-blue">64.5%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.6%"></div></div>
+        <span class="group-pct pct-blue">64.6%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35690 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,690 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T05:11:04+00:00" class="gen-time" title="2026-04-10 05:11 UTC">2026-04-10 05:11 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,690</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -7737,14 +7737,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:94.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="6" data-passed="2">
+<tr class="" data-group="t4" data-tests="6" data-passed="6" data-full-pass="1">
   <td class="mono">t4073-diff-stat-name-width</td>
   <td>t4</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">6</td>
-  <td class="right">2</td>
+  <td class="right">6</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:33.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="4" data-passed="4" data-full-pass="1">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/diffstat.rs
+++ b/grit-lib/src/diffstat.rs
@@ -115,6 +115,22 @@ fn decimal_width(n: usize) -> usize {
 }
 
 /// Truncate a path to fit `area_width` display columns (Git `show_stats` name scaling).
+/// Pad `s` with trailing ASCII spaces so its display width is at least `min_cols`.
+///
+/// Git's diffstat uses display-column width for the name field (`utf8_strnwidth`-style), not
+/// Rust's `{:<n$}` padding which counts Unicode scalar values.
+fn pad_name_to_display_width(s: &str, min_cols: usize) -> String {
+    let w = s.width();
+    if w >= min_cols {
+        return s.to_string();
+    }
+    let pad = min_cols - w;
+    let mut out = String::with_capacity(s.len() + pad);
+    out.push_str(s);
+    out.push_str(&" ".repeat(pad));
+    out
+}
+
 fn truncate_path_for_name_area(path: &str, area_width: usize) -> (String, usize) {
     let full_w = path.width();
     if full_w <= area_width {
@@ -251,26 +267,25 @@ pub fn write_diffstat_block(
         let prefix = opts.line_prefix;
         if f.is_binary {
             let (display_name, _) = truncate_path_for_name_area(&f.path_display, name_width);
+            let name_col = pad_name_to_display_width(&display_name, name_width);
             if prefix.is_empty() {
                 writeln!(
                     out,
-                    " {:<nw_name$} | {:>nw$} {} -> {} bytes",
-                    display_name,
+                    " {} | {:>nw$} {} -> {} bytes",
+                    name_col,
                     "Bin",
                     f.deletions,
                     f.insertions,
-                    nw_name = name_width,
                     nw = number_width
                 )?;
             } else {
                 writeln!(
                     out,
-                    "{prefix}{:<nw_name$} | {:>nw$} {} -> {} bytes",
-                    display_name,
+                    "{prefix}{} | {:>nw$} {} -> {} bytes",
+                    name_col,
                     "Bin",
                     f.deletions,
                     f.insertions,
-                    nw_name = name_width,
                     nw = number_width
                 )?;
             }
@@ -280,6 +295,7 @@ pub fn write_diffstat_block(
         let added = f.insertions;
         let deleted = f.deletions;
         let (display_name, _) = truncate_path_for_name_area(&f.path_display, name_width);
+        let name_col = pad_name_to_display_width(&display_name, name_width);
 
         let mut add = added;
         let mut del = deleted;
@@ -303,21 +319,13 @@ pub fn write_diffstat_block(
 
         let total = added + del;
         if prefix.is_empty() {
-            write!(
-                out,
-                " {:<nw_name$} | {:>nw$}",
-                display_name,
-                total,
-                nw_name = name_width,
-                nw = number_width
-            )?;
+            write!(out, " {} | {:>nw$}", name_col, total, nw = number_width)?;
         } else {
             write!(
                 out,
-                "{prefix}{:<nw_name$} | {:>nw$}",
-                display_name,
+                "{prefix}{} | {:>nw$}",
+                name_col,
                 total,
-                nw_name = name_width,
                 nw = number_width
             )?;
         }
@@ -388,4 +396,50 @@ pub fn write_diffstat_block(
     writeln!(out, "{summary}")?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pad_name_matches_git_display_columns_for_wide_chars() {
+        // Truncated path from t4073: display width 9; Git pads to name_width 10 with one space.
+        let truncated = ".../f再见";
+        assert_eq!(truncated.width(), 9);
+        let padded = pad_name_to_display_width(truncated, 10);
+        assert_eq!(padded.width(), 10);
+        assert_eq!(padded, ".../f再见 ");
+    }
+
+    #[test]
+    fn diffstat_name_width_10_matches_git_padding() {
+        let files = vec![FileStatInput {
+            path_display: "d你好/f再见".to_string(),
+            insertions: 0,
+            deletions: 0,
+            is_binary: false,
+        }];
+        let opts = DiffstatOptions {
+            total_width: 80,
+            line_prefix: "",
+            subtract_prefix_from_terminal: false,
+            stat_name_width: Some(10),
+            stat_graph_width: None,
+            stat_count: None,
+            color_add: "",
+            color_del: "",
+            color_reset: "",
+            graph_bar_slack: 0,
+            graph_prefix_budget_slack: 0,
+        };
+        let mut buf = Vec::new();
+        write_diffstat_block(&mut buf, &files, &opts).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        let line = s.lines().next().unwrap();
+        assert!(
+            line.contains(".../f再见  |"),
+            "expected two spaces before pipe like git, got {line:?}"
+        );
+    }
 }

--- a/logs/2026-04-10_t4073-diff-stat-name-width.md
+++ b/logs/2026-04-10_t4073-diff-stat-name-width.md
@@ -1,0 +1,6 @@
+# t4073-diff-stat-name-width
+
+- **Issue:** `--stat` name column used Rust `{:<n$}` padding (Unicode scalar count). Git pads to `name_width` in **display columns** (`utf8_strnwidth`), so wide characters (e.g. CJK) needed different trailing space counts.
+- **Fix:** `grit-lib/src/diffstat.rs`: `pad_name_to_display_width()` appends ASCII spaces until `unicode_width` display width reaches `name_width`; use that for both text and binary stat lines instead of format padding.
+- **Tests:** `cargo test -p grit-lib --lib`; `./scripts/run-tests.sh t4073-diff-stat-name-width.sh` → 6/6.
+- **Note:** `./scripts/run-tests.sh` copies `target/release/grit`; builds must update that path (default workspace `cargo build --release`) or the harness can run a stale binary.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`git diff --stat` pads the filename column to `--stat-name-width` using **display columns** (Git `utf8_strnwidth`). Rust `"{:<n$}"` pads by **Unicode scalar count**, which breaks for wide characters (e.g. CJK) and fails `t4073-diff-stat-name-width`.

## Changes

- `grit-lib/src/diffstat.rs`: add `pad_name_to_display_width()` and use it for text and binary stat lines instead of format-string left padding.
- Unit tests covering t4073-style truncation/padding.
- Harness refresh: `data/test-files.csv` + dashboards after `./scripts/run-tests.sh t4073-diff-stat-name-width.sh` (6/6).

## Validation

- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t4073-diff-stat-name-width.sh`

**Note:** `run-tests.sh` copies `target/release/grit`; use the default workspace release build so the harness exercises the freshly built binary.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1acfb8eb-ed8c-4080-90d4-a431cba7b25d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1acfb8eb-ed8c-4080-90d4-a431cba7b25d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

