### PR TITLE
fix: make t3102-ls-tree-wildcards pass

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -555,7 +555,7 @@ t3060-ls-files-with-tree	t3	yes	8	8	0	true	ok	0
 t3070-wildmatch	t3	yes	1901	1901	0	true	ok	3
 t3100-ls-tree-restrict	t3	yes	14	14	0	true	ok	0
 t3101-ls-tree-dirname	t3	yes	19	18	1	false	ok	0
-t3102-ls-tree-wildcards	t3	yes	4	2	2	false	ok	0
+t3102-ls-tree-wildcards	t3	yes	4	4	0	true	ok	0
 t3103-ls-tree-misc	t3	yes	10	10	0	true	ok	0
 t3104-ls-tree-format	t3	yes	19	19	0	true	ok	0
 t3105-ls-tree-output	t3	yes	60	60	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,688 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,688 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T05:42:18+00:00" class="gen-time" title="2026-04-10 05:42 UTC">2026-04-10 05:42 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,688</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>759 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -219,7 +219,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t3</span>
         <span class="group-desc">Other basic commands (e.g. ls-files)</span>
-        <span class="group-meta">56/141 files · 2 skipped · 4,052/5,398 tests</span>
+        <span class="group-meta">57/141 files · 2 skipped · 4,054/5,398 tests</span>
       </div>
       <div class="group-line2">
         <div class="bar-bg"><div class="bar-fg pct-blue" style="width:75.1%"></div></div>
@@ -241,11 +241,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35688 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,688 / 45,142 tests · 1,405 files in scope · 759 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T05:42:18+00:00" class="gen-time" title="2026-04-10 05:42 UTC">2026-04-10 05:42 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,688</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -5707,14 +5707,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:94.7%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t3" data-tests="4" data-passed="2">
+<tr class="" data-group="t3" data-tests="4" data-passed="4" data-full-pass="1">
   <td class="mono">t3102-ls-tree-wildcards</td>
   <td>t3</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">4</td>
-  <td class="right">2</td>
+  <td class="right">4</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t3" data-tests="10" data-passed="10" data-full-pass="1">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/pathspec.rs
+++ b/grit-lib/src/pathspec.rs
@@ -263,6 +263,118 @@ pub fn pathspecs_allow_bloom(specs: &[String]) -> bool {
         .all(|s| !s.is_empty() && bloom_lookup_prefix_with_cwd(s, None).is_some())
 }
 
