### PR TITLE
Publish nightly builds to a rolling prerelease (drop gh requirement)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,9 @@ on:
   push:
     tags:
       - "v*"
-  # Allow kicking off a manual test build from the Actions tab. These runs build
-  # and upload the artifacts but do not publish a GitHub Release (see the
-  # `release` job's `if` guard below).
+  # Allow kicking off a build manually from the Actions tab. A manual run
+  # refreshes the rolling `nightly` prerelease (see the `publish-nightly` job) so
+  # `install-nightly` can fetch it with plain curl — no GitHub auth required.
   workflow_dispatch:
 
 permissions:
@@ -73,13 +73,10 @@ jobs:
           tar czf ../../../gs-${{ matrix.target }}.tar.gz gs
         shell: bash
 
-      # Manual (workflow_dispatch) runs publish a `*-nightly` artifact so the
-      # `install-nightly` script can find them; tag pushes keep the plain name
-      # the release job globs over.
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: grit-${{ matrix.target }}${{ github.event_name == 'workflow_dispatch' && '-nightly' || '' }}
+          name: grit-${{ matrix.target }}
           path: |
             grit-${{ matrix.target }}.tar.gz
             gs-${{ matrix.target }}.tar.gz
@@ -122,7 +119,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: gs-${{ matrix.target }}${{ github.event_name == 'workflow_dispatch' && '-nightly' || '' }}
+          name: gs-${{ matrix.target }}
           path: gs-${{ matrix.target }}.zip
 
   release:
@@ -144,3 +141,32 @@ jobs:
             grit-*.tar.gz
             gs-*.tar.gz
             gs-*.zip
+
+  # Manual (workflow_dispatch) runs refresh a rolling `nightly` prerelease.
+  # Release assets are public, so `install-nightly` downloads them with plain
+  # curl — no GitHub CLI or token needed (unlike workflow-run artifacts, which
+  # require authentication). The previous nightly release and its tag are deleted
+  # first so the tag always points at the commit we just built.
+  publish-nightly:
+    needs: [build, build-windows]
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+
+      - name: Refresh the rolling "nightly" prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # `gh` is preinstalled on the runner; this is CI-side only and does not
+          # affect how end users install the nightly build.
+          gh release delete nightly --repo "$GITHUB_REPOSITORY" --cleanup-tag --yes || true
+          gh release create nightly \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --prerelease \
+            --title "Nightly" \
+            --notes "Latest manual build from ${GITHUB_SHA}." \
+            grit-*.tar.gz gs-*.tar.gz gs-*.zip

--- a/docs/install-nightly
+++ b/docs/install-nightly
@@ -1,11 +1,9 @@
 #!/bin/sh
 # grit nightly installer - installs the latest manually-triggered CI build.
 #
-# Unlike the release installer (docs/install), nightly builds are not published
-# as GitHub Releases. They live as `*-nightly` artifacts on the most recent
-# manual (workflow_dispatch) run of the Release workflow. GitHub requires
-# authentication to download workflow artifacts, so this script drives the
-# GitHub CLI (`gh`) - log in first with `gh auth login`.
+# Manual (workflow_dispatch) runs publish to a rolling `nightly` prerelease, so
+# this works exactly like the stable installer (docs/install): it downloads
+# public release assets with plain curl. No GitHub CLI or token required.
 #
 # Installs both `grit` (grit-cli) and `gs` (grit-simple).
 # Usage: curl -fsSL https://grit-scm.com/install-nightly | sh
