### PR TITLE
Rename gs binary (was gi) and bump to 0.4.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           cd target/${{ matrix.target }}/release
           tar czf ../../../grit-${{ matrix.target }}.tar.gz grit
-          tar czf ../../../gi-${{ matrix.target }}.tar.gz gi
+          tar czf ../../../gs-${{ matrix.target }}.tar.gz gs
         shell: bash
 
       - name: Upload artifact
@@ -79,9 +79,9 @@ jobs:
           name: grit-${{ matrix.target }}
           path: |
             grit-${{ matrix.target }}.tar.gz
-            gi-${{ matrix.target }}.tar.gz
+            gs-${{ matrix.target }}.tar.gz
 
-  # Windows ships the `grit-simple` CLI (the `gi` binary), installed via
+  # Windows ships the `grit-simple` CLI (the `gs` binary), installed via
   # `irm grit-scm.com/install.ps1 | iex` (see docs/install.ps1).
   build-windows:
     strategy:
@@ -114,13 +114,13 @@ jobs:
       - name: Package
         shell: pwsh
         run: |
-          Compress-Archive -Path target/${{ matrix.target }}/release/gi.exe -DestinationPath gi-${{ matrix.target }}.zip
+          Compress-Archive -Path target/${{ matrix.target }}/release/gs.exe -DestinationPath gs-${{ matrix.target }}.zip
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: gi-${{ matrix.target }}
-          path: gi-${{ matrix.target }}.zip
+          name: gs-${{ matrix.target }}
+          path: gs-${{ matrix.target }}.zip
 
   release:
     needs: [build, build-windows]
@@ -139,4 +139,5 @@ jobs:
           generate_release_notes: true
           files: |
             grit-*.tar.gz
