### PR TITLE
Library worktree support and t2402 harness

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -522,7 +522,7 @@ t2206-add-submodule-ignored	t2	yes	8	3	5	false	ok	0
 t2300-cd-to-toplevel	t2	yes	5	0	5	false	ok	0
 t2400-worktree-add	t2	skip	89	0	0	false	ok	0
 t2401-worktree-prune	t2	skip	13	12	1	false	ok	0
-t2402-worktree-list	t2	skip	27	20	7	false	ok	0
+t2402-worktree-list	t2	yes	27	27	0	true	ok	0
 t2403-worktree-move	t2	skip	33	26	7	false	ok	0
 t2404-worktree-config	t2	skip	12	0	0	false	ok	0
 t2405-worktree-submodule	t2	skip	11	3	8	false	ok	1

--- a/docs/index.html
+++ b/docs/index.html
@@ -1069,8 +1069,8 @@ grit-lib = <span class="string">"0.1"</span>
               <div class="suite-stat" style="--pct: 43.2%">
                 <span>t1 database</span><strong>43.2%</strong>
               </div>
-              <div class="suite-stat" style="--pct: 53.4%">
-                <span>t2 worktree</span><strong>53.4%</strong>
+              <div class="suite-stat" style="--pct: 54.8%">
+                <span>t2 worktree</span><strong>54.8%</strong>
               </div>
               <div class="suite-stat" style="--pct: 71.1%">
                 <span>t3 ls-files</span><strong>71.1%</strong>
@@ -1095,8 +1095,8 @@ grit-lib = <span class="string">"0.1"</span>
               </div>
             </div>
             <p>
-              Latest generated harness pass rate: 21,159 of
-              41,079 in-scope tests. Open the dashboard for exact
+              Latest generated harness pass rate: 21,186 of
+              41,106 in-scope tests. Open the dashboard for exact
               counts.
             </p>
           </a>

--- a/docs/progress/index.html
+++ b/docs/progress/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="51.5% of harness tests passing (21,159 / 41,079).">
+<meta property="og:description" content="51.5% of harness tests passing (21,186 / 41,106).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="51.5% of harness tests passing (21,159 / 41,079).">
+<meta name="twitter:description" content="51.5% of harness tests passing (21,186 / 41,106).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-05-08T08:48:08+00:00" class="gen-time" title="2026-05-08 08:48 UTC">2026-05-08 08:48 UTC</time> · <a href="https://github.com/schacon/grit/commit/0adad14eda3d3fcad274ed8970e092e2a265575d" style="color:#58a6ff">0adad14</a> · <a href="../testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-05-18T08:49:26+00:00" class="gen-time" title="2026-05-18 08:49 UTC">2026-05-18 08:49 UTC</time> · <a href="https://github.com/schacon/grit/commit/ebc76b1d12e41bb8a015ba567af96757f5cd53ad" style="color:#58a6ff">ebc76b1</a> · <a href="../testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,11 +157,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">21,159</div>
+      <div class="summary-big-val">21,186</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">41,079</div>
+      <div class="summary-big-val">41,106</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -169,11 +169,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:51.5%"></div></div>
   </div>
   <p class="summary-meta">
-    <span>1,417 test files (in scope)</span>
+    <span>1,418 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>383 files fully passing</span>
+    <span>384 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>188 skipped files</span>
+    <span>187 skipped files</span>
   </p>
 </section>
 
@@ -208,11 +208,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t2</span>
         <span class="group-desc">Basic commands concerning the working tree</span>
-        <span class="group-meta">27/61 files · 9 skipped · 467/874 tests</span>
+        <span class="group-meta">28/62 files · 8 skipped · 494/901 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:53.4%"></div></div>
-        <span class="group-pct pct-orange">53.4%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:54.8%"></div></div>
+        <span class="group-pct pct-orange">54.8%</span>
       </div>
     </a>
     <a class="group-card" href="../testfiles.html?group=t3">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">21159 of 41079 tests passing across 1417 harness files (51.5% pass rate).</desc>
