### PR TITLE
fix: t6416 merge corner cases (fast-export, commit, virtual merge base)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1113,7 +1113,7 @@ t6412-merge-large-rename	t6	yes	10	10	0	true	ok	0
 t6413-merge-crlf	t6	yes	3	2	1	false	ok	0
 t6414-merge-rename-nocruft	t6	yes	3	3	0	true	ok	0
 t6415-merge-dir-to-symlink	t6	yes	24	9	15	false	ok	0
-t6416-recursive-corner-cases	t6	yes	37	20	17	false	ok	3
+t6416-recursive-corner-cases	t6	yes	40	23	14	false	ok	3
 t6417-merge-ours-theirs	t6	yes	7	7	0	true	ok	0
 t6418-merge-text-auto	t6	yes	11	9	2	false	ok	0
 t6419-merge-ignorecase	t6	yes	0	0	0	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,689 / 45,145).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,689 / 45,145).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,30 +148,30 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T05:19:11+00:00" class="gen-time" title="2026-04-10 05:19 UTC">2026-04-10 05:19 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,689</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">45,142</div>
+      <div class="summary-big-val">45,145</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>758 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,33 +241,33 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
       <div class="group-line1">
         <span class="group-id">t6</span>
         <span class="group-desc">Revision tree commands (e.g. merge-base)</span>
-        <span class="group-meta">47/105 files · 3 skipped · 1,830/2,822 tests</span>
+        <span class="group-meta">47/105 files · 3 skipped · 1,833/2,825 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.8%"></div></div>
-        <span class="group-pct pct-blue">64.8%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.9%"></div></div>
+        <span class="group-pct pct-blue">64.9%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t7">
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35689 of 45145 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,689 / 45,145 tests · 1,405 files in scope · 758 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T05:19:11+00:00" class="gen-time" title="2026-04-10 05:19 UTC">2026-04-10 05:19 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card"><div class="n" id="sum-tests">45,145</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,689</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11287,14 +11287,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:37.5%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t6" data-tests="37" data-passed="20">
+<tr class="" data-group="t6" data-tests="40" data-passed="23">
   <td class="mono">t6416-recursive-corner-cases</td>
   <td>t6</td>
   <td></td>
-  <td class="right">37</td>
-  <td class="right">20</td>
+  <td class="right">40</td>
+  <td class="right">23</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:54.1%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:57.5%"></div></div></td>
   <td class="right small">3</td>
 </tr>
 <tr class="" data-group="t6" data-tests="7" data-passed="7" data-full-pass="1">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/fast_export.rs
+++ b/grit-lib/src/fast_export.rs
@@ -222,6 +222,23 @@ fn parse_anonymize_maps(entries: &[String]) -> Result<HashMap<String, String>> {
     Ok(out)
 }
 
+/// Ref tips used to assign each exported commit a `commit <ref>` line (Git `revision_sources`).
+///
+/// Includes `refs/heads/*` and peeled `refs/tags/*` so tagged-only commits (e.g. `git tag E` with no
+/// branch) still get a valid source ref. Without tags, `fast-export --all` can fail with
+/// `no ref source for commit` when the walk reaches a commit reachable only via tags.
+fn revision_source_tips(repo: &Repository) -> Result<Vec<(String, ObjectId)>> {
+    let mut tips = refs::list_refs(&repo.git_dir, "refs/heads/")?;
+    for (name, oid) in refs::list_refs(&repo.git_dir, "refs/tags/")? {
+        let tip = match peel_tag_to_commit_oid(repo, oid) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        tips.push((name, tip));
+    }
+    Ok(tips)
+}
+
 fn ref_source_for_commit(
     repo: &Repository,
     oid: ObjectId,
@@ -343,7 +360,7 @@ pub fn export_stream(
         ));
     }
 
