### PR TITLE
Add grit-http-server PoC and fix upload-pack ref advertisement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +95,58 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "base64"
@@ -110,6 +168,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -323,6 +387,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,6 +482,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "grit-http-server"
+version = "0.2.1"
+dependencies = [
+ "anyhow",
+ "axum",
+ "clap",
+ "grit-protocol",
+ "serde",
+ "tokio",
+]
+
+[[package]]
 name = "grit-lib"
 version = "0.2.1"
 dependencies = [
@@ -404,6 +513,14 @@ dependencies = [
  "time",
  "unicode-width",
  "url",
+]
+
+[[package]]
+name = "grit-protocol"
+version = "0.2.1"
+dependencies = [
+ "anyhow",
+ "grit-lib",
 ]
 
 [[package]]
@@ -443,6 +560,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "http"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hungarian"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,6 +613,41 @@ dependencies = [
  "fixedbitset",
  "ndarray",
  "num-traits",
+]
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -620,7 +817,7 @@ dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -636,10 +833,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "matrixmultiply"
@@ -667,6 +879,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -674,6 +892,17 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -748,10 +977,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "plain"
@@ -813,6 +1071,15 @@ name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -915,6 +1182,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,6 +1206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -960,6 +1240,29 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -997,6 +1300,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1009,10 +1322,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -1042,6 +1371,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "synstructure"
@@ -1126,6 +1461,82 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["grit", "grit-lib"]
+members = ["grit", "grit-lib", "grit-protocol", "grit-http-server"]
 resolver = "2"
 
 [workspace.package]

--- a/grit-http-server/Cargo.toml
+++ b/grit-http-server/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "grit-http-server"
+version.workspace = true
+edition.workspace = true
+license = "MIT"
+description = "Git smart HTTP server powered by grit"
+repository = "https://github.com/schacon/grit"
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "grit-http-server"
+path = "src/main.rs"
+
+[dependencies]
+grit-protocol = { version = "0.2", path = "../grit-protocol" }
+axum = "0.8"
+tokio = { version = "1", features = ["full"] }
+anyhow.workspace = true
+clap.workspace = true
+serde = { version = "1", features = ["derive"] }

