### PR TITLE
fix: t3401 directory-rename rebase/am + preserve t6429 replay

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -590,7 +590,7 @@ t3315-notes-merge	t3	yes	4	4	0	true	ok	0
 t3320-notes-merge-worktrees	t3	yes	9	9	0	true	ok	0
 t3321-notes-stripspace	t3	yes	27	1	26	false	ok	0
 t3400-rebase	t3	yes	39	16	23	false	ok	0
-t3401-rebase-and-am-rename	t3	yes	10	6	4	false	ok	0
+t3401-rebase-and-am-rename	t3	yes	10	10	0	true	ok	0
 t3401-rebase-basic	t3	yes	32	32	0	true	ok	0
 t3402-rebase-merge	t3	yes	13	2	11	false	ok	0
 t3403-rebase-skip	t3	yes	20	10	10	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,690 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,690 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T05:41:01+00:00" class="gen-time" title="2026-04-10 05:41 UTC">2026-04-10 05:41 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,690</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -219,7 +219,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">56/141 files · 2 skipped · 4,052/5,398 tests</span>
+        <span class="group-meta">57/141 files · 2 skipped · 4,056/5,398 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:75.1%"></div></div>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35690 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,690 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T05:41:01+00:00" class="gen-time" title="2026-04-10 05:41 UTC">2026-04-10 05:41 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,690</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -6057,14 +6057,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:41.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="10" data-passed="6">
+<tr class="" data-group="t3" data-tests="10" data-passed="10" data-full-pass="1">
   <td class="mono">t3401-rebase-and-am-rename</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">10</td>
-  <td class="right">6</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:60.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="32" data-passed="32" data-full-pass="1">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit/src/commands/am.rs
+++ b/grit/src/commands/am.rs
@@ -25,6 +25,9 @@ use grit_lib::rev_parse::resolve_revision_for_patch_old_blob;
 use grit_lib::state::{resolve_head, HeadState};
 use grit_lib::write_tree::write_tree_from_index;
 
+use super::rebase::{checkout_merged_index, write_rebase_conflict_files};
+use super::replay::merge_trees_for_single_cherry_pick;
+
 /// Arguments for `grit am`.
 #[derive(Debug, ClapArgs)]
 #[command(about = "Apply patches from mailbox")]
@@ -173,6 +176,8 @@ struct MboxPatch {
     diff: String,
     /// Message-ID from the email headers.
     message_id: String,
+    /// When present, the commit OID from a `git format-patch` mbox `From <hex> Mon ...` line.
+    format_patch_commit: Option<ObjectId>,
 }
 
 /// Run the `am` command.
@@ -859,26 +864,36 @@ fn apply_one_patch(repo: &Repository, patch: &MboxPatch, opts: &AmOptions) -> Re
         }
     }
 
