### PR TITLE
fix(ls-files): --full-name skips cwd scope restriction

### DIFF
--- a/grit/src/commands/ls_files.rs
+++ b/grit/src/commands/ls_files.rs
@@ -452,7 +452,7 @@ pub fn run(args: Args) -> Result<()> {
     if let Err(message) = grit_lib::pathspec::validate_attr_pathspecs(&pathspec_display) {
         anyhow::bail!("{message}");
     }
-    if pathspec_filter.is_empty() && !cwd_prefix.is_empty() && !args.full_name {
+    if pathspec_filter.is_empty() && !cwd_prefix.is_empty()  {
         pathspec_filter.push(Pathspec::Literal(cwd_prefix.clone()));
         pathspec_display.push(".".to_string());
     }


### PR DESCRIPTION
## Problem

`grit ls-files --full-name` from a subdirectory lists the **entire repository** instead of only files under the current working directory.

## Root Cause

`grit/src/commands/ls_files.rs:455`:

```rust
if pathspec_filter.is_empty() && !cwd_prefix.is_empty() && !args.full_name {
    pathspec_filter.push(Pathspec::Literal(cwd_prefix.clone()));
}
```

The `!args.full_name` clause prevents adding the cwd-pathspec restriction when `--full-name` is set.

## Fix

Remove `&& !args.full_name`. This is a **1-line change**.

## Safety

- `t6131-pathspec-icase.sh` uses `--full-name` **with explicit pathspecs** → `pathspec_filter.is_empty()` is already false → unaffected.
- Behavior now matches `git ls-files --full-name` (verified against git 2.54.0).

## Discussion

Detailed AID analysis: https://github.com/gitbutlerapp/grit/issues/835#issuecomment-4700622156

Fixes #835