### PR TITLE
fix: handle diff outside repo

### DIFF
--- a/grit/src/commands/diff.rs
+++ b/grit/src/commands/diff.rs
@@ -1703,8 +1703,14 @@ pub fn run(mut args: Args) -> Result<()> {
         revs.retain(|r| r != "-B" && r != "--break-rewrites");
     }
 
-    // Outside any repository, `git diff <path> <path>` behaves like `diff --no-index` (t4035).
-    if repo_opt.is_none() && revs.is_empty() && raw_path_args.len() == 2 && !args.cached {
+    // Outside any repository, `git diff <path> <path>` behaves like `diff --no-index`.
+    if repo_opt.is_none()
+        && !args.cached
+        && ((revs.is_empty() && raw_path_args.len() == 2)
+            || (raw_path_args.is_empty()
+                && revs.len() == 2
+                && revs.iter().all(|p| Path::new(p).exists())))
+    {
         return run_no_index(args);
     }
 
@@ -3125,9 +3131,10 @@ pub fn run(mut args: Args) -> Result<()> {
             }
             // `git diff --stat -p` prints stat then patch only when `-p`/`-u`/etc. appear on argv;
             // plain `--stat` must not append hunks (matches Git).
-            let show_unified_after_stat =
-                diff_cli_requests_unified_patch_alongside_stat(&raw_args) && !args.no_patch;
-            if show_unified_after_stat {
+            let write_unified_patch = !args.no_patch
+                && (!format_besides_unified_patch
+                    || diff_cli_requests_unified_patch_alongside_stat(&raw_args));
+            if write_unified_patch {
                 for patch in &conflict_combined_patches {
                     write!(out, "{patch}")?;
                 }
@@ -4467,6 +4474,10 @@ fn diff_cli_requests_unified_patch_alongside_stat(argv: &[String]) -> bool {
             continue;
         }
         if arg == "-p" || arg == "--patch" || arg == "-u" {
+            emit = true;
+            continue;
+        }
+        if arg == "--patch-with-raw" || arg == "--patch-with-stat" {
             emit = true;
             continue;
         }

--- a/logs/2026-05-19_18:32-diff-outside-repo.md
+++ b/logs/2026-05-19_18:32-diff-outside-repo.md
@@ -1,0 +1,28 @@
+# diff outside repo
+
+Branch: `fix-apply-outside-repo`
+
+Focused on `t1517-outside-repo.sh` without touching dashboard, plan, or progress files from the
+parallel repo-setup PR.
+
+## Findings
+
+- `git diff` saw index/worktree changes but emitted no unified patch by default.
+- That left `sample.patch` empty in `t1517`, which made the outside-repo `git apply` case fail.
+- Outside a repository, `git diff one two` classified both filesystem paths as revisions and
+  errored instead of falling back to no-index diff mode.
+
+## Changes
+
+- Emit unified patch output for plain `git diff` when no other output format is selected.
+- Keep format-only behavior for `--stat`, `--raw`, `--name-only`, etc. unless `-p` is explicitly
+  requested.
+- Treat two existing filesystem paths outside a repository as implicit `--no-index`.
+
+## Validation
+
+- `cargo fmt --check`
+- `cargo check -p grit-cli`
+- `cargo build --release -p grit-cli`
+- `./scripts/run-tests.sh --output-csv /tmp/grit-t1517.csv --no-catalog t1517-outside-repo.sh`
+  moved `t1517-outside-repo` from 185/191 to 187/191.


### PR DESCRIPTION
## Summary

- emit default unified patch output for plain `git diff`
- keep format-only modes format-only unless `-p` is requested
- fall back to no-index diff for two existing paths outside a repo

## Progress

- `t1517-outside-repo.sh`: 185/191 -> 187/191
- Net test progress: +2 passing upstream tests
- Dashboard files were intentionally not refreshed in this PR to avoid conflicting with #762.

## Validation

- `cargo fmt --check`
- `cargo check -p grit-cli`
- `cargo build --release -p grit-cli`
- `./scripts/run-tests.sh --output-csv /tmp/grit-t1517.csv --no-catalog t1517-outside-repo.sh` -> 187/191
