### PR TITLE
Add mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Scott Chacon <schacon@gmail.com> Scott Chacon <schacon+codex@gmail.com>


### PR DESCRIPTION
I noticed that some of your (Scott Chacon) commits weren't getting attributed to you in GitHub.

Unfortunately, this does *not* fix that, but it *does* fix `git log` and `git shortlog`, consolidating commits authored by both `schacon@gmail.com` and `schacon+codex@gmail.com` into a single author. In this mailmap, the first entry is the real name, and the second entry is the alias. So here it's mapping commits by `schacon+codex@gmail.com` to show as `schacon@gmail.com` in `git log` and `git shortlog`.

On the GitHub side of things, you might be able to fix this by registering the alternative email address as a secondary email address for your profile.