### PR TITLE
Compile grit-lib and grit-simple on Windows

### DIFF
--- a/WINDOWS_PORT_PLAN.md
+++ b/WINDOWS_PORT_PLAN.md
@@ -100,35 +100,44 @@ edge cases are a follow-up, not a compile blocker:
 - **Default identity**: `ident_config` resolves the user via `getuid`/passwd on
   Unix; the Windows branch already falls back to env-based resolution.
 
-## Follow-up clean-up (not required to compile, but do before enabling `-D warnings` in CI)
+## Warning clean-up — done
 
-The Windows cross-check emits ~13 warnings, all in already-ported files where an
-import or binding is only used on Unix. Tidy with `#[cfg(unix)]` on the imports /
-`let _ =` bindings or `#[cfg_attr(not(unix), allow(unused))]`:
+The Windows cross-check originally emitted ~12 warnings in already-ported files
+where an import/binding is only used on Unix. All are now resolved by gating the
+imports (`#[cfg(unix)] use …`) or, for parameters, `#[cfg_attr(not(unix),
+allow(unused_variables))]`:
 
-- `porcelain/stash.rs:22` (`PermissionsExt` import), `:444` (`target` unused)
-- `attributes.rs:9`, `ident_resolve.rs:10`, `shared_repo.rs:7`, `mailmap.rs:14`
-  (unused imports under non-unix)
-- `hooks.rs:282`/`:290` (`repo`/`meta` unused on non-unix)
-- `repo.rs:352` (`gitfile` field unused on non-unix)
-- `git_date/compat.rs:12` (`time_t` non-camel-case — pre-existing, allow it)
+- `porcelain/stash.rs` — `MODE_EXECUTABLE` import gated; symlink restore now
+  writes the target as a regular file on Windows (also uses `target`).
+- `attributes.rs`, `ident_resolve.rs`, `shared_repo.rs`, `mailmap.rs` — unused
+  imports gated to `#[cfg(unix)]`.
+- `hooks.rs` — `traditional_hook_candidate` annotated
+  `#[cfg_attr(not(unix), allow(unused_variables))]`.
+- `repo.rs` — dropped the `#[cfg(unix)]` on the `ensure_valid_ownership` call so
+  the existing `#[cfg(not(unix))]` stub is used; this removes both the unused
+  `gitfile` binding **and** the dead-stub warnings at once.
+- `split_index.rs` — `calc_shared_perm` gated to `#[cfg(unix)]`.
+- `git_date/compat.rs` — `#[allow(non_camel_case_types)]` on the Windows
+  `time_t` alias (mirrors the C / `libc` spelling).
 
-## Optional dependency hygiene
+After this, both host and Windows checks emit only the **pre-existing**
+`commit_graph_file.rs` `base_layers_declared` dead-field warning, which is
+present on host independent of the port and is out of scope here.
 
-`grit-lib/Cargo.toml` declares `nix` and `libc` as unconditional dependencies.
-They currently compile for `x86_64-pc-windows-gnu` (their Windows-relevant
-surface is small), so this is **not** a blocker. For cleanliness, move the
-Unix-only ones behind a target table so they are never built on Windows:
+## Dependency hygiene — done
+
+`nix` (signals, poll, uid, `uname`, Unix sockets) is used exclusively behind
+`#[cfg(unix)]`, so it is now declared under a target table in
+`grit-lib/Cargo.toml` and is not built on Windows:
 
 ```toml
 [target.'cfg(unix)'.dependencies]
-nix = { workspace = true }
+nix.workspace = true
 ```
 
-(`libc` must stay generally available — `git_date/compat.rs` references
-`libc::c_char` under `#[cfg(unix)]` only, but a workspace-level move to
-`cfg(unix)` is safe since the Windows path uses bare `extern "C"`.) Validate
-with the cross-check after moving.
+`libc` deliberately stays a general dependency: `refs.rs` compares
+`e.raw_os_error()` against `libc::EISDIR`/`ENOTDIR`/`EPERM` **un-gated**, and
+those errno constants are defined by `libc` on Windows too.
 
 ## MSVC vs GNU note
 
@@ -145,4 +154,4 @@ runner / via `cargo-xwin` as a final gate before declaring the port done.
 2. `cargo check -p grit-simple` (host) — still clean. ✅
 3. (Recommended) `cargo build --target x86_64-pc-windows-msvc -p grit-simple` on
    a Windows runner to validate the `git_date` CRT FFI links.
