### PR TITLE
fix: make t2104-update-index-skip-worktree pass (no-skip-worktree ordering)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -507,7 +507,7 @@ t2100-update-cache-badpath	t2	yes	5	5	0	true	ok	0
 t2101-update-index-reupdate	t2	yes	7	7	0	true	ok	0
 t2102-update-index-symlinks	t2	yes	3	3	0	true	ok	0
 t2103-update-index-ignore-missing	t2	yes	5	3	2	false	ok	0
-t2104-update-index-skip-worktree	t2	yes	7	5	2	false	ok	0
+t2104-update-index-skip-worktree	t2	yes	7	7	0	true	ok	0
 t2105-update-index-gitfile	t2	yes	4	4	0	true	ok	0
 t2106-update-index-assume-unchanged	t2	yes	2	2	0	true	ok	0
 t2107-update-index-basic	t2	yes	10	10	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,688 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,688 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T05:17:17+00:00" class="gen-time" title="2026-04-10 05:17 UTC">2026-04-10 05:17 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,688</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -208,11 +208,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t2</span>
         <span class="group-desc">Basic commands concerning the working tree</span>
-        <span class="group-meta">30/61 files · 9 skipped · 666/872 tests</span>
+        <span class="group-meta">31/61 files · 9 skipped · 668/872 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:76.4%"></div></div>
-        <span class="group-pct pct-blue">76.4%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:76.6%"></div></div>
+        <span class="group-pct pct-blue">76.6%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t3">
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35688 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,688 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T05:17:17+00:00" class="gen-time" title="2026-04-10 05:17 UTC">2026-04-10 05:17 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,688</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -5227,14 +5227,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:60.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t2" data-tests="7" data-passed="5">
+<tr class="" data-group="t2" data-tests="7" data-passed="7" data-full-pass="1">
   <td class="mono">t2104-update-index-skip-worktree</td>
   <td>t2</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">7</td>
-  <td class="right">5</td>
+  <td class="right">7</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:71.4%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t2" data-tests="4" data-passed="4" data-full-pass="1">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit/src/commands/update_index.rs
+++ b/grit/src/commands/update_index.rs
@@ -634,6 +634,36 @@ pub fn run(args: Args, raw_rest: &[String]) -> Result<()> {
             continue;
         }
 
+        // Assume-valid / skip-worktree bit updates must run before the skip-worktree short-circuit
+        // below; otherwise `--no-skip-worktree` could never clear the bit (t2104).
+        if args.assume_unchanged {
+            if let Some(e) = index.get_mut(&rel_bytes, 0) {
+                e.set_assume_unchanged(true);
+            }
+            continue;
+        }
+        if args.no_assume_unchanged {
+            if let Some(e) = index.get_mut(&rel_bytes, 0) {
+                e.set_assume_unchanged(false);
+            }
+            continue;
+        }
+        if args.skip_worktree {
+            if let Some(e) = index.get_mut(&rel_bytes, 0) {
+                e.set_skip_worktree(true);
+                if e.flags_extended.is_some() {
+                    index.version = 3;
+                }
+            }
+            continue;
+        }
+        if args.no_skip_worktree {
+            if let Some(e) = index.get_mut(&rel_bytes, 0) {
+                e.set_skip_worktree(false);
+            }
+            continue;
+        }
+
         // Git `read-cache.c:process_path`: skip-worktree entries are not refreshed from disk.
         // Plain `update-index <path>` is a no-op; `--remove` drops the index entry even when
         // the file still exists, unless `--ignore-skip-worktree-entries` is set.
@@ -663,34 +693,6 @@ pub fn run(args: Args, raw_rest: &[String]) -> Result<()> {
                 continue;
             }
             // File exists on disk — fall through to update it in the index.
-        }
-
-        if args.assume_unchanged {
-            if let Some(e) = index.get_mut(&rel_bytes, 0) {
-                e.set_assume_unchanged(true);
-            }
-            continue;
-        }
-        if args.no_assume_unchanged {
-            if let Some(e) = index.get_mut(&rel_bytes, 0) {
-                e.set_assume_unchanged(false);
-            }
-            continue;
-        }
-        if args.skip_worktree {
-            if let Some(e) = index.get_mut(&rel_bytes, 0) {
-                e.set_skip_worktree(true);
-                if e.flags_extended.is_some() {
-                    index.version = 3;
-                }
-            }
-            continue;
-        }
-        if args.no_skip_worktree {
-            if let Some(e) = index.get_mut(&rel_bytes, 0) {
-                e.set_skip_worktree(false);
-            }
-            continue;
         }
 
         // --chmod=+x or --chmod=-x without --add: change the mode of an existing entry.

--- a/logs/2026-04-10_t2104-update-index-no-skip-worktree.md
+++ b/logs/2026-04-10_t2104-update-index-no-skip-worktree.md
@@ -1,0 +1,5 @@
+## t2104-update-index-skip-worktree — 2026-04-10
+
+- **Issue:** Tests 6–7 failed: `update-index --no-skip-worktree` did not clear skip-worktree because path processing hit the skip-worktree short-circuit (`continue`) before the flag handlers.
+- **Fix:** In `grit/src/commands/update_index.rs`, run assume-unchanged and skip-worktree / no-skip-worktree handling before the “skip-worktree entries are not refreshed” block.
+- **Verify:** `./scripts/run-tests.sh t2104-update-index-skip-worktree.sh` → 7/7; `cargo test -p grit-lib --lib` passed.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`t2104-update-index-skip-worktree` failed on `git update-index --no-skip-worktree` because path processing hit the skip-worktree short-circuit (`continue`) **before** the flag handlers ran, so the bit was never cleared.

## Change

In `update_index`, handle `--assume-unchanged` / `--no-assume-unchanged` / `--skip-worktree` / `--no-skip-worktree` **before** the block that skips refresh for skip-worktree entries.

## Verification

- `./scripts/run-tests.sh t2104-update-index-skip-worktree.sh` → 7/7
- `cargo test -p grit-lib --lib`
- `cargo check -p grit-rs`

Note: `cargo clippy -p grit-rs -- -D warnings` currently reports many pre-existing issues in this workspace; not used as a gate here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca7b4225-9754-47df-88b5-4d36738488a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca7b4225-9754-47df-88b5-4d36738488a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

