### PR TITLE
fix: repair out-of-the-box cargo test and bench report generation

### DIFF
--- a/bench/report.py
+++ b/bench/report.py
@@ -15,8 +15,14 @@ def load_results():
     """Load all bench/*.json result files."""
     benchmarks = []
     for path in sorted(glob.glob(os.path.join(RESULTS_DIR, "*.json"))):
-        with open(path) as f:
-            data = json.load(f)
+        # hyperfine leaves an empty/partial export when a benchmark is
+        # skipped; ignore anything that isn't valid JSON.
+        try:
+            with open(path) as f:
+                data = json.load(f)
+        except json.JSONDecodeError:
+            print(f"skipping invalid result file: {os.path.basename(path)}")
+            continue
         name = os.path.splitext(os.path.basename(path))[0]
         results = data.get("results", [])
         if len(results) < 2:

--- a/grit-lib/examples/cherry_pick.rs
+++ b/grit-lib/examples/cherry_pick.rs
@@ -140,6 +140,7 @@ fn main() -> grit_lib::error::Result<()> {
         theirs_tree,
         MergeFavor::default(),
         WhitespaceMergeOptions::default(),
+        None,
         grit_lib::merge_trees::TreeMergeConflictPresentation {
             label_ours: "HEAD",
             label_theirs: grit_lib::merge_trees::TheirsConflictLabel::Fixed("picked"),


### PR DESCRIPTION
Two small hygiene fixes for things broken on a fresh checkout:

- grit-lib/examples/cherry_pick.rs called merge_trees_three_way with 7
  arguments; the function has since gained a `diff_algorithm:
  Option<&str>` parameter. This made plain `cargo test` fail with E0061
  before running a single test (cargo builds examples for `test`). Pass
  `None` to keep the example's original behavior. Verified: all examples
  build and the example runs end-to-end (self-creates a repo,
  cherry-picks cleanly, exit 0).

- bench/report.py crashed with JSONDecodeError on a clean checkout: 18
  committed bench/results/*.json files are empty exports from skipped
  hyperfine runs, and load_results() parsed them unguarded. Skip invalid
  files with a notice. Verified: `python3 bench/report.py` now generates
  docs/bench.html from the 113 valid committed results.

