### PR TITLE
fix: improve git log -L for t4211-line-log

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -833,7 +833,7 @@ t4208-diff-pathspec-magic	t4	yes	22	21	1	false	ok	0
 t4208-log-magic-pathspec	t4	yes	21	13	8	false	ok	0
 t4209-log-pickaxe	t4	yes	48	47	1	false	ok	0
 t4210-log-i18n	t4	yes	21	17	4	false	ok	0
-t4211-line-log	t4	yes	53	31	22	false	ok	0
+t4211-line-log	t4	yes	53	50	3	false	ok	0
 t4212-log-corrupt	t4	yes	13	12	1	false	ok	0
 t4213-log-tabexpand	t4	yes	9	1	8	false	ok	0
 t4214-log-graph-octopus	t4	yes	17	1	16	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta property="og:description" content="79.1% of harness tests passing (35,705 / 45,142).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="79% of harness tests passing (35,672 / 45,142).">
+<meta name="twitter:description" content="79.1% of harness tests passing (35,705 / 45,142).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-04-10T06:42:23+00:00" class="gen-time" title="2026-04-10 06:42 UTC">2026-04-10 06:42 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a> · <a href="testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-blue">79.0%</div>
+      <div class="summary-big-val pct-blue">79.1%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">35,672</div>
+      <div class="summary-big-val">35,705</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.0%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:79.1%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,405 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>757 files fully passing</span>
+    <span>758 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>200 skipped files</span>
   </p>
@@ -230,22 +230,22 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t4</span>
         <span class="group-desc">Diff commands</span>
-        <span class="group-meta">73/178 files · 2 skipped · 2,862/4,438 tests</span>
+        <span class="group-meta">73/178 files · 2 skipped · 2,881/4,438 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.5%"></div></div>
-        <span class="group-pct pct-blue">64.5%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:64.9%"></div></div>
+        <span class="group-pct pct-blue">64.9%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t5">
       <div class="group-line1">
         <span class="group-id">t5</span>
         <span class="group-desc">Pull and exporting commands</span>
-        <span class="group-meta">33/167 files · 17 skipped · 1,561/4,139 tests</span>
+        <span class="group-meta">33/167 files · 17 skipped · 1,566/4,139 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.7%"></div></div>
-        <span class="group-pct pct-red">37.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-red" style="width:37.8%"></div></div>
+        <span class="group-pct pct-red">37.8%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t6">
@@ -263,11 +263,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t7</span>
         <span class="group-desc">Porcelainish commands concerning the working tree</span>
-        <span class="group-meta">47/126 files · 11 skipped · 2,485/3,616 tests</span>
+        <span class="group-meta">48/126 files · 11 skipped · 2,494/3,616 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:68.7%"></div></div>
-        <span class="group-pct pct-blue">68.7%</span>
+        <div class="bar-bg"><div class="bar-fg pct-blue" style="width:69.0%"></div></div>
+        <span class="group-pct pct-blue">69.0%</span>
       </div>
     </a>
     <a class="group-card" href="testfiles.html?group=t8">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">35672 of 45142 tests passing across 1405 harness files (79% pass rate).</desc>
