### PR TITLE
fix: implement git add -e for t3702-add-edit

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -257,7 +257,7 @@ commit → check it off → move on.
 - [x] `t3307-notes-man` ████████████████████ 3/3 (0 left) — Examples from the git-notes man page
 
 - [x] `t3423-rebase-reword` ████████████████████ 3/3 (0 left) — git rebase interactive with rewording
-- [ ] `t3702-add-edit` ██████░░░░░░░░░░░░░░ 1/3 (2 left) — add -e basic tests
+- [x] `t3702-add-edit` ████████████████████ 3/3 (0 left) — add -e basic tests
 - [ ] `t3450-history` ░░░░░░░░░░░░░░░░░░░░ 0/2 (2 left) — tests for git-history command
 - [x] `t3305-notes-fanout` ████████████████████ 7/7 (0 left) — Test that adding/removing many notes triggers automatic fanout restructuring
 - [ ] `t3005-ls-files-relative` █████░░░░░░░░░░░░░░░ 1/4 (3 left) — ls-files tests with relative paths

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -655,7 +655,7 @@ t3650-replay-basics	t3	yes	31	25	6	false	ok	0
 t3700-add	t3	yes	58	44	14	false	ok	0
 t3700-add-pathspec-file	t3	yes	24	24	0	true	ok	0
 t3701-add-interactive	t3	yes	130	31	99	false	ok	0
-t3702-add-edit	t3	yes	3	1	2	false	ok	0
+t3702-add-edit	t3	yes	3	3	0	true	ok	0
 t3703-add-magic-pathspec	t3	yes	6	4	2	false	ok	0
 t3704-add-pathspec-file	t3	yes	11	11	0	true	ok	0
 t3705-add-sparse-checkout	t3	yes	20	3	17	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,688 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,688 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T05:13:18+00:00" class="gen-time" title="2026-04-10 05:13 UTC">2026-04-10 05:13 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,688</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -219,7 +219,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">56/141 files · 2 skipped · 4,052/5,398 tests</span>
+        <span class="group-meta">57/141 files · 2 skipped · 4,054/5,398 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:75.1%"></div></div>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35688 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,688 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T05:13:18+00:00" class="gen-time" title="2026-04-10 05:13 UTC">2026-04-10 05:13 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,688</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -6707,14 +6707,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:23.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="3" data-passed="1">
+<tr class="" data-group="t3" data-tests="3" data-passed="3" data-full-pass="1">
   <td class="mono">t3702-add-edit</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">3</td>
