### PR TITLE
perf(ls-files): drop per-entry submodule probes, buffer stdout

### DIFF
--- a/grit-lib/src/index.rs
+++ b/grit-lib/src/index.rs
@@ -936,10 +936,15 @@ impl Index {
         let mut pos = 12usize;
         let mut entries = Vec::with_capacity(count as usize);
 
-        let mut prev_path: Vec<u8> = Vec::new();
         for _ in 0..count {
-            let (entry, consumed) = parse_entry(&body[pos..], version, &prev_path, hash_len)?;
-            prev_path = entry.path.clone();
+            // Only v4 prefix-compresses paths against the previous entry;
+            // borrow it from `entries` instead of cloning every path.
+            let prev_path: &[u8] = if version == 4 {
+                entries.last().map_or(&[][..], |e: &IndexEntry| &e.path)
+            } else {
+                &[]
+            };
+            let (entry, consumed) = parse_entry(&body[pos..], version, prev_path, hash_len)?;
             entries.push(entry);
             pos += consumed;
         }
@@ -2122,7 +2127,8 @@ fn parse_entry(
         let suffix = &data[pos..pos + nul];
         pos += nul + 1;
         let keep = prev_path.len().saturating_sub(strip_len);
-        let mut full_path = prev_path[..keep].to_vec();
+        let mut full_path = Vec::with_capacity(keep + suffix.len());
+        full_path.extend_from_slice(&prev_path[..keep]);
         full_path.extend_from_slice(suffix);
         path = full_path;
     } else {

--- a/grit/src/commands/ls_files.rs
+++ b/grit/src/commands/ls_files.rs
@@ -343,18 +343,24 @@ pub fn run(args: Args) -> Result<()> {
         && grit_lib::precompose_config::filesystem_nfd_nfc_aliases(&repo.git_dir);
     let quote_fully = config.quote_path_fully();
     let index_path = resolved_env_index_path(&repo);
-    let raw_index_had_sparse_dirs = grit_lib::index::Index::load(&index_path)
-        .map(|idx| idx.has_sparse_directory_placeholders())
-        .unwrap_or(false);
     let mut index = if args.sparse {
         grit_lib::index::Index::load(&index_path).context("loading index")?
     } else {
         repo.load_index_at(&index_path).context("loading index")?
     };
-    if !args.sparse && args.pathspecs.is_empty() && raw_index_had_sparse_dirs {
+    if !args.sparse && args.pathspecs.is_empty() {
         if let Ok(trace2_event) = std::env::var("GIT_TRACE2_EVENT") {
             if !trace2_event.trim().is_empty() {
-                let _ = crate::trace2_region_json(&trace2_event, "index", "ensure_full_index");
+                // Loaded raw (un-expanded) only here: `load_index_at` has
+                // already expanded sparse placeholders, so re-read to learn
+                // whether the on-disk index had any. Off the hot path —
+                // only when trace2 event output is requested.
+                let raw_index_had_sparse_dirs = grit_lib::index::Index::load(&index_path)
+                    .map(|idx| idx.has_sparse_directory_placeholders())
+                    .unwrap_or(false);
+                if raw_index_had_sparse_dirs {
+                    let _ = crate::trace2_region_json(&trace2_event, "index", "ensure_full_index");
+                }
             }
         }
     }
@@ -401,7 +407,10 @@ pub fn run(args: Args) -> Result<()> {
     }
 
     let stdout = io::stdout();
-    let mut out = stdout.lock();
+    // Rust's StdoutLock is line-buffered; per-entry lines would issue one
+    // write(2) each (10k syscalls on a 10k-file index). Fully buffer like
+    // C git's stdio and flush once at the end.
+    let mut out = io::BufWriter::new(stdout.lock());
 
     let term = if args.null_terminated { b'\0' } else { b'\n' };
     let use_nul = args.null_terminated;
@@ -1281,6 +1290,7 @@ pub fn run(args: Args) -> Result<()> {
         }
     }
 
+    out.flush()?;
     Ok(())
 }
 
@@ -2313,6 +2323,14 @@ fn format_ls_display_path<'a>(
     config: &grit_lib::config::ConfigSet,
 ) -> Result<Cow<'a, [u8]>> {
     if full_name {
+        return Ok(Cow::Borrowed(repo_rel));
+    }
+    // From the work-tree root the cwd-relative display is the repo-relative
+    // path itself, including for paths under an active submodule
+    // (`ls_files_display_through_submodule` reduces to `first_seg/rest`).
+    // Returning it verbatim skips the per-entry submodule probe (~3 stat(2)
+    // per entry) and is byte-exact for non-UTF-8 paths.
+    if normalize_path(cwd) == normalize_path(work_tree) {
         return Ok(Cow::Borrowed(repo_rel));
     }
     if cwd_inside_work_tree(cwd, work_tree) {


### PR DESCRIPTION
ls-files was 31x slower than C git at L scale (10k files: 66.8 ms vs
2.1 ms), with system time dominating. This is P3 in bench/OPTIMIZATION.md,
though profiling showed the listed suspect (index parser allocations) was
the smallest of four costs. strace attribution, per run:

- **30k statx** — `format_ls_display_path` probed every entry's first
  path segment for an active submodule (`is_dir` + `resolve_dot_git` on
  `segment/.git`) to compute the cwd-relative display. From the work-tree
  root that display provably equals the repo-relative path itself
  (pathdiff from root is the identity, and the submodule walk reduces to
  `first_seg/rest`), so return it verbatim — also byte-exact for
  non-UTF-8 paths where the lossy pathdiff conversion was not. Runs from
  a subdirectory keep the existing (correct) path.
- **10k write(2)** — Rust's `StdoutLock` is line-buffered, one syscall
  per printed path. Wrap in `BufWriter` (C git fully buffers stdio) and
  flush once at the end.
- **Double parse** — the index was loaded twice, once just to learn
  whether the on-disk index had sparse placeholders, used only for a
  trace2 event. Load it only when `GIT_TRACE2_EVENT` is actually set.
- **Per-entry clone** (the original P3 item) — `Index::parse` cloned
  every entry's path into `prev_path`, which only v4 prefix-compression
  reads. Borrow it from the previously pushed entry (v4 only), and
  pre-size the v4 path buffer.

Benchmarks (hyperfine A/B vs main, same machine):

```
ls-files @L (10k files)  66.8 ms -> 5.8 ms  (11.5x; 31.7x -> 2.5x vs git)
ls-files @M (1k files)    9.6 ms -> 2.4 ms  (4.0x; 1.8x vs git)
status / diff / add @L   unchanged (1.00-1.01x)
```

Output verified byte-identical to git for plain, `-s`, `-z`, from a
subdirectory, and a v4-index round-trip.

Verification:
- grit-lib suite: 304 pass; only the 2 gitignore failures that already
  exist on main
- harness gates (all match canonical baselines): t3000–t3014 ls-files
  family, t1092-sparse-checkout 106/106, t1600/t1601-index,
  t1700/t1701-split-index, t2107-update-index

Noted while profiling, deliberately not changed here: `ls-files
--full-name` from a subdirectory lists the whole repo, while C git keeps
the cwd-prefix restriction and only changes the display (the
`!args.full_name` condition at the pathspec-defaulting site, present
since April). Worth a separate issue.