-            gi-*.zip
+            gs-*.tar.gz
+            gs-*.zip

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "grit-cli"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "atty",
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "grit-examples"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "grit-http-server"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -508,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "grit-lib"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "base64",
  "encoding_rs",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "grit-protocol"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "grit-lib",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "grit-simple"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "grit-utils"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["grit", "grit-lib", "grit-protocol", "grit-simple"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 repository = "https://github.com/gitbutlerapp/grit"
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1783,7 +1783,7 @@ grit-lib = <span class="string">"0.3"</span>
               </button>
             </div>
             <div class="install-alt">
-              installs <code>grit</code> and <code>gi</code>, or
+              installs <code>grit</code> and <code>gs</code>, or
               <code>cargo install grit-cli</code>
             </div>
           </div>
@@ -1814,7 +1814,7 @@ grit-lib = <span class="string">"0.3"</span>
               </button>
             </div>
             <div class="install-alt">
-              installs <code>gi</code> (run in PowerShell), or
+              installs <code>gs</code> (run in PowerShell), or
               <code>cargo install grit-simple</code>
             </div>
           </div>

--- a/docs/install
+++ b/docs/install
@@ -1,6 +1,6 @@
 #!/bin/sh
 # grit installer - downloads pre-built binaries from GitHub Releases.
-# Installs both `grit` (grit-cli) and `gi` (grit-simple).
+# Installs both `grit` (grit-cli) and `gs` (grit-simple).
 # Usage: curl -fsSL https://grit-scm.com/install | sh
 
 main() {
@@ -60,8 +60,8 @@ main() {
 
   mkdir -p "$INSTALL_DIR"
 
-  # Install both binaries: `grit` (grit-cli) and `gi` (grit-simple).
-  for BIN in grit gi; do
+  # Install both binaries: `grit` (grit-cli) and `gs` (grit-simple).
+  for BIN in grit gs; do
     URL="https://github.com/$REPO/releases/latest/download/${BIN}-${TARGET}.tar.gz"
     echo "Downloading from: $URL"
     curl -fSL "$URL" -o "$TMP/${BIN}.tar.gz"
@@ -77,7 +77,7 @@ main() {
     echo "Add it with:  export PATH=\"$INSTALL_DIR:\$PATH\""
   else
     echo "$(grit --version)"
-    echo "$(gi --version)"
+    echo "$(gs --version)"
   fi
 }
 

--- a/docs/install.ps1
+++ b/docs/install.ps1
@@ -1,4 +1,4 @@
-# grit-simple installer for Windows - downloads a pre-built gi.exe from GitHub Releases
+# grit-simple installer for Windows - downloads a pre-built gs.exe from GitHub Releases
 # Usage: irm grit-scm.com/install.ps1 | iex
 #
 # Override the install location with $env:GRIT_INSTALL_DIR before running.
@@ -10,24 +10,24 @@ $InstallDir = if ($env:GRIT_INSTALL_DIR) { $env:GRIT_INSTALL_DIR } else { Join-P
 
 # Windows ARM64 runs x86_64 binaries via emulation, so x86_64 is the only target we ship.
 $Target = 'x86_64-pc-windows-msvc'
-$Url = "https://github.com/$Repo/releases/latest/download/gi-$Target.zip"
+$Url = "https://github.com/$Repo/releases/latest/download/gs-$Target.zip"
 
 Write-Host "Downloading from: $Url"
 
 $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("grit-" + [System.IO.Path]::GetRandomFileName())
 New-Item -ItemType Directory -Path $tmp | Out-Null
 try {
-  $zip = Join-Path $tmp 'gi.zip'
+  $zip = Join-Path $tmp 'gs.zip'
   Invoke-WebRequest -Uri $Url -OutFile $zip
   Expand-Archive -Path $zip -DestinationPath $tmp -Force
 
   New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
-  Copy-Item -Path (Join-Path $tmp 'gi.exe') -Destination (Join-Path $InstallDir 'gi.exe') -Force
+  Copy-Item -Path (Join-Path $tmp 'gs.exe') -Destination (Join-Path $InstallDir 'gs.exe') -Force
 } finally {
   Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
 }
 
-Write-Host "Installed gi to $InstallDir\gi.exe"
+Write-Host "Installed gs to $InstallDir\gs.exe"
 
 # Add the install dir to the user PATH if it isn't there already.
 $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
@@ -38,4 +38,4 @@ if (($userPath -split ';') -notcontains $InstallDir) {
   Write-Host "Added $InstallDir to your user PATH (restart open terminals to pick it up)."
 }
 
-& "$InstallDir\gi.exe" --version
+& "$InstallDir\gs.exe" --version

--- a/grit-simple/Cargo.toml
+++ b/grit-simple/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/gitbutlerapp/grit"
 readme = "README.md"
 
 [[bin]]
-name = "gi"
+name = "gs"
 path = "src/main.rs"
 
 [lints]

--- a/grit-simple/README.md
+++ b/grit-simple/README.md
@@ -1,8 +1,8 @@
 # grit-simple
 
-`grit-simple` provides `gi`, a small opinionated command line interface backed by [`grit-lib`](https://crates.io/crates/grit-lib).
+`grit-simple` provides `gs`, a small opinionated command line interface backed by [`grit-lib`](https://crates.io/crates/grit-lib).
 
-It is not intended to be a drop-in replacement for Git. For Git-compatible command behavior, use the `grit` binary from the `grit-cli` crate. `gi` is a simpler interface for workflows built on Grit's Rust implementation.
+It is not intended to be a drop-in replacement for Git. For Git-compatible command behavior, use the `grit` binary from the `grit-cli` crate. `gs` is a simpler interface for workflows built on Grit's Rust implementation.
 
 ## Install
 
@@ -10,24 +10,24 @@ It is not intended to be a drop-in replacement for Git. For Git-compatible comma
 cargo install grit-simple
 ```
 
-This installs the `gi` executable.
+This installs the `gs` executable.
 
 ## Commands
 
-`gi` favors one obvious way to do the common thing, plain-language output, and a
+`gs` favors one obvious way to do the common thing, plain-language output, and a
 status screen that doubles as the home base.
 
-### `gi` / `gi status`
+### `gs` / `gs status`
 
-Running `gi` with no arguments shows the dashboard: the current branch, a
+Running `gs` with no arguments shows the dashboard: the current branch, a
 shortlog of the commits you're ahead of the target branch by, your staged and
 unstaged changes, untracked files, and a hint for what to do next.
 
 ```sh
-gi
+gs
 # explicit form / alias:
-gi status
-gi st
+gs status
+gs st
 ```
 
 ```text
@@ -46,87 +46,87 @@ Changed (not staged)
 Untracked
   ?  notes.md
 
-→ gi add <file> to stage  ·  gi commit "message" to commit
+→ gs add <file> to stage  ·  gs commit "message" to commit
 ```
 
-### `gi add`
+### `gs add`
 
-Stage changes. With no paths, stages **everything** that `gi status` reports as
+Stage changes. With no paths, stages **everything** that `gs status` reports as
 changed — modifications, deletions, and untracked files alike. Pass paths to
 stage a subset.
 
 ```sh
-gi add            # stage all changes
-gi add src/ a.txt # stage only these paths
+gs add            # stage all changes
+gs add src/ a.txt # stage only these paths
 ```
 
-### `gi commit`
+### `gs commit`
 
 Record the staged changes as a new commit. The message can be a positional
 argument or `-m`; `-a` stages every change first.
 
 ```sh
-gi commit "what changed"
-gi commit -m "what changed"
-gi commit -a "stage everything, then commit"
+gs commit "what changed"
+gs commit -m "what changed"
+gs commit -a "stage everything, then commit"
 ```
 
 Author/committer identity comes from `user.name` / `user.email` (honoring the
 `GIT_AUTHOR_DATE` / `GIT_COMMITTER_DATE` overrides).
 
-### `gi branch`
+### `gs branch`
 
 List branches, or create / delete one.
 
 ```sh
-gi branch            # list (current marked with *)
-gi branch feature    # create "feature" at HEAD (does not switch)
-gi branch -d feature # delete "feature"
+gs branch            # list (current marked with *)
+gs branch feature    # create "feature" at HEAD (does not switch)
+gs branch -d feature # delete "feature"
 ```
 
-### `gi switch`
+### `gs switch`
 
 Move to another branch, updating the working tree. Refuses to switch with
 uncommitted changes, and won't clobber an untracked file the destination needs.
 
 ```sh
-gi switch main          # switch to an existing branch
-gi switch -c feature    # create "feature" and switch to it
-gi checkout main        # aliases: checkout, co
+gs switch main          # switch to an existing branch
+gs switch -c feature    # create "feature" and switch to it
+gs checkout main        # aliases: checkout, co
 ```
 
-### `gi merge`
+### `gs merge`
 
 Merge another branch into the current one — fast-forwarding when possible,
 otherwise recording a merge commit. Conflicts are reported without leaving a
-half-finished merge (resolving them is out of scope for `gi`).
+half-finished merge (resolving them is out of scope for `gs`).
 
 ```sh
-gi merge feature
+gs merge feature
 ```
 
-### `gi fetch` / `gi pull` / `gi push`
+### `gs fetch` / `gs pull` / `gs push`
 
-Talk to remotes. `gi` keeps these argument-free: they default to `origin` and
+Talk to remotes. `gs` keeps these argument-free: they default to `origin` and
 the current branch's same-named counterpart — no `-u origin <branch>` ceremony.
 
 ```sh
-gi fetch          # download refs/objects from origin (or: gi fetch <remote>)
-gi pull           # fetch, then fast-forward / merge the upstream in
-gi push           # publish the current branch to origin
+gs fetch          # download refs/objects from origin (or: gs fetch <remote>)
+gs pull           # fetch, then fast-forward / merge the upstream in
+gs push           # publish the current branch to origin
 ```
 
 Local (`file://` / path), `git://`, `ssh`, and `http(s)` remotes are supported.
 
-### `gi shortlog`
+### `gs shortlog`
 
 Show the current branch, the target branch, and commits that are reachable from
 `HEAD` but not from the target branch.
 
 ```sh
-gi shortlog
+gs shortlog
 # alias:
-gi sl
+gs sl
 ```
 
 Target branch lookup uses the first available value from:

--- a/grit-simple/src/commands/add.rs
+++ b/grit-simple/src/commands/add.rs
@@ -1,7 +1,7 @@
-//! `gi add` — stage changes. With no paths, stages everything.
+//! `gs add` — stage changes. With no paths, stages everything.
 //!
-//! Staging is driven by the same status model the dashboard uses, so `gi add`
-//! stages exactly what `gi status` reports as changed — including deletions and
+//! Staging is driven by the same status model the dashboard uses, so `gs add`
+//! stages exactly what `gs status` reports as changed — including deletions and
 //! untracked files — without reimplementing worktree walking or ignore rules.
 
 use anyhow::{Context, Result};
@@ -30,12 +30,12 @@ pub fn run(paths: &[String]) -> Result<()> {
 
 /// Stage all changes matching `selectors` (empty selectors = everything).
 ///
-/// Returns the number of paths staged. Shared with `gi commit -a`.
+/// Returns the number of paths staged. Shared with `gs commit -a`.
 pub fn stage(repo: &Repository, selectors: &[String]) -> Result<usize> {
     let work_tree = repo
         .work_tree
         .clone()
-        .context("gi add needs a working tree")?;
+        .context("gs add needs a working tree")?;
     let model = status(repo, &StatusOptions::default(), &mut NullProgress)
         .context("could not compute status")?;
     let mut index = repo.load_index().context("could not load the index")?;

--- a/grit-simple/src/commands/branch.rs
+++ b/grit-simple/src/commands/branch.rs
@@ -1,4 +1,4 @@
-//! `gi branch` — list branches, or create / delete one.
+//! `gs branch` — list branches, or create / delete one.
 
 use anyhow::{bail, Context, Result};
 use grit_lib::refs;

--- a/grit-simple/src/commands/commit.rs
+++ b/grit-simple/src/commands/commit.rs
@@ -1,4 +1,4 @@
-//! `gi commit` — record the staged changes as a new commit.
+//! `gs commit` — record the staged changes as a new commit.
 
 use anyhow::{bail, Context, Result};
 use grit_lib::config::ConfigSet;
@@ -22,13 +22,13 @@ pub fn run(message: Option<String>, all: bool) -> Result<()> {
 
     let message = match message {
         Some(m) if !m.trim().is_empty() => m,
-        _ => bail!("provide a commit message, e.g. gi commit \"what changed\""),
+        _ => bail!("provide a commit message, e.g. gs commit \"what changed\""),
     };
 
     let model = status(&repo, &StatusOptions::default(), &mut NullProgress)
         .context("could not compute status")?;
     if model.staged.is_empty() {
-        bail!("nothing staged to commit — use \"gi add\" first");
+        bail!("nothing staged to commit — use \"gs add\" first");
     }
 
     let (refname, short_name, parent) = match &model.head {
@@ -38,7 +38,7 @@ pub fn run(message: Option<String>, all: bool) -> Result<()> {
             oid,
         } => (refname.clone(), short_name.clone(), *oid),
         HeadState::Detached { .. } => {
-            bail!("HEAD is detached; gi commit needs a branch")
+            bail!("HEAD is detached; gs commit needs a branch")
         }
         HeadState::Invalid => bail!("HEAD is in an unknown state"),
     };

--- a/grit-simple/src/commands/fetch.rs
+++ b/grit-simple/src/commands/fetch.rs
@@ -1,4 +1,4 @@
-//! `gi fetch` — download refs and objects from a remote (default `origin`).
+//! `gs fetch` — download refs and objects from a remote (default `origin`).
 
 use anyhow::{Context, Result};
 use grit_lib::config::ConfigSet;

--- a/grit-simple/src/commands/merge.rs
+++ b/grit-simple/src/commands/merge.rs
@@ -1,8 +1,8 @@
-//! `gi merge` — merge another branch into the current one.
+//! `gs merge` — merge another branch into the current one.
 //!
 //! Fast-forwards when possible; otherwise performs a real three-way merge and
 //! records a merge commit. Conflicts are reported (without leaving a
-//! half-finished state) — resolving them is out of scope for `gi`.
+//! half-finished state) — resolving them is out of scope for `gs`.
 
 use anyhow::{bail, Context, Result};
 use grit_lib::config::ConfigSet;
@@ -36,7 +36,7 @@ pub fn run(branch: &str) -> Result<()> {
     let (refname, head_oid) = match resolve_head(&repo.git_dir)? {
         HeadState::Branch { refname, oid: Some(oid), .. } => (refname, oid),
         HeadState::Branch { .. } => bail!("no commits yet on this branch"),
-        HeadState::Detached { .. } => bail!("HEAD is detached; gi merge needs a branch"),
+        HeadState::Detached { .. } => bail!("HEAD is detached; gs merge needs a branch"),
         HeadState::Invalid => bail!("HEAD is in an unknown state"),
     };
 
@@ -45,7 +45,7 @@ pub fn run(branch: &str) -> Result<()> {
 }
 
 /// Integrate `other` into the branch `into_ref` (currently at `into_oid`):
-/// up-to-date, fast-forward, or three-way merge. Shared with `gi pull`.
+/// up-to-date, fast-forward, or three-way merge. Shared with `gs pull`.
 pub fn integrate(
     repo: &Repository,
     into_ref: &str,

--- a/grit-simple/src/commands/mod.rs
+++ b/grit-simple/src/commands/mod.rs
@@ -1,4 +1,4 @@
-//! `gi` subcommand implementations.
+//! `gs` subcommand implementations.
 
 pub mod add;
 pub mod branch;

--- a/grit-simple/src/commands/pull.rs
+++ b/grit-simple/src/commands/pull.rs
@@ -1,4 +1,4 @@
-//! `gi pull` — fetch from the remote, then integrate the upstream into the
+//! `gs pull` — fetch from the remote, then integrate the upstream into the
 //! current branch (fast-forward when possible, otherwise a merge).
 
 use anyhow::{bail, Context, Result};
@@ -24,7 +24,7 @@ pub fn run() -> Result<()> {
 
     let (refname, short_name, head_oid) = match resolve_head(&repo.git_dir)? {
         HeadState::Branch { refname, short_name, oid } => (refname, short_name, oid),
-        HeadState::Detached { .. } => bail!("HEAD is detached; gi pull needs a branch"),
+        HeadState::Detached { .. } => bail!("HEAD is detached; gs pull needs a branch"),
         HeadState::Invalid => bail!("HEAD is in an unknown state"),
     };
 

--- a/grit-simple/src/commands/push.rs
+++ b/grit-simple/src/commands/push.rs
@@ -1,6 +1,6 @@
-//! `gi push` — publish the current branch to its remote.
+//! `gs push` — publish the current branch to its remote.
 //!
-//! No upstream ceremony: `gi push` sends the current branch to `origin` (or the
+//! No upstream ceremony: `gs push` sends the current branch to `origin` (or the
 //! configured `branch.<name>.remote`) under the same name, creating it on the
 //! remote if needed.
 
@@ -19,7 +19,7 @@ pub fn run() -> Result<()> {
     let (short_name, oid) = match resolve_head(&repo.git_dir)? {
         HeadState::Branch { short_name, oid: Some(oid), .. } => (short_name, oid),
         HeadState::Branch { .. } => bail!("no commits yet to push"),
-        HeadState::Detached { .. } => bail!("HEAD is detached; gi push needs a branch"),
+        HeadState::Detached { .. } => bail!("HEAD is detached; gs push needs a branch"),
         HeadState::Invalid => bail!("HEAD is in an unknown state"),
     };
 
@@ -52,7 +52,7 @@ pub fn run() -> Result<()> {
             PushRefStatus::UpToDate => println!("  {target} already up to date"),
             PushRefStatus::RejectNonFastForward => {
                 rejected = true;
-                eprintln!("  rejected {target}: not a fast-forward — run `gi pull` first");
+                eprintln!("  rejected {target}: not a fast-forward — run `gs pull` first");
             }
             _ => {
                 rejected = true;

--- a/grit-simple/src/commands/shortlog.rs
+++ b/grit-simple/src/commands/shortlog.rs
@@ -1,4 +1,4 @@
-//! `gi shortlog` — the commits on this branch that aren't on the target yet.
+//! `gs shortlog` — the commits on this branch that aren't on the target yet.
 
 use anyhow::{bail, Context, Result};
 use grit_lib::objects::ObjectId;
@@ -43,7 +43,7 @@ fn current_branch_and_oid(head: &HeadState) -> Result<(&str, ObjectId)> {
         HeadState::Branch { short_name, .. } => {
             bail!("branch '{short_name}' does not have any commits yet")
         }
-        HeadState::Detached { .. } => bail!("HEAD is detached; gi shortlog needs a current branch"),
+        HeadState::Detached { .. } => bail!("HEAD is detached; gs shortlog needs a current branch"),
         HeadState::Invalid => bail!("HEAD is invalid"),
     }
 }

--- a/grit-simple/src/commands/status.rs
+++ b/grit-simple/src/commands/status.rs
@@ -1,4 +1,4 @@
-//! `gi status` (and bare `gi`) — the dashboard: where you are, the commits
+//! `gs status` (and bare `gs`) — the dashboard: where you are, the commits
 //! you're ahead by, what's changed, and what to do next.
 
 use anyhow::{Context, Result};
@@ -91,10 +91,10 @@ fn print_changes(model: &StatusModel) {
 fn print_hints(model: &StatusModel) {
     let mut hints = Vec::new();
     if !model.unstaged.is_empty() || !model.untracked.is_empty() {
-        hints.push("gi add <file> to stage");
+        hints.push("gs add <file> to stage");
     }
     if !model.staged.is_empty() {
-        hints.push("gi commit \"message\" to commit");
+        hints.push("gs commit \"message\" to commit");
     }
     if !hints.is_empty() {
         println!("→ {}", hints.join("  ·  "));

--- a/grit-simple/src/commands/switch.rs
+++ b/grit-simple/src/commands/switch.rs
@@ -1,6 +1,6 @@
-//! `gi switch` — move to another branch, updating the working tree.
+//! `gs switch` — move to another branch, updating the working tree.
 //!
-//! `gi` keeps this safe and simple: it refuses to switch when you have
+//! `gs` keeps this safe and simple: it refuses to switch when you have
 //! uncommitted (staged or unstaged) changes, and won't clobber an untracked
 //! file that the destination branch wants to create. Untracked files that don't
 //! collide come along for the ride.

--- a/grit-simple/src/context.rs
+++ b/grit-simple/src/context.rs
@@ -1,4 +1,4 @@
-//! Shared repository helpers used across `gi` commands.
+//! Shared repository helpers used across `gs` commands.
 
 use std::collections::HashSet;
 
@@ -13,7 +13,7 @@ use grit_lib::refs;
 use grit_lib::repo::Repository;
 use time::OffsetDateTime;
 
-/// A resolved "target" branch (the trunk `gi` measures the current branch against).
+/// A resolved "target" branch (the trunk `gs` measures the current branch against).
 #[derive(Debug, Clone)]
 pub struct TargetBranch {
     pub display_name: String,
@@ -32,7 +32,7 @@ pub fn discover() -> Result<Repository> {
     Repository::discover(None).context("not in a repository")
 }
 
-/// Find the branch `gi` should measure the current branch against, trying
+/// Find the branch `gs` should measure the current branch against, trying
 /// `target.branch` from config first, then the usual trunk names.
 pub fn find_target_branch(repo: &Repository) -> Result<Option<TargetBranch>> {
     for candidate in target_branch_candidates(repo)? {
@@ -193,6 +193,6 @@ pub fn reflog_identity(config: &ConfigSet, now: OffsetDateTime) -> String {
 
 fn identity_error(err: IdentityError) -> anyhow::Error {
     anyhow::anyhow!(
-        "{err}\n\nTell gi who you are:\n  grit config --global user.name \"Your Name\"\n  grit config --global user.email \"you@example.com\""
+        "{err}\n\nTell gs who you are:\n  grit config --global user.name \"Your Name\"\n  grit config --global user.email \"you@example.com\""
     )
 }

--- a/grit-simple/src/main.rs
+++ b/grit-simple/src/main.rs
@@ -1,8 +1,8 @@
-//! `gi` — a small, opinionated command line interface backed by `grit-lib`.
+//! `gs` — a small, opinionated command line interface backed by `grit-lib`.
 //!
-//! `gi` deliberately does not mirror Git's UX. It favors a single obvious way
+//! `gs` deliberately does not mirror Git's UX. It favors a single obvious way
 //! to do the common thing, plain-language output, and a status screen that
-//! doubles as the home base: running `gi` with no arguments shows you where you
+//! doubles as the home base: running `gs` with no arguments shows you where you
 //! are, what's changed, and what to do next.
 
 mod commands;
@@ -15,13 +15,13 @@ use clap::{Parser, Subcommand};
 
 /// A simplified alternative to the Git-compatible `grit` command line.
 #[derive(Debug, Parser)]
-#[command(name = "gi", version, about = "A simple Grit-powered CLI")]
+#[command(name = "gs", version, about = "A simple Grit-powered CLI")]
 struct Cli {
     #[command(subcommand)]
     command: Option<Command>,
 }
 
-/// Top-level `gi` commands.
+/// Top-level `gs` commands.
 #[derive(Debug, Subcommand)]
 enum Command {
     /// Show what's changed and where you are (this is the default).

--- a/grit-simple/src/net.rs
+++ b/grit-simple/src/net.rs
@@ -4,7 +4,7 @@
 //! The wire protocols, ref updates, and pack handling all live in grit-lib. The
 //! only binary-specific piece is choosing a transport (and an HTTP client) for a
 //! URL — grit-cli brings its own HTTP stack, so this dispatch lives here in
-//! `gi` rather than in the shared library.
+//! `gs` rather than in the shared library.
 
 use anyhow::{bail, Context, Result};
 use std::path::PathBuf;
@@ -23,7 +23,7 @@ use grit_lib::transport::{
     is_ssh_url, ConnectOptions, Connection, GitDaemonTransport, Service, SshTransport, Transport,
 };
 
-/// The remote `gi` uses when none is named or configured.
+/// The remote `gs` uses when none is named or configured.
 pub const DEFAULT_REMOTE: &str = "origin";
 
 /// Look up `remote.<name>.url`.

--- a/grit-simple/src/ui.rs
+++ b/grit-simple/src/ui.rs
@@ -1,4 +1,4 @@
-//! Small output-formatting helpers shared by `gi` commands.
+//! Small output-formatting helpers shared by `gs` commands.
 
 use grit_lib::diff::{DiffEntry, DiffStatus};
 


### PR DESCRIPTION
`gi` collides with an existing command on Windows, so the grit-simple binary is renamed `gi` → `gs` across the crate, docs, installers, and the release workflow. The crate name (`grit-simple`) and `cargo install grit-simple` are unchanged.

Also fixes the release `files:` glob to publish the Linux/macOS `gs-*.tar.gz` tarballs (previously only `grit-*.tar.gz` and the Windows `gs-*.zip` were uploaded, so `docs/install` would 404 fetching `gs`).

Bumps the shared `[workspace.package]` version `0.4.4` → `0.4.5`. This is the exact commit the `v0.4.5` tag points at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)