-4. (Optional) Warning clean-up + `nix` target-gating per the sections above.
+4. Warning clean-up + `nix` target-gating — done (see sections above).

--- a/WINDOWS_PORT_PLAN.md
+++ b/WINDOWS_PORT_PLAN.md
@@ -1,0 +1,148 @@
+# Windows Compilation Plan — `grit-lib` + `grit-simple`
+
+Goal: get `grit-lib` and `grit-simple` to **compile for Windows**. `grit-cli`
+(`grit/`) and the other workspace members (`grit-http-server`, `grit-protocol`,
+`grit-utils`, `grit-examples`) are explicitly **out of scope**.
+
+`grit-simple` (the `gi` binary) contains **no platform-specific code of its
+own** — it only re-exports `grit-lib` operations through `clap`. So "make
+grit-simple build on Windows" reduces entirely to "make `grit-lib` build on
+Windows with its default feature set" (`test-tools` and `http-ureq` both off).
+
+## Current state
+
+The port is already ~95% complete. Most platform-specific call sites are
+already paired with `#[cfg(unix)]` / `#[cfg(not(unix))]` branches, and the
+infrastructure modules are gated:
+
+- `git_date/compat.rs` — fully cross-platform: `time_t`/`tm` and
+  `localtime_r`/`mktime`/`strftime` route to `libc` on Unix and the MSVC CRT
+  (`_localtime64_s`, `_mktime64`, `strftime`) on Windows. `gmtime` is pure Rust.
+- `simple_ipc` and `unix_process` are `#[cfg(unix)]` modules with
+  `#[cfg(not(unix))]` stubs in `lib.rs` (Unix-domain-socket IPC and
+  `kill(2)`-based process control are Unix-only).
+- `test_tool_progress` (uses `AsRawFd`) and `parse_options_test_tool` are gated
+  behind the `test-tools` feature, which is **off** in `grit-simple`'s build, so
+  they never compile here.
+- Already-ported with both branches: `ident_resolve`, `signing`, `mailmap`,
+  `index`, `crlf`, `attributes`, `untracked_cache`, `ident_config`, `repo`,
+  `split_index`, `shared_repo`, `porcelain/stash`, `porcelain/status`, `odb`,
+  `hooks`.
+
+## Verification method
+
+There is no Windows toolchain in this environment, but `cargo check` does not
+link, so the Windows **std** target is enough to surface every type/path error:
+
+```sh
+rustup target add x86_64-pc-windows-gnu
+cargo check --target x86_64-pc-windows-gnu -p grit-simple
+```
+
+(`grit-simple` pulls in `grit-lib` with default features, so this checks both.)
+
+## Remaining compile errors and their fixes
+
+A clean cross-check surfaced exactly **8 errors across 3 files** — the last
+un-gated Unix call sites. Each is fixed with the same `#[cfg]` pattern already
+used throughout the crate.
+
+### 1. `grit-lib/src/porcelain/checkout.rs` (5 errors)
+
+`apply_index_file_mode` and `write_to_worktree` used
+`std::os::unix::fs::PermissionsExt::set_mode` and
+`std::os::unix::fs::symlink` unconditionally.
+
+- **`apply_index_file_mode`**: gate the `PermissionsExt`/`set_mode` body in
+  `#[cfg(unix)]`; on Windows it is a no-op (no POSIX mode bits — the executable
+  bit is not represented in the filesystem). Mirrors `porcelain/stash.rs`.
+- **`write_to_worktree`**: gate the `symlink` call in `#[cfg(unix)]`; on Windows
+  write the symlink target as a regular file (unprivileged symlink creation is
+  unavailable) so the worktree stays populated. Gate the executable-bit
+  `set_mode` block in `#[cfg(unix)]`.
+
+### 2. `grit-lib/src/diff.rs` (2 errors)
+
+`worktree_content_matches_index_oid` used
+`std::os::unix::ffi::OsStrExt::as_bytes` to hash a symlink target.
+
+- Extract a `symlink_target_bytes(&Path) -> Vec<u8>` helper: raw `OsStr` bytes
+  on Unix, lossy UTF-8 on Windows (WTF-8 `OsStr` has no stable byte view;
+  symlink targets in Git trees are UTF-8 in practice). Mirrors the
+  `porcelain/stash.rs` `symlink_target_to_bytes` pattern.
+
+### 3. `grit-lib/src/difftool.rs` (1 error)
+
+The symlink-backed difftool checkout optimisation called
+`std::os::unix::fs::symlink` unconditionally.
+
+- Gate the whole `if use_symlinks { … symlink … }` fast-path in `#[cfg(unix)]`;
+  on Windows it falls through to the existing file-copy path below.
+
+> Status: **all three files have been fixed in this branch** and
+> `cargo check --target x86_64-pc-windows-gnu -p grit-simple` now completes with
+> **no errors** (warnings only). The host build (`cargo check -p grit-simple`)
+> remains clean.
+
+## Behavioural caveats on Windows (intentional, document but don't block)
+
+These keep the crate compiling and functional; exact Git semantics for these
+edge cases are a follow-up, not a compile blocker:
+
+- **Symlinks**: `checkout`/`stash` materialise mode-`120000` entries as regular
+  files containing the target path rather than real symlinks. `difftool` copies
+  instead of symlinking.
+- **Executable bit**: not stored by the filesystem, so mode application is a
+  no-op. The index already records mode `100644`/`100755` from the tree; only
+  worktree application differs.
+- **`untracked_cache`**: uses `uname(2)` (`nix`) under `#[cfg(unix)]` for cache
+  validity; the `#[cfg(not(unix))]` branch already disables/short-circuits it.
+- **Default identity**: `ident_config` resolves the user via `getuid`/passwd on
+  Unix; the Windows branch already falls back to env-based resolution.
+
+## Follow-up clean-up (not required to compile, but do before enabling `-D warnings` in CI)
+
+The Windows cross-check emits ~13 warnings, all in already-ported files where an
+import or binding is only used on Unix. Tidy with `#[cfg(unix)]` on the imports /
+`let _ =` bindings or `#[cfg_attr(not(unix), allow(unused))]`:
+
+- `porcelain/stash.rs:22` (`PermissionsExt` import), `:444` (`target` unused)
+- `attributes.rs:9`, `ident_resolve.rs:10`, `shared_repo.rs:7`, `mailmap.rs:14`
+  (unused imports under non-unix)
+- `hooks.rs:282`/`:290` (`repo`/`meta` unused on non-unix)
+- `repo.rs:352` (`gitfile` field unused on non-unix)
+- `git_date/compat.rs:12` (`time_t` non-camel-case — pre-existing, allow it)
+
+## Optional dependency hygiene
+
+`grit-lib/Cargo.toml` declares `nix` and `libc` as unconditional dependencies.
+They currently compile for `x86_64-pc-windows-gnu` (their Windows-relevant
+surface is small), so this is **not** a blocker. For cleanliness, move the
+Unix-only ones behind a target table so they are never built on Windows:
+
+```toml
+[target.'cfg(unix)'.dependencies]
+nix = { workspace = true }
+```
+
+(`libc` must stay generally available — `git_date/compat.rs` references
+`libc::c_char` under `#[cfg(unix)]` only, but a workspace-level move to
+`cfg(unix)` is safe since the Windows path uses bare `extern "C"`.) Validate
+with the cross-check after moving.
+
+## MSVC vs GNU note
+
+Validation uses `x86_64-pc-windows-gnu` because `cargo check` needs only the
+target std, not a linker. The one place that actually **links** against the CRT
+is `git_date/compat.rs` (`_localtime64_s`, `_mktime64`, `strftime`). These exist
+in both mingw's `msvcrt` and MSVC's `ucrt`, so a real
+`x86_64-pc-windows-msvc` **build** (not just check) should be run on a Windows
+runner / via `cargo-xwin` as a final gate before declaring the port done.
+
+## Definition of done
+
+1. `cargo check --target x86_64-pc-windows-gnu -p grit-simple` — no errors. ✅ (done in this branch)
+2. `cargo check -p grit-simple` (host) — still clean. ✅
+3. (Recommended) `cargo build --target x86_64-pc-windows-msvc -p grit-simple` on
+   a Windows runner to validate the `git_date` CRT FFI links.
+4. (Optional) Warning clean-up + `nix` target-gating per the sections above.