-    let head_branches: Vec<(String, ObjectId)> = refs::list_refs(&repo.git_dir, "refs/heads/")?;
+    let head_branches = revision_source_tips(repo)?;
 
     let opts = RevListOptions {
         all_refs: true,

--- a/grit/src/commands/commit.rs
+++ b/grit/src/commands/commit.rs
@@ -712,11 +712,14 @@ pub fn run(mut args: Args) -> Result<()> {
             no_ab,
         )?;
         // Match Git: `commit --dry-run` exits 1 when there is nothing to commit (after printing status).
+        // Merge commits are allowed even when the index matches `HEAD^{tree}` (e.g. resolving
+        // modify/delete by keeping our version — tree unchanged but we still record the merge).
         if !args.allow_empty
             && !args.amend
             && !skip_index_tree_vs_parent
             && staged.is_empty()
             && !parents.is_empty()
+            && parents.len() == 1
         {
             let parent_obj = repo.odb.read(&parents[0])?;
             let parent_commit = grit_lib::objects::parse_commit(&parent_obj.data)?;
@@ -743,6 +746,7 @@ pub fn run(mut args: Args) -> Result<()> {
         && !skip_index_tree_vs_parent
         && staged.is_empty()
         && !parents.is_empty()
+        && parents.len() == 1
     {
         let parent_obj = repo.odb.read(&parents[0])?;
         let parent_commit = grit_lib::objects::parse_commit(&parent_obj.data)?;

--- a/grit/src/commands/merge.rs
+++ b/grit/src/commands/merge.rs
@@ -1179,13 +1179,21 @@ pub(crate) fn create_virtual_merge_base(
             MergeDirectoryRenamesMode::FromConfig,
             MergeRenameOptions::from_config(repo),
             None,
+            true,
             None,
         )?;
 
         // Build a tree from the merged index:
         // - use stage-0 entries when clean
-        // - for conflicts (no stage-0), synthesize stage-0 entries from the
-        //   conflict marker content written to conflict_files.
+        // - for conflicts (no stage-0), synthesize stage-0 blobs for the virtual ancestor.
+        //
+        // For three-way content conflicts (stages 1+2+3), keep using stage 2 as the template
+        // and prefer conflict marker content when present (matches prior behavior).
+        //
+        // For modify/delete (stages 1+2 or 1+3 only), using the modified side as the virtual
+        // tree blob makes the outer criss-cross merge think the virtual base already matches one
+        // parent and incorrectly auto-resolves. Git's recursive merge leaves the **base**
+        // version in the virtual merge base so the final merge still conflicts (t6416).
         let mut final_entries: Vec<IndexEntry> = Vec::new();
         let mut seen_paths: std::collections::HashSet<Vec<u8>> = std::collections::HashSet::new();
         let conflict_content_map: HashMap<Vec<u8>, Vec<u8>> = merge_result
@@ -1199,16 +1207,101 @@ pub(crate) fn create_virtual_merge_base(
                 final_entries.push(entry.clone());
             }
         }
-        // For conflicted paths (no stage 0), synthesize from stage 2 and
-        // conflict marker blob content.
+
+        let mut unmerged_paths: BTreeSet<Vec<u8>> = BTreeSet::new();
         for entry in &merge_result.index.entries {
-            if entry.stage() == 2 && seen_paths.insert(entry.path.clone()) {
-                let mut e = entry.clone();
-                e.flags &= !0x3000; // Clear stage bits → stage 0
-                if let Some(content) = conflict_content_map.get(&entry.path) {
+            if entry.stage() != 0 {
+                unmerged_paths.insert(entry.path.clone());
+            }
+        }
+        for entry in &merge_result.index.entries {
+            if entry.stage() == 0 {
+                unmerged_paths.remove(&entry.path);
+            }
+        }
+
+        for path in unmerged_paths {
+            if seen_paths.contains(&path) {
+                continue;
+            }
+            let entries_at: Vec<&IndexEntry> = merge_result
+                .index
+                .entries
+                .iter()
+                .filter(|e| e.path == path)
+                .collect();
+            let has = |s: u8| entries_at.iter().any(|e| e.stage() == s);
+            let add_add = has(2) && has(3) && !has(1);
+            let three_way = has(1) && has(2) && has(3);
+
+            let mut push_entry = |mut e: IndexEntry| -> Result<()> {
+                e.flags &= !0x3000;
+                final_entries.push(e);
+                seen_paths.insert(path.clone());
+                Ok(())
+            };
+
+            if three_way || add_add {
+                let Some(e2) = entries_at.iter().find(|e| e.stage() == 2).copied() else {
+                    continue;
+                };
+                let mut e = e2.clone();
+                if let Some(content) = conflict_content_map.get(&path) {
                     e.oid = repo.odb.write(ObjectKind::Blob, content)?;
                 }
-                final_entries.push(e);
+                push_entry(e)?;
+            } else if has(1) && has(2) && !has(3) {
+                let path_str = String::from_utf8_lossy(&path).into_owned();
+                let df_here = merge_result.conflict_descriptions.iter().any(|d| {
+                    d.kind == "file/directory"
+                        && d.remerge_anchor_path.as_deref() == Some(path_str.as_str())
+                });
+                if df_here {
+                    let Some(e2) = entries_at.iter().find(|e| e.stage() == 2).copied() else {
+                        continue;
+                    };
+                    push_entry(e2.clone())?;
+                } else {
+                    let Some(be) = entries_at.iter().find(|e| e.stage() == 1).copied() else {
+                        continue;
+                    };
+                    let Some(side) = entries_at.iter().find(|e| e.stage() == 2).copied() else {
+                        continue;
+                    };
+                    let mut e = side.clone();
+                    e.oid = be.oid;
+                    e.mode = be.mode;
+                    push_entry(e)?;
+                }
+            } else if has(1) && has(3) && !has(2) {
+                let path_str = String::from_utf8_lossy(&path).into_owned();
+                let df_here = merge_result.conflict_descriptions.iter().any(|d| {
+                    d.kind == "file/directory"
+                        && d.remerge_anchor_path.as_deref() == Some(path_str.as_str())
+                });
+                if df_here {
+                    let Some(e3) = entries_at.iter().find(|e| e.stage() == 3).copied() else {
+                        continue;
+                    };
+                    push_entry(e3.clone())?;
+                } else {
+                    let Some(be) = entries_at.iter().find(|e| e.stage() == 1).copied() else {
+                        continue;
+                    };
+                    let Some(side) = entries_at.iter().find(|e| e.stage() == 3).copied() else {
+                        continue;
+                    };
+                    let mut e = side.clone();
+                    e.oid = be.oid;
+                    e.mode = be.mode;
+                    push_entry(e)?;
+                }
+            } else if let Some(e2) = entries_at.iter().find(|e| e.stage() == 2).copied() {
+                let mut e = e2.clone();
+                if let Some(content) = conflict_content_map.get(&path) {
+                    e.oid = repo.odb.write(ObjectKind::Blob, content)?;
+                }
+                push_entry(e)?;
             }
         }
         final_entries.sort_by(|a, b| a.path.cmp(&b.path));
@@ -1519,6 +1612,7 @@ Aborting"
         MergeRenameOptions::from_config(repo)
     };
 
+    let criss_cross_outer = bases.len() > 1;
     // Merge trees
     let mut merge_result = merge_trees(
         repo,
@@ -1540,6 +1634,7 @@ Aborting"
         MergeDirectoryRenamesMode::FromConfig,
         rename_opts,
         None,
+        criss_cross_outer,
         None,
     )?;
     apply_sparse_checkout_skip_worktree(&repo.git_dir, &mut merge_result.index);
@@ -2436,6 +2531,7 @@ fn do_octopus_merge(
                 MergeDirectoryRenamesMode::FromConfig,
                 MergeRenameOptions::from_config(repo),
                 None,
+                false,
                 None,
             )?;
 
@@ -2527,6 +2623,7 @@ fn do_octopus_merge(
             MergeDirectoryRenamesMode::FromConfig,
             MergeRenameOptions::from_config(repo),
             None,
+            false,
             None,
         )?;
 
@@ -4081,6 +4178,10 @@ fn apply_directory_renames_to_side(
 /// For directory/file conflicts, unmerged entries are placed at `path~SUFFIX` where `SUFFIX`
 /// is the full hex OID of the commit whose tree still has a **file** at that path (not the
 /// side that turned the path into a directory).
+///
+/// When `criss_cross_outer_merge` is true (recursive merge after folding multiple merge bases),
+/// directory/file conflicts use Git merge-ort index layout at the original path with stages
+/// 1+2 or 1+3.
 fn merge_trees(
     repo: &Repository,
     base: &HashMap<Vec<u8>, IndexEntry>,
@@ -4101,6 +4202,7 @@ fn merge_trees(
     merge_directory_renames_mode: MergeDirectoryRenamesMode,
     rename_options: MergeRenameOptions,
     forced_branch_labels: Option<(String, String)>,
+    criss_cross_outer_merge: bool,
     mut auto_merge_paths: Option<&mut Vec<String>>,
 ) -> Result<MergeResult> {
     // Detect renames on each side
@@ -4551,25 +4653,17 @@ fn merge_trees(
                             });
                         }
                     } else {
-                        let mut be_at_new = be.clone();
-                        be_at_new.path = ours_new_path.clone();
-                        stage_entry(&mut index, &be_at_new, 1);
+                        // They deleted the rename source and did not add a different blob at the
+                        // destination — stage base vs ours at `ours_new_path` (Git reports
+                        // `rename/delete` only; t6416 expects `:1:path` / `:2:path` at the final name).
+                        let dest_str = String::from_utf8_lossy(ours_new_path).to_string();
+                        let mut be_at_dest = be.clone();
+                        be_at_dest.path = ours_new_path.clone();
+                        stage_entry(&mut index, &be_at_dest, 1);
                         stage_entry(&mut index, oe, 2);
                         if let Ok(obj) = repo.odb.read(&oe.oid) {
-                            conflict_files.push((new_path_str.clone(), obj.data));
+                            conflict_files.push((dest_str, obj.data));
                         }
-                        let md_body = format!(
-                            "{new_path_str} deleted in {their_name} and modified in {ours_label}.  Version {ours_label} of {new_path_str} left in tree."
-                        );
-                        conflict_descriptions.push(ConflictDescription {
-                            kind: "modify/delete",
-                            body: md_body,
-                            subject_path: new_path_str.clone(),
-                            remerge_anchor_path: None,
-                            rename_rr_ours_dest: None,
-                            rename_rr_theirs_dest: None,
-                            auto_merge_hint_path: None,
-                        });
                     }
                 }
             }
@@ -5073,6 +5167,8 @@ fn merge_trees(
         repo,
         their_name,
         ours_label,
+        base,
+        criss_cross_outer_merge,
         &ours_entries,
         &theirs_entries,
         &mut index,
@@ -5546,8 +5642,8 @@ pub(crate) fn merge_tree_write_tree_core(
         None
     };
 
-    let (base_oid, base_label_prefix) = if let Some(mb) = explicit_merge_base {
-        (mb, short_oid(mb))
+    let (base_oid, base_label_prefix, criss_cross_outer) = if let Some(mb) = explicit_merge_base {
+        (mb, short_oid(mb), false)
     } else {
         let bases =
             grit_lib::merge_base::merge_bases_first_vs_rest(repo, branch1_oid, &[branch2_oid])?;
@@ -5555,14 +5651,19 @@ pub(crate) fn merge_tree_write_tree_core(
             bail!("refusing to merge unrelated histories");
         }
         if bases.is_empty() {
-            (create_empty_base_commit(repo)?, "empty tree".to_string())
+            (
+                create_empty_base_commit(repo)?,
+                "empty tree".to_string(),
+                false,
+            )
         } else if bases.len() > 1 {
             (
                 create_virtual_merge_base(repo, &bases, favor, merge_renormalize)?,
                 "merged common ancestors".to_string(),
+                true,
             )
         } else {
-            (bases[0], short_oid(bases[0]))
+            (bases[0], short_oid(bases[0]), false)
         }
     };
 
@@ -5596,6 +5697,7 @@ pub(crate) fn merge_tree_write_tree_core(
         merge_directory_renames_mode,
         rename_options,
         forced_labels,
+        criss_cross_outer,
         auto_ref,
     )?;
 
@@ -5686,6 +5788,7 @@ pub(crate) fn remerge_merge_tree(
         MergeDirectoryRenamesMode::FromConfig,
         MergeRenameOptions::from_config(repo),
         forced,
+        bases.len() > 1,
         None,
     )?;
 
@@ -5893,6 +5996,7 @@ pub(crate) fn merge_trees_for_replay(
         merge_directory_renames_mode,
         rename_options,
         None,
+        false,
         None,
     )?;
     Ok(ReplayTreeMergeResult {
@@ -6279,10 +6383,17 @@ fn path_has_tree_descendant(map: &HashMap<Vec<u8>, IndexEntry>, path: &[u8]) -> 
 }
 
 /// Directory/file conflicts: one side has a file at `P`, the other only has paths under `P/`.
+///
+/// When `merge_ort_style` is true (recursive merge with a virtual merge base / criss-cross), match
+/// Git merge-ort index layout: unmerged entries at the original path `P` with stages 1+2 or 1+3.
+/// Otherwise use `P~SUFFIX` staging so `git rm P~HEAD` works during initial conflict resolution
+/// (t6416 setup and t4301-style flows).
 fn apply_directory_file_conflicts(
     repo: &Repository,
     their_name: &str,
     ours_label: &str,
+    base: &HashMap<Vec<u8>, IndexEntry>,
+    merge_ort_style: bool,
     ours_entries: &HashMap<Vec<u8>, IndexEntry>,
     theirs_entries: &HashMap<Vec<u8>, IndexEntry>,
     index: &mut Index,
@@ -6320,54 +6431,66 @@ fn apply_directory_file_conflicts(
         .ok_or_else(|| anyhow::anyhow!("directory/file conflict: missing file entry"))?;
 
         let branch_desc = if file_is_ours { ours_label } else { their_name };
-        let new_path_str = format!("{}~{}", String::from_utf8_lossy(&path), branch_desc);
-        let new_path = new_path_str.as_bytes().to_vec();
+        let path_display = String::from_utf8_lossy(&path).into_owned();
+        let new_path_str = format!("{path_display}~{branch_desc}");
 
         let body = format!(
             "directory in the way of {} from {}; moving it to {} instead.",
-            String::from_utf8_lossy(&path),
-            branch_desc,
-            new_path_str
+            path_display, branch_desc, new_path_str
         );
         conflict_descriptions.push(ConflictDescription {
             kind: "file/directory",
             body,
             subject_path: new_path_str.clone(),
-            remerge_anchor_path: Some(String::from_utf8_lossy(&path).into_owned()),
-            rename_rr_ours_dest: None,
-            rename_rr_theirs_dest: None,
-            auto_merge_hint_path: None,
-        });
-
-        // Git also emits modify/delete for the relocated file when the other side removed the
-        // original path in favor of a directory (see t4301-merge-tree-write-tree).
-        let md_body = if file_is_ours {
-            format!(
-                "{new_path_str} deleted in {their_name} and modified in {ours_label}.  Version {ours_label} of {new_path_str} left in tree."
-            )
-        } else {
-            format!(
-                "{new_path_str} deleted in {ours_label} and modified in {their_name}.  Version {their_name} of {new_path_str} left in tree."
-            )
-        };
-        conflict_descriptions.push(ConflictDescription {
-            kind: "modify/delete",
-            body: md_body,
-            subject_path: new_path_str.clone(),
-            remerge_anchor_path: Some(String::from_utf8_lossy(&path).into_owned()),
+            remerge_anchor_path: Some(path_display.clone()),
             rename_rr_ours_dest: None,
             rename_rr_theirs_dest: None,
             auto_merge_hint_path: None,
         });
 
         index.entries.retain(|e| e.path != path);
-        let stage = if file_is_ours { 2u8 } else { 3u8 };
-        let mut staged = file_entry.clone();
-        staged.path = new_path.clone();
-        stage_entry(index, &staged, stage);
 
-        if let Ok(obj) = repo.odb.read(&file_entry.oid) {
-            conflict_files.push((new_path_str, obj.data));
+        if merge_ort_style {
+            if let Some(be) = base.get(&path) {
+                stage_entry(index, be, 1);
+            }
+            let stage = if file_is_ours { 2u8 } else { 3u8 };
+            let mut staged = file_entry.clone();
+            staged.path = path.clone();
+            stage_entry(index, &staged, stage);
+            if let Ok(obj) = repo.odb.read(&file_entry.oid) {
+                // Worktree path must avoid colliding with an existing directory at `path` (the other
+                // side may still have `path/file` checked out).
+                conflict_files.push((new_path_str, obj.data));
+            }
+        } else {
+            let md_body = if file_is_ours {
+                format!(
+                    "{new_path_str} deleted in {their_name} and modified in {ours_label}.  Version {ours_label} of {new_path_str} left in tree."
+                )
+            } else {
+                format!(
+                    "{new_path_str} deleted in {ours_label} and modified in {their_name}.  Version {their_name} of {new_path_str} left in tree."
+                )
+            };
+            conflict_descriptions.push(ConflictDescription {
+                kind: "modify/delete",
+                body: md_body,
+                subject_path: new_path_str.clone(),
+                remerge_anchor_path: Some(path_display.clone()),
+                rename_rr_ours_dest: None,
+                rename_rr_theirs_dest: None,
+                auto_merge_hint_path: None,
+            });
+
+            let stage = if file_is_ours { 2u8 } else { 3u8 };
+            let mut staged = file_entry.clone();
+            staged.path = new_path_str.as_bytes().to_vec();
+            stage_entry(index, &staged, stage);
+
+            if let Ok(obj) = repo.odb.read(&file_entry.oid) {
+                conflict_files.push((new_path_str, obj.data));
+            }
         }
         *has_conflicts = true;
     }

--- a/logs/2026-04-10-t6416-recursive-corner-cases.md
+++ b/logs/2026-04-10-t6416-recursive-corner-cases.md
@@ -1,0 +1,17 @@
+# t6416-recursive-corner-cases
+
+## Progress
+
+- **fast-export**: Include peeled `refs/tags/*` in revision sources so `fast-export --all` + `fast-import` after `git tag E` does not fail with `no ref source for commit` (test 7).
+- **commit**: Allow merge commits when index tree matches first parent (`parents.len() > 1` skips "nothing to commit") so modify/delete resolution can conclude (tests 8–10).
+- **merge / virtual base**: When folding merge bases, synthesize modify/delete virtual blobs from **base** (not modified side); special-case directory/file 1+2 / 1+3 conflicts to keep **ours/theirs file** in the virtual tree; inner `merge_trees` during virtual-base construction uses merge-ort-style directory/file handling + `criss_cross_outer` flag for outer recursive merges.
+- **rename/delete**: When they deleted source and did not add at destination, stage `:1` + `:2` at destination without duplicate modify/delete message.
+- **Harness**: t6416 now **23/40** (was 19/40).
+
+## Remaining
+
+Tests 12+ still fail: merge-ort parity for rename/delete with virtual merge bases (`Temporary merge branch` paths), symlinks, submodules, mode conflicts, nested conflict markers. Upstream Git 2.43 on the same graph for the D1/E1 merge shows only `:2:a` (no `:1:a`), while the ported test expects three index lines including `:1:a` — may need merge-ort alignment or test expectation refresh against current Git.
+
+## Blocked
+
+None; further work is substantial merge-ort feature parity.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves behavior covered by `t6416-recursive-corner-cases`: **19/40 → 23/40** in the harness.

### Changes

- **`fast-export`**: Include peeled `refs/tags/*` in revision-source tips so `fast-export --all` does not fail with `no ref source for commit` when history is only reachable via tags (swapped rename/add test).
- **`commit`**: Skip the "nothing to commit, working tree clean" guard when `MERGE_HEAD` is present (multiple parents), matching Git for modify/delete resolutions that leave the tree identical to the first parent.
- **`merge`**: Virtual merge-base synthesis for modify/delete; directory/file handling during virtual-base construction; `criss_cross_outer` flag to use merge-ort-style D/F index layout only for the outer recursive merge; rename/delete staging at the destination path without spurious modify/delete.

### Remaining

Tests 12+ still need deeper merge-ort parity (rename/delete with `Temporary merge branch` paths, symlinks, submodules, mode conflicts, nested diff3 bases). Note: on Git 2.43 the D1/E1 merge index shows only `:2:a` while the ported test expects `:1:a` and `:2:a` — worth reconciling expectations with current upstream merge-ort.

### Validation

- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t6416-recursive-corner-cases.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c92a3493-67d0-4bd9-bc91-de843b4c0f71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c92a3493-67d0-4bd9-bc91-de843b4c0f71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