+/// True when `spec` is a negated `:(exclude)` / `:!` pattern after global pathspec flags.
+#[must_use]
+pub fn pathspec_is_exclude_only(spec: &str) -> bool {
+    let (elem_magic, _) = parse_element_magic(spec);
+    combine_magic(elem_magic).exclude
+}
+
+/// Whether tree-walking should recurse into directory `full_name` for pathspec `spec` without
+/// `-r` (Git `read_tree` / `show_recursive` “interesting” descent).
+///
+/// Exclude-only patterns never trigger descent alone.
+#[must_use]
+pub fn pathspec_wants_descent_into_tree(spec: &str, full_name: &str) -> bool {
+    if pathspec_is_exclude_only(spec) {
+        return false;
+    }
+    let (elem_magic, raw_pattern) = parse_element_magic(spec);
+    let magic = combine_magic(elem_magic);
+    if magic.exclude {
+        return false;
+    }
+    let pattern = strip_top_magic(raw_pattern);
+    let pattern = pattern.strip_prefix("./").unwrap_or(pattern);
+    if pattern.is_empty() || pattern == "." {
+        return true;
+    }
+    let dir_prefix = format!("{full_name}/");
+    if pattern.starts_with(&dir_prefix) {
+        return true;
+    }
+    let probe = format!("{full_name}/.__grit_ls_tree_probe__");
+    matches_ls_tree_pathspec(spec, &probe, 0o100644, &[])
+}
+
+/// Like [`matches_pathspec_set_for_object`], but uses [`matches_ls_tree_pathspec`] for each
+/// element so `ls-files` / index filtering agrees with `ls-tree` on patterns such as `a[a]`.
+#[must_use]
+pub fn matches_pathspec_set_for_object_ls_tree(
+    specs: &[String],
+    path: &str,
+    mode: u32,
+    attr_rules: &[AttrRule],
+) -> bool {
+    if specs.is_empty() {
+        return true;
+    }
+    let mut positives: Vec<&str> = Vec::new();
+    let mut excludes: Vec<&str> = Vec::new();
+    for s in specs {
+        if pathspec_is_exclude_only(s) {
+            excludes.push(s.as_str());
+        } else {
+            positives.push(s.as_str());
+        }
+    }
+    let positive_ok = if positives.is_empty() {
+        true
+    } else {
+        positives
+            .iter()
+            .any(|s| matches_ls_tree_pathspec(s, path, mode, attr_rules))
+    };
+    if !positive_ok {
+        return false;
+    }
+    for ex in excludes {
+        if matches_ls_tree_pathspec(ex, path, mode, attr_rules) {
+            return false;
+        }
+    }
+    true
+}
+
+/// True if `path` matches the combined pathspec list: any positive spec (or all paths when there
+/// are only excludes, matching Git `parse_pathspec`), and not matched by any exclude spec.
+#[must_use]
+pub fn matches_pathspec_set_for_object(
+    specs: &[String],
+    path: &str,
+    mode: u32,
+    attr_rules: &[AttrRule],
+) -> bool {
+    if specs.is_empty() {
+        return true;
+    }
+    let mut positives: Vec<&str> = Vec::new();
+    let mut excludes: Vec<&str> = Vec::new();
+    for s in specs {
+        if pathspec_is_exclude_only(s) {
+            excludes.push(s.as_str());
+        } else {
+            positives.push(s.as_str());
+        }
+    }
+    let positive_ok = if positives.is_empty() {
+        true
+    } else {
+        positives
+            .iter()
+            .any(|s| matches_pathspec_for_object(s, path, mode, attr_rules))
+    };
+    if !positive_ok {
+        return false;
+    }
+    for ex in excludes {
+        if matches_pathspec_for_object(ex, path, mode, attr_rules) {
+            return false;
+        }
+    }
+    true
+}
+
 /// True if `path` is matched by `spec` (Git pathspec syntax, including magic and globals).
 #[must_use]
 pub fn pathspec_matches(spec: &str, path: &str) -> bool {
@@ -356,6 +468,20 @@ fn path_starts_with(path: &str, prefix: &str, icase: bool) -> bool {
 fn literal_prefix_match(pattern: &str, path: &str) -> bool {
     if let Some(prefix) = pattern.strip_suffix('/') {
         return path == prefix || path.starts_with(&format!("{prefix}/"));
+    }
+    path == pattern || path.starts_with(&format!("{pattern}/"))
+}
+
+/// Literal pathspec match for `ls-tree` when the pattern has no `*`/`?` (brackets stay literal).
+fn ls_tree_literal_match(pattern: &str, path: &str, ctx: PathspecMatchContext) -> bool {
+    if let Some(prefix) = pattern.strip_suffix('/') {
+        if path.starts_with(&format!("{prefix}/")) {
+            return true;
+        }
+        if path == prefix {
+            return ctx.is_directory || ctx.is_git_submodule;
+        }
+        return false;
     }
     path == pattern || path.starts_with(&format!("{pattern}/"))
 }
@@ -455,6 +581,90 @@ pub fn context_from_mode_bits(mode: u32) -> PathspecMatchContext {
     }
 }
 
+/// Pathspec matching for `ls-tree` after Git forces `pathspec.has_wildcard = 0` (`ls-tree.c`).
+///
+/// Metacharacters `*` / `?` still participate in [`wildmatch`]; `[` and `\\` are **not** glob
+/// starters unless a `*` or `?` appears — so `a[a]` matches the literal directory `a[a]` (t3102),
+/// while `a*` matches `a/one`, `aa/two`, `a[a]/three`, …
+#[must_use]
+pub fn matches_ls_tree_pathspec(
+    spec: &str,
+    path: &str,
+    mode: u32,
+    attr_rules: &[AttrRule],
+) -> bool {
+    let (elem_magic, raw_pattern) = parse_element_magic(spec);
+    let mut magic = combine_magic(elem_magic);
+    magic.exclude = false;
+
+    if magic.literal && magic.glob {
+        return false;
+    }
+
+    let ctx = context_from_mode_bits(mode);
+    let is_dir_for_attr = path.ends_with('/') || ctx.is_directory || ctx.is_git_submodule;
+
+    if let Some(ref attr) = magic.attr_name {
+        if !path_has_gitattribute(attr_rules, path, is_dir_for_attr, attr) {
+            return false;
+        }
+    }
+
+    let pattern = strip_top_magic(raw_pattern);
+    let path_for_match = if let Some(prefix) = magic.prefix.as_deref() {
+        if !path.starts_with(prefix) {
+            return false;
+        }
+        &path[prefix.len()..]
+    } else {
+        path
+    };
+
+    if magic.literal || magic.glob || magic.icase {
+        return pathspec_matches_tail(pattern, path_for_match, magic);
+    }
+
+    let spec_nfc: Cow<'_, str> = if pathspec_precompose_enabled() {
+        precompose_utf8_path(pattern)
+    } else {
+        Cow::Borrowed(pattern)
+    };
+    let path_nfc: Cow<'_, str> = if pathspec_precompose_enabled() {
+        precompose_utf8_path(path_for_match)
+    } else {
+        Cow::Borrowed(path_for_match)
+    };
+    let pattern = spec_nfc.as_ref();
+    let path = path_nfc.as_ref();
+
+    let trimmed = pattern.strip_prefix("./").unwrap_or(pattern);
+    if trimmed == "." || trimmed.is_empty() {
+        return true;
+    }
+
+    let uses_star_or_question = trimmed.contains('*') || trimmed.contains('?');
+    if !uses_star_or_question {
+        return ls_tree_literal_match(trimmed, path, ctx);
+    }
+
+    let nwl = simple_length(trimmed);
+    let flags = 0u32;
+    if nwl == trimmed.len() {
+        return wildmatch(trimmed.as_bytes(), path.as_bytes(), flags);
+    }
+    let lit = trimmed.as_bytes().get(..nwl).unwrap_or_default();
+    let path_b = path.as_bytes();
+    if path_b.len() < nwl {
+        return false;
+    }
+    if &path_b[..nwl] != lit {
+        return false;
+    }
+    let pat_rest = &trimmed[nwl..];
+    let path_rest = &path[nwl..];
+    wildmatch(pat_rest.as_bytes(), path_rest.as_bytes(), flags)
+}
+
 /// Match a pathspec against a tree path, using `.gitattributes` for `:(attr:...)`.
 ///
 /// Used by `git archive` style tree walks: `mode` supplies directory/gitlink context for
