### PR TITLE
fix(ls-files): drop !args.full_name clause from cwd-pathspec restriction

### DIFF
--- a/grit/src/commands/ls_files.rs
+++ b/grit/src/commands/ls_files.rs
@@ -452,7 +452,7 @@ pub fn run(args: Args) -> Result<()> {
     if let Err(message) = grit_lib::pathspec::validate_attr_pathspecs(&pathspec_display) {
         anyhow::bail!("{message}");
     }
-    if pathspec_filter.is_empty() && !cwd_prefix.is_empty() && !args.full_name {
+    if pathspec_filter.is_empty() && !cwd_prefix.is_empty() {
         pathspec_filter.push(Pathspec::Literal(cwd_prefix.clone()));
         pathspec_display.push(".".to_string());
     }


### PR DESCRIPTION
Follow-up to #856.

`--full-name` is display-only in git: it controls whether paths are shown
repo-root-relative or cwd-relative. The cwd scope restriction must apply
regardless.

Introduced in commit 7f110774 (Cursor Agent, 2026-04-06). t6131 is unaffected
because it always pairs `--full-name` with explicit pathspecs, so
`pathspec_filter.is_empty()` is already false.