### PR TITLE
docs: clarify cloud dev environment notes in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,5 +221,6 @@ The Git-compatible engine should live in a **library crate** (`grit-lib`); the *
 - **No external services**: Grit is a pure CLI tool with no databases, containers, or network services. Build and test entirely via Cargo and the Bash test runner.
 - **Unit tests**: Run `cargo test -p grit-lib --lib`. The `grit-cli` crate has no lib target; use `cargo test --workspace` to run everything.
 - **Integration tests**: Use `./scripts/run-tests.sh <test-file>` (see TESTING.md). Many tests are expected to fail — Grit is a work-in-progress.
-- **Lint**: `cargo check -p grit-cli 2>&1 | grep warning` — there are 2 pre-existing unused-variable warnings in `grit/src/commands/add.rs`.
+- **Lint**: `cargo check -p grit-cli 2>&1 | grep warning` — there are 2 pre-existing warnings in `grit/src/commands/diff.rs` and `grit/src/commands/reset.rs`. Avoid `cargo clippy --all-targets` on the full workspace unless fixing test-target errors; `cargo check -p grit-cli` is the quick smoke lint.
+- **Known unit test failures**: 2 pre-existing failures in `ignore::gitignore_glob_tests` (`dir_star_extension_*`); the rest of `cargo test -p grit-lib --lib` should pass.
 - **Binary location**: After `cargo build --release`, the binary is at `target/release/grit`. The test harness expects this path.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates Cursor Cloud specific instructions after environment setup validation:

- Correct pre-existing lint warning locations (`diff.rs`, `reset.rs`)
- Note that `cargo clippy --all-targets` hits pre-existing test-target errors; prefer `cargo check -p grit-cli` for smoke lint
- Document 2 known `gitignore_glob_tests` unit test failures so future agents do not treat them as setup regressions

No Rust code changes; dev environment verified (build, unit tests, harness, hello-world workflow).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19c44dc1-a9d9-4006-a31a-f4459bc90046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19c44dc1-a9d9-4006-a31a-f4459bc90046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