--- a/grit-lib/Cargo.toml
+++ b/grit-lib/Cargo.toml
@@ -37,7 +37,6 @@ merge3.workspace = true
 imara-diff.workspace = true
 regex.workspace = true
 libc.workspace = true
-nix.workspace = true
 unicode-width.workspace = true
 encoding_rs = "0.8.35"
 icu_normalizer.workspace = true
@@ -48,3 +47,8 @@ shell-words.workspace = true
 # Optional: the default `ureq`-backed HTTP client (feature `http-ureq`).
 ureq = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
+
+# `nix` (signals, poll, uid, uname, Unix sockets) is only used behind
+# `#[cfg(unix)]`, so it is not pulled in on Windows.
+[target.'cfg(unix)'.dependencies]
+nix.workspace = true

--- a/grit-lib/src/attributes.rs
+++ b/grit-lib/src/attributes.rs
@@ -6,6 +6,7 @@
 
 use crate::config::parse_path;
 use crate::config::ConfigSet;
+#[cfg(unix)]
 use crate::index::normalize_mode;
 use crate::index::Index;
 use crate::index::MODE_EXECUTABLE;

--- a/grit-lib/src/diff.rs
+++ b/grit-lib/src/diff.rs
@@ -2509,6 +2509,23 @@ pub fn refresh_index_stat_content_verified(
     changed
 }
 
