### PR TITLE
Bump workspace version to 0.4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "grit-cli"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "atty",
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "grit-examples"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "grit-http-server"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -508,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "grit-lib"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "base64",
  "encoding_rs",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "grit-protocol"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "grit-lib",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "grit-simple"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "grit-utils"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["grit", "grit-lib", "grit-protocol", "grit-simple"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 repository = "https://github.com/gitbutlerapp/grit"
 


### PR DESCRIPTION
Brings `main` up to the `v0.4.4` release version.

The shared `[workspace.package]` version goes `0.4.3` → `0.4.4` (with the matching `Cargo.lock` workspace-member entries). This is the same commit the pushed `v0.4.4` tag points at, so `main` carries the released version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)