### PR TITLE
fix: rev-list cherry classification, external merge drivers, rebase ORIG_HEAD (t3418 partial)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -605,7 +605,7 @@ t3413-rebase-hook	t3	yes	15	9	6	false	ok	0
 t3415-rebase-autosquash	t3	yes	28	23	5	false	ok	0
 t3416-rebase-onto-threedots	t3	yes	18	12	6	false	ok	0
 t3417-rebase-whitespace-fix	t3	yes	4	4	0	true	ok	0
-t3418-rebase-continue	t3	yes	30	6	24	false	ok	0
+t3418-rebase-continue	t3	yes	30	7	23	false	ok	0
 t3419-rebase-patch-id	t3	yes	8	8	0	true	ok	0
 t3420-rebase-autostash	t3	yes	54	36	18	false	ok	0
 t3421-rebase-topology-linear	t3	yes	63	39	24	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,687 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,687 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T05:36:42+00:00" class="gen-time" title="2026-04-10 05:36 UTC">2026-04-10 05:36 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,687</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>758 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -219,7 +219,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">56/141 files · 2 skipped · 4,052/5,398 tests</span>
+        <span class="group-meta">56/141 files · 2 skipped · 4,053/5,398 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:75.1%"></div></div>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35687 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,687 / 45,142 tests · 1,405 files in scope · 758 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T05:36:42+00:00" class="gen-time" title="2026-04-10 05:36 UTC">2026-04-10 05:36 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,687</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -6207,14 +6207,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="30" data-passed="6">
+<tr class="" data-group="t3" data-tests="30" data-passed="7">
   <td class="mono">t3418-rebase-continue</td>
   <td>t3</td>
   <td></td>
   <td class="right">30</td>
-  <td class="right">6</td>
+  <td class="right">7</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:20.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:23.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="8" data-passed="8" data-full-pass="1">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/rev_list.rs
+++ b/grit-lib/src/rev_list.rs
@@ -704,9 +704,10 @@ pub fn rev_list(
                     left_right_map.insert(oid, true);
                 } else if from_right && !from_left {
                     left_right_map.insert(oid, false);
-                } else {
-                    left_right_map.insert(oid, false);
                 }
+                // Commits reachable from both tips are on the shared ancestry; they must not be
+                // classified as "right-only" or cherry-pick matching breaks (`rev-list A...B
+                // --right-only --cherry-pick`, rebase todo generation; t3418 / t3419).
             }
         }
     }

--- a/grit/src/commands/merge.rs
+++ b/grit/src/commands/merge.rs
@@ -10,6 +10,7 @@ use std::fs;
 use std::io::Write;
 use std::os::unix::fs::MetadataExt as _;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use tempfile::NamedTempFile;
 
 use grit_lib::config::ConfigSet;
