### PR TITLE
perf(odb): cache MIDX reads and delta bases; skip no-op log tree walks

### DIFF
--- a/grit-lib/src/diff.rs
+++ b/grit-lib/src/diff.rs
@@ -6084,6 +6084,16 @@ pub fn apply_rotate_skip_log_entries(
     rotate_to: Option<&str>,
     skip_to: Option<&str>,
 ) -> Result<Vec<DiffEntry>> {
+    // Without --rotate-to/--skip-to this is a no-op (the ordered-paths helper
+    // returns the entries untouched), so skip the full-tree walk that
+    // `all_blob_paths_in_tree_order` performs — per displayed commit it read
+    // every subtree of the commit's tree just to discard the result.
+    fn trimmed(s: Option<&str>) -> Option<&str> {
+        s.map(str::trim).filter(|t| !t.is_empty())
+    }
+    if trimmed(rotate_to).is_none() && trimmed(skip_to).is_none() {
+        return Ok(entries);
+    }
     let tree_paths = crate::merge_diff::all_blob_paths_in_tree_order(odb, commit_tree);
     apply_rotate_skip_ordered_paths(&tree_paths, entries, rotate_to, skip_to)
 }

--- a/grit-lib/src/diffstat.rs
+++ b/grit-lib/src/diffstat.rs
@@ -38,21 +38,30 @@ pub fn terminal_columns() -> usize {
             }
         }
     }
-    if let Ok(output) = std::process::Command::new("stty")
-        .arg("size")
-        .stdin(std::process::Stdio::inherit())
-        .stderr(std::process::Stdio::null())
-        .output()
-    {
+    // The terminal size is constant for the life of the process (matching
+    // C git, which caches `term_columns()` after the first call); spawning
+    // `stty` once per --stat commit dominated history walks. The `COLUMNS`
+    // check above stays uncached so per-call env overrides keep working.
+    static STTY_COLS: std::sync::OnceLock<Option<usize>> = std::sync::OnceLock::new();
+    if let Some(w) = *STTY_COLS.get_or_init(|| {
+        let output = std::process::Command::new("stty")
+            .arg("size")
+            .stdin(std::process::Stdio::inherit())
+            .stderr(std::process::Stdio::null())
+            .output()
+            .ok()?;
         let s = String::from_utf8_lossy(&output.stdout);
         let parts: Vec<&str> = s.split_whitespace().collect();
         if parts.len() == 2 {
             if let Ok(w) = parts[1].parse::<usize>() {
                 if w > 0 {
-                    return w;
+                    return Some(w);
                 }
             }
         }
+        None
+    }) {
+        return w;
     }
     80
 }

--- a/grit-lib/src/midx.rs
+++ b/grit-lib/src/midx.rs
@@ -246,13 +246,110 @@ fn repo_midx_hash_version(pack_dir: &Path) -> u8 {
     repo_midx_hash_version_for_objects_dir(objects_dir)
 }
 
