### PR TITLE
fix: handle gitfile GIT_DIR in repo setup

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -445,7 +445,7 @@ t1506-rev-parse-diagnosis	t1	yes	30	30	0	true	ok	0
 t1507-rev-parse-upstream	t1	yes	29	29	0	true	ok	0
 t1508-at-combinations	t1	yes	35	35	0	true	ok	0
 t1509-root-work-tree	t1	yes	0	0	0	false	ok	0
-t1510-repo-setup	t1	yes	109	73	36	false	ok	0
+t1510-repo-setup	t1	yes	109	109	0	true	ok	0
 t1511-rev-parse-caret	t1	yes	17	11	6	false	ok	0
 t1512-rev-parse-disambiguation	t1	yes	38	32	6	false	ok	0
 t1513-rev-parse-prefix	t1	yes	11	11	0	true	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -1060,14 +1060,14 @@ grit-lib = <span class="string">"0.1"</span>
             href="progress/"
             aria-label="Open progress dashboard"
           >
-            <div class="big-stat">51.5%</div>
-            <div class="bar" aria-hidden="true"><span style="width: 51.5%"></span></div>
+            <div class="big-stat">51.6%</div>
+            <div class="bar" aria-hidden="true"><span style="width: 51.6%"></span></div>
             <div class="suite-grid" aria-label="Pass rate by Git test suite">
               <div class="suite-stat" style="--pct: 90.4%">
                 <span>t0 basics</span><strong>90.4%</strong>
               </div>
-              <div class="suite-stat" style="--pct: 43.2%">
-                <span>t1 database</span><strong>43.2%</strong>
+              <div class="suite-stat" style="--pct: 43.4%">
+                <span>t1 database</span><strong>43.4%</strong>
               </div>
               <div class="suite-stat" style="--pct: 54.8%">
                 <span>t2 worktree</span><strong>54.8%</strong>
@@ -1095,7 +1095,7 @@ grit-lib = <span class="string">"0.1"</span>
               </div>
             </div>
             <p>
-              Latest generated harness pass rate: 21,186 of
+              Latest generated harness pass rate: 21,222 of
               41,106 in-scope tests. Open the dashboard for exact
               counts.
             </p>

--- a/docs/progress/index.html
+++ b/docs/progress/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="51.5% of harness tests passing (21,186 / 41,106).">
+<meta property="og:description" content="51.6% of harness tests passing (21,222 / 41,106).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="51.5% of harness tests passing (21,186 / 41,106).">
+<meta name="twitter:description" content="51.6% of harness tests passing (21,222 / 41,106).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,16 +148,16 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-05-18T08:49:26+00:00" class="gen-time" title="2026-05-18 08:49 UTC">2026-05-18 08:49 UTC</time> · <a href="https://github.com/schacon/grit/commit/ebc76b1d12e41bb8a015ba567af96757f5cd53ad" style="color:#58a6ff">ebc76b1</a> · <a href="../testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-05-20T01:12:12+00:00" class="gen-time" title="2026-05-20 01:12 UTC">2026-05-20 01:12 UTC</time> · <a href="https://github.com/schacon/grit/commit/31ca9a92f60db9e7781cc31fbd9443dd42d4d114" style="color:#58a6ff">31ca9a9</a> · <a href="../testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
     <div class="summary-big-item">
-      <div class="summary-big-val pct-orange">51.5%</div>
+      <div class="summary-big-val pct-orange">51.6%</div>
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">21,186</div>
+      <div class="summary-big-val">21,222</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
@@ -166,12 +166,12 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
     </div>
   </div>
   <div class="summary-bar-wrap" aria-hidden="true">
-    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:51.5%"></div></div>
+    <div class="summary-bar-bg"><div class="summary-bar-fg" style="width:51.6%"></div></div>
   </div>
   <p class="summary-meta">
     <span>1,418 test files (in scope)</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
-    <span>384 files fully passing</span>
+    <span>385 files fully passing</span>
     <span class="summary-meta-sep" aria-hidden="true">·</span>
     <span>187 skipped files</span>
   </p>
@@ -197,11 +197,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">80/368 files · 8 skipped · 5,493/12,727 tests</span>
+        <span class="group-meta">81/368 files · 8 skipped · 5,529/12,727 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:43.2%"></div></div>
-        <span class="group-pct pct-orange">43.2%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:43.4%"></div></div>
+        <span class="group-pct pct-orange">43.4%</span>
       </div>
     </a>
     <a class="group-card" href="../testfiles.html?group=t2">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">21186 of 41106 tests passing across 1418 harness files (51.5% pass rate).</desc>
