### PR TITLE
fix: list tags from packed refs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,7 +386,7 @@ dependencies = [
 
 [[package]]
 name = "grit-lib"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "encoding_rs",
  "filetime",

--- a/grit-lib/src/git_date/approx.rs
+++ b/grit-lib/src/git_date/approx.rs
@@ -1,8 +1,8 @@
 //! Git `approxidate` (ported from `date.c`).
 
+use super::compat::{self, time_t, tm};
 use super::parse::{match_multi_number, MONTH_NAMES, WEEKDAY_NAMES};
 use super::tm::{get_time_sec, match_string, parse_timestamp_prefix};
-use super::compat::{self, time_t, tm};
 use std::mem::MaybeUninit;
 
 fn update_tm(tm: &mut tm, now: &tm, sec: i64) -> time_t {

--- a/grit-lib/src/git_date/compat.rs
+++ b/grit-lib/src/git_date/compat.rs
@@ -96,12 +96,7 @@ pub unsafe fn strftime(
 }
 
 #[cfg(not(unix))]
-pub unsafe fn strftime(
-    buf: *mut i8,
-    max: usize,
-    fmt: *const i8,
-    tm: *const tm,
-) -> usize {
+pub unsafe fn strftime(buf: *mut i8, max: usize, fmt: *const i8, tm: *const tm) -> usize {
     unsafe extern "C" {
         fn strftime(buf: *mut i8, max: usize, fmt: *const i8, tm: *const tm) -> usize;
     }

--- a/grit-lib/src/git_date/mod.rs
+++ b/grit-lib/src/git_date/mod.rs
@@ -43,7 +43,11 @@ pub fn test_tool_date(args: &[String]) -> Result<TestToolDateResult, String> {
             Ok(TestToolDateResult::Exit(code))
         }
         "time_t-is64bit" => {
-            let code = if size_of::<compat::time_t>() == 8 { 0 } else { 1 };
+            let code = if size_of::<compat::time_t>() == 8 {
+                0
+            } else {
+                1
+            };
             Ok(TestToolDateResult::Exit(code))
         }
         "relative" => {

--- a/grit-lib/src/git_date/parse.rs
+++ b/grit-lib/src/git_date/parse.rs
@@ -1,10 +1,10 @@
 //! Git-compatible date parsing (`parse_date_basic`, `parse_date`) — ported from Git `date.c`.
 
+use super::compat::{self, time_t, tm};
 use super::tm::{
     get_time_sec, init_tm_unknown, is_date_known, match_string, maybeiso8601, nodate,
     parse_timestamp_prefix, skip_alpha, tm_to_time_t, TIMESTAMP_MAX,
 };
-use super::compat::{self, time_t, tm};
 use std::mem::MaybeUninit;
 
 struct TzName {

--- a/grit-lib/src/git_date/show.rs
+++ b/grit-lib/src/git_date/show.rs
@@ -1,10 +1,10 @@
 //! Git-compatible date display (`show_date`, `show_date_relative`, strftime handling).
 
+use super::compat::{self, time_t, tm};
 use super::tm::{
     empty_tm, get_time_sec, init_tm_unknown, local_time_tzoffset, local_tzoffset, time_to_tm,
     time_to_tm_local, tm_to_time_t, TzHhmm,
 };
-use super::compat::{self, time_t, tm};
 use std::ffi::CString;
 use std::io::IsTerminal;
 

--- a/grit/src/commands/tag.rs
+++ b/grit/src/commands/tag.rs
@@ -389,21 +389,14 @@ fn list_tags(
     no_contains: Option<&str>,
     points_at: Option<&str>,
 ) -> Result<()> {
-    let mut tags: Vec<(String, ObjectId)> = if grit_lib::reftable::is_reftable_repo(&repo.git_dir) {
-        grit_lib::reftable::reftable_list_refs(&repo.git_dir, "refs/tags/")
-            .map_err(|e| anyhow::anyhow!("{e}"))?
-            .into_iter()
-            .map(|(name, oid)| {
-                let short = name.strip_prefix("refs/tags/").unwrap_or(&name).to_owned();
-                (short, oid)
-            })
-            .collect()
-    } else {
-        let tags_dir = repo.git_dir.join("refs/tags");
-        let mut t = Vec::new();
-        collect_tags(&tags_dir, "", &mut t)?;
-        t
-    };
+    let mut tags: Vec<(String, ObjectId)> = grit_lib::refs::list_refs(&repo.git_dir, "refs/tags/")
+        .map_err(|e| anyhow::anyhow!("{e}"))?
+        .into_iter()
+        .map(|(name, oid)| {
+            let short = name.strip_prefix("refs/tags/").unwrap_or(&name).to_owned();
+            (short, oid)
+        })
+        .collect();
 
     // Filter by --contains
     if let Some(rev) = contains {
@@ -457,37 +450,6 @@ fn list_tags(
             }
         } else {
             writeln!(out, "{name}")?;
-        }
-    }
-
-    Ok(())
-}
-
-/// Collect all tag refs recursively from the tags directory.
-fn collect_tags(dir: &Path, prefix: &str, out: &mut Vec<(String, ObjectId)>) -> Result<()> {
-    let entries = match fs::read_dir(dir) {
-        Ok(e) => e,
-        Err(_) => return Ok(()),
-    };
-
-    let mut sorted: Vec<_> = entries.filter_map(|e| e.ok()).collect();
-    sorted.sort_by_key(|e| e.file_name());
-
-    for entry in sorted {
-        let path = entry.path();
-        let file_name = entry.file_name().to_string_lossy().to_string();
-        let full_name = if prefix.is_empty() {
-            file_name
-        } else {
-            format!("{prefix}/{file_name}")
-        };
-
-        if path.is_dir() {
-            collect_tags(&path, &full_name, out)?;
-        } else if let Ok(content) = fs::read_to_string(&path) {
-            if let Ok(oid) = ObjectId::from_hex(content.trim()) {
-                out.push((full_name, oid));
-            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Route tag listing through `grit_lib::refs::list_refs` so loose, packed, and reftable refs share one path.
- Remove the duplicate loose tag directory walker from the CLI.
- Include rustfmt/Cargo.lock sync from the branch.

## Test plan
- Not run in this turn; branch already contains the implementation commits.

Made with [Cursor](https://cursor.com)