### PR TITLE
fix: deduplicate commit-tree parents

### DIFF
--- a/grit/src/commands/commit_tree.rs
+++ b/grit/src/commands/commit_tree.rs
@@ -8,6 +8,7 @@
 
 use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
+use std::collections::HashSet;
 use std::env;
 use std::io::Read;
 use time::format_description::well_known::Rfc3339;
@@ -51,12 +52,15 @@ pub fn run(args: Args) -> Result<()> {
     let tree_oid = resolve_revision_for_commit_tree_tree(&repo, &args.tree)
         .with_context(|| format!("not a valid object name: '{}'", args.tree))?;
 
-    // Preserve parent order and duplicates: `git commit-tree -p P -p P` records two parent lines.
+    // Preserve parent order, but omit duplicates like Git.
     let mut parent_oids: Vec<ObjectId> = Vec::new();
+    let mut seen_parents = HashSet::new();
     for p in &args.parents {
         let oid = resolve_revision_for_range_end(&repo, p)
             .with_context(|| format!("not a valid object name: '{p}'"))?;
-        parent_oids.push(oid);
+        if seen_parents.insert(oid) {
+            parent_oids.push(oid);
+        }
     }
 
     // Build commit message

--- a/logs/2026-05-19_18:56-commit-tree-dedup-parents.md
+++ b/logs/2026-05-19_18:56-commit-tree-dedup-parents.md
@@ -1,0 +1,24 @@
+# commit-tree duplicate parents
+
+Branch: `fix-commit-tree-dedup-parents`
+
+Focused on `t0000-basic` without touching the files owned by the existing review branches.
+
+## Findings
+
+- `git commit-tree <tree> -p P -p P` should write one `parent` header.
+- Grit was preserving duplicate `-p` arguments, so the raw commit contained duplicate parent lines.
+
+## Changes
+
+- Deduplicate resolved parent object IDs while preserving first-seen parent order.
+
+## Validation
+
+- `cargo fmt`
+- `cargo fmt --check`
+- `cargo check -p grit-cli`
+- `cargo build --release -p grit-cli`
+- Manual duplicate-parent reproduction produced one `parent` header.
+- `./scripts/run-tests.sh --output-csv /tmp/grit-t0000.csv --no-catalog t0000-basic.sh`
+  moved `t0000-basic` from 91/92 to 92/92.


### PR DESCRIPTION
## Summary

- deduplicate repeated `commit-tree -p` parent arguments after resolving them
- preserve first-seen parent order
- keep dashboard files untouched to avoid conflicts with the existing dashboard PR

## Progress

- `t0000-basic.sh`: 91/92 -> 92/92
- Net test progress: +1 passing upstream test

## Validation

- `cargo fmt`
- `cargo fmt --check`
- `cargo check -p grit-cli`
- `cargo build --release -p grit-cli`
- manual duplicate-parent reproduction produced one `parent` header
- `./scripts/run-tests.sh --output-csv /tmp/grit-t0000.csv --no-catalog t0000-basic.sh` -> 92/92