-    // Try to apply the diff to the working tree. With `--3way`, Git verifies patch index
-    // preimages against the work tree even when a fuzzy apply could succeed; mismatch must
-    // fall through to the 3-way path (t4151 `changes.mbox`).
-    let apply_result =
-        apply_patch_to_worktree(work_tree, &patch.diff, opts.keep_cr, opts.three_way);
+    if opts.three_way {
+        if let Some(()) = apply_am_format_patch_tree_merge(repo, patch)? {
+            // `format-patch` mbox: cherry-pick-style tree merge (directory renames, etc.).
+        } else {
+            // Try to apply the diff to the working tree. With `--3way`, Git verifies patch index
+            // preimages against the work tree even when a fuzzy apply could succeed; mismatch must
+            // fall through to the 3-way path (t4151 `changes.mbox`).
+            let apply_result =
+                apply_patch_to_worktree(work_tree, &patch.diff, opts.keep_cr, opts.three_way);
 
-    match apply_result {
-        Ok(affected_paths) => {
-            // Stage only the files that the patch touched
-            stage_affected_files(repo, &affected_paths)?;
+            match apply_result {
+                Ok(affected_paths) => {
+                    stage_affected_files(repo, &affected_paths)?;
+                }
+                Err(_e) => {
+                    apply_three_way(repo, patch)?;
+                }
+            }
         }
-        Err(e) => {
-            if opts.three_way {
-                // Attempt 3-way merge
-                apply_three_way(repo, patch)?;
-            } else {
+    } else {
+        let apply_result =
+            apply_patch_to_worktree(work_tree, &patch.diff, opts.keep_cr, opts.three_way);
+        match apply_result {
+            Ok(affected_paths) => {
+                stage_affected_files(repo, &affected_paths)?;
+            }
+            Err(e) => {
                 if opts.reject {
                     let _ = write_reject_files_for_patch(work_tree, &patch.diff);
                 }
-                // Save message for --continue
                 fs::write(git_dir.join("MERGE_MSG"), &patch.message)?;
                 return Err(e);
             }
@@ -974,6 +989,88 @@ fn merge_three_way_text_am(
     }
     out.push_str(&format!(">>>>>>> {patch_label}\n"));
     AmThreeWayMerge::Conflict(out)
+}
+
+/// When the mbox carries a `git format-patch` commit OID, run a full tree merge (rename + directory
+/// rename) like `git cherry-pick` / `git rebase`, instead of per-file textual 3-way merge.
+///
+/// Returns `Ok(Some(()))` when a clean merge was written to the index and work tree.
+/// Returns `Ok(None)` when this helper does not apply (no OID, missing objects): use per-file 3-way.
+/// Returns `Err` on merge conflicts (index/worktree updated) or other failures.
+fn apply_am_format_patch_tree_merge(repo: &Repository, patch: &MboxPatch) -> Result<Option<()>> {
+    let Some(picked_oid) = patch.format_patch_commit else {
+        return Ok(None);
+    };
+    let git_dir = &repo.git_dir;
+    let work_tree = repo
+        .work_tree
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("no work tree"))?;
+
+    let picked_obj = match repo.odb.read(&picked_oid) {
+        Ok(o) => o,
+        Err(_) => return Ok(None),
+    };
+    if picked_obj.kind != ObjectKind::Commit {
+        return Ok(None);
+    }
+    let picked_commit = parse_commit(&picked_obj.data)?;
+    let parent_tree_oid = match picked_commit.parents.first() {
+        Some(p) => {
+            let po = repo.odb.read(p)?;
+            if po.kind != ObjectKind::Commit {
+                return Ok(None);
+            }
+            parse_commit(&po.data)?.tree
+        }
+        None => ObjectId::from_hex("4b825dc642cb6eb9a060e54bf8d69288fbee4904")
+            .map_err(|e| anyhow::anyhow!(e))?,
+    };
+
+    let head_oid = resolve_head(git_dir)?
+        .oid()
+        .copied()
+        .ok_or_else(|| anyhow::anyhow!("HEAD is unborn"))?;
+    let head_obj = repo.odb.read(&head_oid)?;
+    let head_commit = parse_commit(&head_obj.data)?;
+
+    let zero_parent = ObjectId::from_hex("0000000000000000000000000000000000000000")
+        .map_err(|e| anyhow::anyhow!(e))?;
+    let parent_oid = picked_commit
+        .parents
+        .first()
+        .copied()
+        .unwrap_or(zero_parent);
+
+    let merge_result = merge_trees_for_single_cherry_pick(
+        repo,
+        parent_tree_oid,
+        head_commit.tree,
+        picked_commit.tree,
+        &picked_oid,
+        &parent_oid,
+        &head_oid,
+    )?;
+
+    let mut merged_index = merge_result.index;
+    let conflict_files: Vec<(Vec<u8>, Vec<u8>)> = merge_result
+        .conflict_files
+        .into_iter()
+        .map(|(p, c)| (p.into_bytes(), c))
+        .collect();
+    let has_conflicts =
+        merged_index.entries.iter().any(|e| e.stage() != 0) || !conflict_files.is_empty();
+
+    let old_index = load_index(repo)?;
+    repo.write_index(&mut merged_index)?;
+    checkout_merged_index(repo, work_tree, &old_index, &merged_index)?;
+    if has_conflicts {
+        fs::write(git_dir.join("MERGE_MSG"), &patch.message)?;
+        write_rebase_conflict_files(work_tree, &conflict_files)?;
+        bail!("3-way merge has conflicts");
+    }
+
+    Ok(Some(()))
 }
 
 /// Attempt a 3-way merge when a patch doesn't apply cleanly.
@@ -2273,6 +2370,7 @@ fn parse_stgit_patch(input: &str) -> Result<Vec<MboxPatch>> {
         content_charset: None,
         diff,
         message_id: String::new(),
+        format_patch_commit: None,
     }])
 }
 
@@ -2391,6 +2489,7 @@ fn parse_hg_patch(input: &str) -> Result<Vec<MboxPatch>> {
         content_charset: None,
         diff,
         message_id: String::new(),
+        format_patch_commit: None,
     }])
 }
 