+  <desc id="svg-desc">35705 of 45142 tests passing across 1405 harness files (79.1% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79% pass rate · 35,672 / 45,142 tests · 1,405 files in scope · 757 fully passing · 200 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">79.1% pass rate · 35,705 / 45,142 tests · 1,405 files in scope · 758 fully passing · 200 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="553" height="18" rx="9" fill="#58a6ff"/>
+  <rect x="40" y="80" width="554" height="18" rx="9" fill="#58a6ff"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-09T19:00:52+00:00" class="gen-time" title="2026-04-09 19:00 UTC">2026-04-09 19:00 UTC</time> · <a href="https://github.com/schacon/grit/commit/16c9276830ad0d064c6b9300b00e576d098eda35" style="color:#58a6ff">16c9276</a></p>
+<p class="sub"><a href="index.html">Dashboard</a> · <time datetime="2026-04-10T06:42:23+00:00" class="gen-time" title="2026-04-10 06:42 UTC">2026-04-10 06:42 UTC</time> · <a href="https://github.com/schacon/grit/commit/ec986e432ab23e09bbbea85956f9146169adb102" style="color:#58a6ff">ec986e4</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,405</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">45,142</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">35,672</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">79.0%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">35,705</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">79.1%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -8487,14 +8487,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:81.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t4" data-tests="53" data-passed="31">
+<tr class="" data-group="t4" data-tests="53" data-passed="50">
   <td class="mono">t4211-line-log</td>
   <td>t4</td>
   <td></td>
   <td class="right">53</td>
-  <td class="right">31</td>
+  <td class="right">50</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:58.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:94.3%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t4" data-tests="13" data-passed="12">
@@ -10027,14 +10027,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:56.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t5" data-tests="11" data-passed="5">
+<tr class="" data-group="t5" data-tests="11" data-passed="10">
   <td class="mono">t5571-pre-push-hook</td>
   <td>t5</td>
   <td></td>
   <td class="right">11</td>
-  <td class="right">5</td>
+  <td class="right">10</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:45.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:90.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t5" data-tests="69" data-passed="22">
@@ -11667,14 +11667,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">1</td>
 </tr>
-<tr class="" data-group="t7" data-tests="18" data-passed="9">
+<tr class="" data-group="t7" data-tests="18" data-passed="18" data-full-pass="1">
   <td class="mono">t7007-show</td>
   <td>t7</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">18</td>
-  <td class="right">9</td>
+  <td class="right">18</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:50.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t7" data-tests="6" data-passed="5">

--- a/grit-lib/src/line_log.rs
+++ b/grit-lib/src/line_log.rs
@@ -4,13 +4,17 @@
 //! ranges at the walk tip, map ranges across Myers line diffs toward parents,
 //! filter the revision list, and emit synthetic unified hunks.
 
+use crate::config::ConfigSet;
+use crate::crlf::{get_file_attrs, load_gitattributes, DiffAttr};
 use crate::diff::{detect_renames, diff_trees, zero_oid, DiffEntry};
 use crate::error::{Error, Result};
 use crate::objects::{parse_commit, parse_tree, ObjectId, ObjectKind, TreeEntry};
 use crate::odb::Odb;
-use regex::bytes::Regex as BytesRegex;
+use crate::userdiff::{matcher_for_driver, FuncnameMatcher};
+use regex::bytes::RegexBuilder as BytesRegexBuilder;
 use similar::{Algorithm, ChangeTag, TextDiff};
 use std::collections::{HashMap, HashSet};
+use std::path::Path;
 
 /// Half-open line range using 0-based indices (Git internal).
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -347,11 +351,20 @@ fn nth_line<'a>(data: &'a [u8], line: i64, ends: &[usize]) -> &'a [u8] {
     &data[idx..]
 }
 
-fn nth_line_end(data: &[u8], line: i64, ends: &[usize], total_lines: i64) -> usize {
-    if line >= total_lines {
-        return data.len();
-    }
-    ends[line as usize] + 1
+/// Line content as Git `nth_line` + `nth_line(line+1)` (used for funcname boundary checks).
+fn line_content_git_style<'a>(
+    data: &'a [u8],
+    line_idx: i64,
+    ends: &[usize],
+    total_lines: i64,
+) -> &'a [u8] {
+    let start = line_byte_offset(line_idx, ends);
+    let end = if line_idx + 1 >= total_lines {
+        data.len()
+    } else {
+        line_byte_offset(line_idx + 1, ends)
+    };
+    &data[start..end]
 }
 
 /// Parse one `-L` location (Git `parse_loc`). `anchor_for_regex` is `-N` for the first