@@ -16,12 +14,9 @@ main() {
   REPO="gitbutlerapp/grit"
   INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
 
-  for cmd in command uname tr tar mkdir gh; do
+  for cmd in command uname tr curl tar mkdir; do
     if ! command -v "$cmd" >/dev/null 2>&1; then
       echo "error: required command '$cmd' not found" >&2
-      if [ "$cmd" = "gh" ]; then
-        echo "Install the GitHub CLI (https://cli.github.com) and run 'gh auth login'." >&2
-      fi
       exit 1
     fi
   done
@@ -65,32 +60,18 @@ main() {
 
   echo "Detected: $OS/$ARCH -> $TARGET"
 
-  # Find the most recent successful manual (workflow_dispatch) build.
-  echo "Looking up the latest manual build..."
-  RUN_ID=$(gh run list --repo "$REPO" --workflow release.yml \
-    --event workflow_dispatch --status success --limit 1 \
-    --json databaseId --jq '.[0].databaseId')
-
-  if [ -z "$RUN_ID" ]; then
-    echo "error: no successful manual build found." >&2
-    echo "Trigger one from the Actions tab (Run workflow) and try again." >&2
-    exit 1
-  fi
-  echo "Using run #$RUN_ID"
-
   TMP=$(mktemp -d)
   trap 'rm -rf "$TMP"' EXIT
 
   mkdir -p "$INSTALL_DIR"
 
-  # The unix build uploads both tarballs under a single `grit-<target>-nightly`
-  # artifact. Download it once, then extract `grit` and `gs`.
-  ART="grit-${TARGET}-nightly"
-  echo "Downloading artifact: $ART"
-  gh run download "$RUN_ID" --repo "$REPO" -n "$ART" -D "$TMP"
-
+  # Install both binaries from the rolling `nightly` prerelease: `grit`
+  # (grit-cli) and `gs` (grit-simple).
   for BIN in grit gs; do
-    tar xzf "$TMP/${BIN}-${TARGET}.tar.gz" -C "$TMP"
+    URL="https://github.com/$REPO/releases/download/nightly/${BIN}-${TARGET}.tar.gz"
+    echo "Downloading from: $URL"
+    curl -fSL "$URL" -o "$TMP/${BIN}.tar.gz"
+    tar xzf "$TMP/${BIN}.tar.gz" -C "$TMP"
     mv "$TMP/${BIN}" "$INSTALL_DIR/${BIN}"
     chmod +x "$INSTALL_DIR/${BIN}"
     echo "Installed ${BIN} to $INSTALL_DIR/${BIN}"

--- a/docs/install-nightly.ps1
+++ b/docs/install-nightly.ps1
@@ -1,10 +1,8 @@
 # grit-simple nightly installer for Windows - installs the latest manually-triggered CI build.
 #
-# Unlike the release installer (docs/install.ps1), nightly builds are not
-# published as GitHub Releases. They live as a `gs-<target>-nightly` artifact on
-# the most recent manual (workflow_dispatch) run of the Release workflow. GitHub
-# requires authentication to download workflow artifacts, so this script drives
-# the GitHub CLI (`gh`) - log in first with `gh auth login`.
+# Manual (workflow_dispatch) runs publish to a rolling `nightly` prerelease, so
+# this works exactly like the stable installer (docs/install.ps1): it downloads
+# a public release asset with Invoke-WebRequest. No GitHub CLI or token required.
 #
 # Usage: irm grit-scm.com/install-nightly.ps1 | iex
 #
@@ -17,30 +15,16 @@ $InstallDir = if ($env:GRIT_INSTALL_DIR) { $env:GRIT_INSTALL_DIR } else { Join-P
 
 # Windows ARM64 runs x86_64 binaries via emulation, so x86_64 is the only target we ship.
 $Target = 'x86_64-pc-windows-msvc'
+$Url = "https://github.com/$Repo/releases/download/nightly/gs-$Target.zip"
 
-if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
-  throw "The GitHub CLI (gh) is required. Install it from https://cli.github.com and run 'gh auth login'."
-}
-
-# Find the most recent successful manual (workflow_dispatch) build.
-Write-Host "Looking up the latest manual build..."
-$RunId = gh run list --repo $Repo --workflow release.yml `
-  --event workflow_dispatch --status success --limit 1 `
-  --json databaseId --jq '.[0].databaseId'
-
-if ([string]::IsNullOrWhiteSpace($RunId)) {
-  throw "No successful manual build found. Trigger one from the Actions tab (Run workflow) and try again."
-}
-Write-Host "Using run #$RunId"
+Write-Host "Downloading from: $Url"
 
 $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("grit-" + [System.IO.Path]::GetRandomFileName())
 New-Item -ItemType Directory -Path $tmp | Out-Null
 try {
-  $Artifact = "gs-$Target-nightly"
-  Write-Host "Downloading artifact: $Artifact"
-  gh run download $RunId --repo $Repo -n $Artifact -D $tmp
-
-  Expand-Archive -Path (Join-Path $tmp "gs-$Target.zip") -DestinationPath $tmp -Force
+  $zip = Join-Path $tmp 'gs.zip'
+  Invoke-WebRequest -Uri $Url -OutFile $zip
+  Expand-Archive -Path $zip -DestinationPath $tmp -Force
 
   New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
   Copy-Item -Path (Join-Path $tmp 'gs.exe') -Destination (Join-Path $InstallDir 'gs.exe') -Force


### PR DESCRIPTION
Manual (workflow_dispatch) runs now refresh a public `nightly` prerelease
instead of leaving artifacts on the workflow run. The publish-nightly job
deletes the old nightly release+tag and recreates it at the built commit, so
release assets are publicly downloadable.

install-nightly and install-nightly.ps1 are rewritten to fetch those assets
with plain curl / Invoke-WebRequest from releases/download/nightly — no GitHub
CLI or token needed. Reverted the now-unused -nightly artifact name suffix.