### PR TITLE
fix: handle invalid double-star wildmatch

### DIFF
--- a/grit-lib/src/wildmatch.rs
+++ b/grit-lib/src/wildmatch.rs
@@ -65,7 +65,6 @@ fn dowild(p: &[u8], text: &[u8], flags: u32) -> i32 {
                 }
             }
             b'*' => {
-                let star_start = pi;
                 // Determine if this is ** and whether it matches slashes.
                 let prev_p = pi; // position of first *
                 pi += 1;
@@ -115,7 +114,7 @@ fn dowild(p: &[u8], text: &[u8], flags: u32) -> i32 {
                         ti += pos;
                         // Git: leave `text` at `/`, then the for-loop does `text++, p++`.
                         ti += 1;
-                        pi = star_start + 2;
+                        pi += 1;
                         continue;
                     } else {
                         return WM_ABORT_ALL;

--- a/logs/2026-05-19_19:36-wildmatch-invalid-double-star.md
+++ b/logs/2026-05-19_19:36-wildmatch-invalid-double-star.md
@@ -1,0 +1,22 @@
+# wildmatch invalid double-star slash handling
+
+## Goal
+
+Make gitignore pathname wildmatch treat invalid `**` runs as ordinary `*` patterns.
+
+## Notes
+
+- Reproduced `t0008-ignores.sh` failing at `** not confused by matching leading prefix`.
+- Pattern `foo**/bar` should match `foo/bar`, but not `foobar`.
+- In pathname mode, invalid `**` does not get special recursive-directory semantics; it behaves like ordinary stars.
+- The matcher already recognized invalid `**`, but its `*` followed by `/` fast path advanced to the slash in the pattern instead of past it.
+
+## Validation
+
+- `cargo fmt`
+- `cargo check -p grit-cli`
+- `cargo build --release -p grit-cli`
+- `./scripts/run-tests.sh --output-csv /tmp/grit-t0008-fixed.csv --no-catalog t0008-ignores.sh` -> `398/398`
+- `cargo fmt --check`
+- `cargo test -p grit-lib --lib` -> `199 passed`
+- `cargo clippy --fix --allow-dirty -p grit-cli` completed with pre-existing warnings


### PR DESCRIPTION
## Summary

- Treat invalid `**` runs in pathname wildmatch as ordinary star patterns.
- Fix the `*`-followed-by-`/` fast path so `foo**/bar` matches `foo/bar` without matching `foobar`.
- Keep this isolated to the shared wildmatch engine; no tests were modified.

## Progress

- `t0008-ignores.sh`: 397/398 -> 398/398
- Net progress: +1 passing test case

## Validation

- `cargo fmt`
- `cargo check -p grit-cli`
- `cargo build --release -p grit-cli`
- `./scripts/run-tests.sh --output-csv /tmp/grit-t0008-fixed.csv --no-catalog t0008-ignores.sh`
- `cargo fmt --check`
- `cargo test -p grit-lib --lib`
- `cargo clippy --fix --allow-dirty -p grit-cli` completed with pre-existing warnings