### PR TITLE
test: add regression tests for --full-name from subdirectory

### DIFF
--- a/tests/t835-full-name-scope.sh
+++ b/tests/t835-full-name-scope.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+test_description='--full-name does not affect scope in ls-files / ls-tree'
+
+. ./test-lib.sh
+
+test_expect_success 'setup' '
+	test_commit root &&
+	mkdir sub &&
+	test_commit sub/a &&
+	test_commit sub/b
+'
+
+test_expect_success 'ls-files: --full-name from subdirectory (no pathspec)' '
+	(
+		cd sub &&
+		git ls-files --full-name >actual &&
+		cat >expect <<-\EOF &&
+		sub/a
+		sub/b
+		EOF
+		test_cmp expect actual
+	)
+'
+
+test_expect_success 'ls-files: --full-name from subdirectory (explicit pathspec)' '
+	(
+		cd sub &&
+		git ls-files --full-name -- sub >actual &&
+		cat >expect <<-\EOF &&
+		sub/a
+		sub/b
+		EOF
+		test_cmp expect actual
+	)
+'
+
+test_expect_success 'ls-tree: --full-name HEAD from subdirectory (no pathspec)' '
+	(
+		cd sub &&
+		git ls-tree --full-name HEAD >actual &&
+		grep sub/a actual &&
+		grep sub/b actual &&
+		! grep root actual
+	)
+'
+
+test_expect_success 'ls-tree: --full-name HEAD from subdirectory (explicit pathspec)' '
+	(
+		cd sub &&
+		git ls-tree --full-name HEAD -- sub >actual &&
+		grep sub/a actual &&
+		grep sub/b actual
+	)
+'
+
+test_done


### PR DESCRIPTION
Follow-up to #856.

Neither `ls-files --full-name` nor `ls-tree --full-name` from a subdirectory
(without explicit pathspecs) was covered by the existing test suite. Both
exhibited the same bug: `--full-name` expanded scope instead of only changing
display format.

These tests ensure the cwd restriction is applied regardless of `--full-name`,
matching git's behaviour. Covers both commands with and without explicit
pathspecs.