+  <desc id="svg-desc">21222 of 41106 tests passing across 1418 harness files (51.6% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">51.5% pass rate · 21,186 / 41,106 tests · 1,418 files in scope · 384 fully passing · 187 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">51.6% pass rate · 21,222 / 41,106 tests · 1,418 files in scope · 385 fully passing · 187 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
-  <rect x="40" y="80" width="360" height="18" rx="9" fill="#d29922"/>
+  <rect x="40" y="80" width="361" height="18" rx="9" fill="#d29922"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>
 </svg>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,13 +100,13 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="progress/">Dashboard</a> · <time datetime="2026-05-18T08:49:27+00:00" class="gen-time" title="2026-05-18 08:49 UTC">2026-05-18 08:49 UTC</time> · <a href="https://github.com/schacon/grit/commit/ebc76b1d12e41bb8a015ba567af96757f5cd53ad" style="color:#58a6ff">ebc76b1</a></p>
+<p class="sub"><a href="progress/">Dashboard</a> · <time datetime="2026-05-20T01:12:12+00:00" class="gen-time" title="2026-05-20 01:12 UTC">2026-05-20 01:12 UTC</time> · <a href="https://github.com/schacon/grit/commit/31ca9a92f60db9e7781cc31fbd9443dd42d4d114" style="color:#58a6ff">31ca9a9</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,418</div><div class="lbl">Files in scope</div></div>
   <div class="card"><div class="n" id="sum-tests">41,106</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">21,186</div><div class="lbl">Tests passed</div></div>
-  <div class="card accent"><div class="n" id="sum-pct">51.5%</div><div class="lbl">Pass rate</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">21,222</div><div class="lbl">Tests passed</div></div>
+  <div class="card accent"><div class="n" id="sum-pct">51.6%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
 
@@ -4607,14 +4607,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:0.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="109" data-passed="73">
+<tr class="" data-group="t1" data-tests="109" data-passed="109" data-full-pass="1">
   <td class="mono">t1510-repo-setup</td>
   <td>t1</td>
-  <td></td>
+  <td><span class="badge ok">full pass</span></td>
   <td class="right">109</td>
-  <td class="right">73</td>
+  <td class="right">109</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:67.0%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:100.0%"></div></div></td>
   <td class="right small">0</td>
 </tr>
 <tr class="" data-group="t1" data-tests="17" data-passed="11">

--- a/grit/src/alias.rs
+++ b/grit/src/alias.rs
@@ -233,7 +233,11 @@ pub(crate) fn run_command_with_aliases(
 ) -> Result<()> {
     let git_dir = std::env::var("GIT_DIR")
         .ok()
-        .map(PathBuf::from)
+        .filter(|raw| !raw.is_empty())
+        .and_then(|raw| {
+            let path = PathBuf::from(raw);
+            grit_lib::repo::resolve_git_directory_arg(&path).ok()
+        })
         .or_else(|| {
             grit_lib::repo::Repository::discover(None)
                 .ok()

--- a/grit/src/main.rs
+++ b/grit/src/main.rs
@@ -992,9 +992,7 @@ fn run_test_tool_ref_store(rest: &[String]) -> Result<()> {
         }
         "create-symref" => {
             if rest.len() < 5 {
-                bail!(
-                    "usage: test-tool ref-store main create-symref <refname> <target> [logmsg]"
-                );
+                bail!("usage: test-tool ref-store main create-symref <refname> <target> [logmsg]");
             }
             let refname = &rest[3];
             let target = &rest[4];

--- a/logs/2026-05-19-repository-session-api.md
+++ b/logs/2026-05-19-repository-session-api.md
@@ -1,0 +1,27 @@
+# 2026-05-19 — Repository session API
+
+## Goal
+
+Improve repository setup/discovery behavior for `t1510-repo-setup.sh` as part of plan item 0.1.
+
+## Work
+
+- Claimed plan item 0.1.
+- Recreated missing `progress.md` and `test-results.md` tracking files.
+- Building release `grit` before running the focused harness.
+
+## Update
+
+- Fixed `scripts/run-tests.sh` compatibility with macOS Bash 3 (`mapfile`, empty arrays under `set -u`).
+- Found first `t1510` failure: alias config loading used raw gitfile-valued `GIT_DIR`.
+- Patched alias dispatch to resolve `GIT_DIR` through `grit_lib::repo::resolve_git_directory_arg`.
+
+## Validation
+
+- `cargo build --release -p grit-cli` passed.
+- `./scripts/run-tests.sh t1510-repo-setup.sh` passed, 109/109.
+- `./scripts/run-tests.sh t1517-outside-repo.sh` remains 185/191; first remaining failure is `git apply` outside a repository.
+- `cargo test -p grit-lib --lib` passed, 199/199.
+- `cargo fmt --check` passed after formatting.
+- `cargo check` passed.
+- `cargo clippy --fix --allow-dirty` completed, with pre-existing warnings still reported across unrelated modules.

--- a/plan.md
+++ b/plan.md
@@ -64,7 +64,7 @@ inject **time** and **environment** at boundaries; no `.unwrap()` in library cod
 
 Keep existing strengths stable while moving logic down from the binary.
 
-- [ ] **0.1 Repository session API** — Single `Repository::open` path with explicit
+- [~] **0.1 Repository session API** — Single `Repository::open` path with explicit
   `GitDir`, common dir, work tree, commondir, and config load order documented.
   - Harness: `t1510-repo-setup`, `t1517-outside-repo` (subset: open/discovery only)
 - [ ] **0.2 Move transport negotiation to lib** — `fetch_transport` / smart HTTP

--- a/progress.md
+++ b/progress.md
@@ -1,0 +1,14 @@
+# Progress
+
+Updated: 2026-05-19
+
+- Total tasks: 83
+- Completed: 1
+- Claimed/in progress: 3
+- Remaining open: 79
+
+## Remaining
+
+- Phase 0: finish Repository session API, move transport negotiation into `grit-lib`, and audit binary-only domain helpers.
+- Phase 1: complete linked worktree lifecycle, config overlays, command integration, and remaining worktree harness files.
+- Phases 2-8: sparse checkout, partial clone/promisor behavior, signing, hooks, core workflow polish, submodules, and release gate.

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -174,8 +174,12 @@ else
   unset GRIT_FAMILY_FILTER 2>/dev/null || true
 fi
 
-# Build list of files to run: skip in_scope=skip
-mapfile -t FILES < <(
+# Build list of files to run: skip in_scope=skip. Use a read loop instead of
+# Bash 4 `mapfile` so the runner works with macOS' default Bash 3.
+FILES=()
+while IFS= read -r file; do
+  FILES+=("$file")
+done < <(
   python3 - "$CSV" "$TESTS_DIR" "$FROM" "${POS[@]}" <<'PY'
 import csv, os, sys, glob
 
@@ -323,6 +327,8 @@ LINE_TMP="$(mktemp)"
 trap 'rm -f "$LINE_TMP"' EXIT
 
 run_one() {
+  # Bash 3 treats empty array expansions as unbound under `set -u`.
+  set +u
   local f="$1"
   local base="${f%.sh}"
   local output summary total pass fail status ef
@@ -366,6 +372,7 @@ run_one() {
         GIT_CONFIG_PARAMETERS= \
         "${timeout_prefix[@]}" bash "$f" 2>&1
   ) || true
+  set -u
   summary=$(echo "$output" | grep "^# Tests:" | tail -1) || true
   total=0 pass=0 fail=0 status="error"
   if [[ -n "$summary" ]]; then

--- a/test-results.md
+++ b/test-results.md
@@ -1,0 +1,12 @@
+# Test Results
+
+Updated: 2026-05-19
+
+- `cargo build --release -p grit-cli`: pass.
+- `cargo fmt --check`: pass after formatting.
+- `cargo check`: pass.
+- `cargo clippy --fix --allow-dirty`: completed, but the workspace still reports many pre-existing clippy warnings; clippy also reported failed auto-fixes in unrelated files.
+- `cargo test -p grit-lib --lib`: pass, 199/199.
+- `./tests/harness/run.sh`: skipped; project uses `./scripts/run-tests.sh` for CSV/dashboard updates.
+- Focus harness: `./scripts/run-tests.sh t1510-repo-setup.sh` pass, 109/109.
+- Companion harness: `./scripts/run-tests.sh t1517-outside-repo.sh` still 185/191; first remaining failure is `git apply` outside a repository, not repo setup discovery.


### PR DESCRIPTION
## Summary

- resolve gitfile-valued `GIT_DIR` before alias config lookup
- make `scripts/run-tests.sh` compatible with macOS Bash 3
- refresh `t1510-repo-setup` dashboard/progress data after the fix

## Progress

- `t1510-repo-setup.sh`: 73/109 -> 109/109
- Net test progress: +36 passing upstream tests
- Dashboard progress: 51.5% -> 51.6%

## Root Cause

`t1510-repo-setup` failed when `GIT_DIR` pointed at a `.git` gitfile because alias dispatch loaded config from the raw `GIT_DIR` path before command dispatch. That made it try to read `.git/config` where `.git` was a file, not the resolved git directory.

## Validation

- `./scripts/run-tests.sh t1510-repo-setup.sh` -> 109/109
- `cargo build --release -p grit-cli`
- `cargo check`
- `cargo fmt --check`
- `cargo test -p grit-lib --lib` -> 199/199

Note: `t1517-outside-repo.sh` remained 185/191 in this PR; that was handled separately in #763.
