### PR TITLE
build: statically-linked musl releases + installer auto-detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,15 @@ jobs:
             os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
+          # Statically-linked musl builds (portable across distros, e.g. Alpine).
+          # Built with `cross` so the right musl C toolchain is provided for
+          # native dependencies (e.g. ring) on both architectures.
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            cross: true
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            cross: true
           - target: x86_64-apple-darwin
             os: macos-latest
           - target: aarch64-apple-darwin
@@ -39,8 +48,19 @@ jobs:
           sudo apt-get install -y gcc-aarch64-linux-gnu
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
 
+      - name: Install cross
+        if: matrix.cross
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+
       - name: Build
+        if: ${{ !matrix.cross }}
         run: cargo build --release --target ${{ matrix.target }} -p grit-cli
+
+      - name: Build (cross)
+        if: matrix.cross
+        run: cross build --release --target ${{ matrix.target }} -p grit-cli
 
       - name: Package
         run: |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To install the `grit` CLI via Bash, you can run our install script:
 $ curl -fsSL https://grit-scm.com/install | sh
 ```
 
-There are builds for Mac and Linux, (aarch64 and x86_64 for both). Windows is on the list, but there's some work to do there.
+There are builds for Mac and Linux, (aarch64 and x86_64 for both). Linux ships both glibc and statically-linked musl binaries, so the installer works on distros like Alpine too — it auto-detects which one your system needs. Windows is on the list, but there's some work to do there.
 
 ## Updating
 

--- a/docs/install
+++ b/docs/install
@@ -20,7 +20,17 @@ main() {
 
   case "$OS" in
     darwin)  OS_TARGET="apple-darwin" ;;
-    linux)   OS_TARGET="unknown-linux-gnu" ;;
+    linux)
+      # Pick the right C library flavor. musl-based distros (e.g. Alpine) get the
+      # statically-linked musl binary; everything else gets the glibc (gnu) one.
+      LIBC="gnu"
+      if { command -v ldd >/dev/null 2>&1 && ldd --version 2>&1 | grep -qi musl; } \
+         || ls /lib/ld-musl-* >/dev/null 2>&1 \
+         || { [ -f /etc/os-release ] && grep -qiE '^(ID|ID_LIKE)=.*alpine' /etc/os-release; }; then
+        LIBC="musl"
+      fi
+      OS_TARGET="unknown-linux-${LIBC}"
+      ;;
     mingw*|msys*|cygwin*)
       echo "On Windows, download from: https://github.com/$REPO/releases/latest" >&2
       exit 1


### PR DESCRIPTION
Closes #832.

Adds portable, statically-linked musl binaries so Grit installs cleanly on distros like Alpine.

## Changes

**`.github/workflows/release.yml`**
- Adds `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` to the release matrix.
- Builds these via [`cross`](https://github.com/cross-rs/cross) (installed with `taiki-e/install-action`) so the correct musl C toolchain is available for native deps like `ring`.
- glibc, macOS, and aarch64-gnu builds are unchanged. The `release` job already globs `grit-*.tar.gz`, so the new artifacts publish automatically.

**`docs/install`** (the script served at `grit-scm.com/install`)
- The Linux branch now detects the C library flavor and downloads the matching asset:
  - `musl` when `ldd --version` reports musl, `/lib/ld-musl-*` exists, or `/etc/os-release` identifies Alpine
  - `gnu` otherwise
- `grit update` re-runs this same script, so existing installs pick up the right flavor on the next update — no Rust changes needed.

**`README.md`**
- Notes that Linux ships both glibc and musl binaries with auto-detection.

## Verification
- `sh -n docs/install` passes; workflow YAML validates.
- Ran the detection logic on a glibc host → correctly resolves to `unknown-linux-gnu`.

## Note
The release workflow only runs on `v*` tag pushes, so the musl assets first appear with the next tagged release.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BDTex8kJ4ToT5DMmWc5qSj)_