+  <desc id="svg-desc">21186 of 41106 tests passing across 1418 harness files (51.5% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">51.5% pass rate · 21,159 / 41,079 tests · 1,417 files in scope · 383 fully passing · 188 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">51.5% pass rate · 21,186 / 41,106 tests · 1,418 files in scope · 384 fully passing · 187 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="360" height="18" rx="9" fill="#d29922"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="progress/">Dashboard</a> · <time datetime="2026-05-08T08:48:08+00:00" class="gen-time" title="2026-05-08 08:48 UTC">2026-05-08 08:48 UTC</time> · <a href="https://github.com/schacon/grit/commit/0adad14eda3d3fcad274ed8970e092e2a265575d" style="color:#58a6ff">0adad14</a></p>
+<p class="sub"><a href="progress/">Dashboard</a> · <time datetime="2026-05-18T08:49:27+00:00" class="gen-time" title="2026-05-18 08:49 UTC">2026-05-18 08:49 UTC</time> · <a href="https://github.com/schacon/grit/commit/ebc76b1d12e41bb8a015ba567af96757f5cd53ad" style="color:#58a6ff">ebc76b1</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
-  <div class="card"><div class="n" id="sum-files">1,417</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">41,079</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">21,159</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n" id="sum-files">1,418</div><div class="lbl">Files in scope</div></div>
+  <div class="card"><div class="n" id="sum-tests">41,106</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">21,186</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">51.5%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -5377,14 +5377,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="row-skip" data-group="t2" data-tests="27" data-passed="20">
+<tr class="" data-group="t2" data-tests="27" data-passed="27" data-full-pass="1">
   <td class="mono">t2402-worktree-list</td>
   <td>t2</td>
-  <td><span class="badge skip">skipped</span></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">27</td>
-  <td class="right">—</td>
-  <td class="right">—</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0%"></div></div></td>
+  <td class="right">27</td>
+  <td class="right">ok</td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="row-skip" data-group="t2" data-tests="33" data-passed="26">

--- a/grit-lib/src/lib.rs
+++ b/grit-lib/src/lib.rs
@@ -140,6 +140,7 @@ pub mod url_rewrite;
 pub mod userdiff;
 pub mod whitespace_rule;
 pub mod wildmatch;
+pub mod worktree;
 pub mod worktree_cwd;
 pub mod write_tree;
 pub mod ws;

--- a/grit-lib/src/state.rs
+++ b/grit-lib/src/state.rs
@@ -185,10 +185,18 @@ pub fn resolve_head(git_dir: &Path) -> Result<HeadState> {
             .to_owned();
 
         // Resolve the branch tip via the shared refs backend (worktrees, packed-refs).
-        // Missing ref => unborn branch (`None`); propagate I/O and other errors.
+        // Missing `refs/heads/*` => unborn branch (`None`). A symref to a non-branch
+        // target that cannot be resolved (e.g. HEAD -> `.broken`) is invalid, matching
+        // Git `refs_resolve_ref_unsafe` returning no target for `worktree list`.
         let oid = match crate::refs::resolve_ref(git_dir, &refname) {
             Ok(oid) => Some(oid),
-            Err(Error::InvalidRef(msg)) if msg.starts_with("ref not found:") => None,
+            Err(Error::InvalidRef(msg)) if msg.starts_with("ref not found:") => {
+                if refname.starts_with("refs/heads/") {
+                    None
+                } else {
+                    return Ok(HeadState::Invalid);
+                }
+            }
             Err(e) => return Err(e),
         };
 

--- a/grit-lib/src/worktree.rs
+++ b/grit-lib/src/worktree.rs
@@ -10,8 +10,6 @@ use std::path::{Path, PathBuf};
 
 use crate::config::ConfigSet;
 use crate::error::{Error, Result};
-use crate::objects::ObjectId;
-use crate::refs;
 use crate::repo::{common_git_dir_for_config, Repository};
 use crate::state::{resolve_head, HeadState};
 
@@ -40,31 +38,8 @@ pub fn common_git_dir(git_dir: &Path) -> PathBuf {
 
 /// Resolve HEAD for a linked worktree admin dir (`HEAD` local, branch refs in `common`).
 #[must_use]
-pub fn resolve_linked_head(admin: &Path, common: &Path) -> HeadState {
-    let head_path = admin.join("HEAD");
-    let content = match fs::read_to_string(&head_path) {
-        Ok(c) => c,
-        Err(_) => return HeadState::Invalid,
-    };
-    let trimmed = content.trim();
-    if let Some(refname) = trimmed.strip_prefix("ref: ") {
-        let refname = refname.to_owned();
-        let short_name = refname
-            .strip_prefix("refs/heads/")
-            .unwrap_or(&refname)
-            .to_owned();
-        let oid = refs::resolve_ref(common, &refname).ok();
-        HeadState::Branch {
-            refname,
-            short_name,
-            oid,
-        }
-    } else {
-        match ObjectId::from_hex(trimmed) {
-            Ok(oid) => HeadState::Detached { oid },
-            Err(_) => HeadState::Invalid,
-        }
-    }
+pub fn resolve_linked_head(admin: &Path, _common: &Path) -> HeadState {
+    resolve_head(admin).unwrap_or(HeadState::Invalid)
 }
 
 /// Whether `common` is configured as a bare repository (`core.bare=true`).

--- a/grit-lib/src/worktree.rs
+++ b/grit-lib/src/worktree.rs
@@ -1,0 +1,213 @@
+//! Linked worktree registry: discovery, listing, and admin-dir layout.
+//!
+//! Git stores linked worktrees under `<common-git-dir>/worktrees/<id>/` with
+//! `gitdir`, `commondir`, `HEAD`, and optional `locked` / `prunable` files.
+//! This module reads that layout; lifecycle mutations (`add` / `remove`) remain
+//! in the CLI for now and will move here in Phase 1.2.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::config::ConfigSet;
+use crate::error::{Error, Result};
+use crate::objects::ObjectId;
+use crate::refs;
+use crate::repo::{common_git_dir_for_config, Repository};
+use crate::state::{resolve_head, HeadState};
+
+/// One row returned by [`list_worktrees`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorktreeEntry {
+    /// Absolute path to the working tree (for bare main worktree, the common git dir).
+    pub path: PathBuf,
+    /// Resolved HEAD for this worktree.
+    pub head: HeadState,
+    /// Whether this worktree is bare (only the main entry can be bare).
+    pub is_bare: bool,
+    /// True when `<admin>/locked` exists.
+    pub is_locked: bool,
+    /// Contents of the `locked` file when non-empty.
+    pub lock_reason: Option<String>,
+    /// Administrative directory: common git dir for main, else `worktrees/<id>/`.
+    pub admin_dir: PathBuf,
+}
+
+/// Shared git directory for `git_dir` (follows `commondir` for linked worktrees).
+#[must_use]
+pub fn common_git_dir(git_dir: &Path) -> PathBuf {
+    common_git_dir_for_config(git_dir)
+}
+
+/// Resolve HEAD for a linked worktree admin dir (`HEAD` local, branch refs in `common`).
+#[must_use]
+pub fn resolve_linked_head(admin: &Path, common: &Path) -> HeadState {
+    let head_path = admin.join("HEAD");
+    let content = match fs::read_to_string(&head_path) {
+        Ok(c) => c,
+        Err(_) => return HeadState::Invalid,
+    };
+    let trimmed = content.trim();
+    if let Some(refname) = trimmed.strip_prefix("ref: ") {
+        let refname = refname.to_owned();
+        let short_name = refname
+            .strip_prefix("refs/heads/")
+            .unwrap_or(&refname)
+            .to_owned();
+        let oid = refs::resolve_ref(common, &refname).ok();
+        HeadState::Branch {
+            refname,
+            short_name,
+            oid,
+        }
+    } else {
+        match ObjectId::from_hex(trimmed) {
+            Ok(oid) => HeadState::Detached { oid },
+            Err(_) => HeadState::Invalid,
+        }
+    }
+}
+
+/// Whether `common` is configured as a bare repository (`core.bare=true`).
+#[must_use]
+pub fn is_bare_repository(common: &Path) -> bool {
+    ConfigSet::load(Some(common), true)
+        .ok()
+        .and_then(|cfg| cfg.get_bool("core.bare"))
+        .and_then(|r| r.ok())
+        .unwrap_or_else(|| {
+            // Heuristic when config is missing: bare repos usually are not named `.git`.
+            !common.ends_with(".git") && common.join("config").is_file()
+        })
+}
+
+/// Enumerate the main and linked worktrees for `repo`.
+///
+/// Order matches Git: main worktree first, then linked worktrees sorted by admin id.
+pub fn list_worktrees(repo: &Repository) -> Result<Vec<WorktreeEntry>> {
+    let common = common_git_dir(&repo.git_dir);
+    let mut entries = Vec::new();
+
+    let bare = is_bare_repository(&common);
+    let main_path = if bare {
+        common.clone()
+    } else if let Some(wt) = repo.work_tree.as_ref() {
+        // When opened from the main worktree, use the discovered work tree path.
+        if repo.git_dir == common || !repo.git_dir.starts_with(common.join("worktrees")) {
+            wt.clone()
+        } else {
+            common.parent().unwrap_or(&common).to_path_buf()
+        }
+    } else {
+        common.parent().unwrap_or(&common).to_path_buf()
+    };
+
+    let main_head = resolve_head(&common).unwrap_or(HeadState::Invalid);
+    entries.push(WorktreeEntry {
+        path: main_path,
+        head: main_head,
+        is_bare: bare,
+        is_locked: false,
+        lock_reason: None,
+        admin_dir: common.clone(),
+    });
+
+    let worktrees_dir = common.join("worktrees");
+    if !worktrees_dir.is_dir() {
+        return Ok(entries);
+    }
+
+    let mut names: Vec<String> = fs::read_dir(&worktrees_dir)
+        .map_err(Error::Io)?
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .collect();
+    names.sort();
+
+    for name in names {
+        let admin = worktrees_dir.join(&name);
+        let wt_head = resolve_linked_head(&admin, &common);
+        let wt_path = read_worktree_path(&admin)?;
+        let (is_locked, lock_reason) = read_lock_state(&admin)?;
+        entries.push(WorktreeEntry {
+            path: wt_path,
+            head: wt_head,
+            is_bare: false,
+            is_locked,
+            lock_reason,
+            admin_dir: admin,
+        });
+    }
+
+    Ok(entries)
+}
+
+/// Read the working tree path from `<admin>/gitdir` (parent of the worktree `.git` file).
+pub fn read_worktree_path(admin: &Path) -> Result<PathBuf> {
+    let gitdir_path = admin.join("gitdir");
+    if !gitdir_path.is_file() {
+        return Ok(admin.to_path_buf());
+    }
+    let raw = fs::read_to_string(&gitdir_path).map_err(Error::Io)?;
+    let p = PathBuf::from(raw.trim());
+    let parent = p.parent().unwrap_or(&p).to_path_buf();
+    Ok(parent.canonicalize().unwrap_or(parent))
+}
+
+fn read_lock_state(admin: &Path) -> Result<(bool, Option<String>)> {
+    let locked_file = admin.join("locked");
+    if !locked_file.is_file() {
+        return Ok((false, None));
+    }
+    let content = fs::read_to_string(&locked_file).map_err(Error::Io)?;
+    let reason = content.trim();
+    if reason.is_empty() {
+        Ok((true, None))
+    } else {
+        Ok((true, Some(reason.to_owned())))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repo::Repository;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn list_main_worktree_only() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("repo");
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(root.join(".git/HEAD"), "ref: refs/heads/main\n").unwrap();
+        fs::create_dir_all(root.join(".git/objects")).unwrap();
+        fs::write(
+            root.join(".git/config"),
+            "[core]\n\trepositoryformatversion = 0\n",
+        )
+        .unwrap();
+
+        let repo = Repository::open(&root.join(".git"), Some(&root)).unwrap();
+        let list = list_worktrees(&repo).unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].path, root.canonicalize().unwrap());
+        assert!(!list[0].is_bare);
+    }
+
+    #[test]
+    fn read_worktree_path_from_gitdir_file() {
+        let tmp = TempDir::new().unwrap();
+        let admin = tmp.path().join("wt-admin");
+        fs::create_dir_all(&admin).unwrap();
+        let wt = tmp.path().join("linked");
+        fs::create_dir_all(wt.join(".git")).unwrap();
+        fs::write(
+            admin.join("gitdir"),
+            format!("{}\n", wt.join(".git").display()),
+        )
+        .unwrap();
+        let path = read_worktree_path(&admin).unwrap();
+        assert_eq!(path, wt.canonicalize().unwrap());
+    }
+}

--- a/grit/src/commands/rev_parse.rs
+++ b/grit/src/commands/rev_parse.rs
@@ -59,8 +59,10 @@ enum PathDefaultMode {
     Unmodified,
     /// Realpath / canonical absolute (default for `--git-dir` inside a work tree).
     Canonical,
-    /// `relative_path(realpath(path), realpath(cwd))` (Git `DEFAULT_RELATIVE_IF_SHARED`).
+    /// `relative_path(realpath(path), realpath(cwd))` (Git `DEFAULT_RELATIVE`).
     RelativeToCwd,
+    /// Git `DEFAULT_RELATIVE_IF_SHARED` (`--git-path` default).
+    RelativeIfShared,
 }
 
 fn print_rev_parse_path(
@@ -92,7 +94,36 @@ fn print_rev_parse_path(
             PathDefaultMode::RelativeToCwd => {
                 println!("{}", to_relative_path(&path_abs, &cwd_abs));
             }
+            PathDefaultMode::RelativeIfShared => {
+                let prefix = cli_prefix.filter(|p| !p.as_os_str().is_empty());
+                match prefix {
+                    None => {
+                        println!("{}", path_abs.display());
+                    }
+                    Some(base) => {
+                        let base_abs = realpath_forgiving(base);
+                        if paths_share_root(&path_abs, &base_abs) {
+                            println!("{}", to_relative_path(&path_abs, &base_abs));
+                        } else {
+                            println!("{}", path_abs.display());
+                        }
+                    }
+                }
+            }
         },
+    }
+}
+
+/// True when `a` and `b` are under the same filesystem root (Git `have_same_root`).
+fn paths_share_root(a: &Path, b: &Path) -> bool {
+    use std::path::Component;
+    let mut ac = a.components().filter(|c| !matches!(c, Component::CurDir));
+    let mut bc = b.components().filter(|c| !matches!(c, Component::CurDir));
+    match (ac.next(), bc.next()) {
+        (Some(Component::RootDir), Some(Component::RootDir)) => true,
+        (Some(Component::Prefix(pa)), Some(Component::Prefix(pb))) => pa == pb,
+        (Some(Component::Normal(a0)), Some(Component::Normal(b0))) => a0 == b0,
+        _ => false,
     }
 }
 
