### PR TITLE
fix: cat-file --textconv parity with Git (t8007)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -919,7 +919,7 @@ commit → check it off → move on.
 - [ ] `t8009-blame-vs-topicbranches` ██████████░░░░░░░░░░ 1/2 (1 left) — blaming through history with topic branches
 - [x] `t8010-cat-file-filters` ████████████████████ 9/9 — git cat-file filters support
 - [ ] `t8015-blame-diff-algorithm` █████░░░░░░░░░░░░░░░ 2/7 (5 left) — git blame with specific diff algorithm
-- [ ] `t8007-cat-file-textconv` ████████████░░░░░░░░ 9/15 (6 left) — git cat-file textconv support
+- [x] `t8007-cat-file-textconv` ████████████████████ 15/15 — git cat-file textconv support
 - [ ] `t8011-blame-split-file` ████░░░░░░░░░░░░░░░░ 2/10 (8 left) — 
 
 - [ ] `t8006-blame-textconv` ███████░░░░░░░░░░░░░ 6/16 (10 left) — git blame textconv support

--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -1288,7 +1288,7 @@ t8003-blame-corner-cases	t8	yes	30	27	3	false	ok	0
 t8004-blame-with-conflicts	t8	yes	3	3	0	true	ok	0
 t8005-blame-i18n	t8	yes	5	0	5	false	ok	0
 t8006-blame-textconv	t8	yes	16	7	9	false	ok	0
-t8007-cat-file-textconv	t8	yes	15	10	5	false	ok	0
+t8007-cat-file-textconv	t8	yes	15	15	0	true	ok	0
 t8008-blame-formats	t8	yes	5	4	1	false	ok	0
 t8009-blame-vs-topicbranches	t8	yes	2	2	0	true	ok	0
 t8010-cat-file-batch	t8	yes	26	26	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,691 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,691 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T05:31:04+00:00" class="gen-time" title="2026-04-10 05:31 UTC">2026-04-10 05:31 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,691</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,22 +263,22 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">
       <div class="group-line1">
         <span class="group-id">t8</span>
         <span class="group-desc">Porcelainish commands concerning forensics</span>
-        <span class="group-meta">81/105 files · 0 skipped · 2,866/3,116 tests</span>
+        <span class="group-meta">82/105 files · 0 skipped · 2,871/3,116 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-green" style="width:92.0%"></div></div>
-        <span class="group-pct pct-green">92.0%</span>
+        <div class="bar-bg"><div class="bar-fg pct-green" style="width:92.1%"></div></div>
+        <span class="group-pct pct-green">92.1%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t9">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35691 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,691 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T05:31:04+00:00" class="gen-time" title="2026-04-10 05:31 UTC">2026-04-10 05:31 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,691</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">
@@ -13037,14 +13037,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:43.8%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t8" data-tests="15" data-passed="10">
+<tr class="" data-group="t8" data-tests="15" data-passed="15" data-full-pass="1">
   <td class="mono">t8007-cat-file-textconv</td>
   <td>t8</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">15</td>
-  <td class="right">10</td>
+  <td class="right">15</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:66.7%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t8" data-tests="5" data-passed="4">

--- a/grit-lib/src/rev_parse.rs
+++ b/grit-lib/src/rev_parse.rs
@@ -1034,7 +1034,8 @@ pub fn resolve_treeish_blob_at_path(repo: &Repository, spec: &str) -> Result<Tre
         Err(e) => return Err(e),
     };
 
