### PR TITLE
fix: honor disabled reflog auto creation

### DIFF
--- a/grit-lib/src/refs.rs
+++ b/grit-lib/src/refs.rs
@@ -1046,9 +1046,8 @@ pub fn append_reflog(
     let storage_dir = ref_storage_dir(git_dir, refname);
     let stor = crate::ref_namespace::storage_ref_name(refname);
     let log_path = storage_dir.join("logs").join(&stor);
-    let may_write =
-        force_create || should_autocreate_reflog(git_dir, refname) || !message.is_empty();
-    if !may_write && !log_path.exists() {
+    let may_create = force_create || should_autocreate_reflog(git_dir, refname);
+    if !may_create && !log_path.exists() {
         return Ok(());
     }
     if let Some(parent) = log_path.parent() {

--- a/logs/2026-05-19_19:16-logallrefupdates-reflog-create.md
+++ b/logs/2026-05-19_19:16-logallrefupdates-reflog-create.md
@@ -1,0 +1,21 @@
+# core.logAllRefUpdates reflog creation
+
+## Goal
+
+Make reflog creation honor `core.logAllRefUpdates=0` so unreachable commits are not kept alive by reflogs that Git would not create.
+
+## Notes
+
+- Reproduced `t1420-lost-found.sh` failing because `fsck --lost-found` only wrote the dangling blob, not the reset-away commit.
+- The reset-away commit was still reachable through `.git/logs/HEAD`, created despite `core.logAllRefUpdates = 0`.
+- Fixed `append_reflog` so nonempty messages do not force creation of a missing reflog. Existing reflogs still append, and explicit `force_create` still creates.
+
+## Validation
+
+- `cargo fmt`
+- `cargo check -p grit-cli`
+- `cargo build --release -p grit-cli`
+- `./scripts/run-tests.sh --output-csv /tmp/grit-t1420-fixed.csv --no-catalog t1420-lost-found.sh` -> `2/2`
+- `cargo fmt --check`
+- `cargo test -p grit-lib --lib`
+- `cargo clippy --fix --allow-dirty -p grit-lib` (completed with pre-existing warnings)


### PR DESCRIPTION
## Summary

- Honor `core.logAllRefUpdates=0` when deciding whether to create a missing reflog.
- Keep appending to existing reflogs, and preserve explicit `force_create` behavior.
- Fixes `fsck --lost-found` reachability for reset-away commits that Git would leave dangling.

## Progress

- `t1420-lost-found.sh`: `1/2` -> `2/2`
- Net progress: `+1` passing test case

## Validation

- `cargo fmt`
- `cargo check -p grit-cli`
- `cargo build --release -p grit-cli`
- `./scripts/run-tests.sh --output-csv /tmp/grit-t1420-fixed.csv --no-catalog t1420-lost-found.sh`
- `cargo fmt --check`
- `cargo test -p grit-lib --lib`
- `cargo clippy --fix --allow-dirty -p grit-lib` completed with pre-existing warnings