@@ -1155,7 +1186,7 @@ pub fn run(args: Args) -> Result<()> {
                         &cwd,
                         cli_prefix_path.as_deref(),
                         *fmt,
-                        PathDefaultMode::RelativeToCwd,
+                        PathDefaultMode::RelativeIfShared,
                     );
                 } else {
                     bail!("not a git repository");

--- a/grit/src/commands/worktree.rs
+++ b/grit/src/commands/worktree.rs
@@ -11,6 +11,7 @@ use grit_lib::objects::ObjectId;
 use grit_lib::refs;
 use grit_lib::repo::Repository;
 use grit_lib::state::{resolve_head, HeadState};
+use grit_lib::worktree::{self, WorktreeEntry};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -218,23 +219,9 @@ pub fn run(args: Args) -> Result<()> {
     }
 }
 
-/// Helper: find the "common dir" (the main `.git` directory).
-/// For the main worktree this is just git_dir; for a linked worktree
-/// we follow the `commondir` file.
+/// Shared git directory (main `.git` for linked worktrees).
 fn common_dir(git_dir: &Path) -> Result<PathBuf> {
-    let commondir_file = git_dir.join("commondir");
-    if commondir_file.exists() {
-        let raw = fs::read_to_string(&commondir_file).context("reading commondir")?;
-        let rel = raw.trim();
-        let p = if Path::new(rel).is_absolute() {
-            PathBuf::from(rel)
-        } else {
-            git_dir.join(rel)
-        };
-        Ok(p.canonicalize().context("canonicalizing common dir")?)
-    } else {
-        Ok(git_dir.to_path_buf())
-    }
+    Ok(worktree::common_git_dir(git_dir))
 }
 
 /// Resolve a commit-ish string to an ObjectId within the given repo.