@@ -2405,6 +2504,9 @@ fn parse_patches(
     keep_cr: bool,
     quoted_cr_action: QuotedCrAction,
 ) -> Result<Vec<MboxPatch>> {
+    // `format-patch` output read as UTF-8 may carry a BOM; without stripping it, the first line
+    // no longer matches `From <40-hex> Mon ...` and we lose embedded commit OIDs (t3401 am path).
+    let input = input.strip_prefix('\u{feff}').unwrap_or(input);
     let fmt = format.unwrap_or_else(|| detect_patch_format(input));
     match fmt {
         "stgit" => parse_stgit_patch(input),
@@ -2614,6 +2716,22 @@ fn split_message_body_and_diff(payload_lines: &[String]) -> (Vec<String>, Vec<St
 }
 
 /// Parse an mbox file into individual patches with options.
+/// If `line` is a `git format-patch` mbox separator (`From <40-hex> Mon Sep 17 ...`), return the
+/// commit OID; otherwise `None` (e.g. `From: user@host` in mail headers).
+fn parse_format_patch_commit_oid_from_mbox_line(line: &str) -> Option<ObjectId> {
+    let after_from = line.strip_prefix("From")?;
+    // `From: mailbox` (RFC 822) is not a format-patch separator.
+    if after_from.starts_with(':') {
+        return None;
+    }
+    let rest = after_from.trim_start();
+    let (token, tail) = rest.split_once(char::is_whitespace)?;
+    if token.len() != 40 || !tail.trim_start().starts_with("Mon ") {
+        return None;
+    }
+    ObjectId::from_hex(token).ok()
+}
+
 fn parse_mbox_with_opts(
     input: &str,
     keep: bool,
@@ -2639,12 +2757,14 @@ fn parse_mbox_with_opts(
         let mut message_id = String::new();
         let _body = String::new();
         let mut found_from = false;
+        let mut format_patch_commit: Option<ObjectId> = None;
 
         // Look for "From " separator line
         while let Some(&line) = lines.peek() {
             let line_no_cr = line.strip_suffix('\r').unwrap_or(line);
             if line_no_cr.starts_with("From ") && line_no_cr.len() > 5 {
                 found_from = true;
+                format_patch_commit = parse_format_patch_commit_oid_from_mbox_line(line_no_cr);
                 lines.next(); // consume "From " line
                 break;
             }
@@ -2861,6 +2981,7 @@ fn parse_mbox_with_opts(
                 content_charset,
                 diff: diff_section,
                 message_id: message_id.clone(),
+                format_patch_commit,
             });
         }
     }
@@ -3109,6 +3230,9 @@ fn serialize_mbox_patch(patch: &MboxPatch) -> String {
     let mut out = String::new();
     out.push_str(&format!("Author: {}\n", patch.author));
     out.push_str(&format!("Date: {}\n", patch.date));
+    if let Some(oid) = patch.format_patch_commit {
+        out.push_str(&format!("Format-Patch-Commit: {}\n", oid.to_hex()));
+    }
     if let Some(ref cs) = patch.content_charset {
         out.push_str(&format!("Content-Charset: {cs}\n"));
     }
@@ -3129,6 +3253,7 @@ fn deserialize_mbox_patch(data: &str) -> Result<MboxPatch> {
     let mut date = String::new();
     let mut message_id = String::new();
     let mut content_charset: Option<String> = None;
+    let mut format_patch_commit: Option<ObjectId> = None;
     let mut msg_len = 0usize;
     let mut diff_len = 0usize;
 
@@ -3148,6 +3273,8 @@ fn deserialize_mbox_patch(data: &str) -> Result<MboxPatch> {
             date = v.to_string();
         } else if let Some(v) = line.strip_prefix("Message-ID: ") {
             message_id = v.to_string();
+        } else if let Some(v) = line.strip_prefix("Format-Patch-Commit: ") {
+            format_patch_commit = ObjectId::from_hex(v.trim()).ok();
         } else if let Some(v) = line.strip_prefix("Content-Charset: ") {
             content_charset = Some(v.to_string());
         } else if let Some(v) = line.strip_prefix("Message-Length: ") {
@@ -3178,6 +3305,7 @@ fn deserialize_mbox_patch(data: &str) -> Result<MboxPatch> {
         content_charset,
         diff,
         message_id,
+        format_patch_commit,
     })
 }
 

--- a/grit/src/commands/merge.rs
+++ b/grit/src/commands/merge.rs
@@ -5848,6 +5848,51 @@ fn materialize_unmerged_entries_for_remerge_tree(
     Ok(())
 }
 
+/// Apply merge-ort directory rename adjustment to `ours` and `theirs` entry maps before a replay
+/// merge, matching [`merge_trees`] when `merge.directoryRenames` is enabled.
+///
+/// [`merge_trees`] runs this pass internally; [`merge_trees_for_replay`] disables that pass to
+/// avoid double-handling with replay’s rename cache. Call this helper when replay needs directory
+/// rename detection (e.g. `git rebase` with `merge.directoryRenames=true`).
+pub(crate) fn replay_preprocess_directory_renames_for_trees(
+    repo: &Repository,
+    base: &HashMap<Vec<u8>, IndexEntry>,
+    ours: &HashMap<Vec<u8>, IndexEntry>,
+    theirs: &HashMap<Vec<u8>, IndexEntry>,
+    merge_directory_renames_mode: MergeDirectoryRenamesMode,
+    rename_options: MergeRenameOptions,
+) -> (HashMap<Vec<u8>, IndexEntry>, HashMap<Vec<u8>, IndexEntry>) {
+    if !merge_directory_renames_enabled_for_mode(repo, merge_directory_renames_mode) {
+        return (ours.clone(), theirs.clone());
+    }
+    let (mut ours_renames, mut theirs_renames) =
+        detect_merge_renames(repo, base, ours, theirs, rename_options);
+    let mut ours_entries = ours.clone();
+    let mut theirs_entries = theirs.clone();
+
+    let ours_dir_renames = merge_directory_rename_maps(
+        build_directory_rename_map(&ours_renames),
+        infer_pure_directory_renames(base, &ours_entries),
+    );
+    let theirs_dir_renames = merge_directory_rename_maps(
+        build_directory_rename_map(&theirs_renames),
+        infer_pure_directory_renames(base, &theirs_entries),
+    );
+    apply_directory_renames_to_side(
+        base,
+        &mut ours_entries,
+        &mut ours_renames,
+        &theirs_dir_renames,
+    );
+    apply_directory_renames_to_side(
+        base,
+        &mut theirs_entries,
+        &mut theirs_renames,
+        &ours_dir_renames,
+    );
+    (ours_entries, theirs_entries)
+}
+
 /// Perform a single three-way tree merge with merge-ort style rename handling.
 ///
 /// This is a thin wrapper over the internal merge engine used by `merge` and

--- a/grit/src/commands/rebase.rs
+++ b/grit/src/commands/rebase.rs
@@ -37,6 +37,7 @@ use grit_lib::whitespace_rule::{fix_blob_bytes, parse_whitespace_rule, WS_DEFAUL
 use grit_lib::write_tree::write_tree_from_index;
 
 use super::checkout::check_dirty_worktree;
+use super::replay::merge_trees_for_single_cherry_pick;
 use super::stash;
 use crate::ident::{resolve_email, resolve_name, IdentRole};
 
@@ -3239,21 +3240,43 @@ fn cherry_pick_for_rebase(
         backend,
         picked_subject: commit.message.lines().next().unwrap_or("replayed commit"),
     };
-    let merge_result = three_way_merge_with_content(
-        repo,
-        &base_entries,
-        &ours_entries,
-        &theirs_entries,
-        &conflict_ctx,
-    )?;
-    let mut merged_index = merge_result.index;
+
+    let (mut merged_index, merge_conflict_files) = if ws_fix_rule.is_none() {
+        let tree_merge = merge_trees_for_single_cherry_pick(
+            repo,
+            base_tree_oid,
+            head_tree_oid,
+            commit_tree_oid,
+            commit_oid,
+            commit
+                .parents
+                .first()
+                .ok_or_else(|| anyhow::anyhow!("cherry-pick of root commit not supported"))?,
+            &head_oid,
+        )?;
+        let cf = tree_merge
+            .conflict_files
+            .into_iter()
+            .map(|(p, c)| (p.into_bytes(), c))
+            .collect::<Vec<_>>();
+        (tree_merge.index, cf)
+    } else {
+        let merge_result = three_way_merge_with_content(
+            repo,
+            &base_entries,
+            &ours_entries,
+            &theirs_entries,
+            &conflict_ctx,
+        )?;
+        (merge_result.index, merge_result.conflict_files)
+    };
 
     if let Some(rule) = ws_fix_rule {
         apply_ws_fix_to_index(repo, &mut merged_index, rule)?;
     }
 
-    let has_conflicts = merged_index.entries.iter().any(|e| e.stage() != 0)
-        || !merge_result.conflict_files.is_empty();
+    let has_conflicts =
+        merged_index.entries.iter().any(|e| e.stage() != 0) || !merge_conflict_files.is_empty();
 
     // Write index
     let old_index = load_index(repo)?;
@@ -3263,7 +3286,7 @@ fn cherry_pick_for_rebase(
     if let Some(wt) = &repo.work_tree {
         checkout_merged_index(repo, wt, &old_index, &merged_index)?;
         if has_conflicts {
-            write_rebase_conflict_files(wt, &merge_result.conflict_files)?;
+            write_rebase_conflict_files(wt, &merge_conflict_files)?;
         }
     }
 
@@ -4559,7 +4582,7 @@ fn content_merge_or_conflict(
     Ok(())
 }
 
-fn write_rebase_conflict_files(
+pub(crate) fn write_rebase_conflict_files(
     work_tree: &Path,
     conflict_files: &[(Vec<u8>, Vec<u8>)],
 ) -> Result<()> {
@@ -4574,7 +4597,7 @@ fn write_rebase_conflict_files(
     Ok(())
 }
 
-fn checkout_merged_index(
+pub(crate) fn checkout_merged_index(
     repo: &Repository,
     work_tree: &Path,
     old_index: &Index,

--- a/grit/src/commands/replay.rs
+++ b/grit/src/commands/replay.rs
@@ -6,7 +6,7 @@
 //! `--ref-action=print`.
 
 use crate::commands::merge::{
-    merge_trees_for_replay, MergeDirectoryRenamesMode, MergeRenameOptions,
+    merge_trees_for_replay, MergeDirectoryRenamesMode, MergeRenameOptions, ReplayTreeMergeResult,
 };
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
@@ -419,6 +419,97 @@ pub fn run(args: Args) -> Result<()> {
     Ok(())
 }
 
+/// One cherry-pick-style tree merge with an empty upstream rename cache (`git rebase`, `git am --3way`).
+///
+/// Uses merge-ort directory-rename preprocess then [`merge_trees_for_replay`] with directory
+/// renames disabled inside the engine (t3401, t6429 part 2).
+pub(crate) fn merge_trees_for_single_cherry_pick(
+    repo: &Repository,
+    base_tree: ObjectId,
+    ours_tree: ObjectId,
+    theirs_tree: ObjectId,
+    picked_oid: &ObjectId,
+    parent_oid: &ObjectId,
+    head_oid: &ObjectId,
+) -> Result<ReplayTreeMergeResult> {
+    let merge_renormalize = read_merge_renormalize(repo);
+    let directory_renames = read_directory_renames(repo);
+    let rename_opts = MergeRenameOptions::from_config(repo);
+    let mut cached_upstream_renames: HashMap<Vec<u8>, Vec<u8>> = HashMap::new();
+
+    let base_entries_raw = tree_to_map(tree_to_index_entries(repo, &base_tree, "")?);
+    let ours_entries = tree_to_map(tree_to_index_entries(repo, &ours_tree, "")?);
+    let theirs_entries_raw = tree_to_map(tree_to_index_entries(repo, &theirs_tree, "")?);
+
+    let changed_paths = collect_changed_paths(&base_entries_raw, &theirs_entries_raw);
+    if should_refresh_upstream_rename_cache(
+        &base_entries_raw,
+        &theirs_entries_raw,
+        &cached_upstream_renames,
+    ) {
+        let detected = detect_side_renames(repo, &base_entries_raw, &ours_entries, true)?;
+        cached_upstream_renames = filter_renames_for_changed_paths(detected, &changed_paths);
+    }
+
+    if likely_has_rename_candidates(&base_entries_raw, &theirs_entries_raw) {
+        let topic_renames =
+            detect_side_renames(repo, &base_entries_raw, &theirs_entries_raw, true)?;
+        for (old, new) in &topic_renames {
+            if cached_upstream_renames.get(old) == Some(new) {
+                cached_upstream_renames.remove(old);
+            }
+        }
+    }
+
+    let base_entries = apply_cached_renames(
+        &base_entries_raw,
+        &cached_upstream_renames,
+        &ours_entries,
+        Some(&base_entries_raw),
+    );
+    let theirs_entries = apply_cached_renames(
+        &theirs_entries_raw,
+        &cached_upstream_renames,
+        &ours_entries,
+        Some(&base_entries_raw),
+    );
+
+    let dir_renames_preprocess_mode = if directory_renames {
+        MergeDirectoryRenamesMode::FromConfig
+    } else {
+        MergeDirectoryRenamesMode::Disabled
+    };
+    let (ours_for_merge, theirs_for_merge) =
+        crate::commands::merge::replay_preprocess_directory_renames_for_trees(
+            repo,
+            &base_entries,
+            &ours_entries,
+            &theirs_entries,
+            dir_renames_preprocess_mode,
+            rename_opts,
+        );
+
+    merge_trees_for_replay(
+        repo,
+        &base_entries,
+        &ours_for_merge,
+        &theirs_for_merge,
+        &short_oid(*picked_oid),
+        &short_oid(*parent_oid),
+        &head_oid.to_hex(),
+        &picked_oid.to_hex(),
+        MergeFavor::None,
+        None,
+        merge_renormalize,
+        false,
+        false,
+        false,
+        false,
+        MergeDirectoryRenamesMode::Disabled,
+        rename_opts,
+    )
+}
+
 /// Replay `commits` (oldest first) onto `onto`, returning the new tip and a map from each
 /// source commit OID to its replayed OID (used by `grit replay` and `grit history reword`).
 pub(crate) fn replay_commits_onto(
@@ -428,11 +519,6 @@ pub(crate) fn replay_commits_onto(
 ) -> Result<(ObjectId, HashMap<ObjectId, ObjectId>)> {
     let merge_renormalize = read_merge_renormalize(repo);
     let directory_renames = read_directory_renames(repo);
-    // `replay` already applies upstream/topic rename detection and cached renames before
-    // calling `merge_trees`. Running merge-ort directory rename handling again inside
-    // `merge_trees` can incorrectly relocate recreated paths (e.g. `olddir/unrelated` →
-    // `newdir/unrelated` in t6429 part 2). Match sequencer-style replay by disabling the
-    // inner directory-rename pass.
     let merge_dir_mode = MergeDirectoryRenamesMode::Disabled;
     let rename_opts = MergeRenameOptions::from_config(repo);
 
@@ -658,10 +744,20 @@ fn read_merge_renormalize(repo: &Repository) -> bool {
 }
 
 fn read_directory_renames(repo: &Repository) -> bool {
+    // Replay/sequencer enables directory-rename *preprocess* only when this key is set
+    // explicitly (Git documents `merge.directoryRenames`; tests use `-c` or repo config).
+    // Do not mirror merge-ort's "default on when unset" here — that changes replay caching
+    // and trace expectations (t6429) without matching upstream replay integration yet.
     ConfigSet::load(Some(&repo.git_dir), true)
         .ok()
-        .and_then(|c| c.get("merge.directoryRenames"))
-        .map(|v| v == "true" || v == "1")
+        .and_then(|c| {
+            c.get("merge.directoryRenames")
+                .or_else(|| c.get("merge.directoryrenames"))
+        })
+        .map(|v| {
+            let t = v.trim().to_ascii_lowercase();
+            matches!(t.as_str(), "true" | "yes" | "on" | "1" | "conflict" | "")
+        })
         .unwrap_or(false)
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Rebase cherry-picks** use `merge_trees_for_single_cherry_pick`: cached upstream renames + `replay_preprocess_directory_renames_for_trees`, then `merge_trees_for_replay` with inner directory renames disabled (matches the t3401 / merge-ort path without double-applying directory renames).
- **`git replay`** keeps the previous implementation (upstream rename cache + `apply_directory_renames_to_ours_additions`) so **t6429** trace counts and conflict behavior stay correct.
- **`git am --3way`** on `format-patch` output: persist `Format-Patch-Commit` in AM serialized state (patches are deserialized without the mbox `From` line), parse `From <hex>` after optional whitespace, strip UTF-8 BOM before parsing.

## Tests

- `./scripts/run-tests.sh t3401-rebase-and-am-rename.sh` (10/10)
- `./scripts/run-tests.sh t6429-merge-sequence-rename-caching.sh` (11/11)
- `cargo fmt`, `cargo check -p grit-rs`, `cargo clippy -p grit-rs --fix --allow-dirty`, `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da12b9f5-4144-4ad7-aa7d-003dfb1f3b4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da12b9f5-4144-4ad7-aa7d-003dfb1f3b4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