@@ -364,7 +377,9 @@ fn parse_loc<'a>(
     anchor_for_regex: i64,
     rel_begin_line: i64,
 ) -> Result<(i64, &'a str)> {
-    let rel_ok = (1..=lines).contains(&rel_begin_line);
+    // Git: `if (1 <= begin && (spec[0] == '+' || spec[0] == '-'))` — the second `-L` component
+    // passes `begin = *begin + 1`, which can be `lines + 1` when the first line is the last line.
+    let rel_ok = rel_begin_line >= 1;
 
     let bytes = spec.as_bytes();
     if rel_ok && !spec.is_empty() && (bytes[0] == b'+' || bytes[0] == b'-') {
@@ -433,7 +448,10 @@ fn parse_loc<'a>(
 
     let begin0 = (anchor_line - 1).max(0).min(lines.saturating_sub(1).max(0));
     let line_start = nth_line(data, begin0, ends);
-    let re = BytesRegex::new(&pattern).map_err(|e| Error::CorruptObject(format!("regex: {e}")))?;
+    let re = BytesRegexBuilder::new(&pattern)
+        .multi_line(true)
+        .build()
+        .map_err(|e| Error::CorruptObject(format!("regex: {e}")))?;
     let mat = re
         .find(line_start)
         .ok_or_else(|| Error::CorruptObject("no match".to_owned()))?;
@@ -467,12 +485,44 @@ fn match_funcname_line(line: &[u8]) -> bool {
     c.is_ascii_alphabetic() || c == b'_' || c == b'$'
 }
 
+fn line_matches_funcname(matcher: Option<&FuncnameMatcher>, line: &[u8]) -> bool {
+    let mut end = line.len();
+    while end > 0 && (line[end - 1] == b'\n' || line[end - 1] == b'\r') {
+        end -= 1;
+    }
+    let body = &line[..end];
+    if let Some(m) = matcher {
+        let s = String::from_utf8_lossy(body);
+        m.match_line(s.as_ref()).is_some()
+    } else {
+        match_funcname_line(body)
+    }
+}
+
+/// Git only applies `userdiff` funcname rules when `diff=<driver>` is set in `.gitattributes`
+/// (`userdiff_find_by_path`); filename-based driver guessing is not used for `-L :pat:file`.
+fn funcname_matcher_for_path(
+    git_dir: &Path,
+    work_tree: Option<&Path>,
+    path: &str,
+) -> Option<FuncnameMatcher> {
+    let wt = work_tree?;
+    let rules = load_gitattributes(wt);
+    let config = ConfigSet::load(Some(git_dir), true).unwrap_or_default();
+    let fa = get_file_attrs(&rules, path, false, &config);
+    let DiffAttr::Driver(ref name) = fa.diff_attr else {
+        return None;
+    };
+    matcher_for_driver(&config, name).ok().flatten()
+}
+
 fn parse_range_funcname<'a>(
     arg: &'a str,
     data: &[u8],
     ends: &[usize],
     lines: i64,
     mut anchor: i64,
+    userdiff: Option<&FuncnameMatcher>,
 ) -> Result<(i64, i64, &'a str)> {
     let mut s = arg;
     if s.starts_with('^') && s.get(1..2) == Some(":") {
@@ -506,10 +556,8 @@ fn parse_range_funcname<'a>(
         let mut line_idx = anchor0;
         let mut found_begin = None;
         while line_idx < lines {
-            let bol = nth_line(data, line_idx, ends);
-            let eol_idx = nth_line_end(data, line_idx, ends, lines);
-            let slice = &data[bol.as_ptr() as usize - data.as_ptr() as usize..eol_idx];
-            if match_funcname_line(slice) {
+            let slice = line_content_git_style(data, line_idx, ends, lines);
+            if line_matches_funcname(userdiff, slice) {
                 found_begin = Some(line_idx);
                 break;
             }
@@ -518,10 +566,8 @@ fn parse_range_funcname<'a>(
         let begin = found_begin.ok_or_else(|| Error::CorruptObject("no match".to_owned()))?;
         let mut end = begin + 1;
         while end < lines {
-            let bol = nth_line(data, end, ends);
-            let eol_idx = nth_line_end(data, end, ends, lines);
-            let slice = &data[bol.as_ptr() as usize - data.as_ptr() as usize..eol_idx];
-            if match_funcname_line(slice) {
+            let slice = line_content_git_style(data, end, ends, lines);
+            if line_matches_funcname(userdiff, slice) {
                 break;
             }
             end += 1;
@@ -531,7 +577,10 @@ fn parse_range_funcname<'a>(
     }
 
     let start_search = nth_line(data, anchor0, ends);
-    let re = BytesRegex::new(pattern).map_err(|e| Error::CorruptObject(format!("regex: {e}")))?;
+    let re = BytesRegexBuilder::new(pattern)
+        .multi_line(true)
+        .build()
+        .map_err(|e| Error::CorruptObject(format!("regex: {e}")))?;
 
     let mut p = start_search;
     let found_bol = loop {
@@ -551,7 +600,7 @@ fn parse_range_funcname<'a>(
             eol += 1;
         }
         let line_slice = &data[bol..eol.min(data.len())];
-        if match_funcname_line(line_slice) {
+        if line_matches_funcname(userdiff, line_slice) {
             break Some(bol);
         }
         p = &data[eol.min(data.len())..];
@@ -575,10 +624,8 @@ fn parse_range_funcname<'a>(
 
     let mut end = begin + 1;
     while end < lines {
-        let bol = nth_line(data, end, ends);
-        let eol_idx = nth_line_end(data, end, ends, lines);
-        let slice = &data[bol.as_ptr() as usize - data.as_ptr() as usize..eol_idx];
-        if match_funcname_line(slice) {
+        let slice = line_content_git_style(data, end, ends, lines);
+        if line_matches_funcname(userdiff, slice) {
             break;
         }
         end += 1;
@@ -647,9 +694,10 @@ fn parse_range_arg(
     ends: &[usize],
     lines: i64,
     anchor: i64,
+    userdiff: Option<&FuncnameMatcher>,
 ) -> Result<(i64, i64)> {
     let (begin, end) = if arg.starts_with(':') || arg.starts_with("^:") {
-        let (b, e, rest) = parse_range_funcname(arg, data, ends, lines, anchor)?;
+        let (b, e, rest) = parse_range_funcname(arg, data, ends, lines, anchor, userdiff)?;
         if !rest.is_empty() {
             return Err(Error::CorruptObject("malformed -L argument".to_owned()));
         }
@@ -707,7 +755,9 @@ fn parse_range_arg(
         if !rest.is_empty() {
             return Err(Error::CorruptObject("malformed -L argument".to_owned()));
         }
-        (n, n)
+        // Git leaves `end` at 0 when the comma branch is absent; `parse_lines` then sets
+        // `end = lines` ("from N through end of file").
+        (n, 0)
     };
 
     if (lines == 0 && (begin != 0 || end != 0)) || (lines > 0 && lines < begin) {
@@ -818,7 +868,8 @@ fn split_l_arg(spec: &str) -> Result<(&str, &str)> {
         return Ok((&spec[..1 + idx + 1], path));
     }
     if spec.starts_with('/') {
-        return split_regex_line_range(spec);
+        return split_regex_line_range(spec)
+            .map_err(|_| Error::CorruptObject("-L argument not 'start,end:file'".to_owned()));
     }
     let idx = spec
         .rfind(':')
@@ -883,6 +934,8 @@ fn read_blob_at_path(odb: &Odb, tree_oid: &ObjectId, path: &str) -> Result<Vec<u
 /// Parse all `-L` specs at `tip_oid` into per-file merged ranges.
 pub fn parse_line_log_ranges(
     odb: &Odb,
+    git_dir: &Path,
+    work_tree: Option<&Path>,
     tip_oid: &ObjectId,
     specs: &[String],
 ) -> Result<Vec<LineLogFile>> {
@@ -897,6 +950,7 @@ pub fn parse_line_log_ranges(
 
     for spec in specs {
         let (range_part, path) = split_l_arg(spec)?;
+        let userdiff = funcname_matcher_for_path(git_dir, work_tree, path);
         let blob_data = read_blob_at_path(odb, &tree_oid, path)?;
         let (lines, ends) = fill_line_ends(&blob_data);
 
@@ -909,7 +963,14 @@ pub fn parse_line_log_ranges(
             1
         };
 
-        let (begin, end) = parse_range_arg(range_part, &blob_data, &ends, lines, anchor)?;
+        let (begin, end) = parse_range_arg(
+            range_part,
+            &blob_data,
+            &ends,
+            lines,
+            anchor,
+            userdiff.as_ref(),
+        )?;
         line_log_insert(&mut files, path.to_owned(), begin, end);
     }
 
@@ -942,6 +1003,17 @@ fn filter_entries_for_paths(entries: Vec<DiffEntry>, paths: &[String]) -> Vec<Di
                 .unwrap_or(false)
         })
         .collect()
+}
+
+fn paths_from_range_files(range: &[LineLogFile]) -> Vec<String> {
+    let mut v: Vec<String> = range
+        .iter()
+        .filter(|f| !f.ranges.is_empty())
+        .map(|f| f.path.clone())
+        .collect();
+    v.sort();
+    v.dedup();
+    v
 }
 
 fn diff_tree_pair(
@@ -1100,7 +1172,6 @@ fn process_ranges_ordinary_commit(
     parents: &[ObjectId],
     tree_oid: &ObjectId,
     range: &[LineLogFile],
-    paths: &[String],
     rename_threshold: u32,
     state: &mut LineLogState,
     display: &mut HashMap<ObjectId, Vec<LineLogDisplay>>,
@@ -1110,7 +1181,14 @@ fn process_ranges_ordinary_commit(
     let parent_tree = parent
         .map(|p| parse_commit(&odb.read(p)?.data).map(|c| c.tree))
         .transpose()?;
-    let queue = diff_tree_pair(odb, parent_tree.as_ref(), tree_oid, paths, rename_threshold)?;
+    let path_keys = paths_from_range_files(range);
+    let queue = diff_tree_pair(
+        odb,
+        parent_tree.as_ref(),
+        tree_oid,
+        &path_keys,
+        rename_threshold,
+    )?;
     let (parent_range, disp, changed) = process_all_files(odb, &queue, range)?;
     if !disp.is_empty() {
         display.insert(commit_oid, disp);
@@ -1126,7 +1204,6 @@ fn process_ranges_merge_commit(
     parents: &[ObjectId],
     tree_oid: &ObjectId,
     range: &[LineLogFile],
-    paths: &[String],
     rename_threshold: u32,
     first_parent_only: bool,
     state: &mut LineLogState,
@@ -1140,7 +1217,8 @@ fn process_ranges_merge_commit(
     for i in 0..nparents {
         let p = parents[i];
         let ptree = parse_commit(&odb.read(&p)?.data)?.tree;
-        let queue = diff_tree_pair(odb, Some(&ptree), tree_oid, paths, rename_threshold)?;
+        let path_keys = paths_from_range_files(range);
+        let queue = diff_tree_pair(odb, Some(&ptree), tree_oid, &path_keys, rename_threshold)?;
         let (prange, _, changed_here) = process_all_files(odb, &queue, range)?;
         if !changed_here {
             state.insert(p, prange);
@@ -1157,7 +1235,8 @@ fn process_ranges_merge_commit(
 
     let p0 = parents[0];
     let ptree = parse_commit(&odb.read(&p0)?.data)?.tree;
-    let queue = diff_tree_pair(odb, Some(&ptree), tree_oid, paths, rename_threshold)?;
+    let path_keys = paths_from_range_files(range);
+    let queue = diff_tree_pair(odb, Some(&ptree), tree_oid, &path_keys, rename_threshold)?;
     // Display uses the commit-side ranges (`range`), matching Git's merge limitation.
     let (_, disp, _) = process_all_files(odb, &queue, range)?;
     if !disp.is_empty() {
@@ -1172,7 +1251,6 @@ pub fn line_log_filter_commits(
     commits: Vec<ObjectId>,
     tip: ObjectId,
     initial: Vec<LineLogFile>,
-    paths: Vec<String>,
     rename_threshold: u32,
     first_parent_only: bool,
 ) -> Result<(
@@ -1202,7 +1280,6 @@ pub fn line_log_filter_commits(
                 &parents,
                 &c.tree,
                 &range,
-                &paths,
                 rename_threshold,
                 first_parent_only,
                 &mut state,
@@ -1215,7 +1292,6 @@ pub fn line_log_filter_commits(
                 &parents,
                 &c.tree,
                 &range,
-                &paths,
                 rename_threshold,
                 &mut state,
                 &mut display_map,

--- a/grit/src/commands/log.rs
+++ b/grit/src/commands/log.rs
@@ -885,16 +885,19 @@ fn run_line_log(repo: &Repository, args: Args, _patch_context: usize) -> Result<
     )?;
     let order: Vec<ObjectId> = walk.iter().map(|(o, _)| *o).collect();
 
-    let initial = parse_line_log_ranges(&repo.odb, &tip, &args.line_range)
-        .map_err(|e| anyhow::anyhow!("{}", e))?;
-    let paths: Vec<String> = initial.iter().map(|f| f.path.clone()).collect();
-
+    let initial = parse_line_log_ranges(
+        &repo.odb,
+        &repo.git_dir,
+        repo.work_tree.as_deref(),
+        &tip,
+        &args.line_range,
+    )
+    .map_err(|e| anyhow::anyhow!("{}", e))?;
     let (filtered, _state, displays) = line_log_filter_commits(
         &repo.odb,
         order,
         tip,
         initial,
-        paths,
         rename_threshold,
         args.first_parent,
     )
@@ -948,6 +951,25 @@ fn run_line_log(repo: &Repository, args: Args, _patch_context: usize) -> Result<
 
     let show_patch = !args.suppress_diff && !args.no_patch;
 
+    let (graph_line_log_pipe_pfx, graph_line_log_space_pfx) = if args.graph && show_patch {
+        let use_color_g = log_resolve_stdout_color(&args, &repo.git_dir);
+        let cfg = ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default();
+        let red = if use_color_g {
+            cfg.get("color.diff.meta")
+                .and_then(|s| grit_lib::config::parse_color(&s).ok())
+                .unwrap_or_else(|| "\x1b[31m".to_string())
+        } else {
+            String::new()
+        };
+        let reset = if use_color_g { "\x1b[m" } else { "" };
+        (
+            Some(format!("{line_prefix}{red}|{reset} ")),
+            Some(format!("{line_prefix}  ")),
+        )
+    } else {
+        (None, None)
+    };
+
     if args.graph {
         let mut nodes = Vec::new();
         let mut seen = HashSet::new();
@@ -967,8 +989,6 @@ fn run_line_log(repo: &Repository, args: Args, _patch_context: usize) -> Result<
         }
 
         let abbrev_len = parse_abbrev(&args.abbrev);
-        let stdout = io::stdout();
-        let mut out = stdout.lock();
         let mut graph = AsciiGraph::new();
 
         let node_count = nodes.len();
@@ -995,37 +1015,45 @@ fn run_line_log(repo: &Repository, args: Args, _patch_context: usize) -> Result<
                         abbrev_len,
                         &parent_line,
                     );
-                    writeln!(out, "{line_prefix}{line}{rendered}")?;
+                    writeln!(out_main, "{line_prefix}{line}{rendered}")?;
                     break;
                 }
-                writeln!(out, "{line_prefix}{line}")?;
+                writeln!(out_main, "{line_prefix}{line}")?;
             }
 
             while !graph.is_commit_finished() {
                 let (line, _) = graph.next_line();
-                writeln!(out, "{line_prefix}{line}")?;
+                writeln!(out_main, "{line_prefix}{line}")?;
             }
 
             if show_patch {
-                if let Some(ds) = displays.get(&node.oid) {
-                    for d in ds {
-                        write!(
-                            out,
-                            "{}",
-                            format_line_log_diff(
-                                line_prefix,
-                                &d.old_path,
-                                &d.new_path,
-                                &d.old_bytes,
-                                &d.new_bytes,
-                                &d.commit_ranges,
-                                &d.touched,
-                            )
-                        )?;
+                let nparents = load_raw_parents(repo, node.oid)?.len();
+                if nparents <= 1 {
+                    if let Some(ds) = displays.get(&node.oid) {
+                        let diff_pfx = match graph_line_log_pipe_pfx.as_deref() {
+                            Some(pipe) if node_idx == 0 => pipe,
+                            Some(_) => graph_line_log_space_pfx.as_deref().unwrap_or(line_prefix),
+                            None => line_prefix,
+                        };
+                        for d in ds {
+                            write!(
+                                out_main,
+                                "{}",
+                                format_line_log_diff(
+                                    diff_pfx,
+                                    &d.old_path,
+                                    &d.new_path,
+                                    &d.old_bytes,
+                                    &d.new_bytes,
+                                    &d.commit_ranges,
+                                    &d.touched,
+                                )
+                            )?;
+                        }
                     }
-                    if node_idx + 1 < node_count {
-                        writeln!(out)?;
-                    }
+                } else if node_idx + 1 < node_count {
+                    writeln!(out_main)?;
+                    writeln!(out_main)?;
                 }
             }
         }
@@ -1069,26 +1097,33 @@ fn run_line_log(repo: &Repository, args: Args, _patch_context: usize) -> Result<
             None,
             None,
         )?;
+        let nparents = load_raw_parents(repo, *oid)?.len();
         if show_patch {
-            if let Some(ds) = displays.get(oid) {
-                for d in ds {
-                    write!(
-                        out_main,
-                        "{}",
-                        format_line_log_diff(
-                            line_prefix,
-                            &d.old_path,
-                            &d.new_path,
-                            &d.old_bytes,
-                            &d.new_bytes,
-                            &d.commit_ranges,
-                            &d.touched,
-                        )
-                    )?;
+            if nparents <= 1 {
+                if let Some(ds) = displays.get(oid) {
+                    for d in ds {
+                        write!(
+                            out_main,
+                            "{}",
+                            format_line_log_diff(
+                                line_prefix,
+                                &d.old_path,
+                                &d.new_path,
+                                &d.old_bytes,
+                                &d.new_bytes,
+                                &d.commit_ranges,
+                                &d.touched,
+                            )
+                        )?;
+                    }
+                    if i + 1 < n_filtered {
+                        writeln!(out_main)?;
+                    }
                 }
-                if i + 1 < n_filtered {
-                    writeln!(out_main)?;
-                }
+            } else if i + 1 < n_filtered {
+                // Git prints an extra blank line after merge commits when emitting line-log patches.
+                writeln!(out_main)?;
+                writeln!(out_main)?;
             }
         }
     }

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -3564,9 +3564,10 @@ fn preprocess_log_args(rest: &[String]) -> Vec<String> {
             i += 1;
             continue;
         }
-        if let Some(spec) = arg.strip_prefix("-L:") {
+        // `-L:pat:file` must keep the leading `:` (e.g. `-L:$:file.c` → `:$:file.c` for line-log).
+        if arg.starts_with("-L:") {
             result.push("-L".to_string());
-            result.push(spec.to_string());
+            result.push(arg[2..].to_string());
             i += 1;
             continue;
         }

--- a/logs/2026-04-10_t4211-line-log.md
+++ b/logs/2026-04-10_t4211-line-log.md
@@ -1,0 +1,21 @@
+# t4211-line-log work log
+
+## Result
+
+Harness `t4211-line-log.sh`: **50/53** passing (was 31/53 at start of branch per CSV).
+
+Remaining failures (Git topo / merge parent ordering vs our date-ordered `walk_commits` line-log walk):
+
+- `-M -L ':f:b.c' parallel-change`
+- fancy rename following #1 / #2 (`-L1:renamed-1`, `-L1:renamed-2`)
+
+## Changes (summary)
+
+- **`-L` parsing (`grit-lib/line_log.rs`)**: multiline regex for `/.../` (`^`/`$` across lines); Git-style line slices for funcname end detection; `+N`/`-N` relative second component when anchor is `lines+1`; single `N:file` leaves end 0 until clamp (through EOF); malformed `/foo:bar` → `start,end:file` style error; diff path filter uses current range file paths (rename-safe).
+- **Funcname + `.gitattributes`**: apply userdiff matcher only when `diff=<driver>` is set (not filename guessing).
+- **`grit log` line-log (`log.rs`)**: merge commits omit synthetic diff; extra blank line after merge when patches shown; `--graph` prefixes line-log hunks like `run_graph_log` (first commit `| `, later `  `); no stray blank between last two commits in graph mode.
+- **`preprocess_log_args` (`main.rs`)**: `-L:...` keeps leading `:` so `-L:$:file` works.
+
+## Follow-up
+
+Match Git’s full `rev-list --topo-order` + line-log interaction for the three failing rename/merge order tests (likely need revision-walk ordering aligned with `prepare_revision_walk`, not post-filter reorder).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements several `git log -L` (line-log) fixes so **t4211-line-log** advances from **31/53 → 50/53** in the harness.

### What changed

- **Regex `-L` ranges**: compile with multiline mode so patterns like `/^}/` work when the match is not on the first line of the tail substring.
- **Funcname (`:pat:file`)**: use Git-style line content for detecting the end boundary; only apply **userdiff** funcname rules when `.gitattributes` sets `diff=<driver>` (avoid wrong C++-style matching on plain `.c` files).
- **Relative second component**: allow `+N`/`-N` when the anchor line is `lines + 1` (e.g. `-L 24,+1` on a 24-line file).
- **Single `-L N:file`**: treat as “from N through EOF” like Git (end 0 until clamp).
- **Renames**: build diff queues from the **current** tracked paths in range state so first-parent `a.c` vs tip `b.c` merges are not dropped.
- **Merge output**: omit synthetic line-log diff for merge commits; add the blank line Git prints after merge headers when patches are shown.
- **Graph + line-log**: prefix hacky line-log hunks with the same `|` / two-space column layout as normal `log --graph` patches.
- **CLI**: `preprocess_log_args` keeps the leading `:` for glued `-L:...` so `-L:$:file` parses correctly.

### Remaining (3 tests)

Still failing vs upstream Git due to **topological / merge parent ordering** differences in the line-log walk vs `git rev-list --topo-order`:

- `-M -L ':f:b.c' parallel-change`
- fancy rename following #1 / #2

See `logs/2026-04-10_t4211-line-log.md` for notes.

### Validation

- `cargo test -p grit-lib --lib`
- `./scripts/run-tests.sh t4211-line-log.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8931070c-8814-4823-86a5-0e6ce66d38d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8931070c-8814-4823-86a5-0e6ce66d38d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