-  <td class="right">1</td>
+  <td class="right">3</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:33.3%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="6" data-passed="4">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit/src/commands/add.rs
+++ b/grit/src/commands/add.rs
@@ -25,6 +25,10 @@ use std::io::Read;
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 
+use crate::commands::apply;
+use crate::commands::commit::launch_commit_editor;
+use crate::commands::diff::unstaged_patch_for_add_edit;
+
 fn resolved_env_index_path(repo: &Repository) -> PathBuf {
     if let Ok(raw) = std::env::var("GIT_INDEX_FILE") {
         let p = PathBuf::from(raw);
@@ -38,6 +42,34 @@ fn resolved_env_index_path(repo: &Repository) -> PathBuf {
     } else {
         repo.index_path()
     }
+}
+
+/// `git add -e`: write unstaged diff to `ADD_EDIT.patch`, run the editor, apply with `apply --recount --cached`.
+fn run_add_edit(repo: &Repository, pathspecs: &[String]) -> Result<()> {
+    let patch_path = repo.git_dir.join("ADD_EDIT.patch");
+    let initial = unstaged_patch_for_add_edit(repo, pathspecs)?;
+    if initial.trim().is_empty() {
+        bail!("No changes.");
+    }
+    fs::write(&patch_path, initial).with_context(|| format!("writing {}", patch_path.display()))?;
+    launch_commit_editor(repo, &patch_path).context("editing patch failed")?;
+    let edited = fs::read_to_string(&patch_path)
+        .with_context(|| format!("reading {}", patch_path.display()))?;
+    if edited.trim().is_empty() {
+        let _ = fs::remove_file(&patch_path);
+        bail!("empty patch. aborted");
+    }
+    let apply_args = apply::Args {
+        cached: true,
+        recount: true,
+        strip: 1,
+        patches: vec![patch_path.clone()],
+        ..Default::default()
+    };
+    apply::run(apply_args)
+        .with_context(|| format!("could not apply '{}'", patch_path.display()))?;
+    let _ = fs::remove_file(&patch_path);
+    Ok(())
 }
 
 /// Arguments for `grit add`.
@@ -185,20 +217,26 @@ pub fn run(mut args: Args) -> Result<()> {
     }
 
     // --dry-run is incompatible with interactive modes
-    if args.dry_run && (args.interactive || args.patch) {
-        bail!("options '--dry-run' and '--interactive'/'--patch' cannot be used together");
+    if args.dry_run && (args.interactive || args.patch || args.edit) {
+        bail!("options '--dry-run' and '--interactive'/'--patch'/'--edit' cannot be used together");
+    }
+
+    if args.edit {
+        let repo = Repository::discover(None).context("not a git repository")?;
+        repo.work_tree
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("this operation must be run in a work tree"))?;
+        run_add_edit(&repo, &args.pathspec)?;
+        return Ok(());
     }
 
     // Stubs for unsupported interactive modes — accept the flags
     // gracefully so scripts that pass them don't hard-fail.
-    if args.patch || args.interactive || args.edit {
-        // Real git would enter interactive mode; we just warn and succeed.
+    if args.patch || args.interactive {
         let mode_name = if args.patch {
             "-p/--patch"
-        } else if args.interactive {
-            "-i/--interactive"
         } else {
-            "-e/--edit"
+            "-i/--interactive"
         };
         eprintln!(
             "warning: {} mode is not yet implemented; doing nothing",

--- a/grit/src/commands/apply.rs
+++ b/grit/src/commands/apply.rs
@@ -31,7 +31,7 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 /// Arguments for `grit apply`.
-#[derive(Debug, ClapArgs)]
+#[derive(Debug, Default, ClapArgs)]
 #[command(about = "Apply a patch to files and/or to the index")]
 pub struct Args {
     /// Apply the patch to the index instead of the working tree.

--- a/grit/src/commands/diff.rs
+++ b/grit/src/commands/diff.rs
@@ -549,7 +549,7 @@ fn no_index_blob_abbrev(data: &[u8]) -> String {
 }
 
 /// Arguments for `grit diff`.
-#[derive(Debug, ClapArgs)]
+#[derive(Debug, Default, ClapArgs)]
 #[command(about = "Show changes between commits, commit and working tree, etc.")]
 pub struct Args {
     /// Show staged changes (index vs HEAD). Alias: --staged.
@@ -990,6 +990,93 @@ fn write_no_index_index_lines(
         let _ = writeln!(out, "old mode {mode_a}");
         let _ = writeln!(out, "new mode {mode_b}");
     }
+}
+
+/// Build the unstaged patch Git writes for `git add -e` (index vs work tree, 7 context lines).
+///
+/// Matches `edit_patch` in Git's `builtin/add.c`: `run_diff_files` with `context = 7`, patch format,
+/// no color, and submodule dirty paths ignored like `ignore_dirty_submodules`.
+pub(crate) fn unstaged_patch_for_add_edit(
+    repo: &Repository,
+    pathspecs: &[String],
+) -> Result<String> {
+    let work_tree = repo
+        .work_tree
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("this operation must be run in a work tree"))?;
+
+    let index = match repo.load_index() {
+        Ok(idx) => idx,
+        Err(Error::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => Index::new(),
+        Err(e) => return Err(e.into()),
+    };
+
+    let entries = diff_index_to_worktree(&repo.odb, &index, work_tree)?;
+
+    let cwd = repo.effective_pathspec_cwd();
+    let mut pathspec_prefix_buf = show_prefix(repo, &cwd);
+    if !pathspec_prefix_buf.is_empty() {
+        pathspec_prefix_buf.pop();
+    }
+    let pathspec_prefix = (!pathspec_prefix_buf.is_empty()).then_some(pathspec_prefix_buf.as_str());
+    let resolved_specs: Vec<String> = pathspecs
+        .iter()
+        .map(|p| resolve_pathspec(p, work_tree, pathspec_prefix.as_deref()))
+        .collect();
+    let entries = filter_by_paths(entries, &resolved_specs);
+
+    let ignore_sm = "dirty";
+
+    let diff_config = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+    let merged_attrs = load_gitattributes_for_diff(repo)?;
+    let merged_attrs = Arc::new(merged_attrs);
+    let ignore_case_attrs = diff_config
+        .get("core.ignorecase")
+        .is_some_and(|v| matches!(v.to_ascii_lowercase().as_str(), "true" | "yes" | "1"));
+    let diff_algo_ctx = DiffAlgoContext {
+        attrs: Arc::clone(&merged_attrs),
+        config: Arc::new(diff_config.clone()),
+        ignore_case_attrs,
+    };
+    let diff_algo_cli = parse_cli_diff_algorithm_from_argv();
+
+    let mut diff_args = Args::default();
+    diff_args.color = Some("never".to_owned());
+    let (src_prefix, dst_prefix) = resolve_diff_prefixes(&diff_args, repo, false);
+    let relative_prefix = resolve_diff_relative_prefix(Some(work_tree), &repo.git_dir, &diff_args);
+
+    let mut out = Vec::new();
+    write_patch_with_prefix(
+        &mut out,
+        repo,
+        &entries,
+        &repo.odb,
+        &repo.git_dir,
+        &diff_config,
+        7,
+        false,
+        false,
+        Some(work_tree),
+        false,
+        7,
+        0,
+        false,
+        false,
+        false,
+        true,
+        &src_prefix,
+        &dst_prefix,
+        None,
+        submodule_ignore_flags_from_diff_arg(ignore_sm),
+        None,
+        &diff_algo_ctx,
+        diff_algo_cli,
+        false,
+        true,
+        None,
+        relative_prefix.as_deref(),
+    )?;
+    Ok(String::from_utf8(out).context("diff patch was not valid UTF-8")?)
 }
 
 /// Run the `diff` command.

--- a/logs/2026-04-10_t3702-add-edit.md
+++ b/logs/2026-04-10_t3702-add-edit.md
@@ -1,0 +1,5 @@
+# t3702-add-edit (2026-04-10)
+
+- Implemented `git add -e` / `--edit`: build unstaged index↔worktree patch (7 context lines, no color, `ignore-submodules=dirty`), write `.git/ADD_EDIT.patch`, run `launch_commit_editor`, reject empty edited patch, run `apply --cached --recount` with explicit `strip: 1` so `a/` paths map to index keys.
+- Added `diff::unstaged_patch_for_add_edit`; `#[derive(Default)]` on `diff::Args` and `apply::Args` for struct updates.
+- Harness: `./scripts/run-tests.sh t3702-add-edit.sh` → 3/3. `cargo test -p grit-lib --lib` → 160 passed. `cargo fmt` + `cargo clippy -p grit-rs --fix --allow-dirty`.

--- a/progress.md
+++ b/progress.md
@@ -1,20 +1,21 @@
 # Progress — Grit Test Coverage
 
-**Updated:** 2026-04-09
+**Updated:** 2026-04-10
 
 ## Counts (derived from plan.md)
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   325 |
+| Completed   |   326 |
 | In progress |     5 |
-| Remaining   |   441 |
+| Remaining   |   440 |
 | **Total**   |   771 |
 
-Task lines in `PLAN.md`: 325 completed (`[x]`), 5 in progress (`[~]`), 441 remaining (`[ ]`).
+Task lines in `PLAN.md`: 326 completed (`[x]`), 5 in progress (`[~]`), 440 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t3702-add-edit` — 3/3 tests pass (`git add -e`: unstaged index↔worktree patch with 7 context lines, editor via `launch_commit_editor`, `apply --cached --recount --strip=1`; empty patch / editor failure match Git)
 - `t3309-notes-merge-auto-resolve` — 31/31 tests pass (`notes merge`: `union` / `cat_sort_uniq` blob combine like Git; successful merge commits use two parents; `notes.mergeStrategy` config errors match upstream expectations)
 - `t4063-diff-blobs` — 18/18 tests pass (`diff`: blob↔blob and `rev:path` pairs without treating blobs as trees; `HEAD:one..HEAD:two` range split; `rev:path` vs worktree file uses tree path + modes + `write_patch_with_prefix`; raw blob OID vs existing file uses filename as old path; `rev_parse::resolve_treeish_blob_at_path` for tree walks)
 - `t5524-pull-msg` — 3/3 tests pass (`git pull --no-rebase --log` merge message preserves `$` in subject lines; `--log=1` limits shortlog; harness CSV/dashboards refreshed; `PLAN.md` marked complete)

--- a/test-results.md
+++ b/test-results.md
@@ -1,5 +1,10 @@
 # Test results
 
+**2026-04-10 (t3702 / add -e)**
+
+- `cargo test -p grit-lib --lib`: 160 passed
+- `./scripts/run-tests.sh t3702-add-edit.sh`: 3/3 passed
+
 **2026-04-09 (t4063 / diff blobs)**
 
 - `cargo test -p grit-lib --lib`: 155 passed


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements `git add -e` / `--edit` to match Git's `edit_patch` flow: write an unstaged index↔worktree unified diff (7 context lines, no color, submodule handling aligned with `ignore-submodules=dirty`) to `.git/ADD_EDIT.patch`, run the configured editor (`launch_commit_editor`), then apply with `apply --cached --recount` using explicit `strip: 1` so `a/`/`b/` paths resolve to index keys.

Also rejects empty edited patches and propagates editor failure like upstream.

## Testing

- `./scripts/run-tests.sh t3702-add-edit.sh` — 3/3
- `cargo test -p grit-lib --lib` — 160 passed
- `cargo clippy -p grit-rs --fix --allow-dirty`

## Tracking

- `PLAN.md`: `t3702-add-edit` marked complete
- `progress.md`, `test-results.md`, harness CSV + dashboards refreshed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-efe83b01-3f80-4c54-8dcd-8d1edb5ca6e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efe83b01-3f80-4c54-8dcd-8d1edb5ca6e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

