### PR TITLE
fix: format rev-parse git paths

### DIFF
--- a/grit/src/commands/rev_parse.rs
+++ b/grit/src/commands/rev_parse.rs
@@ -98,7 +98,7 @@ fn print_rev_parse_path(
                 let prefix = cli_prefix.filter(|p| !p.as_os_str().is_empty());
                 match prefix {
                     None => {
-                        println!("{}", path_abs.display());
+                        println!("{}", to_relative_path(&path_abs, &cwd_abs));
                     }
                     Some(base) => {
                         let base_abs = realpath_forgiving(base);
@@ -1145,8 +1145,17 @@ pub fn run(args: Args) -> Result<()> {
                             grit_lib::config::ConfigSet::load(Some(&current.git_dir), true)?;
                         if let Some(hooks_path) = config.get("core.hooksPath") {
                             let hooks_dir = std::path::Path::new(&hooks_path);
-                            if path_arg == "hooks" {
+                            let hook_base = current
+                                .work_tree
+                                .as_deref()
+                                .unwrap_or(current.git_dir.as_path());
+                            let hooks_dir = if hooks_dir.is_absolute() {
                                 hooks_dir.to_path_buf()
+                            } else {
+                                hook_base.join(hooks_dir)
+                            };
+                            if path_arg == "hooks" {
+                                hooks_dir
                             } else {
                                 let remainder = &path_arg["hooks/".len()..];
                                 hooks_dir.join(remainder)

--- a/logs/2026-05-19_18:51-rev-parse-git-path.md
+++ b/logs/2026-05-19_18:51-rev-parse-git-path.md
@@ -1,0 +1,32 @@
+# rev-parse git-path formatting
+
+Branch: `fix-rev-parse-git-path-relative`
+
+Focused on `rev-parse --git-path` without touching the dashboard/script files from the repo-setup
+PR or the diff command from the outside-repo PR.
+
+## Findings
+
+- `git rev-parse --git-path objects` printed an absolute path by default.
+- Relative `core.hooksPath` values were treated as raw relative paths during `--git-path hooks/...`
+  formatting, which produced paths relative to the process cwd machinery rather than the work tree.
+- Fixing the default `--git-path objects` behavior advances specific `t1500` cases, but that file
+  still has a separate shallow-clone failure.
+
+## Changes
+
+- Make default `--git-path` output relative to the current directory when no explicit
+  `--path-format` is supplied.
+- Resolve relative `core.hooksPath` against the work tree before formatting `--git-path hooks/...`.
+
+## Validation
+
+- `cargo fmt`
+- `cargo fmt --check`
+- `cargo check -p grit-cli`
+- `cargo build --release -p grit-cli`
+- `cargo clippy --fix --allow-dirty` completed with pre-existing warnings and no unrelated edits.
+- `./scripts/run-tests.sh --output-csv /tmp/grit-t1350.csv --no-catalog t1350-config-hooks-path.sh`
+  moved `t1350-config-hooks-path` from 3/4 to 4/4.
+- `./scripts/run-tests.sh --output-csv /tmp/grit-t1500.csv --no-catalog t1500-rev-parse.sh`
+  remains 80/81 due to the separate shallow-clone failure.


### PR DESCRIPTION
## Summary

- make default rev-parse --git-path output relative to the current directory
- resolve relative core.hooksPath against the work tree before formatting --git-path hooks/...
- keep dashboard files untouched to avoid conflicting with the repo-setup dashboard PR

## Progress

- t1350-config-hooks-path.sh: 3/4 -> 4/4
- Net test progress: +1 passing upstream test
- t1500-rev-parse.sh still remains 80/81 because of a separate shallow-clone object checkout failure

## Validation

- cargo fmt
- cargo fmt --check
- cargo check -p grit-cli
- cargo build --release -p grit-cli
- cargo clippy --fix --allow-dirty completed with pre-existing warnings and no unrelated edits
- ./scripts/run-tests.sh --output-csv /tmp/grit-t1350.csv --no-catalog t1350-config-hooks-path.sh -> 4/4
- ./scripts/run-tests.sh --output-csv /tmp/grit-t1500.csv --no-catalog t1500-rev-parse.sh -> 80/81