+// ── Process-lifetime MIDX read cache ─────────────────────────────────
+//
+// `try_read_object_via_midx` / `midx_oid_listed_in_tip` run once per object
+// lookup, and each used to re-read the entire multi-pack-index file, re-parse
+// the referenced pack `.idx`, and re-scan `[extensions] objectformat` from the
+// repo config. History walks paid for it per object (`log --stat` issued ~90
+// full MIDX reads per commit). Cache the MIDX bytes keyed by path and the
+// sniffed hash version keyed by config path, both revalidated with stat
+// stamps (mtime + size, recorded before the read) on every access. In-process
+// MIDX writers evict their pack dir, closing the same-mtime-tick rewrite
+// window; C git opens the MIDX once per process with no revalidation at all,
+// so serving a stamped copy is strictly more conservative than upstream.
+mod midx_cache {
+    use crate::error::{Error, Result};
+    use std::collections::HashMap;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::sync::{Arc, Mutex, OnceLock};
+    use std::time::SystemTime;
+
+    type Stamp = (SystemTime, u64);
+
+    #[derive(Default)]
+    struct State {
+        bytes: HashMap<PathBuf, (Stamp, Arc<Vec<u8>>)>,
+        hash_version: HashMap<PathBuf, (Option<Stamp>, u8)>,
+    }
+
+    static CACHE: OnceLock<Mutex<State>> = OnceLock::new();
+
+    fn lock() -> std::sync::MutexGuard<'static, State> {
+        CACHE
+            .get_or_init(|| Mutex::new(State::default()))
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn stamp(path: &Path) -> Option<Stamp> {
+        let m = fs::metadata(path).ok()?;
+        Some((m.modified().unwrap_or(SystemTime::UNIX_EPOCH), m.len()))
+    }
+
+    /// MIDX file bytes, re-read from disk only when the file's stamp changes.
+    pub fn get_bytes(path: &Path) -> Result<Arc<Vec<u8>>> {
+        let sig = stamp(path);
+        if let Some(sig) = sig {
+            let g = lock();
+            if let Some((s, b)) = g.bytes.get(path) {
+                if *s == sig {
+                    return Ok(Arc::clone(b));
+                }
+            }
+        }
+        let data = Arc::new(fs::read(path).map_err(Error::Io)?);
+        if let Some(sig) = sig {
+            lock()
+                .bytes
+                .insert(path.to_path_buf(), (sig, Arc::clone(&data)));
+        }
+        Ok(data)
+    }
+
+    /// Cached `[extensions] objectformat` sniff keyed by the config path,
+    /// re-computed only when the config file's stamp changes (an absent
+    /// config is cached too, stamped as `None`).
+    pub fn hash_version(config_path: &Path, compute: impl FnOnce() -> u8) -> u8 {
+        let sig = stamp(config_path);
+        {
+            let g = lock();
+            if let Some((s, v)) = g.hash_version.get(config_path) {
+                if *s == sig {
+                    return *v;
+                }
+            }
+        }
+        let v = compute();
+        lock()
+            .hash_version
+            .insert(config_path.to_path_buf(), (sig, v));
+        v
+    }
+
+    /// Drop cached MIDX bytes under `pack_dir` (called by in-process writers).
+    pub fn evict_pack_dir(pack_dir: &Path) {
+        lock().bytes.retain(|p, _| !p.starts_with(pack_dir));
+    }
+}
+
 /// Like [`repo_midx_hash_version`] but starting from the `objects` directory.