-    let (oid, mode_str) = walk_tree_to_blob_entry(repo, &tree_oid, &clean_path)?;
+    let (oid, mode_str) = walk_tree_to_blob_entry(repo, &tree_oid, &clean_path)
+        .map_err(|e| diagnose_tree_path_error(repo, before, after, &clean_path, e))?;
     Ok(TreeishBlobAtPath {
         path: clean_path,
         oid,

--- a/grit/src/commands/cat_file.rs
+++ b/grit/src/commands/cat_file.rs
@@ -12,6 +12,7 @@ use grit_lib::rev_list::{self, ObjectFilter};
 use std::io::{self, BufRead, Write};
 use std::path::{Path, PathBuf};
 
+use grit_lib::index::MODE_SYMLINK;
 use grit_lib::objects::{parse_commit, parse_tree, ObjectId, ObjectKind};
 use grit_lib::repo::Repository;
 use grit_lib::rev_parse;
@@ -195,9 +196,28 @@ pub fn run(args: Args) -> Result<()> {
         (None, _) => return Err(anyhow::anyhow!("object required when not in batch mode")),
     };
 
-    let oid = match resolve_object(&repo, obj_str) {
-        Ok(oid) => oid,
+    let transform_mode = args.textconv || args.filters;
+    let (oid, blob_mode_for_transform) = match if transform_mode {
+        resolve_object_with_mode_lib(&repo, obj_str)
+    } else {
+        resolve_object_lib(&repo, obj_str).map(|o| (o, None))
+    } {
+        Ok(pair) => pair,
+        Err(LibError::Message(msg)) if args.exists => {
+            eprintln!("{msg}");
+            std::process::exit(128);
+        }
         Err(_) if args.exists => std::process::exit(1),
+        Err(LibError::Message(msg))
+            if transform_mode && !obj_str.contains(':') && msg.contains("ambiguous argument") =>
+        {
+            eprintln!("fatal: Not a valid object name {obj_str}");
+            std::process::exit(128);
+        }
+        Err(LibError::Message(msg)) => {
+            eprintln!("{msg}");
+            std::process::exit(128);
+        }
         Err(_) => {
             if args.show_type || args.size {
                 if looks_like_full_hex_object_id(obj_str) {
@@ -251,7 +271,14 @@ pub fn run(args: Args) -> Result<()> {
     }
 
     if args.textconv || args.filters {
-        return cat_file_emit_transformed(&repo, &args, &oid, &obj, obj_str);
+        return cat_file_emit_transformed(
+            &repo,
+            &args,
+            &oid,
+            &obj,
+            obj_str,
+            blob_mode_for_transform,
+        );
     }
 
     if let Some(kind) = expected_kind {
@@ -1270,6 +1297,7 @@ fn cat_file_batch_blob_payload(
     path: &str,
     blob: &[u8],
     oid_hex: &str,
+    blob_mode: Option<u32>,
     opts: BatchWriteOpts<'_>,
 ) -> Result<Vec<u8>> {
     let config = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
@@ -1289,6 +1317,9 @@ fn cat_file_batch_blob_payload(
     )
     .map_err(|e| anyhow::anyhow!("could not convert '{oid_hex}' {path}: {e}"))?;
     if opts.batch_filters {
+        return Ok(smudged);
+    }
+    if blob_mode == Some(MODE_SYMLINK) {
         return Ok(smudged);
     }
     let rules = match index.as_ref() {
@@ -1503,7 +1534,7 @@ fn print_batch_entry(
                         }
                         let oid_hex = oid.to_string();
                         let payload =
-                            cat_file_batch_blob_payload(repo, p, &obj.data, &oid_hex, opts)?;
+                            cat_file_batch_blob_payload(repo, p, &obj.data, &oid_hex, mode, opts)?;
                         emit_batch_object_lines(
                             repo,
                             oid,
@@ -1674,6 +1705,7 @@ fn cat_file_emit_transformed(
     oid: &ObjectId,
     obj: &grit_lib::objects::Object,
     obj_spec: &str,
+    blob_mode: Option<u32>,
 ) -> Result<()> {
     let path = cat_file_transform_path(args, obj_spec)?;
     let config = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
@@ -1708,6 +1740,8 @@ fn cat_file_emit_transformed(
     .map_err(|e| anyhow::anyhow!("could not convert '{oid_hex}' {path}: {e}"))?;
 
     let data = if args.filters {
+        smudged
+    } else if blob_mode == Some(MODE_SYMLINK) {
         smudged
     } else {
         let rules = match index.as_ref() {
@@ -1796,50 +1830,16 @@ fn resolve_object_with_mode_lib(
     repo: &Repository,
     obj_str: &str,
 ) -> LibResult<(ObjectId, Option<u32>)> {
-    // Check if this is a treeish:path reference
-    if let Some(colon_pos) = obj_str.find(':') {
-        let treeish_part = &obj_str[..colon_pos];
-        let path_part = &obj_str[colon_pos + 1..];
-        if !treeish_part.is_empty() && !path_part.is_empty() {
-            // Resolve the treeish part
-            if let Ok(treeish_oid) = resolve_object_lib(repo, treeish_part) {
-                // Get the tree oid
-                let object = read_object_with_promisor_lazy_fetch(repo, &treeish_oid, false)?;
-                let tree_oid = match object.kind {
-                    ObjectKind::Commit => {
-                        let commit = parse_commit(&object.data)?;
-                        commit.tree
-                    }
-                    ObjectKind::Tree => treeish_oid,
-                    _ => {
-                        // Fall back to regular resolution
-                        let oid = resolve_object_lib(repo, obj_str)?;
-                        return Ok((oid, None));
-                    }
-                };
-
-                // Walk the tree path to find the entry mode
-                let parts: Vec<&str> = path_part.split('/').filter(|p| !p.is_empty()).collect();
-                let mut current_tree = tree_oid;
-                for (i, part) in parts.iter().enumerate() {
-                    let tree_obj =
-                        read_object_with_promisor_lazy_fetch(repo, &current_tree, false)?;
-                    let entries = parse_tree(&tree_obj.data)?;
-                    if let Some(entry) = entries.iter().find(|e| e.name == part.as_bytes()) {
-                        if i == parts.len() - 1 {
-                            // Last component: return the entry's oid and mode
-                            return Ok((entry.oid, Some(entry.mode)));
-                        }
-                        current_tree = entry.oid;
-                    } else {
-                        break;
-                    }
-                }
-            }
-        }
+    if let Ok(Some(entry)) = rev_parse::resolve_index_path_entry(repo, obj_str) {
+        return Ok((entry.oid, Some(entry.mode)));
     }
 
-    // No tree path or couldn't resolve mode
+    if rev_parse::split_treeish_colon(obj_str).is_some() {
+        let info = rev_parse::resolve_treeish_blob_at_path(repo, obj_str)?;
+        let mode = u32::from_str_radix(info.mode.as_str(), 8).ok();
+        return Ok((info.oid, mode));
+    }
+
     let oid = resolve_object_lib(repo, obj_str)?;
     Ok((oid, None))
 }

--- a/logs/2026-04-10_t8007-cat-file-textconv.md
+++ b/logs/2026-04-10_t8007-cat-file-textconv.md
@@ -1,0 +1,21 @@
+# t8007-cat-file-textconv
+
+## Goal
+
+Make `tests/t8007-cat-file-textconv.sh` pass (15/15).
+
+## Changes
+
+- **`grit-lib` `rev_parse::resolve_treeish_blob_at_path`**: Run `diagnose_tree_path_error` when tree walk fails so missing paths report `fatal: path '…' does not exist in 'HEAD'` like Git.
+- **`grit` `cat_file`**:
+  - For `--textconv` / `--filters`, resolve via `resolve_object_with_mode_lib` (index `:path`, `resolve_treeish_blob_at_path` for `rev:path`) and print `Error::Message` verbatim; `-e` exits 128 on those messages (matches Git).
+  - Map ambiguous bare rev + transform mode to `fatal: Not a valid object name <rev>` (Git behavior for `cat-file --textconv HEAD2`).
+  - Symlink blobs (`MODE_SYMLINK`): skip `run_textconv_raw` in single-object and `--batch` paths; output smudged symlink target bytes.
+- **`PLAN.md` / `progress.md`**: Mark t8007 complete; bump counts.
+- **Harness**: `./scripts/run-tests.sh t8007-cat-file-textconv.sh` → 15/15, CSV/dashboards updated.
+
+## Validation
+
+- `cargo fmt`, `cargo clippy --fix --allow-dirty` (workspace scope as run)
+- `cargo test -p grit-lib --lib`
+- `GUST_BIN=... sh tests/t8007-cat-file-textconv.sh`

--- a/progress.md
+++ b/progress.md
@@ -1,20 +1,21 @@
 # Progress — Grit Test Coverage
 
-**Updated:** 2026-04-09
+**Updated:** 2026-04-10
 
 ## Counts (derived from plan.md)
 
 | Status      | Count |
 |-------------|-------|
-| Completed   |   325 |
+| Completed   |   326 |
 | In progress |     5 |
-| Remaining   |   441 |
+| Remaining   |   440 |
 | **Total**   |   771 |
 
-Task lines in `PLAN.md`: 325 completed (`[x]`), 5 in progress (`[~]`), 441 remaining (`[ ]`).
+Task lines in `PLAN.md`: 326 completed (`[x]`), 5 in progress (`[~]`), 440 remaining (`[ ]`).
 
 ## Recently completed
 
+- `t8007-cat-file-textconv` — 15/15 tests pass (`cat-file --textconv` / `--filters`: treeish:path and `:path` resolution use rev-parse diagnostics; symlink blobs skip textconv like Git; batch textconv skips driver for `120000` entries; `resolve_treeish_blob_at_path` applies missing-path diagnosis)
 - `t3309-notes-merge-auto-resolve` — 31/31 tests pass (`notes merge`: `union` / `cat_sort_uniq` blob combine like Git; successful merge commits use two parents; `notes.mergeStrategy` config errors match upstream expectations)
 - `t4063-diff-blobs` — 18/18 tests pass (`diff`: blob↔blob and `rev:path` pairs without treating blobs as trees; `HEAD:one..HEAD:two` range split; `rev:path` vs worktree file uses tree path + modes + `write_patch_with_prefix`; raw blob OID vs existing file uses filename as old path; `rev_parse::resolve_treeish_blob_at_path` for tree walks)
 - `t5524-pull-msg` — 3/3 tests pass (`git pull --no-rebase --log` merge message preserves `$` in subject lines; `--log=1` limits shortlog; harness CSV/dashboards refreshed; `PLAN.md` marked complete)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes `t8007-cat-file-textconv` pass (15/15) by aligning `grit cat-file --textconv` / `--filters` with upstream Git.

## Changes

- **`rev_parse::resolve_treeish_blob_at_path`**: pipe tree-walk failures through `diagnose_tree_path_error` so missing paths emit `fatal: path '…' does not exist in '<rev>'` instead of a generic "Not a valid object name" for the full spec.
- **`cat-file` transform mode**: resolve objects via index entry + `resolve_treeish_blob_at_path` when applicable; propagate `Error::Message` verbatim; `-e` exits 128 on those messages (matches Git). Bare ambiguous rev + `--textconv` maps to `fatal: Not a valid object name <rev>`.
- **Symlinks (`120000`)**: skip `textconv` driver for symlink blob content (matches Git: output is the symlink target string).
- **Batch `--textconv`**: same symlink skip when mode is known from the tree walk.
- **Docs**: `PLAN.md` / `progress.md`, harness CSV + dashboards, task log under `logs/`.

## Validation

- `cargo fmt`, `cargo clippy --fix --allow-dirty`
- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t8007-cat-file-textconv.sh` → 15/15

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-309d29c1-9063-4291-8406-e0bd537eacc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-309d29c1-9063-4291-8406-e0bd537eacc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