+/// Symlink target as the byte string Git hashes for the blob OID.
+///
+/// On Unix the raw `OsStr` bytes are used verbatim. On Windows `OsStr` is WTF-8
+/// and has no stable byte view, so the lossy UTF-8 form is used (symlink targets
+/// in Git trees are UTF-8 in practice).
+fn symlink_target_bytes(target: &Path) -> Vec<u8> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt as _;
+        target.as_os_str().as_bytes().to_vec()
+    }
+    #[cfg(not(unix))]
+    {
+        target.as_os_str().to_string_lossy().as_bytes().to_vec()
+    }
+}
+
 /// Whether the work tree blob at `abs` matches the index entry OID (raw bytes, no CRLF smudge).
 fn worktree_content_matches_index_oid(ie: &IndexEntry, abs: &Path, meta: &fs::Metadata) -> bool {
     use crate::index::{MODE_EXECUTABLE, MODE_REGULAR, MODE_SYMLINK};
@@ -2516,9 +2533,8 @@ fn worktree_content_matches_index_oid(ie: &IndexEntry, abs: &Path, meta: &fs::Me
         if !meta.file_type().is_symlink() {
             return false;
         }
-        use std::os::unix::ffi::OsStrExt as _;
         fs::read_link(abs)
-            .map(|t| Odb::hash_object_data(ObjectKind::Blob, t.as_os_str().as_bytes()) == ie.oid)
+            .map(|t| Odb::hash_object_data(ObjectKind::Blob, &symlink_target_bytes(&t)) == ie.oid)
             .unwrap_or(false)
     } else if ie.mode == MODE_REGULAR || ie.mode == MODE_EXECUTABLE {
         if !meta.file_type().is_file() {

--- a/grit-lib/src/difftool.rs
+++ b/grit-lib/src/difftool.rs
@@ -987,6 +987,9 @@ fn populate_dir_side(
         std::fs::create_dir_all(parent).map_err(Error::Io)?;
     }
 
+    // Symlink-backed difftool checkout is a Unix optimisation; on Windows we fall
+    // through to copying the work-tree file into the temp dir below.
+    #[cfg(unix)]
     if !is_left && use_symlinks {
         let wt = work_tree.join(rel);
         if wt.is_file() {
@@ -995,6 +998,8 @@ fn populate_dir_side(
             return Ok(());
         }
     }
+    #[cfg(not(unix))]
+    let _ = use_symlinks;
 
     if !is_left {
         let wt = work_tree.join(rel);

--- a/grit-lib/src/git_date/compat.rs
+++ b/grit-lib/src/git_date/compat.rs
@@ -9,6 +9,7 @@
 pub use libc::time_t;
 
 #[cfg(not(unix))]
+#[allow(non_camel_case_types)] // mirror the C / `libc` spelling used on Unix
 pub type time_t = i64;
 
 #[cfg(unix)]

--- a/grit-lib/src/hooks.rs
+++ b/grit-lib/src/hooks.rs
@@ -278,6 +278,9 @@ fn same_dir(a: &Path, b: &Path) -> bool {
     }
 }
 
+// `repo`/`meta` are only read on Unix (executable-bit advice); Windows has no
+// POSIX permission bits, so the candidate is returned without that check.
+#[cfg_attr(not(unix), allow(unused_variables))]
 fn traditional_hook_candidate(
     repo: &Repository,
     hooks_dir: &Path,

--- a/grit-lib/src/ident_resolve.rs
+++ b/grit-lib/src/ident_resolve.rs
@@ -7,6 +7,7 @@ use std::ffi::OsString;
 
 use thiserror::Error;
 
+#[cfg(unix)]
 use crate::commit_encoding::decode_bytes;
 use crate::config::ConfigSet;
 use crate::ident_config::ident_default_name;

--- a/grit-lib/src/mailmap.rs
+++ b/grit-lib/src/mailmap.rs
@@ -11,6 +11,7 @@ use crate::repo::Repository;
 use crate::rev_parse::resolve_revision;
 use std::collections::BTreeMap;
 use std::fs;
+#[cfg(unix)]
 use std::io::Read;
 use std::path::{Path, PathBuf};
 

--- a/grit-lib/src/porcelain/checkout.rs
+++ b/grit-lib/src/porcelain/checkout.rs
@@ -19,15 +19,22 @@ use crate::index::{MODE_EXECUTABLE, MODE_SYMLINK};
 
 /// Set `abs_path` permissions to match Git index `mode` (regular vs executable blob).
 pub fn apply_index_file_mode(abs_path: &Path, mode: u32) -> Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-    let mut perms = std::fs::metadata(abs_path)?.permissions();
-    let new_mode = if mode == MODE_EXECUTABLE {
-        0o755
-    } else {
-        0o644
-    };
-    perms.set_mode(new_mode);
-    std::fs::set_permissions(abs_path, perms)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(abs_path)?.permissions();
+        let new_mode = if mode == MODE_EXECUTABLE {
+            0o755
+        } else {
+            0o644
+        };
+        perms.set_mode(new_mode);
+        std::fs::set_permissions(abs_path, perms)?;
+    }
+    // Windows has no POSIX mode bits; the executable bit is not represented in
+    // the filesystem, so this is a no-op there.
+    #[cfg(not(unix))]
+    let _ = (abs_path, mode);
     Ok(())
 }
 
@@ -87,17 +94,26 @@ pub fn write_to_worktree(work_tree: &Path, rel_path: &str, data: &[u8], mode: u3
         let target = std::str::from_utf8(data).map_err(|_| {
             Error::PathError(format!("symlink target for '{rel_path}' is not UTF-8"))
         })?;
+        #[cfg(unix)]
         std::os::unix::fs::symlink(target, &abs_path)
             .map_err(|e| Error::PathError(format!("creating symlink '{rel_path}': {e}")))?;
+        // Windows lacks unprivileged symlink creation; materialise the link as a
+        // regular file containing the target path so the worktree stays populated.
+        #[cfg(not(unix))]
+        std::fs::write(&abs_path, target.as_bytes())
+            .map_err(|e| Error::PathError(format!("writing symlink '{rel_path}': {e}")))?;
     } else {
         std::fs::write(&abs_path, data)
             .map_err(|e| Error::PathError(format!("writing '{rel_path}': {e}")))?;
 
         if mode == MODE_EXECUTABLE {
-            use std::os::unix::fs::PermissionsExt;
-            let mut perms = std::fs::metadata(&abs_path)?.permissions();
-            perms.set_mode(0o755);
-            std::fs::set_permissions(&abs_path, perms)?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let mut perms = std::fs::metadata(&abs_path)?.permissions();
+                perms.set_mode(0o755);
+                std::fs::set_permissions(&abs_path, perms)?;
+            }
         }
     }
 

--- a/grit-lib/src/porcelain/stash.rs
+++ b/grit-lib/src/porcelain/stash.rs
@@ -19,7 +19,10 @@ use std::io;
 use std::path::Path;
 
 use crate::error::{Error, Result};
-use crate::index::{Index, IndexEntry, MODE_EXECUTABLE, MODE_GITLINK, MODE_SYMLINK};
+use crate::index::{Index, IndexEntry, MODE_GITLINK, MODE_SYMLINK};
+// `MODE_EXECUTABLE` only drives the Unix executable-bit application below.
+#[cfg(unix)]
+use crate::index::MODE_EXECUTABLE;
 use crate::objects::{parse_commit, parse_tree, CommitData, ObjectId};
 use crate::odb::Odb;
 use crate::repo::Repository;
@@ -448,6 +451,10 @@ pub fn apply_stash(
                     }
                     #[cfg(unix)]
                     std::os::unix::fs::symlink(&target, &file_path)?;
+                    // Windows lacks unprivileged symlinks; keep the worktree
+                    // populated by writing the target as a regular file.
+                    #[cfg(not(unix))]
+                    fs::write(&file_path, target.as_bytes())?;
                 } else if head_moved {
                     // Three-way merge: base (head_at_stash), ours (current HEAD), theirs (stash)
                     let base_content = base_map

--- a/grit-lib/src/repo.rs
+++ b/grit-lib/src/repo.rs
@@ -386,7 +386,6 @@ impl Repository {
                 if assume_different {
                     repo.enforce_safe_directory()?;
                 } else {
-                    #[cfg(unix)]
                     ensure_valid_ownership(
                         gitfile.as_deref(),
                         repo.work_tree.as_deref(),

--- a/grit-lib/src/shared_repo.rs
+++ b/grit-lib/src/shared_repo.rs
@@ -4,6 +4,7 @@
 //! `path.c`.
 
 use crate::config::{parse_bool, ConfigSet};
+#[cfg(unix)]
 use std::fs;
 use std::path::Path;
 

--- a/grit-lib/src/split_index.rs
+++ b/grit-lib/src/split_index.rs
@@ -69,6 +69,7 @@ fn parse_shared_repository_perm(raw: Option<&str>) -> i32 {
     }
 }
 
+#[cfg(unix)]
 fn calc_shared_perm(shared_repo: i32, mode: u32) -> u32 {
     let tweak = if shared_repo < 0 {
         (-shared_repo) as u32


### PR DESCRIPTION
## Summary

Gets **`grit-lib`** and **`grit-simple`** (the `gi` binary) compiling for Windows. `grit-cli` and the other workspace members are out of scope.

`grit-simple` has no platform-specific code of its own, so this reduces entirely to making `grit-lib` build on Windows with default features. The port was already ~95% done (most call sites paired `#[cfg(unix)]`/`#[cfg(not(unix))]`, IPC/process modules gated, `git_date` fully cross-platform). This PR closes the last gaps.

## Changes

**Last un-gated Unix call sites (the actual compile errors):**
- `porcelain/checkout.rs` — `cfg`-gate `PermissionsExt::set_mode` (no-op on Windows) and the symlink creation in `write_to_worktree` (Windows materialises symlink targets as regular files).
- `diff.rs` — add `symlink_target_bytes()` helper (raw `OsStr` bytes on Unix, lossy UTF-8 on Windows) instead of `OsStrExt::as_bytes`.
- `difftool.rs` — `cfg`-gate the symlink fast-path so Windows copies instead.

**Warning clean-up (Windows-only warnings):**
- Gate Unix-only imports behind `#[cfg(unix)]` (`stash` `MODE_EXECUTABLE`, `attributes` `normalize_mode`, `ident_resolve` `decode_bytes`, `shared_repo` `std::fs`, `mailmap` `std::io::Read`).
- `hooks.rs` — `#[cfg_attr(not(unix), allow(unused_variables))]` on `traditional_hook_candidate`.
- `repo.rs` — drop `#[cfg(unix)]` on the `ensure_valid_ownership` call so the existing non-unix stub is used (removes the unused `gitfile` binding and the dead-stub warning together).
- `split_index.rs` — gate `calc_shared_perm` to `#[cfg(unix)]`.
- `git_date/compat.rs` — `#[allow(non_camel_case_types)]` on the Windows `time_t` alias.
- `stash.rs` — materialise symlink restores as regular files on Windows.

**Dependency hygiene:**
- Move `nix` to `[target.'cfg(unix)'.dependencies]` in `grit-lib/Cargo.toml` (used only behind `#[cfg(unix)]`). `libc` stays general — `refs.rs` compares against `libc::EISDIR`/`ENOTDIR`/`EPERM` un-gated, and those errno constants exist on Windows too.

**Docs:** `WINDOWS_PORT_PLAN.md` documents the state, fixes, behavioural caveats, and verification.

## Verification

```sh
rustup target add x86_64-pc-windows-gnu
cargo check --target x86_64-pc-windows-gnu -p grit-simple   # no errors
cargo check -p grit-simple                                  # host, still clean
```

Both now emit only the pre-existing `commit_graph_file.rs` `base_layers_declared` dead-field warning (present on host independent of this port, out of scope).

## Behavioural caveats on Windows (intentional; exact semantics are follow-ups, not compile blockers)
- Symlink tree-entries (mode `120000`) are written as regular files containing the target path; `difftool` copies instead of symlinking.
- The executable bit isn't stored by the filesystem, so worktree mode application is a no-op.

## Not validated here
`cargo check` doesn't link. The one place that links CRT functions is `git_date/compat.rs` (`_localtime64_s`, `_mktime64`, `strftime`); a real `x86_64-pc-windows-msvc` **build** on a Windows runner should be the final gate.

https://claude.ai/code/session_01DtkavNnBq3sJZYviHVwbXz

---
_Generated by [Claude Code](https://claude.ai/code/session_01DtkavNnBq3sJZYviHVwbXz)_