### PR TITLE
fix: avoid duplicate update-ref transaction hooks

### DIFF
--- a/grit/src/commands/update_ref.rs
+++ b/grit/src/commands/update_ref.rs
@@ -507,7 +507,7 @@ fn verify_refname_available_for_batch_create(
     }
 }
 
-fn commit_batch_staged(repo: &Repository, args: &Args, staged: &[(bool, BatchOp)]) -> Result<()> {
+fn verify_batch_staged(repo: &Repository, staged: &[(bool, BatchOp)]) -> Result<()> {
     for (nd, op) in staged {
         match op {
             BatchOp::CreateOid { refname, .. } => {
@@ -520,12 +520,21 @@ fn commit_batch_staged(repo: &Repository, args: &Args, staged: &[(bool, BatchOp)
             _ => {}
         }
     }
+    Ok(())
+}
 
-    let hook_updates = hook_updates_for_ops(staged)?;
-    run_ref_transaction_prepare(repo, &hook_updates)?;
+fn apply_batch_staged(repo: &Repository, args: &Args, staged: &[(bool, BatchOp)]) -> Result<()> {
     for (nd, op) in staged {
         apply_batch_op(repo, args, *nd, op.clone())?;
     }
+    Ok(())
+}
+
+fn commit_batch_staged(repo: &Repository, args: &Args, staged: &[(bool, BatchOp)]) -> Result<()> {
+    verify_batch_staged(repo, staged)?;
+    let hook_updates = hook_updates_for_ops(staged)?;
+    run_ref_transaction_prepare(repo, &hook_updates)?;
+    apply_batch_staged(repo, args, staged)?;
     run_ref_transaction_committed(repo, &hook_updates);
     Ok(())
 }
@@ -774,10 +783,11 @@ fn process_batch_command(
 
             let drained: Vec<(bool, BatchOp)> = staged.drain(..).collect();
             let hook_updates = hook_updates_for_ops(&drained)?;
+            verify_batch_staged(repo, &drained)?;
             if !*transaction_prepared {
                 run_ref_transaction_prepare(repo, &hook_updates)?;
             }
-            match commit_batch_staged(repo, args, &drained) {
+            match apply_batch_staged(repo, args, &drained) {
                 Ok(()) => {
                     run_ref_transaction_committed(repo, &hook_updates);
                 }

--- a/logs/2026-05-19_19:47-update-ref-explicit-transaction-hooks.md
+++ b/logs/2026-05-19_19:47-update-ref-explicit-transaction-hooks.md
@@ -1,0 +1,21 @@
+# update-ref explicit transaction hook phases
+
+## Goal
+
+Avoid duplicate `reference-transaction` hook phases when `git update-ref --stdin` uses explicit `prepare` and `commit` commands.
+
+## Notes
+
+- Reproduced `t1416-ref-transaction-hooks.sh` failing at `hook gets all queued symref updates`.
+- The explicit `commit` command prepared the transaction, then called `commit_batch_staged`, which prepared and committed hooks again.
+- Split batch verification/application from hook orchestration so implicit batches keep their hook behavior while explicit transactions run each phase once.
+
+## Validation
+
+- `cargo fmt`
+- `cargo check -p grit-cli`
+- `cargo build --release -p grit-cli`
+- `./scripts/run-tests.sh --output-csv /tmp/grit-t1416-fixed.csv --no-catalog t1416-ref-transaction-hooks.sh` -> `10/10`
+- `cargo fmt --check`
+- `cargo test -p grit-lib --lib` -> `199 passed`
+- `cargo clippy --fix --allow-dirty -p grit-cli` completed with pre-existing warnings


### PR DESCRIPTION
## Summary

- Split update-ref batch verification/application from hook orchestration.
- Avoid replaying `reference-transaction` prepare/commit hooks when `update-ref --stdin` already ran an explicit `prepare`.
- Keep implicit stdin batches using the existing prepare/apply/committed path.

## Progress

- `t1416-ref-transaction-hooks.sh`: 9/10 -> 10/10
- Net progress: +1 passing test case

## Validation

- `cargo fmt`
- `cargo check -p grit-cli`
- `cargo build --release -p grit-cli`
- `./scripts/run-tests.sh --output-csv /tmp/grit-t1416-fixed.csv --no-catalog t1416-ref-transaction-hooks.sh`
- `cargo fmt --check`
- `cargo test -p grit-lib --lib`
- `cargo clippy --fix --allow-dirty -p grit-cli` completed with pre-existing warnings