@@ -467,12 +677,10 @@ pub fn matches_pathspec_for_object(
     attr_rules: &[AttrRule],
 ) -> bool {
     let (elem_magic, raw_pattern) = parse_element_magic(spec);
-    let magic = combine_magic(elem_magic);
+    let mut magic = combine_magic(elem_magic);
+    magic.exclude = false;
 
     if magic.literal && magic.glob {
-        return false;
-    }
-    if magic.exclude {
         return false;
     }
 
@@ -526,6 +734,21 @@ mod tree_entry_pathspec_tests {
         ));
         assert!(matches_pathspec("file0", "file0"));
         assert!(!matches_pathspec("path", "path1/file1"));
+    }
+
+    #[test]
+    fn ls_tree_bracket_in_name_is_literal_prefix() {
+        assert!(matches_ls_tree_pathspec(
+            "a[a]",
+            "a[a]/three",
+            0o100644,
+            &[]
+        ));
+        assert!(!matches_pathspec_with_context(
+            "a[a]",
+            "a[a]/three",
+            PathspecMatchContext::default()
+        ));
     }
 
     #[test]

--- a/grit/src/commands/ls_files.rs
+++ b/grit/src/commands/ls_files.rs
@@ -279,19 +279,49 @@ pub fn run(args: Args) -> Result<()> {
 
     let attrs_for_eol = grit_lib::crlf::load_gitattributes(work_tree);
 
+    for (i, spec) in pathspec_filter.iter().enumerate() {
+        let s = match spec {
+            Pathspec::Literal(b) => String::from_utf8_lossy(b).into_owned(),
+            Pathspec::Glob(g) => g.clone(),
+            Pathspec::Magic(m) => m.clone(),
+        };
+        if grit_lib::pathspec::pathspec_is_exclude_only(&s) {
+            matched_index[i] = true;
+            matched_others[i] = true;
+        }
+    }
+
     let mut last_dedup_path: Option<Vec<u8>> = None;
     for entry in &index.entries {
         if entry.overlay_tree_skip_output() {
             continue;
         }
-        // Filter by pathspec
+        // Filter by pathspec (Git OR for positives, AND with negated excludes).
         if !pathspec_filter.is_empty() {
-            let idx = pathspec_filter
+            let path_str = String::from_utf8_lossy(&entry.path);
+            let specs: Vec<String> = pathspec_filter
                 .iter()
-                .position(|spec| spec.matches(&entry.path));
-            match idx {
-                Some(i) => matched_index[i] = true,
-                None => continue,
+                .map(|spec| match spec {
+                    Pathspec::Literal(b) => String::from_utf8_lossy(b).into_owned(),
+                    Pathspec::Glob(g) => g.clone(),
+                    Pathspec::Magic(m) => m.clone(),
+                })
+                .collect();
+            if !grit_lib::pathspec::matches_pathspec_set_for_object_ls_tree(
+                &specs,
+                path_str.as_ref(),
+                entry.mode,
+                &attrs_for_eol,
+            ) {
+                continue;
+            }
+            for (i, spec) in pathspec_filter.iter().enumerate() {
+                if grit_lib::pathspec::pathspec_is_exclude_only(&specs[i]) {
+                    continue;
+                }
+                if spec.matches(&entry.path) {
+                    matched_index[i] = true;
+                }
             }
         }
 
@@ -487,14 +517,31 @@ pub fn run(args: Args) -> Result<()> {
         untracked.sort();
 
         let mut filtered_untracked: Vec<Vec<u8>> = Vec::new();
+        let specs_strings: Vec<String> = pathspec_filter
+            .iter()
+            .map(|spec| match spec {
+                Pathspec::Literal(b) => String::from_utf8_lossy(b).into_owned(),
+                Pathspec::Glob(g) => g.clone(),
+                Pathspec::Magic(m) => m.clone(),
+            })
+            .collect();
+
         for path_bytes in &untracked {
             if !pathspec_filter.is_empty() {
-                let idx = pathspec_filter
-                    .iter()
-                    .position(|spec| spec.matches(path_bytes));
-                match idx {
-                    Some(_) => {}
-                    None => continue,
+                let path_str = String::from_utf8_lossy(path_bytes);
+                let mode = if path_str.ends_with('/') {
+                    0o040000
+                } else {
+                    0o100644
+                };
+                let path_for_match = path_str.trim_end_matches('/');
+                if !grit_lib::pathspec::matches_pathspec_set_for_object_ls_tree(
+                    &specs_strings,
+                    path_for_match,
+                    mode,
+                    &attrs_for_eol,
+                ) {
+                    continue;
                 }
             }
 
@@ -520,6 +567,9 @@ pub fn run(args: Args) -> Result<()> {
 
             if !pathspec_filter.is_empty() {
                 for (i, spec) in pathspec_filter.iter().enumerate() {
+                    if grit_lib::pathspec::pathspec_is_exclude_only(&specs_strings[i]) {
+                        continue;
+                    }
                     if spec.matches(path_bytes) {
                         matched_others[i] = true;
                     }

--- a/grit/src/commands/ls_tree.rs
+++ b/grit/src/commands/ls_tree.rs
@@ -6,7 +6,11 @@ use std::io::{self, Write};
 use std::path::Path;
 
 use grit_lib::config::ConfigSet;
+use grit_lib::crlf::AttrRule;
 use grit_lib::objects::{parse_commit, parse_tag, parse_tree, ObjectId, ObjectKind, TreeEntry};
+use grit_lib::pathspec::{
+    matches_pathspec_set_for_object_ls_tree, pathspec_wants_descent_into_tree,
+};
 use grit_lib::refs::resolve_ref;
 use grit_lib::repo::Repository;
 use grit_lib::rev_parse::abbreviate_object_id;
@@ -286,6 +290,11 @@ pub fn run(mut args: Args) -> Result<()> {
     let config = ConfigSet::load(Some(&repo.git_dir), true)?;
     let max_tree_depth = resolve_max_tree_depth(&config)?;
     let quote_fully = config.quote_path_fully();
+    let attr_rules = if let Some(ref wt) = repo.work_tree {
+        grit_lib::crlf::load_gitattributes(wt)
+    } else {
+        Vec::new()
+    };
 
     apply_ls_tree_implications(&mut args);
 
@@ -295,6 +304,8 @@ pub fn run(mut args: Args) -> Result<()> {
 
     // Resolve pathspecs relative to cwd within the work tree, then express
     // them as repo-root-relative paths so the tree walk can match correctly.
+    // Resolve cwd-relative pathspecs to repo-root-relative paths (join cwd prefix inside the work
+    // tree, then normalize `..` — see t3102 `../a[a]` from a subdirectory).
     if !args.paths.is_empty() && !args.full_tree {
         if let Some(ref wt) = repo.work_tree {
             let cwd = std::env::current_dir().context("resolving cwd")?;
@@ -366,15 +377,21 @@ pub fn run(mut args: Args) -> Result<()> {
     });
     let use_full_paths = args.full_name || args.full_tree || at_repo_root;
 
+    let cwd_rel = if use_full_paths {
+        None
+    } else {
+        cwd_relative_to_work_tree(&repo)?
+    };
+
     // Git narrows the listing to the tree object for the current directory (see `read_tree` +
-    // pathspec prefix). Without this, we would list the repository root and fake "relative" names
-    // with `../`, which breaks bash completion (`__gitcomp_directories`) and differs from Git.
+    // pathspec prefix). Pathspec arguments disable narrowing: `read_tree` matches against the full
+    // tree so patterns like `../a[a]` from a subdirectory still resolve (t3102).
     let mut narrowed_prefix = String::new();
-    if !use_full_paths {
-        if let Some(cwd_rel) = cwd_relative_to_work_tree(&repo)? {
+    if !use_full_paths && args.paths.is_empty() {
+        if let Some(ref cwd_rel) = cwd_rel {
             if !cwd_rel.is_empty() {
                 let Some((oid, pfx)) =
-                    descend_tree_to_path(&repo, tree_oid, String::new(), &cwd_rel)?
+                    descend_tree_to_path(&repo, tree_oid, String::new(), cwd_rel)?
                 else {
                     return Ok(());
                 };
@@ -392,10 +409,16 @@ pub fn run(mut args: Args) -> Result<()> {
     // Prefix for paths under `list_tree` (repo-root-relative), and cwd-relative display adjustment.
     let (list_prefix, cwd_prefix) = if use_full_paths {
         (String::new(), None)
-    } else if narrowed_prefix.is_empty() {
-        (String::new(), None)
-    } else {
+    } else if !narrowed_prefix.is_empty() {
         (narrowed_prefix.clone(), Some(narrowed_prefix))
+    } else if let Some(ref rel) = cwd_rel {
+        if !rel.is_empty() {
+            (String::new(), Some(rel.clone()))
+        } else {
+            (String::new(), None)
+        }
+    } else {
+        (String::new(), None)
     };
 
     list_tree(
@@ -409,6 +432,7 @@ pub fn run(mut args: Args) -> Result<()> {
         term,
         cwd_prefix.as_deref(),
         quote_fully,
+        &attr_rules,
     )?;
 
     Ok(())
@@ -448,6 +472,7 @@ fn list_tree(
     term: u8,
     cwd_prefix: Option<&str>,
     quote_fully: bool,
+    attr_rules: &[AttrRule],
 ) -> Result<()> {
     if depth > max_tree_depth {
         bail!(
@@ -470,19 +495,14 @@ fn list_tree(
         let is_tree = entry.mode == 0o040000;
         let is_submodule = file_type_mask(entry.mode) == 0o160000;
 
-        // Apply path filter
+        // Apply path filter (Git pathspec semantics, including `:(exclude)` and literal `[` paths).
         if !args.paths.is_empty() {
-            let matches = args.paths.iter().any(|p| {
-                let has_trailing_slash = p.ends_with('/');
-                let ps = p.strip_suffix('/').unwrap_or(p.as_str());
-                // Trailing-slash pathspec only matches trees, not blobs
-                if has_trailing_slash && !is_tree && full_name == ps {
-                    return false;
-                }
-                full_name == ps
-                    || full_name.starts_with(&format!("{ps}/"))
-                    || ps.starts_with(&format!("{full_name}/"))
-            });
+            let matches = matches_pathspec_set_for_object_ls_tree(
+                &args.paths,
+                &full_name,
+                entry.mode,
+                attr_rules,
+            );
             if !matches {
                 continue;
             }
@@ -490,11 +510,10 @@ fn list_tree(
             // Exact match without trailing slash shows the tree entry itself.
             // Trailing slash or deeper path means descend into the tree.
             let is_ancestor = is_tree
-                && args.paths.iter().any(|p| {
-                    let ps = p.strip_suffix('/').unwrap_or(p.as_str());
-                    ps.starts_with(&format!("{full_name}/"))
-                        || (p.ends_with('/') && ps == full_name)
-                });
+                && args
+                    .paths
+                    .iter()
+                    .any(|p| pathspec_wants_descent_into_tree(p, &full_name));
             if is_tree && is_ancestor && !args.recursive {
                 // Match Git's `read_tree` + `show_recursive`: with pathspecs we descend into prefix
                 // trees even without `-r`. `-t` then lists those intermediate trees (see t3100).
@@ -514,6 +533,7 @@ fn list_tree(
                     term,
                     cwd_prefix,
                     quote_fully,
+                    attr_rules,
                 )?;
                 continue;
             }
@@ -536,6 +556,7 @@ fn list_tree(
                 term,
                 cwd_prefix,
                 quote_fully,
+                attr_rules,
             )?;
             continue;
         }

--- a/logs/2026-04-10-t3102-ls-tree-wildcards.md
+++ b/logs/2026-04-10-t3102-ls-tree-wildcards.md
@@ -1,0 +1,16 @@
+# t3102-ls-tree-wildcards
+
+## Goal
+
+Make `tests/t3102-ls-tree-wildcards.sh` pass (4/4).
+
+## Changes
+
+- **`grit-lib/pathspec`**: Added `matches_ls_tree_pathspec` (Git `ls-tree` after it clears `has_wildcard`: no `*`/`?` → literal match so `a[a]` works; with `*`/`?` → `simple_length` + `wildmatch` tail). Added `pathspec_is_exclude_only`, `matches_pathspec_set_for_object_ls_tree`, `pathspec_wants_descent_into_tree`, and `matches_pathspec_set_for_object` for combined positive + `:(exclude)` lists (archive/update-index keep using per-spec `matches_pathspec_for_object`).
+- **`grit ls-tree`**: Pathspec filtering via `matches_pathspec_set_for_object_ls_tree` + `.gitattributes` load; skip tree narrowing when pathspecs present (full tree walk like Git `read_tree`); cwd-relative display still uses `cwd_rel` as prefix for `../` paths outside cwd.
+- **`grit ls-files`**: Combined pathspec matching with excludes via `matches_pathspec_set_for_object_ls_tree`; mark exclude-only specs satisfied for `--error-unmatch`; same for `--others` untracked paths.
+
+## Verification
+
+- `./scripts/run-tests.sh t3102-ls-tree-wildcards.sh` → 4/4
+- `cargo test -p grit-lib --lib`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Git-compatible `ls-tree` pathspec behavior for t3102: literal paths containing `[` without `*`/`?`, combined `:(exclude)` + glob pathspecs, and correct listing from a subdirectory when pathspecs reference paths outside the cwd (`../…`).

## Key changes

- **`grit-lib`**: `matches_ls_tree_pathspec`, `matches_pathspec_set_for_object_ls_tree`, `pathspec_wants_descent_into_tree`, `pathspec_is_exclude_only`; keep `matches_pathspec_set_for_object` on `matches_pathspec_for_object` for archive/update-index.
- **`ls-tree`**: filter with the new helpers, load gitattributes, skip tree narrowing when pathspecs are present, preserve cwd-relative display with `../` for out-of-cwd matches.
- **`ls-files`**: apply the same combined pathspec logic for index and untracked paths; treat exclude-only specs as satisfied for `--error-unmatch`.

## Testing

- `./scripts/run-tests.sh t3102-ls-tree-wildcards.sh` (4/4)
- `cargo test -p grit-lib --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e07bb06d-e6a2-4b76-8828-794206cf679b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e07bb06d-e6a2-4b76-8828-794206cf679b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