@@ -1095,128 +1082,8 @@ fn add_worktree_tree_to_index(
 // worktree list
 // ---------------------------------------------------------------------------
 
-/// Information about a single worktree entry.
-struct WorktreeInfo {
-    path: PathBuf,
-    head: HeadState,
-    is_bare: bool,
-    is_locked: bool,
-    lock_reason: Option<String>,
-}
-
-/// Resolve HEAD for a linked worktree admin dir.
-/// The HEAD file is in the admin dir, but branch refs live in the common dir.
-fn resolve_linked_head(admin: &Path, common: &Path) -> HeadState {
-    let head_path = admin.join("HEAD");
-    let content = match fs::read_to_string(&head_path) {
-        Ok(c) => c,
-        Err(_) => return HeadState::Invalid,
-    };
-    let trimmed = content.trim();
-    if let Some(refname) = trimmed.strip_prefix("ref: ") {
-        let refname = refname.to_owned();
-        let short_name = refname
-            .strip_prefix("refs/heads/")
-            .unwrap_or(&refname)
-            .to_owned();
-        // Resolve the ref against the common dir where refs actually live
-        let oid = refs::resolve_ref(common, &refname).ok();
-        HeadState::Branch {
-            refname,
-            short_name,
-            oid,
-        }
-    } else {
-        match ObjectId::from_hex(trimmed) {
-            Ok(oid) => HeadState::Detached { oid },
-            Err(_) => HeadState::Invalid,
-        }
-    }
-}
-
-fn collect_worktrees(repo: &Repository) -> Result<Vec<WorktreeInfo>> {
-    let common = common_dir(&repo.git_dir)?;
-    let mut entries = Vec::new();
-
-    // Main worktree (or bare repo)
-    let main_head = resolve_head(&common).unwrap_or(HeadState::Invalid);
-    // Determine if the repo is bare based on the common dir
-    let common_is_bare = !common.ends_with(".git") && common.join("config").exists() && {
-        // Check core.bare in config
-        if let Ok(content) = std::fs::read_to_string(common.join("config")) {
-            content.contains("bare = true")
-        } else {
-            false
-        }
-    };
-    // The main worktree path: for non-bare repos, it's common.parent() (i.e. /repo for /repo/.git)
-    // For bare repos, it's the common dir itself
-    let main_path = if common_is_bare {
-        common.clone()
-    } else {
-        common.parent().unwrap_or(&common).to_path_buf()
-    };
-    let is_bare = common_is_bare;
-    entries.push(WorktreeInfo {
-        path: main_path,
-        head: main_head,
-        is_bare,
-        is_locked: false,
-        lock_reason: None,
-    });
-
-    // Linked worktrees
-    let worktrees_dir = common.join("worktrees");
-    if worktrees_dir.is_dir() {
-        let mut names: Vec<_> = fs::read_dir(&worktrees_dir)?
-            .filter_map(|e| e.ok())
-            .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
-            .map(|e| e.file_name().to_string_lossy().to_string())
-            .collect();
-        names.sort();
-
-        for name in names {
-            let admin = worktrees_dir.join(&name);
-            let wt_head = resolve_linked_head(&admin, &common);
-
-            // Read the gitdir file to find the worktree path
-            let gitdir_path = admin.join("gitdir");
-            let wt_path = if gitdir_path.exists() {
-                let raw = fs::read_to_string(&gitdir_path).unwrap_or_default();
-                let p = PathBuf::from(raw.trim());
-                // gitdir points to <worktree>/.git, so parent is the worktree
-                let parent = p.parent().unwrap_or(&p).to_path_buf();
-                // Canonicalize to resolve relative paths like '../there'
-                parent.canonicalize().unwrap_or(parent)
-            } else {
-                admin.clone()
-            };
-
-            let locked_file = admin.join("locked");
-            let is_locked = locked_file.exists();
-            let lock_reason = if is_locked {
-                let content = fs::read_to_string(&locked_file).unwrap_or_default();
-                let reason = content.trim().to_string();
-                if reason.is_empty() {
-                    None
-                } else {
-                    Some(reason)
-                }
-            } else {
-                None
-            };
-
-            entries.push(WorktreeInfo {
-                path: wt_path,
-                head: wt_head,
-                is_bare: false,
-                is_locked,
-                lock_reason,
-            });
-        }
-    }
-
-    Ok(entries)
+fn collect_worktrees(repo: &Repository) -> Result<Vec<WorktreeEntry>> {
+    worktree::list_worktrees(repo).map_err(Into::into)
 }
 
 /// C-quote a path string when it contains non-ASCII characters (core.quotepath behavior).

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -990,6 +990,30 @@ fn run_test_tool_ref_store(rest: &[String]) -> Result<()> {
             }
             Ok(())
         }
+        "create-symref" => {
+            if rest.len() < 5 {
+                bail!(
+                    "usage: test-tool ref-store main create-symref <refname> <target> [logmsg]"
+                );
+            }
+            let refname = &rest[3];
+            let target = &rest[4];
+            let common = grit_lib::worktree::common_git_dir(&git_dir);
+            let base = if refname.starts_with("refs/worktree/") {
+                &git_dir
+            } else {
+                &common
+            };
+            let path = base.join(refname);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            let lock_path = grit_lib::refs::lock_path_for_ref(&path);
+            std::fs::write(&lock_path, format!("ref: {target}\n"))?;
+            std::fs::rename(lock_path, path)?;
+            Ok(())
+        }
+        "resolve-ref" => commands::test_tool_ref_store::run(&rest[2..]),
         other => bail!("test-tool ref-store: unsupported subcommand '{other}'"),
     }
 }

