### PR TITLE
fix: sparse-checkout worktree config and apply (t1091 54/77)

### DIFF
--- a/data/test-files.csv
+++ b/data/test-files.csv
@@ -190,7 +190,7 @@ t10880-reset-hard-soft-path	t1	yes	31	1	30	false	ok	0
 t10890-cherry-pick-message	t1	yes	30	2	28	false	ok	0
 t1090-sparse-checkout-scope	t1	yes	7	5	2	false	ok	0
 t10900-for-each-ref-pattern-sort	t1	yes	34	2	32	false	ok	0
-t1091-sparse-checkout-builtin	t1	yes	76	27	49	false	ok	1
+t1091-sparse-checkout-builtin	t1	yes	77	54	22	false	ok	1
 t10910-show-ref-tags-branches	t1	yes	35	3	32	false	ok	0
 t1092-sparse-checkout-compatibility	t1	yes	106	1	105	false	ok	0
 t10920-update-ref-create-delete	t1	yes	29	2	27	false	ok	0

--- a/docs/index.html
+++ b/docs/index.html
@@ -1066,8 +1066,8 @@ grit-lib = <span class="string">"0.1"</span>
               <div class="suite-stat" style="--pct: 90.5%">
                 <span>t0 basics</span><strong>90.5%</strong>
               </div>
-              <div class="suite-stat" style="--pct: 43.2%">
-                <span>t1 database</span><strong>43.2%</strong>
+              <div class="suite-stat" style="--pct: 43.4%">
+                <span>t1 database</span><strong>43.4%</strong>
               </div>
               <div class="suite-stat" style="--pct: 55.4%">
                 <span>t2 worktree</span><strong>55.4%</strong>
@@ -1095,8 +1095,8 @@ grit-lib = <span class="string">"0.1"</span>
               </div>
             </div>
             <p>
-              Latest generated harness pass rate: 21,257 of
-              41,219 in-scope tests. Open the dashboard for exact
+              Latest generated harness pass rate: 21,284 of
+              41,220 in-scope tests. Open the dashboard for exact
               counts.
             </p>
           </a>

--- a/docs/progress/index.html
+++ b/docs/progress/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Grit Project Progress</title>
 <meta property="og:title" content="Grit Project Progress">
-<meta property="og:description" content="51.6% of harness tests passing (21,257 / 41,219).">
+<meta property="og:description" content="51.6% of harness tests passing (21,284 / 41,220).">
 <meta property="og:image" content="https://schacon.github.io/grit/test-progress.svg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Grit Project Progress">
-<meta name="twitter:description" content="51.6% of harness tests passing (21,257 / 41,219).">
+<meta name="twitter:description" content="51.6% of harness tests passing (21,284 / 41,220).">
 <meta name="twitter:image" content="https://schacon.github.io/grit/test-progress.svg">
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -148,7 +148,7 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
 </head>
 <body>
 <h1>Grit Project Progress</h1>
-<p class="sub">Generated <time datetime="2026-05-20T08:50:17+00:00" class="gen-time" title="2026-05-20 08:50 UTC">2026-05-20 08:50 UTC</time> · <a href="https://github.com/schacon/grit/commit/d692228eb87e20b80d24eb4451625f67e99ef28f" style="color:#58a6ff">d692228</a> · <a href="../testfiles.html" style="color:#58a6ff">All test files</a></p>
+<p class="sub">Generated <time datetime="2026-05-20T09:38:21+00:00" class="gen-time" title="2026-05-20 09:38 UTC">2026-05-20 09:38 UTC</time> · <a href="https://github.com/schacon/grit/commit/13cfb30c9304a5f19703222e7ce9d96e5747b643" style="color:#58a6ff">13cfb30</a> · <a href="../testfiles.html" style="color:#58a6ff">All test files</a></p>
 
 <section class="summary-hero" aria-label="Overall test progress">
   <div class="summary-big">
@@ -157,11 +157,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="summary-big-lbl">Passing</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">21,257</div>
+      <div class="summary-big-val">21,284</div>
       <div class="summary-big-lbl">Tests passed</div>
     </div>
     <div class="summary-big-item">