--- a/grit-http-server/src/main.rs
+++ b/grit-http-server/src/main.rs
@@ -1,0 +1,225 @@
+//! Minimal Git smart HTTP server powered by grit.
+//!
+//! Implements the four endpoints required for git clone/push over HTTP:
+//!   GET  /:repo/info/refs?service=git-upload-pack
+//!   GET  /:repo/info/refs?service=git-receive-pack
+//!   POST /:repo/git-upload-pack
+//!   POST /:repo/git-receive-pack
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::Result;
+use axum::{
+    body::Bytes,
+    extract::{Path, Query, State},
+    http::{header, StatusCode},
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use clap::Parser;
+
+#[derive(Parser)]
+#[command(name = "grit-http-server", about = "Git smart HTTP server powered by grit")]
+struct Args {
+    /// Root directory containing bare repositories
+    #[arg(short, long, default_value = ".")]
+    root: PathBuf,
+
+    /// Address to bind to
+    #[arg(short, long, default_value = "127.0.0.1:9418")]
+    bind: String,
+}
+
+#[derive(Clone)]
+struct AppState {
+    root: PathBuf,
+}
+
+impl AppState {
+    fn repo_path(&self, repo: &str) -> Result<PathBuf, Response> {
+        // Sanitize: reject path traversal
+        if repo.contains("..") {
+            return Err((StatusCode::BAD_REQUEST, "invalid repository path").into_response());
+        }
+        let path = self.root.join(repo);
+        grit_protocol::validate_repo_path(&path).map_err(|_| {
+            (StatusCode::NOT_FOUND, "repository not found").into_response()
+        })
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct InfoRefsQuery {
+    service: Option<String>,
+}
+
+fn pkt_line(data: &str) -> Vec<u8> {
+    let len = data.len() + 4;
+    format!("{len:04x}{data}").into_bytes()
+}
+
+fn no_cache_headers(builder: axum::http::response::Builder) -> axum::http::response::Builder {
+    builder
+        .header(header::EXPIRES, "Fri, 01 Jan 1980 00:00:00 GMT")
+        .header(header::PRAGMA, "no-cache")
+        .header(header::CACHE_CONTROL, "no-cache, max-age=0, must-revalidate")
+}
+
+// GET /:repo/info/refs?service=git-upload-pack or git-receive-pack
+async fn info_refs(
+    State(state): State<Arc<AppState>>,
+    Path(repo): Path<String>,
+    Query(query): Query<InfoRefsQuery>,
+) -> Response {
+    let service = match &query.service {
+        Some(s) if s == "git-upload-pack" || s == "git-receive-pack" => s.clone(),
+        _ => {
+            return (StatusCode::BAD_REQUEST, "unsupported service").into_response();
+        }
+    };
+
+    let repo_path = match state.repo_path(&repo) {
+        Ok(p) => p,
+        Err(e) => return e,
+    };
+
+    // Parse protocol version from query (Git protocol v2 sends it via Git-Protocol header,
+    // but for the PoC we just support v1 and detect v2 from the environment)
+    let protocol_version = None; // v1 for now
+
+    let content_type = format!("application/x-{service}-advertisement");
+
+    let advertisement = match service.as_str() {
+        "git-upload-pack" => {
+            grit_protocol::upload_pack::advertise_refs(&repo_path, protocol_version)
+        }
+        "git-receive-pack" => grit_protocol::receive_pack::advertise_refs(&repo_path),
+        _ => unreachable!(),
+    };
+
+    let raw_adv = match advertisement {
+        Ok(data) => data,
+        Err(e) => {
+            eprintln!("info/refs error: {e:#}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "internal error").into_response();
+        }
+    };
+
+    // Build the response: pkt-line service header + flush + raw advertisement
+    let mut body = Vec::new();
+    body.extend_from_slice(&pkt_line(&format!("# service={service}\n")));
+    body.extend_from_slice(b"0000"); // flush-pkt
+    body.extend_from_slice(&raw_adv);
+
+    no_cache_headers(axum::http::Response::builder())
+        .header(header::CONTENT_TYPE, content_type)
+        .body(axum::body::Body::from(body))
+        .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
+}
+
+// POST /:repo/git-upload-pack
+async fn upload_pack_rpc(
+    State(state): State<Arc<AppState>>,
+    Path(repo): Path<String>,
+    body: Bytes,
+) -> Response {
+    let repo_path = match state.repo_path(&repo) {
+        Ok(p) => p,
+        Err(e) => return e,
+    };
+
+    let protocol_version = None;
+
+    match grit_protocol::upload_pack::stateless_rpc(&repo_path, &body, protocol_version) {
+        Ok(data) => no_cache_headers(axum::http::Response::builder())
+            .header(header::CONTENT_TYPE, "application/x-git-upload-pack-result")
+            .body(axum::body::Body::from(data))
+            .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response()),
+        Err(e) => {
+            eprintln!("upload-pack error: {e:#}");
+            (StatusCode::INTERNAL_SERVER_ERROR, "upload-pack failed").into_response()
+        }
+    }
+}
+
+// POST /:repo/git-receive-pack
+async fn receive_pack_rpc(
+    State(state): State<Arc<AppState>>,
+    Path(repo): Path<String>,
+    body: Bytes,
+) -> Response {
+    let repo_path = match state.repo_path(&repo) {
+        Ok(p) => p,
+        Err(e) => return e,
+    };
+
+    match grit_protocol::receive_pack::stateless_rpc(&repo_path, &body) {
+        Ok(data) => no_cache_headers(axum::http::Response::builder())
+            .header(header::CONTENT_TYPE, "application/x-git-receive-pack-result")
+            .body(axum::body::Body::from(data))
+            .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response()),
+        Err(e) => {
+            eprintln!("receive-pack error: {e:#}");
+            (StatusCode::INTERNAL_SERVER_ERROR, "receive-pack failed").into_response()
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+
+    let root = std::fs::canonicalize(&args.root)?;
+    eprintln!("Serving repositories from: {}", root.display());
+
+    let state = Arc::new(AppState { root });
+
+    let app = Router::new()
+        .route("/{*repo}", get(info_refs_dispatch).post(rpc_dispatch))
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind(&args.bind).await?;
+    eprintln!("Listening on {}", args.bind);
+    axum::serve(listener, app).await?;
+
+    Ok(())
+}
+
+// Dispatch GET requests — only info/refs is valid
+async fn info_refs_dispatch(
+    state: State<Arc<AppState>>,
+    Path(full_path): Path<String>,
+    query: Query<InfoRefsQuery>,
+) -> Response {
+    if let Some(repo) = full_path.strip_suffix("/info/refs") {
+        if repo.is_empty() {
+            return (StatusCode::BAD_REQUEST, "missing repository").into_response();
+        }
+        info_refs(state, Path(repo.to_string()), query).await
+    } else {
+        (StatusCode::NOT_FOUND, "not found").into_response()
+    }
+}
+
+// Dispatch POST requests to upload-pack or receive-pack
+async fn rpc_dispatch(
+    state: State<Arc<AppState>>,
+    Path(full_path): Path<String>,
+    body: Bytes,
+) -> Response {
+    if let Some(repo) = full_path.strip_suffix("/git-upload-pack") {
+        if repo.is_empty() {
+            return (StatusCode::BAD_REQUEST, "missing repository").into_response();
+        }
+        upload_pack_rpc(state, Path(repo.to_string()), body).await
+    } else if let Some(repo) = full_path.strip_suffix("/git-receive-pack") {
+        if repo.is_empty() {
+            return (StatusCode::BAD_REQUEST, "missing repository").into_response();
+        }
+        receive_pack_rpc(state, Path(repo.to_string()), body).await
+    } else {
+        (StatusCode::NOT_FOUND, "not found").into_response()
+    }
+}

--- a/grit-protocol/Cargo.toml
+++ b/grit-protocol/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "grit-protocol"
+version.workspace = true
+edition.workspace = true
+license = "MIT"
+description = "Git smart protocol handlers for the grit implementation"
+repository = "https://github.com/schacon/grit"
+
+[lints]
+workspace = true
+
+[dependencies]
+grit-lib = { version = "0.2", path = "../grit-lib" }
+anyhow.workspace = true

--- a/grit-protocol/src/lib.rs
+++ b/grit-protocol/src/lib.rs
@@ -1,0 +1,47 @@
+//! Git smart protocol handlers for HTTP transport.
+//!
+//! Provides a clean Rust API for running git upload-pack and receive-pack
+//! operations. Currently implemented by spawning `grit` as a subprocess
+//! with piped I/O — the same model as `git-http-backend`.
+//!
+//! Future work: replace subprocess calls with in-process protocol handling
+//! once the core protocol logic is libified with generic Read/Write streams.
+
+pub mod upload_pack;
+pub mod receive_pack;
+
+use std::path::{Path, PathBuf};
+
+/// Find the grit executable path.
+///
+/// Checks `GUST_BIN` env var first (for test harness compatibility),
+/// then falls back to `grit` on PATH.
+pub fn grit_executable() -> PathBuf {
+    if let Ok(bin) = std::env::var("GUST_BIN") {
+        if !bin.is_empty() {
+            return PathBuf::from(bin);
+        }
+    }
+    // Try the same binary that's running (if we're inside grit)
+    if let Ok(exe) = std::env::current_exe() {
+        let name = exe.file_name().unwrap_or_default().to_string_lossy();
+        if name.starts_with("grit") {
+            return exe;
+        }
+    }
+    PathBuf::from("grit")
+}
+
+/// Validate that a path looks like a git repository (bare or non-bare).
+pub fn validate_repo_path(path: &Path) -> anyhow::Result<PathBuf> {
+    // Bare repo: has HEAD file directly
+    if path.join("HEAD").is_file() {
+        return Ok(path.to_path_buf());
+    }
+    // Non-bare: has .git/HEAD
+    let dot_git = path.join(".git");
+    if dot_git.join("HEAD").is_file() {
+        return Ok(path.to_path_buf());
+    }
+    anyhow::bail!("not a git repository: {}", path.display())
+}

--- a/grit-protocol/src/receive_pack.rs
+++ b/grit-protocol/src/receive_pack.rs
@@ -1,0 +1,137 @@
+//! Receive-pack protocol handler (server side of push).
+//!
+//! Wraps `grit receive-pack` subprocess with piped I/O for use in
+//! HTTP smart transport.
+
+use anyhow::{Context, Result};
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+/// Find the byte offset of the first flush packet (`0000`) in pkt-line data.
+/// Returns the offset of the `0000` itself, or `None` if not found.
+fn find_flush(data: &[u8]) -> Option<usize> {
+    let mut pos = 0;
+    while pos + 4 <= data.len() {
+        let len_hex = &data[pos..pos + 4];
+        if len_hex == b"0000" {
+            return Some(pos);
+        }
+        if let Ok(s) = std::str::from_utf8(len_hex) {
+            if let Ok(len) = usize::from_str_radix(s, 16) {
+                if len < 4 || pos + len > data.len() {
+                    break;
+                }
+                pos += len;
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    None
+}
+
+/// Return only the ref advertisement (up to and including the flush).
+///
+/// `grit receive-pack` with stdin closed outputs the advertisement
+/// followed by a spurious report-status. We truncate at the first flush.
+fn advertisement_only(data: &[u8]) -> Vec<u8> {
+    match find_flush(data) {
+        Some(pos) => data[..pos + 4].to_vec(),
+        None => data.to_vec(),
+    }
+}
+
+/// Strip the ref advertisement prefix from receive-pack output,
+/// returning only the report-status that follows the first flush.
+fn strip_advertisement(data: &[u8]) -> Vec<u8> {
+    match find_flush(data) {
+        Some(pos) => data[pos + 4..].to_vec(),
+        None => data.to_vec(),
+    }
+}
+
+/// Run receive-pack ref advertisement (for `GET /info/refs?service=git-receive-pack`).
+///
+/// Returns the raw pkt-line advertisement bytes.
+pub fn advertise_refs(repo_path: &Path) -> Result<Vec<u8>> {
+    let grit = crate::grit_executable();
+    let mut cmd = Command::new(&grit);
+    cmd.arg("receive-pack")
+        .arg(repo_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    // For info/refs discovery, we need to get just the advertisement.
+    // receive-pack writes the advertisement then reads from stdin.
+    // We close stdin immediately to make it exit after advertising.
+    let mut child = cmd
+        .spawn()
+        .with_context(|| format!("failed to spawn '{} receive-pack'", grit.display()))?;
+
+    // Close stdin immediately — receive-pack will write its ref advertisement
+    // and then try to read, hitting EOF and exiting.
+    drop(child.stdin.take());
+
+    let output = child
+        .wait_with_output()
+        .context("failed to wait for receive-pack")?;
+
+    // receive-pack may exit non-zero when stdin closes early — that's expected
+    // for the advertisement phase. We just need the stdout.
+    if output.stdout.is_empty() && !output.status.success() {
+        let err = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("receive-pack advertisement failed: {}", err.trim());
+    }
+
+    Ok(advertisement_only(&output.stdout))
+}
+
+/// Run a stateless receive-pack RPC exchange (for `POST /git-receive-pack`).
+///
+/// Takes the request body (pkt-line commands + pack data) and returns
+/// the response (report-status).
+pub fn stateless_rpc(
+    repo_path: &Path,
+    request_body: &[u8],
+) -> Result<Vec<u8>> {
+    let grit = crate::grit_executable();
+    let mut cmd = Command::new(&grit);
+    cmd.arg("receive-pack")
+        .arg(repo_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = cmd
+        .spawn()
+        .with_context(|| format!("failed to spawn '{} receive-pack'", grit.display()))?;
+
+    // Write the request body to stdin.
+    // receive-pack first writes its advertisement to stdout, then reads from stdin.
+    // For HTTP stateless mode, the advertisement was already sent in the info/refs phase.
+    // We need to feed the push data after the advertisement is written.
+    if let Some(mut stdin) = child.stdin.take() {
+        // Write request body — the push commands + pack data
+        let _ = stdin.write_all(request_body);
+        // Close stdin to signal end of input
+    }
+
+    let output = child
+        .wait_with_output()
+        .context("failed to wait for receive-pack")?;
+
+    if !output.status.success() {
+        let err = String::from_utf8_lossy(&output.stderr);
+        if !output.stdout.is_empty() {
+            eprintln!("receive-pack stderr (non-fatal): {}", err.trim());
+            return Ok(strip_advertisement(&output.stdout));
+        }
+        anyhow::bail!("receive-pack failed: {}", err.trim());
+    }
+
+    Ok(strip_advertisement(&output.stdout))
+}

--- a/grit-protocol/src/upload_pack.rs
+++ b/grit-protocol/src/upload_pack.rs
@@ -1,0 +1,105 @@
+//! Upload-pack protocol handler (server side of fetch/clone).
+//!
+//! Wraps `grit upload-pack` subprocess with piped I/O for use in
+//! HTTP smart transport.
+
+use anyhow::{Context, Result};
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+/// Run upload-pack ref advertisement (for `GET /info/refs?service=git-upload-pack`).
+///
+/// Returns the raw pkt-line advertisement bytes suitable for wrapping
+/// in an HTTP response with service header.
+pub fn advertise_refs(
+    repo_path: &Path,
+    protocol_version: Option<u8>,
+) -> Result<Vec<u8>> {
+    let grit = crate::grit_executable();
+    let mut cmd = Command::new(&grit);
+    cmd.arg("upload-pack")
+        .arg("--stateless-rpc")
+        .arg("--http-backend-info-refs")
+        .arg(repo_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    if let Some(v) = protocol_version {
+        cmd.env("GIT_PROTOCOL", format!("version={v}"));
+    }
+
+    let output = cmd
+        .output()
+        .with_context(|| format!("failed to spawn '{} upload-pack'", grit.display()))?;
+
+    if !output.status.success() {
+        let err = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("upload-pack --advertise-refs failed: {}", err.trim());
+    }
+
+    Ok(output.stdout)
+}
+
+/// Run a stateless upload-pack RPC exchange (for `POST /git-upload-pack`).
+///
+/// Takes the request body as input and returns the response body.
+/// Supports both protocol v1 (stateless-rpc) and v2.
+pub fn stateless_rpc(
+    repo_path: &Path,
+    request_body: &[u8],
+    protocol_version: Option<u8>,
+) -> Result<Vec<u8>> {
+    let grit = crate::grit_executable();
+    let mut cmd = Command::new(&grit);
+
+    if protocol_version == Some(2) {
+        // Protocol v2 uses serve-v2 --stateless-rpc
+        cmd.arg("serve-v2")
+            .arg("--stateless-rpc");
+    } else {
+        cmd.arg("upload-pack")
+            .arg("--stateless-rpc")
+            .arg(repo_path);
+    }
+
+    cmd.stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    if let Some(v) = protocol_version {
+        cmd.env("GIT_PROTOCOL", format!("version={v}"));
+    }
+
+    // For serve-v2, set GIT_DIR since it discovers from cwd
+    if protocol_version == Some(2) {
+        cmd.current_dir(repo_path);
+    }
+
+    let mut child = cmd
+        .spawn()
+        .with_context(|| format!("failed to spawn '{} upload-pack'", grit.display()))?;
+
+    // Write request body to stdin
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin.write_all(request_body)?;
+    }
+
+    let output = child
+        .wait_with_output()
+        .context("failed to wait for upload-pack")?;
+
+    if !output.status.success() {
+        let err = String::from_utf8_lossy(&output.stderr);
+        // Don't fail on non-zero exit for upload-pack — some errors are normal
+        // (e.g., client disconnect). Log but return what we have.
+        if !output.stdout.is_empty() {
+            eprintln!("upload-pack stderr (non-fatal): {}", err.trim());
+            return Ok(output.stdout);
+        }
+        anyhow::bail!("upload-pack failed: {}", err.trim());
+    }
+
+    Ok(output.stdout)
+}

--- a/grit/src/commands/upload_pack.rs
+++ b/grit/src/commands/upload_pack.rs
@@ -396,7 +396,7 @@ fn write_ref_advertisement(w: &mut impl Write, git_dir: &Path) -> Result<()> {
 
     let mut first = true;
     if let Ok(head_oid) = refs::resolve_ref(git_dir, "HEAD") {
-        let line = format!("{}\tHEAD\0{}\n", head_oid.to_hex(), caps);
+        let line = format!("{} HEAD\0{}\n", head_oid.to_hex(), caps);
         let len = 4 + line.len();
         write!(w, "{:04x}{}", len, line)?;
         first = false;
@@ -411,21 +411,21 @@ fn write_ref_advertisement(w: &mut impl Write, git_dir: &Path) -> Result<()> {
         if !non_standard.is_empty() {
             for (i, (refname, oid)) in non_standard.iter().enumerate() {
                 let line = if i == 0 {
-                    format!("{}\t{}\0{}\n", oid.to_hex(), refname, caps)
+                    format!("{} {}\0{}\n", oid.to_hex(), refname, caps)
                 } else {
-                    format!("{}\t{}\n", oid.to_hex(), refname)
+                    format!("{} {}\n", oid.to_hex(), refname)
                 };
                 let len = 4 + line.len();
                 write!(w, "{:04x}{}", len, line)?;
             }
             first = false;
         } else if let Ok(HeadState::Detached { oid }) = resolve_head(git_dir) {
-            let line = format!("{}\tHEAD\0{}\n", oid.to_hex(), caps);
+            let line = format!("{} HEAD\0{}\n", oid.to_hex(), caps);
             let len = 4 + line.len();
             write!(w, "{:04x}{}", len, line)?;
             first = false;
         } else if let Ok(HeadState::Branch { oid: Some(oid), .. }) = resolve_head(git_dir) {
-            let line = format!("{}\tHEAD\0{}\n", oid.to_hex(), caps);
+            let line = format!("{} HEAD\0{}\n", oid.to_hex(), caps);
             let len = 4 + line.len();
             write!(w, "{:04x}{}", len, line)?;
             first = false;
@@ -434,7 +434,7 @@ fn write_ref_advertisement(w: &mut impl Write, git_dir: &Path) -> Result<()> {
             // object format (64 hex zeros for SHA-256, 40 for SHA-1) so a hash-aware client can
             // detect the format from an empty repository (`t5551` empty SHA-256 clone, proto v0).
             let z = zero_oid_hex_for_format(&object_format);
-            let line = format!("{z}\tHEAD\0{caps}\n");
+            let line = format!("{z} HEAD\0{caps}\n");
             let len = 4 + line.len();
             write!(w, "{:04x}{}", len, line)?;
             first = false;
@@ -444,12 +444,12 @@ fn write_ref_advertisement(w: &mut impl Write, git_dir: &Path) -> Result<()> {
     let all_refs = list_all_refs(git_dir)?;
     for (refname, oid) in &all_refs {
         if first {
-            let line = format!("{}\t{}\0{}\n", oid.to_hex(), refname, caps);
+            let line = format!("{} {}\0{}\n", oid.to_hex(), refname, caps);
             let len = 4 + line.len();
             write!(w, "{:04x}{}", len, line)?;
             first = false;
         } else {
-            let line = format!("{}\t{}\n", oid.to_hex(), refname);
+            let line = format!("{} {}\n", oid.to_hex(), refname);
             let len = 4 + line.len();
             write!(w, "{:04x}{}", len, line)?;
         }


### PR DESCRIPTION
- New grit-protocol crate: subprocess-based API wrapping upload-pack and receive-pack for HTTP smart transport
- New grit-http-server crate: minimal axum server implementing the 4 Git smart HTTP endpoints (info/refs + RPC for both services)
- Fix upload-pack ref advertisement: use SP (0x20) between hash and refname per the pack protocol spec, not TAB (0x09)

Clone and push both verified working via HTTP round-trip.