--- a/logs/2026-05-18-worktree-lib.md
+++ b/logs/2026-05-18-worktree-lib.md
@@ -9,3 +9,18 @@ Move worktree discovery/listing from `grit/src/commands/worktree.rs` into `grit-
 - Add `grit-lib/src/worktree.rs`: registry scan, `WorktreeEntry`, linked HEAD resolution.
 - Thin CLI `worktree list` to call the library API.
 - Validate with `cargo test -p grit-lib --lib` and `t2402-worktree-list.sh`.
+
+## Follow-up (same day)
+
+- `t2402-worktree-list` flipped to `in_scope=yes` in `data/test-files.csv`.
+- Fixed `rev-parse --git-path objects` for linked worktrees: use Git
+  `DEFAULT_RELATIVE_IF_SHARED` (absolute path when no `--prefix`).
+- Harness: **26/27** (`rev-parse --git-path` passes); remaining: broken-HEAD
+  porcelain list (`test 24`).
+
+## t2402 full pass
+
+- `resolve_head`: symref to non-`refs/heads/*` target that does not resolve →
+  `HeadState::Invalid` (Git `worktree list` `(error)` + porcelain `ZERO_OID`).
+- `test-tool ref-store main create-symref` wired in `grit/src/main.rs`.
+- `./scripts/run-tests.sh t2402-worktree-list.sh`: **27/27**.

--- a/logs/2026-05-18-worktree-lib.md
+++ b/logs/2026-05-18-worktree-lib.md
@@ -1,0 +1,11 @@
+# 2026-05-18 — Phase 1.1 worktree library
+
+## Goal
+
+Move worktree discovery/listing from `grit/src/commands/worktree.rs` into `grit-lib`.
+
+## Work
+
+- Add `grit-lib/src/worktree.rs`: registry scan, `WorktreeEntry`, linked HEAD resolution.
+- Thin CLI `worktree list` to call the library API.
+- Validate with `cargo test -p grit-lib --lib` and `t2402-worktree-list.sh`.

--- a/plan.md
+++ b/plan.md
@@ -83,9 +83,9 @@ tests. Most logic belongs in a new **`grit-lib/src/worktree.rs`** (and friends).
 
 ### 1.1 Core worktree filesystem model
 
-- [ ] Create `worktrees/` registry under common git dir (`worktrees/<id>/gitdir`,
+- [~] Create `worktrees/` registry under common git dir (`worktrees/<id>/gitdir`,
   `commondir`, `locked`, `prunable`, `HEAD`, private refs).
-- [ ] Resolve `git_dir` vs `common_dir` vs per-worktree refs (`refs/worktree/*`).
+- [~] Resolve `git_dir` vs `common_dir` vs per-worktree refs (`refs/worktree/*`).
 - [ ] `config.worktree` overlay and `extensions.worktreeConfig` behavior.
 
 ### 1.2 Worktree lifecycle API
@@ -104,7 +104,8 @@ tests. Most logic belongs in a new **`grit-lib/src/worktree.rs`** (and friends).
 ### 1.4 Harness targets (worktrees)
 
 - [ ] `t2400-worktree-add`
-- [ ] `t2402-worktree-list`, `t2401-worktree-prune`, `t2406-worktree-repair`
+- [x] `t2402-worktree-list`
+- [ ] `t2401-worktree-prune`, `t2406-worktree-repair`
 - [ ] `t2404-worktree-config`, `t2407-worktree-heads`
 - [ ] `t3908-stash-in-worktree`, `t2205-add-worktree-config` (non-interactive paths)
 - [ ] `t1415-worktree-refs`, `t1407-worktree-ref-store` (plumbing)

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,355 @@
+# PLAN.md — Grit v1 Library Release
+
+**Updated:** 2026-05-18
+
+## Goal
+
+Ship **`grit-lib`** as a fast, solid Git-compatible client engine that covers nearly all
+**commonly used, non-interactive** local and network workflows. **`grit-cli`** is a thin
+wrapper used to run the upstream harness (`./scripts/run-tests.sh`); **behavior and
+tests should be driven through library APIs**, not ad hoc logic in the binary.
+
+### Success criteria
+
+1. **Library-first:** New work lands in `grit-lib/` with small, typed public surfaces;
+   `grit/src/commands/` only parses argv, opens `Repository`, maps errors to exit codes.
+2. **Harness-backed:** Each milestone below names primary upstream test files to turn
+   green (in `./tests`, not `git/t/`). Full upstream parity is not required for v1.
+3. **Explicit non-goals for v1** (do not schedule work here):
+   - Interactive UX: `rebase -i`, `add -p`, `checkout -p`, `restore -p`, `clean -i`,
+     `commit -p`, `am --interactive`, etc.
+   - Complex HTTP authentication: Digest, NTLM, Negotiate/SPNEGO, OAuth device flows,
+     TLS client certificates, curl-grade multistage auth (Basic + credential helpers
+     already in scope is enough).
+   - **fsmonitor** / builtin fsmonitor daemon integration and status acceleration
+     that depends on it (`core.fsmonitor`, untracked-cache *for fsmonitor paths*).
+   - Shell completion, `git send-email`, `git shell`, Scalar, server/daemon parity.
+4. **Submodules:** last milestone before v1 tag—after worktrees, sparse, promisor,
+   signing, and hooks are solid.
+
+### How to work
+
+1. Claim a task: change `[ ]` → `[~]` and add a line in `logs/YYYY-MM-DD-<topic>.md`.
+2. Implement in **`grit-lib`** first; wire CLI only when a command needs it.
+3. Validate: `cargo test -p grit-lib --lib`, then `./scripts/run-tests.sh <file>.sh`.
+4. Update **`progress.md`** when checkboxes change (counts from this file).
+5. Mark `[x]` when the listed harness files for that task are fully passing.
+
+---
+
+## Architecture: target library layout
+
+Consolidate command-sized logic currently living in `grit/src/` into cohesive
+`grit-lib` modules. Suggested end state (modules may be merged or split as needed):
+
+| Module / area | Responsibility |
+|---------------|----------------|
+| `repo`, `odb`, `objects`, `pack` | Open repo, object store, pack read/write |
+| `refs`, `reflog`, `reftable`, `state` | Refs, HEAD, bisect state, worktree refs |
+| `index`, `split_index`, `sparse_checkout` | Index v2/v3, sparse patterns, checkout scope |
+| `worktree` (**new**) | Linked worktrees: add/list/remove/lock/repair/prune |
+| `promisor`, `shallow`, `fetch_negotiator` | Partial clone, lazy fetch, backfill |
+| `merge_*`, `diff`, `combined_*` | Merge, diff, conflict markers |
+| `hooks` | Multihook config + traditional `.git/hooks` execution |
+| `signing` (**new**) | Create/verify GPG and SSH-signed commits/tags |
+| `transport` (**new**) | upload-pack / receive-pack over bidirectional streams |
+| `submodule_*` | Gitlinks, `.gitmodules`, recursive fetch (last) |
+
+Public API style: **`Repository`** (or `GitDir` + work tree) as the entry handle;
+inject **time** and **environment** at boundaries; no `.unwrap()` in library code.
+
+---
+
+## Phase 0 — Foundation and CLI thinning (ongoing)
+
+Keep existing strengths stable while moving logic down from the binary.
+
+- [ ] **0.1 Repository session API** — Single `Repository::open` path with explicit
+  `GitDir`, common dir, work tree, commondir, and config load order documented.
+  - Harness: `t1510-repo-setup`, `t1517-outside-repo` (subset: open/discovery only)
+- [ ] **0.2 Move transport negotiation to lib** — `fetch_transport` / smart HTTP
+  session types live in `grit-lib::transport`; CLI calls `Repository::fetch_pack` /
+  `push_pack` style methods.
+  - Harness: `t5551-http-fetch-smart`, `t5541-http-push-smart` (regression guard)
+- [ ] **0.3 Audit binary-only helpers** — List `grit/src/` modules that implement
+  domain rules (index, merge, checkout, signing) and file issues per module to relocate.
+
+---
+
+## Phase 1 — Worktrees (highest priority)
+
+Git-linked checkouts are required for real multi-branch workflows and many porcelain
+tests. Most logic belongs in a new **`grit-lib/src/worktree.rs`** (and friends).
+
+### 1.1 Core worktree filesystem model
+
+- [ ] Create `worktrees/` registry under common git dir (`worktrees/<id>/gitdir`,
+  `commondir`, `locked`, `prunable`, `HEAD`, private refs).
+- [ ] Resolve `git_dir` vs `common_dir` vs per-worktree refs (`refs/worktree/*`).
+- [ ] `config.worktree` overlay and `extensions.worktreeConfig` behavior.
+
+### 1.2 Worktree lifecycle API
+
+- [ ] `Worktree::add(branch, path, opts)` — checkout new or existing branch, write
+  `.git` / gitfile, seed `HEAD`, index, optionally fetch.
+- [ ] `Worktree::list` / `remove` / `lock` / `unlock` / `move` / `repair` / `prune`.
+- [ ] Prevent unsafe operations (checkout branch checked out elsewhere, orphan paths).
+
+### 1.3 Commands using worktree index and refs
+
+- [ ] Index path: per-worktree `index` and shared vs private ref reads on
+  `status`, `diff`, `commit`, `reset`, `merge`, `checkout` (non-interactive).
+- [ ] Hook env: correct `GIT_WORK_TREE`, `GIT_DIR`, `GIT_COMMON_DIR` per worktree.
+
+### 1.4 Harness targets (worktrees)
+
+- [ ] `t2400-worktree-add`
+- [ ] `t2402-worktree-list`, `t2401-worktree-prune`, `t2406-worktree-repair`
+- [ ] `t2404-worktree-config`, `t2407-worktree-heads`
+- [ ] `t3908-stash-in-worktree`, `t2205-add-worktree-config` (non-interactive paths)
+- [ ] `t1415-worktree-refs`, `t1407-worktree-ref-store` (plumbing)
+
+---
+
+## Phase 2 — Sparse checkout (cone + compatibility)
+
+Build on existing `sparse_checkout.rs` and index `sdir` extension support.
+
+### 2.1 Sparse index and read-tree integration
+
+- [ ] Cone/non-cone pattern load/save (`$GIT_DIR/info/sparse-checkout`,
+  `index.sparse` config).
+- [ ] `read-tree` / checkout: only materialize included paths; skip-worktree +
+  sparse directory entries in index v4.
+- [ ] `ls-files`, `add`, `rm`, `mv`, `clean`, `status` respect sparse specification
+  (no interactive modes).
+
+### 2.2 Merge and diff under sparse
+
+- [ ] `merge-recursive` / `merge-ort` path limiting vs sparse patterns.
+- [ ] `diff` / `diff-tree` skip out-of-cone paths unless `--sparse` / config says otherwise.
+
+### 2.3 Harness targets (sparse)
+
+- [ ] `t1091-sparse-checkout-builtin`
+- [ ] `t1092-sparse-checkout-compatibility`
+- [ ] `t1011-read-tree-sparse-checkout`, `t1090-sparse-checkout-scope`
+- [ ] `t6428-merge-conflicts-sparse`, `t6435-merge-sparse`
+- [ ] `t3705-add-sparse-checkout`, `t3602-rm-sparse-checkout`, `t7002-mv-sparse-checkout`
+
+---
+
+## Phase 3 — Partial clone, promisor remotes, lazy objects
+
+Extend `promisor.rs`, `shallow.rs`, and ODB miss handling.
+
+### 3.1 Promisor ODB and packs
+
+- [ ] Align promisor marker with Git (`promisor` remote config, `.promisor` pack sidecars,
+  `extensions.partialClone` / `core.promisorRemote`).
+- [ ] `odb` miss → promisor remote fetch (single blob/tree/commit) without full clone.
+- [ ] `rev-list --missing`, `--exclude-promisor-objects`, connectivity checks.
+
+### 3.2 Clone/fetch filters
+
+- [ ] `filter=blob:none|tree:0|...` on clone/fetch; record filter in config.
+- [ ] Lazy fetch in merge, checkout, `cat-file`, `apply` (blob touch paths).
+- [ ] `backfill` / `promisor hydrate` as library API.
+
+### 3.3 Shallow + partial interaction
+
+- [ ] Shallow boundary + promisor: fetch deepen, push shallow (non-interactive).
+
+### 3.4 Harness targets (partial / promisor)
+
+- [ ] `t0410-partial-clone`, `t5616-partial-clone`
+- [ ] `t6421-merge-partial-clone`, `t1022-read-tree-partial-clone`
+- [ ] `t5620-backfill`, `t6110-rev-list-sparse` (promisor-related cases)
+- [ ] `t4067-diff-partial-clone`, `t5537-fetch-shallow` (non-interactive)
+
+---
+
+## Phase 4 — Signing (GPG + SSH)
+
+New **`grit-lib/src/signing.rs`** (and small `gpg.rs` / `ssh_sign.rs` if needed).
+
+### 4.1 Commit signing
+
+- [ ] Read `user.signingkey`, `gpg.program`, `gpg.format` (`openpgp` vs `ssh`).
+- [ ] Produce `gpgsig` / `gpgsig-sha256` on commit; SSH cert/key parsing per Git 2.x.
+- [ ] `commit -S` / `--no-gpg-sign` plumbing via library `CommitOptions`.
+
+### 4.2 Tag signing
+
+- [ ] Annotated tag signing; `verify-tag` / `verify-commit` in library.
+- [ ] `push` signed-tag checks where server advertises `allowSignedPush` (client side).
+
+### 4.3 Harness targets (signing)
+
+- [ ] `t7510-signed-commit`
+- [ ] `t7528-signed-commit-ssh`
+- [ ] `t7031-verify-tag-signed-ssh`
+- [ ] `t5534-push-signed` (client-side generation/verification only)
+
+---
+
+## Phase 5 — Hooks (multihook + porcelain integration)
+
+Extend existing **`grit-lib/src/hooks.rs`**.
+
+### 5.1 Hook runner completeness
+
+- [ ] `hook.<name>.*` multihook ordering, `hookPath`, `core.hooksPath`, `init.templateDir`.
+- [ ] All v1-required hook names wired with correct stdin/stdout/env:
+  `pre-commit`, `prepare-commit-msg`, `commit-msg`, `post-commit`,
+  `pre-merge-commit`, `pre-push`, `post-merge`, `post-checkout`, `post-rewrite`,
+  `update` / `pre-receive` (push path, client-side invocation of local hooks only).
+- [ ] `GIT_HOOK_INFO` for post-checkout; exit code propagation and `--no-verify`.
+
+### 5.2 Library call sites
+
+- [ ] `commit`, `merge`, `checkout`, `push`, `fetch` (where Git runs hooks) call
+  `hooks::run_*` with shared `CommitHookEnv`.
+- [ ] `git hook run` / `git hook list` delegate to library.
+
+### 5.3 Harness targets (hooks)
+
+- [ ] `t1800-hook`
+- [ ] `t7503-pre-commit-and-pre-merge-commit-hooks`
+- [ ] `t7504-commit-msg-hook`, `t7505-prepare-commit-msg-hook`
+- [ ] `t5571-pre-push-hook`, `t5402-post-merge-hook`, `t5403-post-checkout-hook`
+- [ ] `t5407-post-rewrite-hook`, `t5401-update-hooks`
+
+---
+
+## Phase 6 — Core client workflows (non-interactive polish)
+
+Fill gaps in everyday commands **without** interactive modes. Prefer library APIs
+used by multiple commands.
+
+### 6.1 Index + worktree + checkout
+
+- [ ] Non-interactive `checkout`, `restore`, `reset` (--hard/mixed/soft, pathspecs,
+  merge abort, unborn branch).
+- [ ] Racy git / untracked overwrite rules (`t2021`, `t2500`).
+
+### 6.2 Merge and sequencer (non-interactive only)
+
+- [ ] Porcelain `merge`, `pull` (no interactive conflict resolution UI).
+- [ ] `cherry-pick`, `revert` (no `rebase -i`); `rerere` optional if cheap.
+- [ ] Harness: `t7600-merge`, `t7110-reset-merge`, `t3500-cherry`–`t3511` (skip `-i` cases).
+
+### 6.3 Status, diff, log (no fsmonitor)
+
+- [ ] `status` porcelain v1/v2, branch ahead/behind, conflict summaries.
+- [ ] `diff` / `log` formats used by scripts (`--name-status`, `--oneline`, `-L` line-log
+  if already started in `line_log.rs`).
+- [ ] Harness: `t7508-status`, `t7064-wtstatus-pv2`, `t4202-log` (non-graph-interactive).
+
+### 6.4 Transport hardening (simple auth only)
+
+- [ ] `core.sshCommand` in lib SSH spawn; live fetch/push stream parity.
+- [ ] HTTP: keep Basic + credential helper + proactive/empty auth; no new curl auth.
+- [ ] Harness: `t5813-proto-disable-ssh`, `t5563-simple-http-auth` (Basic/Bearer helper
+  cases only), `t5545-push-options`, `t5547-push-quarantine`.
+
+### 6.5 Maintenance
+
+- [ ] `gc`, `repack`, `maintenance run` as library schedulers over `odb`/`refs`.
+- [ ] Harness: `t6500-gc`, `t7700-repack`, `t7900-maintenance` (non-interactive).
+
+---
+
+## Phase 7 — Submodules (last)
+
+Only after Phases 1–6 are stable.
+
+### 7.1 Submodule library API
+
+- [ ] `.gitmodules` parse/cache (`submodule_config*`), gitdir/gitfile layout.
+- [ ] `submodule init/update/sync/deinit` without interactive prompts.
+- [ ] Recursive fetch/clone; superproject pointer updates on `commit` / `status`.
+
+### 7.2 Cross-command behavior
+
+- [ ] `diff`/`status`/`ls-files` recurse-submodules (non-interactive).
+- [ ] Merge/cherry-pick with gitlinks (no `rebase -i` with submodules).
+
+### 7.3 Harness targets (submodules)
+
+- [ ] `t7406-submodule-update`, `t7403-submodule-sync`, `t7407-submodule-foreach`
+- [ ] `t7506-status-submodule`, `t2013-checkout-submodule` (non-interactive)
+- [ ] `t6437-submodule-merge`, `t4059-diff-submodule-not-initialized`
+- [ ] Keep `t7400-submodule-basic` green as regression guard
+
+---
+
+## Phase 8 — v1 release gate
+
+- [ ] **Public API review** — Document stable `grit-lib` entry points in crate rustdoc;
+  hide or `#[doc(hidden)]` experimental modules.
+- [ ] **Performance** — Benchmark pack indexing, status, diff on large trees (no fsmonitor);
+  fix hot paths found in profiling.
+- [ ] **CI contract** — `cargo fmt`, `clippy`, `cargo test -p grit-lib --lib`, and
+  in-scope harness subset (Phases 1–7 file list) required green for release tag.
+- [ ] **Explicit v1 exclusions doc** — Short `docs/v1-scope.md` listing out-of-scope
+  interactive, auth, and fsmonitor features so users know what to expect.
+
+---
+
+## Task checklist (execution order)
+
+Use this as the single queue for the next major step. Phases are sequential; tasks
+within a phase can be parallelized where noted.
+
+| ID | Phase | Task | Primary harness |
+|----|-------|------|-----------------|
+| 0.1 | 0 | Repository session API | `t1510-repo-setup` |
+| 0.2 | 0 | Transport in `grit-lib` | `t5551`, `t5541` |
+| 0.3 | 0 | Binary audit / relocation list | — |
+| 1.1 | 1 | Worktree filesystem model | `t1407`, `t1415` |
+| 1.2 | 1 | Worktree lifecycle API | `t2400`, `t2402` |
+| 1.3 | 1 | Per-worktree index/refs in commands | `t2404`, `t2407` |
+| 1.4 | 1 | Worktree repair/prune/lock | `t2401`, `t2406` |
+| 2.1 | 2 | Sparse index + checkout | `t1091`, `t1011` |
+| 2.2 | 2 | Sparse merge/diff | `t1092`, `t6435` |
+| 2.3 | 2 | Sparse add/rm/mv/status | `t3705`, `t3602` |
+| 3.1 | 3 | Promisor ODB + packs | `t0410` |
+| 3.2 | 3 | Filter clone/fetch + lazy fetch | `t5616` |
+| 3.3 | 3 | Backfill + merge on partial | `t5620`, `t6421` |
+| 4.1 | 4 | GPG/SSH commit signing | `t7510`, `t7528` |
+| 4.2 | 4 | Tag verify + push signed | `t7031`, `t5534` |
+| 5.1 | 5 | Multihook runner complete | `t1800` |
+| 5.2 | 5 | Hook integration in commit/merge/push | `t7503`–`t7505`, `t5571` |
+| 5.3 | 5 | post-checkout/merge/rewrite hooks | `t5402`, `t5403`, `t5407` |
+| 6.1 | 6 | Checkout/restore/reset polish | `t7201`, `t7102` |
+| 6.2 | 6 | Merge/pull/cherry-pick (no `-i`) | `t7600`, `t3500` |
+| 6.3 | 6 | Status/log/diff polish | `t7508`, `t4202` |
+| 6.4 | 6 | SSH `core.sshCommand` + push options | `t5813`, `t5545` |
+| 6.5 | 6 | gc/repack/maintenance | `t6500`, `t7900` |
+| 7.1 | 7 | Submodule init/update API | `t7406` |
+| 7.2 | 7 | Submodule status/diff/fetch | `t7506`, `t7400` |
+| 8.1 | 8 | API + docs + release gate | — |
+
+---
+
+## Out of scope (do not block v1)
+
+- Interactive patch modes (`-p`, `-i`) for add/checkout/restore/clean/commit/rebase/am
+- `rebase -i`, `rebase --exec` todo editor flows
+- Digest/NTLM/Kerberos HTTP, TLS client certs, OAuth refresh in credential protocol
+- fsmonitor, `core.fsmonitor`, builtin-fsmonitor, fsmonitor-driven fast status
+- `git send-email`, tab completion, `git shell`, Scalar monorepo wizard
+- Full reftable-by-default, reftable migration UX
+- Server-side: `git daemon`, `http-backend`, `receive-pack` on server (client hooks only)
+
+---
+
+## Tracking
+
+- **Progress counts:** derive from checkbox lines in this file (`- [x]` / `[~]` / `[ ]`).
+- **Harness dashboard:** `data/test-files.csv` after `./scripts/run-tests.sh`.
+- **Session logs:** `logs/` per AGENTS.md loop contract.
+
+When a phase completes, run the listed harness files together and refresh the dashboard
+before starting the next phase.


### PR DESCRIPTION
## Summary

- Add `grit-lib::worktree` for linked worktree discovery and listing; thin `grit worktree list` to use it.
- Replace `plan.md` with a v1 library-first release roadmap (worktrees, sparse/partial clone, signing, hooks; submodules last).
- Fix `rev-parse --git-path` for linked worktrees (Git `DEFAULT_RELATIVE_IF_SHARED`).
- Treat broken `HEAD` symrefs as invalid so `worktree list` matches Git (`(error)` + porcelain zero OID).
- Wire `test-tool ref-store main create-symref` for harness tests.
- Enable `t2402-worktree-list` in scope; harness **27/27**.

## Test plan

- [x] `./scripts/run-tests.sh t2402-worktree-list.sh` (27/27)
- [x] `cargo test -p grit-lib worktree --lib`
- [x] `cargo build -p grit-cli`


Made with [Cursor](https://cursor.com)