+/// The config sniff is cached per config path with stat-stamp revalidation
+/// (see [`midx_cache`]).
 fn repo_midx_hash_version_for_objects_dir(objects_dir: &Path) -> u8 {
     let Some(gitdir) = objects_dir.parent() else {
         return HASH_VERSION_SHA1;
     };
     let config_path = gitdir.join("config");
-    let Ok(text) = fs::read_to_string(&config_path) else {
+    midx_cache::hash_version(&config_path, || {
+        sniff_objectformat_hash_version(&config_path)
+    })
+}
+
+/// Uncached `[extensions] objectformat` scan of one config file.
+fn sniff_objectformat_hash_version(config_path: &Path) -> u8 {
+    let Ok(text) = fs::read_to_string(config_path) else {
         return HASH_VERSION_SHA1;
     };
     // Minimal scan for `[extensions]` ... `objectformat = sha256`. Section and key
@@ -1686,7 +1783,7 @@ pub fn midx_oid_listed_in_tip(objects_dir: &Path, oid: &ObjectId) -> Result<Opti
     let Some(midx_path) = resolve_tip_midx_path(&pack_dir) else {
         return Ok(None);
     };
-    let data = fs::read(&midx_path).map_err(Error::Io)?;
+    let data = midx_cache::get_bytes(&midx_path)?;
     let hash_len = midx_hash_len(&data);
     let MidxReadView {
         oidf_off,
@@ -1990,7 +2087,7 @@ pub fn try_read_object_via_midx(
     let Some(midx_path) = resolve_tip_midx_path(&pack_dir) else {
         return Ok(None);
     };
-    let data = fs::read(&midx_path).map_err(Error::Io)?;
+    let data = midx_cache::get_bytes(&midx_path)?;
 
     // Load-time validation, mirroring `load_multi_pack_index` in git/midx.c.
     // Fatal corruptions `die()` (print error + fatal, exit 128); recoverable
@@ -2071,7 +2168,7 @@ pub fn try_read_object_via_midx(
     // surfacing the parse error as fatal. Use the non-verifying parse to match
     // `open_pack_index`, which does not validate the trailing checksum (a pack
     // `.idx` with a stale checksum but valid structure must still be usable).
-    let idx = match crate::pack::read_pack_index_no_verify(&idx_path) {
+    let idx = match crate::pack::read_pack_index_cached(&idx_path) {
         Ok(idx) => idx,
         Err(_) => {
             let mut pack_path = idx_path.clone();
@@ -2468,6 +2565,7 @@ pub fn write_multi_pack_index_with_options(
         }
     }
 
+    midx_cache::evict_pack_dir(pack_dir);
     Ok(())
 }
 
@@ -2691,6 +2789,7 @@ pub fn compact_multi_pack_index(
     // Drop the now-removed range layers and their sidecars.
     clear_stale_split_layers(pack_dir, &new_chain)?;
 
+    midx_cache::evict_pack_dir(pack_dir);
     Ok(())
 }
 

--- a/grit-lib/src/pack.rs
+++ b/grit-lib/src/pack.rs
@@ -320,8 +320,8 @@ pub fn read_local_pack_indexes(objects_dir: &Path) -> Result<Vec<PackIndex>> {
 /// verifies pack indexes during `fsck`/`verify-pack`, not on every object lookup. Use
 /// [`read_pack_index`] when verification is required.
 mod pack_cache {
-    use super::{read_pack_index_no_verify, Error, PackIndex, Result};
-    use std::collections::HashMap;
+    use super::{read_pack_index_no_verify, Error, ObjectKind, PackIndex, Result};
+    use std::collections::{HashMap, VecDeque};
     use std::fs;
     use std::io;
     use std::path::{Path, PathBuf};
@@ -345,11 +345,23 @@ mod pack_cache {
         bytes: Arc<Vec<u8>>,
     }
 
+    /// Upper bound on retained delta-base bytes, matching git's default
+    /// `core.deltaBaseCacheLimit` (96 MiB).
+    const DELTA_BASE_CACHE_LIMIT: usize = 96 * 1024 * 1024;
+
     #[derive(Default)]
     struct State {
         by_dir: HashMap<PathBuf, CachedDir>,
         by_idx: HashMap<PathBuf, CachedIdx>,
         by_pack: HashMap<PathBuf, CachedPack>,
+        /// Resolved delta bases keyed by pack path → in-pack offset (git's
+        /// `delta_base_cache`). Entries are dropped whenever the pack's bytes
+        /// are re-read (stamp change), so they can never outlive the pack
+        /// content they were inflated from.
+        delta_bases: HashMap<PathBuf, HashMap<u64, (ObjectKind, Arc<Vec<u8>>)>>,
+        /// FIFO eviction order for `delta_bases` (size-bounded).
+        delta_order: VecDeque<(PathBuf, u64)>,
+        delta_bytes: usize,
     }
 
     static CACHE: OnceLock<Mutex<State>> = OnceLock::new();
@@ -476,6 +488,9 @@ mod pack_cache {
             }
             let bytes = Arc::new(fs::read(pack_path).map_err(Error::Io)?);
             let mut g = lock();
+            // The pack's content (re)entered the cache: any delta bases
+            // inflated from a previous read of this path are now suspect.
+            drop_delta_entries_locked(&mut g, pack_path);
             g.by_pack.insert(
                 pack_path.to_path_buf(),
                 CachedPack {
@@ -500,6 +515,65 @@ mod pack_cache {
         g.by_dir.clear();
         g.by_idx.clear();
         g.by_pack.clear();
+        g.delta_bases.clear();
+        g.delta_order.clear();
+        g.delta_bytes = 0;
+    }
+
+    /// Drop every cached delta base inflated from `pack_path`.
+    fn drop_delta_entries_locked(g: &mut State, pack_path: &Path) {
+        if let Some(per) = g.delta_bases.remove(pack_path) {
+            let removed: usize = per.values().map(|(_, d)| d.len()).sum();
+            g.delta_bytes = g.delta_bytes.saturating_sub(removed);
+            g.delta_order.retain(|(p, _)| p != pack_path);
+        }
+    }
+
+    /// Cached delta base at `(pack_path, offset)`, if still resident.
+    pub fn get_delta_base(pack_path: &Path, offset: u64) -> Option<(ObjectKind, Arc<Vec<u8>>)> {
+        let g = lock();
+        let (kind, data) = g.delta_bases.get(pack_path)?.get(&offset)?;
+        Some((*kind, Arc::clone(data)))
+    }
+
+    /// Insert a resolved delta base, evicting oldest entries past the size cap.
+    pub fn put_delta_base(pack_path: &Path, offset: u64, kind: ObjectKind, data: Arc<Vec<u8>>) {
+        let sz = data.len();
+        if sz > DELTA_BASE_CACHE_LIMIT {
+            return;
+        }
+        let mut g = lock();
+        while g.delta_bytes.saturating_add(sz) > DELTA_BASE_CACHE_LIMIT {
+            let Some((p, off)) = g.delta_order.pop_front() else {
+                break;
+            };
+            let mut removed = 0;
+            let mut now_empty = false;
+            if let Some(per) = g.delta_bases.get_mut(&p) {
+                if let Some((_, old)) = per.remove(&off) {
+                    removed = old.len();
+                }
+                now_empty = per.is_empty();
+            }
+            if now_empty {
+                g.delta_bases.remove(&p);
+            }
+            g.delta_bytes = g.delta_bytes.saturating_sub(removed);
+        }
+        let prev = g
+            .delta_bases
+            .entry(pack_path.to_path_buf())
+            .or_default()
+            .insert(offset, (kind, data));
+        match prev {
+            Some((_, old)) => {
+                g.delta_bytes = g.delta_bytes.saturating_sub(old.len()).saturating_add(sz);
+            }
+            None => {
+                g.delta_order.push_back((pack_path.to_path_buf(), offset));
+                g.delta_bytes = g.delta_bytes.saturating_add(sz);
+            }
+        }
     }
 
     /// Re-stamp the cached signature for `pack_path` after the caller deliberately touched the
@@ -1300,6 +1374,27 @@ fn decompress_pack_data(bytes: &[u8], pos: &mut usize, expected_size: u64) -> Re
 ///
 /// Handles OFS_DELTA and REF_DELTA by recursively reading the base object.
 /// The `idx` is used for REF_DELTA resolution (to find a base by OID).
+/// Resolve an in-pack delta base through the process-wide delta-base cache
+/// (git's `cache_or_unpack_entry`). Without it every delta resolution
+/// re-inflates the full chain below it; `log --stat/-p` walks chains whose
+/// bases are shared across consecutive commits, turning history walks
+/// quadratic in chain depth.
+fn read_pack_base_cached(
+    pack_bytes: &[u8],
+    base_offset: u64,
+    idx: &PackIndex,
+    objects_dir: Option<&Path>,
+    depth: usize,
+) -> Result<(ObjectKind, Arc<Vec<u8>>)> {
+    if let Some(hit) = pack_cache::get_delta_base(&idx.pack_path, base_offset) {
+        return Ok(hit);
+    }
+    let (kind, data) = read_pack_object_at(pack_bytes, base_offset, idx, objects_dir, depth + 1)?;
+    let data = Arc::new(data);
+    pack_cache::put_delta_base(&idx.pack_path, base_offset, kind, Arc::clone(&data));
+    Ok((kind, data))
+}
+
 fn read_pack_object_at(
     pack_bytes: &[u8],
     offset: u64,
@@ -1328,7 +1423,7 @@ fn read_pack_object_at(
             // resolve in-pack first. Loose or other-pack copies of the base are consulted only
             // when the in-pack read fails (e.g. a corrupt base rescued by another copy), which
             // keeps hot reads free of per-link loose-path stats and pack-directory probes.
-            let in_pack = read_pack_object_at(pack_bytes, base_offset, idx, objects_dir, depth + 1);
+            let in_pack = read_pack_base_cached(pack_bytes, base_offset, idx, objects_dir, depth);
             match in_pack {
                 Ok((base_kind, base_data)) => {
                     let result = apply_delta(&base_data, &delta_data)?;
@@ -1388,7 +1483,7 @@ fn read_pack_object_at(
                 .map(|i| idx.entries[i].offset);
             let mut in_pack_err = None;
             if let Some(base_offset) = in_pack_offset {
-                match read_pack_object_at(pack_bytes, base_offset, idx, objects_dir, depth + 1) {
+                match read_pack_base_cached(pack_bytes, base_offset, idx, objects_dir, depth) {
                     Ok((base_kind, base_data)) => {
                         let result = apply_delta(&base_data, &delta_data)?;
                         return Ok((base_kind, result));


### PR DESCRIPTION
`log --stat` was 803x slower than C git at L scale (200 commits: 13.3 s
vs 16 ms) and 897x at H scale (4,000 commits: 142.9 s vs 159 ms). This
started as P4 from bench/OPTIMIZATION.md, but the listed suspect
(tree-vs-tree subtree pruning) turned out to be already implemented —
profiling found four real costs instead:

- **Per-lookup MIDX re-reads** — `try_read_object_via_midx` /
  `midx_oid_listed_in_tip` re-read the entire multi-pack-index file,
  re-parsed the referenced pack `.idx`, and re-scanned
  `[extensions] objectformat` from the repo config on *every* object
  lookup (~90 full MIDX reads per displayed commit). Added a
  process-lifetime `midx_cache` (bytes keyed by path, hash-version
  sniff keyed by config path), stat-stamp revalidated per access, with
  in-process MIDX writers evicting their pack dir; `.idx` parsing now
  routes through the existing `pack::read_pack_index_cached`. C git
  opens the MIDX once per process with no revalidation at all, so a
  stamped copy is strictly more conservative.
- **No delta-base cache** — delta chains were re-inflated from scratch
  on every resolution. Added one (96 MiB cap, matching git's default
  `core.deltaBaseCacheLimit`) keyed by (pack path, offset), wired into
  both the OFS and REF delta arms. Entries are dropped whenever the
  pack's bytes re-enter the byte cache and on `clear_pack_cache`, so a
  base can never outlive the pack content it was inflated from. `log`'s
  tree reads share bases across consecutive commits, which made history
  walks quadratic in chain depth.
- **No-op full-tree walks** — `apply_rotate_skip_log_entries` walked
  the *entire* commit tree (~100 object reads per displayed commit at
  L) to build an ordered path list that the helper immediately discards
  when `--rotate-to`/`--skip-to` are not set. The no-op check is now
  hoisted above the walk.
- **One subprocess per commit** — `diffstat::terminal_columns` spawned
  `stty size` per `--stat` commit. The stty result is now cached for
  the process lifetime (C git parity); the `COLUMNS` env check stays
  per-call.

Benchmarks (hyperfine A/B vs main, same machine):

```
log --stat @L (200 commits)    12.18 s -> 144 ms   (85x; 803x -> 9.3x vs git)
log -p     @L                  11.79 s -> 205 ms   (57x)
log --stat @H (4,000 commits)  142.9 s -> 2.56 s   (56x; 897x -> 16x vs git)
status @L                      1.14x faster
grep @M                        1.06x faster
diff / ls-files @L             unchanged
```

Output verified byte-identical to git for `log --stat`, `--raw
--no-abbrev`, `--rotate-to`, and the H-scale walk; `-p` output is
identical to main grit.

Verification:
- grit-lib suite: 304 pass; only the 2 gitignore failures that already
  exist on main
- harness gates: t5300-pack-object 63/63 + unpack 23/23,
  t5303-pack-corruption(-resilience) 25/25 + 36/36 (exercises the
  delta rescue paths), t5306-pack-nobase 4/4, t4013-diff-various
  230/230, t7700-repack 47/47; t4202-log 146/149 and t4052-stat-output
  81/89 fail exactly the same cases as a main-built binary (verified by
  running main against both files); t5319/t5326 MIDX test files are
  marked out of scope in the harness

Pre-existing divergences observed while verifying (present on main,
untouched here, possibly worth separate issues): OID auto-abbreviation
emits 7 hex chars where git picks 8 at this object count, and
`--skip-to` path selection differs from git.