-      <div class="summary-big-val">41,219</div>
+      <div class="summary-big-val">41,220</div>
       <div class="summary-big-lbl">Total tests</div>
     </div>
   </div>
@@ -197,11 +197,11 @@ h1 { font-size: 1.75rem; margin-bottom: 0.25rem; color: #f0f6fc; }
       <div class="group-line1">
         <span class="group-id">t1</span>
         <span class="group-desc">Basic commands concerning the database</span>
-        <span class="group-meta">80/368 files · 8 skipped · 5,493/12,727 tests</span>
+        <span class="group-meta">80/368 files · 8 skipped · 5,520/12,728 tests</span>
       </div>
       <div class="group-line2">
-        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:43.2%"></div></div>
-        <span class="group-pct pct-orange">43.2%</span>
+        <div class="bar-bg"><div class="bar-fg pct-orange" style="width:43.4%"></div></div>
+        <span class="group-pct pct-orange">43.4%</span>
       </div>
     </a>
     <a class="group-card" href="../testfiles.html?group=t2">

--- a/docs/test-progress.svg
+++ b/docs/test-progress.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 132" width="780" height="132" role="img" aria-labelledby="svg-title svg-desc">
   <title id="svg-title">Grit harness: upstream test progress</title>
-  <desc id="svg-desc">21257 of 41219 tests passing across 1424 harness files (51.6% pass rate).</desc>
+  <desc id="svg-desc">21284 of 41220 tests passing across 1424 harness files (51.6% pass rate).</desc>
   <rect x="0" y="0" width="780" height="132" rx="6" fill="#0d1117" stroke="#30363d"/>
   <text x="40" y="38" fill="#f0f6fc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="600">Grit harness test progress</text>
-  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">51.6% pass rate · 21,257 / 41,219 tests · 1,424 files in scope · 389 fully passing · 183 skipped</text>
+  <text x="40" y="64" fill="#8b949e" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">51.6% pass rate · 21,284 / 41,220 tests · 1,424 files in scope · 389 fully passing · 183 skipped</text>
   <rect x="40" y="80" width="700" height="18" rx="9" fill="#21262d" stroke="#30363d"/>
   <rect x="40" y="80" width="361" height="18" rx="9" fill="#d29922"/>
   <text x="40" y="118" fill="#6e7681" font-family="ui-monospace,monospace" font-size="11">Generated from data/test-files.csv</text>

--- a/docs/testfiles.html
+++ b/docs/testfiles.html
@@ -100,12 +100,12 @@ tr.row-skip td { opacity: 0.65; }
 </head>
 <body>
 <h1>Test files</h1>
-<p class="sub"><a href="progress/">Dashboard</a> · <time datetime="2026-05-20T08:50:17+00:00" class="gen-time" title="2026-05-20 08:50 UTC">2026-05-20 08:50 UTC</time> · <a href="https://github.com/schacon/grit/commit/d692228eb87e20b80d24eb4451625f67e99ef28f" style="color:#58a6ff">d692228</a></p>
+<p class="sub"><a href="progress/">Dashboard</a> · <time datetime="2026-05-20T09:38:21+00:00" class="gen-time" title="2026-05-20 09:38 UTC">2026-05-20 09:38 UTC</time> · <a href="https://github.com/schacon/grit/commit/13cfb30c9304a5f19703222e7ce9d96e5747b643" style="color:#58a6ff">13cfb30</a></p>
 
 <div class="summary-cards" id="summaryCards" aria-label="Aggregate counts for the current view (group, search, and Remaining work only)" aria-live="polite">
   <div class="card"><div class="n" id="sum-files">1,424</div><div class="lbl">Files in scope</div></div>
-  <div class="card"><div class="n" id="sum-tests">41,219</div><div class="lbl">Unskipped tests</div></div>
-  <div class="card accent"><div class="n" id="sum-passed">21,257</div><div class="lbl">Tests passed</div></div>
+  <div class="card"><div class="n" id="sum-tests">41,220</div><div class="lbl">Unskipped tests</div></div>
+  <div class="card accent"><div class="n" id="sum-passed">21,284</div><div class="lbl">Tests passed</div></div>
   <div class="card accent"><div class="n" id="sum-pct">51.6%</div><div class="lbl">Pass rate</div></div>
 </div>
 <p class="summary-note" id="summaryNote"></p>
@@ -2057,14 +2057,14 @@ tr.row-skip td { opacity: 0.65; }
   <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:5.9%"></div></div></td>
   <td class="right small">0</td>
 </tr>
-<tr class="" data-group="t1" data-tests="76" data-passed="27">
+<tr class="" data-group="t1" data-tests="77" data-passed="54">
   <td class="mono">t1091-sparse-checkout-builtin</td>
   <td>t1</td>
   <td></td>
-  <td class="right">76</td>
-  <td class="right">27</td>
+  <td class="right">77</td>
+  <td class="right">54</td>
   <td class="right">ok</td>
-  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:35.5%"></div></div></td>
+  <td class="bar"><div class="bar-bg"><div class="bar-fg" style="width:70.1%"></div></div></td>
   <td class="right small">1</td>
 </tr>
 <tr class="" data-group="t1" data-tests="35" data-passed="3">

--- a/grit-lib/src/ignore.rs
+++ b/grit-lib/src/ignore.rs
@@ -693,6 +693,8 @@ fn gitignore_prefix_is_literal(prefix: &str) -> bool {
 struct SparsePattern {
     negative: bool,
     directory_only: bool,
+    /// Git `PATTERN_FLAG_NODIR`: pattern has no `/` (e.g. `/*`) — matches files only.
+    nodir: bool,
     anchored: bool,
     has_slash: bool,
     body: String,
@@ -743,9 +745,11 @@ impl SparsePattern {
         }
 
         let has_slash = raw.contains('/');
+        let nodir = !has_slash && !directory_only;
         Some(Self {
             negative,
             directory_only,
+            nodir,
             anchored,
             has_slash,
             body: raw,
@@ -759,6 +763,9 @@ impl SparsePattern {
 /// patterns with a trailing `/` in the sparse file (`PATTERN_FLAG_MUSTBEDIR`) only
 /// participate in those iterations.
 fn sparse_pattern_matches(p: &SparsePattern, pathname: &str, as_directory: bool) -> bool {
+    if p.nodir && as_directory {
+        return false;
+    }
     if p.directory_only && !as_directory {
         return false;
     }
@@ -970,6 +977,25 @@ fn path_to_slash(path: &Path) -> String {
         out.push_str(&component.as_os_str().to_string_lossy());
     }
     out
+}
+
+#[cfg(test)]
+mod sparse_checkout_tests {
+    use super::*;
+
+    #[test]
+    fn non_cone_default_init_patterns() {
+        let lines = vec!["/*".into(), "!/*/".into()];
+        assert!(path_in_sparse_checkout("a", &lines, None));
+        assert!(!path_in_sparse_checkout("folder1/a", &lines, None));
+        let wt = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+        // work_tree only affects directory vs file matching on parent walks
+        let wt = std::env::temp_dir().join("grit-sparse-wt-test");
+        let _ = std::fs::create_dir_all(wt.join("folder1"));
+        let _ = std::fs::write(wt.join("a"), b"x");
+        assert!(!path_in_sparse_checkout("folder1/a", &lines, Some(&wt)));
+        assert!(!path_in_sparse_checkout("folder1", &lines, Some(&wt)));
+    }
 }
 
 #[cfg(test)]

--- a/grit-lib/src/repo.rs
+++ b/grit-lib/src/repo.rs
@@ -1131,6 +1131,72 @@ pub fn worktree_config_enabled(common_dir: &Path) -> bool {
     false
 }
 
+fn open_or_create_config_file(path: &Path, scope: ConfigScope) -> Result<ConfigFile> {
+    match ConfigFile::from_path(path, scope)? {
+        Some(f) => Ok(f),
+        None => {
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).map_err(Error::Io)?;
+            }
+            ConfigFile::parse(path, "", scope)
+        }
+    }
+}
+
+fn config_file_bool_true(cfg: &ConfigFile, key: &str) -> bool {
+    cfg.get(key).is_some_and(|v| {
+        matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "true" | "yes" | "on" | "1"
+        )
+    })
+}
+
+/// Enable per-worktree configuration (`extensions.worktreeConfig`) and create
+/// `config.worktree`, matching Git's `init_worktree_config` in `worktree.c`.
+///
+/// When `core.bare` is true or `core.worktree` is set in the common config,
+/// those keys are moved into `config.worktree` so linked worktrees keep working.
+///
+/// # Errors
+///
+/// Returns [`Error::Io`] or [`Error::ConfigError`] if config files cannot be read or written.
+pub fn init_worktree_config(git_dir: &Path) -> Result<()> {
+    let common_dir = common_git_dir_for_config(git_dir);
+    let common_config_path = common_dir.join("config");
+    let worktree_config_path = git_dir.join("config.worktree");
+
+    if worktree_config_enabled(&common_dir) {
+        if !worktree_config_path.exists() {
+            if let Some(parent) = worktree_config_path.parent() {
+                fs::create_dir_all(parent).map_err(Error::Io)?;
+            }
+            fs::write(&worktree_config_path, "").map_err(Error::Io)?;
+        }
+        return Ok(());
+    }
+
+    let mut common_cfg =
+        open_or_create_config_file(&common_config_path, ConfigScope::Local)?;
+    common_cfg.set("extensions.worktreeConfig", "true")?;
+
+    let mut wt_cfg =
+        open_or_create_config_file(&worktree_config_path, ConfigScope::Worktree)?;
+
+    if config_file_bool_true(&common_cfg, "core.bare") {
+        wt_cfg.set("core.bare", "true")?;
+        common_cfg.unset("core.bare")?;
+    }
+    if let Some(worktree) = common_cfg.get("core.worktree") {
+        wt_cfg.set("core.worktree", &worktree)?;
+        common_cfg.unset("core.worktree")?;
+    }
+
+    common_cfg.write()?;
+    wt_cfg.write()?;
+    Ok(())
+}
+
 /// If the common `config` declares a repository format newer than Git's
 /// `GIT_REPO_VERSION_READ`, return the human message Git prints for
 /// `discover_git_directory_reason` / t1309.

--- a/grit/src/commands/sparse_checkout.rs
+++ b/grit/src/commands/sparse_checkout.rs
@@ -149,7 +149,7 @@ pub(crate) fn finalize_sparse_clone(repo: &Repository, apply_to_index: bool) -> 
     if apply_to_index {
         crate::commands::clone::ensure_index_from_head_if_missing(repo)?;
     }
-    init_worktree_config(repo)?;
+    grit_lib::repo::init_worktree_config(&repo.git_dir)?;
     set_sparse_config(repo, true)?;
     set_cone_config(repo, true)?;
     let ws = ConeWorkspace::default();
@@ -199,18 +199,6 @@ fn worktree_config_path(repo: &Repository) -> PathBuf {
     repo.git_dir.join("config.worktree")
 }
 
-fn init_worktree_config(repo: &Repository) -> Result<()> {
-    let p = worktree_config_path(repo);
-    if p.exists() {
-        return Ok(());
-    }
-    if let Some(parent) = p.parent() {
-        fs::create_dir_all(parent).ok();
-    }
-    fs::write(&p, "").context("creating config.worktree")?;
-    Ok(())
-}
-
 fn load_merged_config(repo: &Repository) -> grit_lib::config::ConfigSet {
     grit_lib::config::ConfigSet::load(Some(&repo.git_dir), true).unwrap_or_default()
 }
@@ -242,7 +230,7 @@ fn release_sparse_lock(repo: &Repository) {
 }
 
 fn set_sparse_config(repo: &Repository, enable: bool) -> Result<()> {
-    init_worktree_config(repo)?;
+    grit_lib::repo::init_worktree_config(&repo.git_dir)?;
     let path = worktree_config_path(repo);
     let content = fs::read_to_string(&path).unwrap_or_default();
     let mut cfg = ConfigFile::parse(&path, &content, ConfigScope::Worktree)?;
@@ -252,7 +240,7 @@ fn set_sparse_config(repo: &Repository, enable: bool) -> Result<()> {
 }
 
 fn set_cone_config(repo: &Repository, cone: bool) -> Result<()> {
-    init_worktree_config(repo)?;
+    grit_lib::repo::init_worktree_config(&repo.git_dir)?;
     let path = worktree_config_path(repo);
     let content = fs::read_to_string(&path).unwrap_or_default();
     let mut cfg = ConfigFile::parse(&path, &content, ConfigScope::Worktree)?;
@@ -265,7 +253,7 @@ fn set_cone_config(repo: &Repository, cone: bool) -> Result<()> {
 }
 
 fn set_sparse_index_config(repo: &Repository, enable: bool) -> Result<()> {
-    init_worktree_config(repo)?;
+    grit_lib::repo::init_worktree_config(&repo.git_dir)?;
     let path = worktree_config_path(repo);
     let content = fs::read_to_string(&path).unwrap_or_default();
     let mut cfg = ConfigFile::parse(&path, &content, ConfigScope::Worktree)?;
@@ -1191,14 +1179,9 @@ fn apply_sparse_patterns(repo: &Repository, patterns: &[String], cone_mode: bool
                 }
             }
         } else {
-            // Paths explicitly materialized in the work tree (`skip-worktree` cleared, e.g.
-            // `git update-index --no-skip-worktree` or `git add --sparse`) must not be deleted
-            // when sparse rules are reapplied (`git reset` → `reapply_sparse_checkout_if_configured`).
-            let preserve_worktree_file =
-                !entry.skip_worktree() && fs::symlink_metadata(work_tree.join(&path_str)).is_ok();
             entry.set_skip_worktree(true);
             let full_path = work_tree.join(&path_str);
-            if full_path.exists() && !preserve_worktree_file {
+            if fs::symlink_metadata(&full_path).is_ok() {
                 let _ = fs::remove_file(&full_path);
                 if let Some(parent) = full_path.parent() {
                     remove_empty_dirs_up_to(parent, work_tree);

--- a/logs/2026-05-20-sparse-checkout-t1091.md
+++ b/logs/2026-05-20-sparse-checkout-t1091.md
@@ -1,0 +1,3 @@
+# Sparse checkout — t1091 (2026-05-20)
+
+Claimed Phase 2.1 cone/non-cone pattern load/save. Baseline: `t1091-sparse-checkout-builtin` 27/76 in `data/test-files.csv`.

--- a/plans/old-plan.md
+++ b/plans/old-plan.md
@@ -121,7 +121,7 @@ Build on existing `sparse_checkout.rs` and index `sdir` extension support.
 
 ### 2.1 Sparse index and read-tree integration
 
-- [ ] Cone/non-cone pattern load/save (`$GIT_DIR/info/sparse-checkout`,
+- [~] Cone/non-cone pattern load/save (`$GIT_DIR/info/sparse-checkout`,
   `index.sparse` config).
 - [ ] `read-tree` / checkout: only materialize included paths; skip-worktree +
   sparse directory entries in index v4.


### PR DESCRIPTION
## Summary
- Enable `extensions.worktreeConfig` when sparse-checkout writes `config.worktree` so `core.sparseCheckout` is visible to the config layer.
- Fix non-cone `/*` pattern matching (Git `PATTERN_FLAG_NODIR`) and remove excluded worktree files on sparse-checkout apply/reapply.
- Phase 2.1 in progress: `t1091-sparse-checkout-builtin` **54/77** (was 27/77).

## Test plan
- [x] `./scripts/run-tests.sh t1091-sparse-checkout-builtin.sh`

Made with [Cursor](https://cursor.com)