@@ -214,6 +215,32 @@ enum SubtreeShift {
 /// First `-s` strategy wins for merge-tree behavior; empty means default (ort).
 fn primary_merge_strategy(args: &Args) -> Option<&str> {
     args.strategy.first().map(String::as_str)
+}
+
+fn is_builtin_merge_strategy(name: &str) -> bool {
+    matches!(
+        name,
+        "recursive" | "ort" | "resolve" | "octopus" | "ours" | "theirs" | "subtree"
+    )
+}
+
+/// `git-merge-<name>` on `PATH`, matching Git's custom merge strategy discovery.
+fn resolve_git_merge_driver(strategy: &str) -> Option<PathBuf> {
+    let name = format!("git-merge-{strategy}");
+    let path_var = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path_var) {
+        let candidate = dir.join(&name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn use_external_merge_strategy(args: &Args) -> bool {
+    args.strategy.len() == 1
+        && !is_builtin_merge_strategy(&args.strategy[0])
+        && resolve_git_merge_driver(&args.strategy[0]).is_some()
 }
 
 /// Subtree path shifting for `merge_trees`: `-s subtree` implies auto-detect unless `-X subtree` set a prefix.
@@ -638,40 +665,46 @@ pub fn run(mut args: Args) -> Result<()> {
         bail!("fatal: You cannot combine --squash with --commit.");
     }
 
-    // Validate --strategy: each `-s` is one strategy name (space-separated lists come from
-    // `pull.twohead` / `pull.octopus`, expanded before `merge` runs).
+    // Validate --strategy: built-ins or `git-merge-<name>` on PATH (Git `merge.c` / `try_merge_command`).
     for strat in &args.strategy {
-        match strat.as_str() {
-            "recursive" | "ort" | "resolve" | "octopus" | "ours" | "theirs" | "subtree" => {}
-            other => bail!("Could not find merge strategy '{}'", other),
+        if is_builtin_merge_strategy(strat) {
+            continue;
         }
+        if resolve_git_merge_driver(strat).is_some() {
+            continue;
+        }
+        bail!("Could not find merge strategy '{}'", strat);
     }
 
-    // Parse -X strategy options
+    let external_driver_merge = use_external_merge_strategy(&args);
+
+    // Parse -X strategy options (ignored for external drivers; passed through as `--<opt>`).
     let mut favor = MergeFavor::None;
     let mut diff_algorithm: Option<String> = None;
     let mut subtree_shift = SubtreeShift::Disabled;
-    for xopt in &args.strategy_option {
-        if let Some(algo) = xopt.strip_prefix("diff-algorithm=") {
-            diff_algorithm = Some(algo.to_string());
-        } else if xopt == "renormalize" {
-            merge_renormalize = true;
-        } else if xopt == "no-renormalize" {
-            merge_renormalize = false;
-        } else if xopt == "subtree" {
-            subtree_shift = SubtreeShift::Auto;
-        } else if let Some(path) = xopt.strip_prefix("subtree=") {
-            let normalized = path.trim_matches('/');
-            subtree_shift = if normalized.is_empty() {
-                SubtreeShift::Auto
+    if !external_driver_merge {
+        for xopt in &args.strategy_option {
+            if let Some(algo) = xopt.strip_prefix("diff-algorithm=") {
+                diff_algorithm = Some(algo.to_string());
+            } else if xopt == "renormalize" {
+                merge_renormalize = true;
+            } else if xopt == "no-renormalize" {
+                merge_renormalize = false;
+            } else if xopt == "subtree" {
+                subtree_shift = SubtreeShift::Auto;
+            } else if let Some(path) = xopt.strip_prefix("subtree=") {
+                let normalized = path.trim_matches('/');
+                subtree_shift = if normalized.is_empty() {
+                    SubtreeShift::Auto
+                } else {
+                    SubtreeShift::Prefix(normalized.to_string())
+                };
             } else {
-                SubtreeShift::Prefix(normalized.to_string())
-            };
-        } else {
-            match xopt.as_str() {
-                "ours" => favor = MergeFavor::Ours,
-                "theirs" => favor = MergeFavor::Theirs,
-                other => bail!("unknown strategy option: -X {other}"),
+                match xopt.as_str() {
+                    "ours" => favor = MergeFavor::Ours,
+                    "theirs" => favor = MergeFavor::Theirs,
+                    other => bail!("unknown strategy option: -X {other}"),
+                }
             }
         }
     }
@@ -789,6 +822,10 @@ pub fn run(mut args: Args) -> Result<()> {
     // True merge needed
     if args.ff_only {
         bail!("Not possible to fast-forward, aborting.");
+    }
+
+    if use_external_merge_strategy(&args) {
+        return run_external_merge_driver(&repo, &head, head_oid, merge_oid, &args);
     }
 
     if args.strategy.len() > 1 {
@@ -918,6 +955,9 @@ fn try_merge_strategies(
                 true,
                 false,
             ),
+            _ if use_external_merge_strategy(&sub) => {
+                run_external_merge_driver(repo, head, head_oid, merge_oid, &sub)
+            }
             other => bail!("Could not find merge strategy '{other}'"),
         };
 
@@ -1409,6 +1449,211 @@ fn prefixed_path(path: &[u8], prefix: &str) -> Vec<u8> {
     out.push(b'/');
     out.extend_from_slice(path);
     out
+}
+
+/// Run `git-merge-<strategy>` from `PATH` (Git `try_merge_command` / `merge.c`).
+fn run_external_merge_driver(
+    repo: &Repository,
+    head: &HeadState,
+    head_oid: ObjectId,
+    merge_oid: ObjectId,
+    args: &Args,
+) -> Result<()> {
+    let strategy_name = args
+        .strategy
+        .first()
+        .map(String::as_str)
+        .ok_or_else(|| anyhow::anyhow!("internal: external merge without strategy"))?;
+    let Some(driver) = resolve_git_merge_driver(strategy_name) else {
+        bail!("Could not find merge strategy '{strategy_name}'");
+    };
+
+    if matches!(
+        primary_merge_strategy(args),
+        Some("recursive" | "ort" | "subtree" | "octopus")
+    ) {
+        bail_if_index_tree_differs_from_head(repo, head_oid, args.autostash)?;
+    }
+
+    let bases = grit_lib::merge_base::merge_bases_first_vs_rest(repo, head_oid, &[merge_oid])?;
+    if bases.is_empty() && !args.allow_unrelated_histories {
+        bail!("refusing to merge unrelated histories");
+    }
+
+    if !args.autostash && diff_index::index_cached_differs_from_head(repo)? {
+        return Err(anyhow::Error::new(ExplicitExit {
+            code: 2,
+            message: "Your local changes to the following files would be overwritten by merge:\n\
+Please commit your changes or stash them before you merge.\n\
+Aborting"
+                .to_string(),
+        }));
+    }
+
+    fs::write(
+        repo.git_dir.join("ORIG_HEAD"),
+        format!("{}\n", head_oid.to_hex()),
+    )?;
+
+    let wt = repo
+        .work_tree
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("external merge strategy requires a work tree"))?;
+
+    let mut cmd = Command::new(&driver);
+    for xopt in &args.strategy_option {
+        cmd.arg(format!("--{xopt}"));
+    }
+    for b in &bases {
+        cmd.arg(b.to_hex());
+    }
+    cmd.args(["--", "HEAD", &merge_oid.to_hex()]);
+    cmd.current_dir(wt);
+
+    let status = cmd
+        .status()
+        .with_context(|| format!("failed to execute {}", driver.display()))?;
+    let code = status.code().unwrap_or(1);
+    // Git: 0 = clean, 1 = conflicts left, 2 = strategy does not handle this merge.
+    if code == 2 {
+        bail!("Merge with strategy {strategy_name} failed.");
+    }
+
+    let mut index = repo.load_index()?;
+    let has_conflicts = index.entries.iter().any(|e| e.stage() != 0);
+
+    if has_conflicts {
+        if code == 0 {
+            bail!("external merge driver reported success but index has unmerged entries");
+        }
+        refresh_index_stat_cache_from_worktree(repo, &mut index)?;
+        repo.write_index(&mut index)?;
+
+        if args.squash {
+            let mut msg = build_squash_msg(repo, head_oid, &[merge_oid])?;
+            msg.push_str("# Conflicts:\n");
+            fs::write(repo.git_dir.join("SQUASH_MSG"), &msg)?;
+        } else {
+            fs::write(
+                repo.git_dir.join("MERGE_HEAD"),
+                format!("{}\n", merge_oid.to_hex()),
+            )?;
+            let msg = build_merge_message(head, &args.commits[0], args.message.as_deref(), repo);
+            fs::write(repo.git_dir.join("MERGE_MSG"), &msg)?;
+            fs::write(repo.git_dir.join("MERGE_MODE"), "")?;
+        }
+
+        println!("Automatic merge failed; fix conflicts and then commit the result.");
+        let rr = if args.no_rerere_autoupdate {
+            grit_lib::rerere::RerereAutoupdate::No
+        } else if args.rerere_autoupdate {
+            grit_lib::rerere::RerereAutoupdate::Yes
+        } else {
+            grit_lib::rerere::RerereAutoupdate::FromConfig
+        };
+        let _ = grit_lib::rerere::repo_rerere(repo, rr);
+        return Err(anyhow::Error::new(SilentNonZeroExit { code: 1 }));
+    }
+
+    if code != 0 {
+        bail!("Merge with strategy {strategy_name} failed.");
+    }
+
+    refresh_index_stat_cache_from_worktree(repo, &mut index)?;
+    repo.write_index(&mut index)?;
+
+    if args.squash {
+        return do_squash_from_merge(repo, index, head, head_oid, merge_oid, args);
+    }
+
+    if args.no_commit {
+        fs::write(
+            repo.git_dir.join("MERGE_HEAD"),
+            format!("{}\n", merge_oid.to_hex()),
+        )?;
+        let msg = build_merge_message(head, &args.commits[0], args.message.as_deref(), repo);
+        fs::write(repo.git_dir.join("MERGE_MSG"), &msg)?;
+        fs::write(repo.git_dir.join("MERGE_MODE"), "no-ff\n")?;
+        if !args.quiet {
+            eprintln!("Automatic merge went well; stopped before committing as requested");
+        }
+        run_post_merge_hook(repo, false);
+        return Ok(());
+    }
+
+    let tree_oid = write_tree_from_index(&repo.odb, &index, "")?;
+    let config = ConfigSet::load(Some(&repo.git_dir), true)?;
+    let effective_custom_msg = if let Some(ref file_path) = args.file {
+        Some(read_merge_message_from_file(Path::new(file_path), &config)?)
+    } else {
+        args.message.clone()
+    };
+    let mut msg = build_merge_message(
+        head,
+        &args.commits[0],
+        effective_custom_msg.as_deref(),
+        repo,
+    );
+    if let Some(max_log) = args.log {
+        let log_entries = build_merge_log(repo, head_oid, merge_oid, &args.commits[0], max_log)?;
+        if !log_entries.is_empty() {
+            if !msg.ends_with('\n') {
+                msg.push('\n');
+            }
+            msg.push('\n');
+            msg.push_str(&log_entries);
+        }
+    }
+    let now = OffsetDateTime::now_utc();
+    let author = resolve_ident(&config, "author", now)?;
+    let committer = resolve_ident(&config, "committer", now)?;
+    if args.signoff && !args.no_signoff {
+        let sob_name = std::env::var("GIT_COMMITTER_NAME")
+            .ok()
+            .or_else(|| config.get("user.name"))
+            .unwrap_or_else(|| "Unknown".to_owned());
+        let sob_email = std::env::var("GIT_COMMITTER_EMAIL")
+            .ok()
+            .or_else(|| config.get("user.email"))
+            .unwrap_or_default();
+        msg = append_signoff(&msg, &sob_name, &sob_email);
+    }
+    if let Some(ref mode) = args.cleanup {
+        msg = cleanup_message(&msg, mode);
+    }
+    let finalized = finalize_merge_commit_message(msg, &config);
+    let commit_data = CommitData {
+        tree: tree_oid,
+        parents: vec![head_oid, merge_oid],
+        author,
+        committer,
+        author_raw: Vec::new(),
+        committer_raw: Vec::new(),
+        encoding: finalized.encoding,
+        message: finalized.message,
+        raw_message: finalized.raw_message,
+    };
+    let commit_bytes = serialize_commit(&commit_data);
+    let commit_oid = repo.odb.write(ObjectKind::Commit, &commit_bytes)?;
+    update_head(&repo.git_dir, head, &commit_oid)?;
+
+    if !args.quiet {
+        let short = &commit_oid.to_hex()[..7];
+        let branch = head.branch_name().unwrap_or("HEAD");
+        let first_line = commit_data.message.lines().next().unwrap_or("");
+        println!("[{branch} {short}] {first_line}");
+        println!("Merge made by the '{strategy_name}' strategy.");
+        let show_stat = args.stat || args.summary || !args.no_stat;
+        if show_stat {
+            let old_tree = commit_tree(repo, head_oid)?;
+            let new_tree = commit_tree(repo, merge_oid)?;
+            if let Ok(diff_entries) = diff_trees(&repo.odb, Some(&old_tree), Some(&new_tree), "") {
+                print_diffstat(repo, &diff_entries, args.compact_summary);
+            }
+        }
+    }
+    run_post_merge_hook(repo, false);
+    Ok(())
 }
 
 fn do_real_merge(

--- a/grit/src/commands/rebase.rs
+++ b/grit/src/commands/rebase.rs
@@ -2146,6 +2146,12 @@ fn do_rebase(args: Args, pre_rebase_hook_second: Option<String>) -> Result<()> {
             let _ = append_reflog(git_dir, refname, &head_oid, &head_oid, &ident, &msg, false);
             let _ = append_reflog(git_dir, "HEAD", &head_oid, &head_oid, &ident, &msg, false);
         }
+        // Git still records ORIG_HEAD when the rebase is a no-op because every commit was skipped
+        // as a cherry-pick equivalent (t3418-rebase-continue ORIG_HEAD tests).
+        fs::write(
+            git_dir.join("ORIG_HEAD"),
+            format!("{}\n", head_oid.to_hex()),
+        )?;
         if let Some(ref oid) = autostash_oid {
             apply_autostash_after_ff(&repo, oid)?;
         }
@@ -2165,6 +2171,10 @@ fn do_rebase(args: Args, pre_rebase_hook_second: Option<String>) -> Result<()> {
     };
     fs::write(rb_dir.join("head-name"), &head_name)?;
     fs::write(rb_dir.join("orig-head"), head_oid.to_hex())?;
+    fs::write(
+        git_dir.join("ORIG_HEAD"),
+        format!("{}\n", head_oid.to_hex()),
+    )?;
     fs::write(rb_dir.join("onto"), onto_oid.to_hex())?;
     fs::write(rb_dir.join("onto-name"), format!("{onto_name_for_state}\n"))?;
     fs::write(

--- a/logs/2026-04-10_t3418-rebase-continue.md
+++ b/logs/2026-04-10_t3418-rebase-continue.md
@@ -1,0 +1,18 @@
+# t3418-rebase-continue (partial)
+
+## Done
+
+- **rev_list**: Symmetric-diff left/right map no longer marks commits reachable from *both* tips as right-only. Shared ancestry entries are omitted from the map so `--right-only --cherry-pick` matches Git (fixes empty rebase todo when all commits were misclassified).
+- **merge**: Unknown `-s <name>` resolves to `git-merge-<name>` on `PATH`; invokes it with merge bases, `--`, `HEAD`, remote OID, and passes `-X` as `--<option>` (Git `try_merge_command`). Wired into single-strategy merge and `try_merge_strategies`.
+- **rebase**: Write `.git/ORIG_HEAD` when starting a rebase and when the todo is empty after cherry filtering (no-op skip path).
+
+## Still failing in t3418 (23 tests)
+
+Rerere autoupdate flags during rebase, `break` / patch file, reschedule-failed-exec, commentChar=auto, fixup/skip message cleanup, and full strategy persistence for `-r` still need sequencer/rebase state parity with Git.
+
+## Verify
+
+- `cargo check -p grit-rs`
+- `cargo test -p grit-lib --lib`
+- `./scripts/run-tests.sh t3419-rebase-patch-id.sh` (still 8/8)
+- `./scripts/run-tests.sh t3418-rebase-continue.sh` (7/30 at time of log)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Progress on `t3418-rebase-continue.sh` and related Git parity:

- **Symmetric diff / cherry**: `rev_list` no longer stores shared-ancestry commits in the left/right map as right-only, fixing `--right-only --cherry-pick` behavior (matches Git; keeps `t3419-rebase-patch-id` green).
- **Custom merge strategies**: `grit merge -s <name>` now runs `git-merge-<name>` from `PATH` when present, forwarding merge bases and `-X` options as Git does (`try_merge_command`).
- **Rebase ORIG_HEAD**: Write `ORIG_HEAD` when a rebase starts and when the todo is empty after cherry filtering (no-op skip path).

## Testing

- `cargo check -p grit-rs`
- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t3419-rebase-patch-id.sh` — 8/8
- `./scripts/run-tests.sh t3418-rebase-continue.sh` — **7/30** (23 remaining: rerere flags, break/patch, reschedule-failed-exec, commentChar=auto, fixup/skip messaging, `-r` strategy wiring, etc.)

## Notes

Full t3418 pass still needs more sequencer/rebase state parity with upstream Git.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37c3bf5e-920f-4952-a3f6-d99114059eea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37c3bf5e-920f-4952-a3f6-d99114059eea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

