### PR TITLE
config: resolve home dir via USERPROFILE on Windows

### DIFF
--- a/grit-lib/src/config.rs
+++ b/grit-lib/src/config.rs
@@ -3355,8 +3355,30 @@ fn global_config_paths() -> Vec<PathBuf> {
 }
 
 /// Return the user's home directory.
+///
+/// `$HOME` is honored on every platform. On Windows, where `$HOME` is usually
+/// unset outside a Git-for-Windows/MSYS shell, we fall back to the same sources
+/// Git does: `%HOMEDRIVE%%HOMEPATH%`, then `%USERPROFILE%`. Without this, global
+/// config (`~/.gitconfig`) would be invisible on a stock Windows shell.
 fn home_dir() -> Option<PathBuf> {
-    std::env::var("HOME").ok().map(PathBuf::from)
+    if let Some(home) = std::env::var_os("HOME").filter(|h| !h.is_empty()) {
+        return Some(PathBuf::from(home));
+    }
+    #[cfg(windows)]
+    {
+        if let (Some(drive), Some(path)) = (
+            std::env::var_os("HOMEDRIVE").filter(|d| !d.is_empty()),
+            std::env::var_os("HOMEPATH").filter(|p| !p.is_empty()),
+        ) {
+            let mut combined = drive;
+            combined.push(path);
+            return Some(PathBuf::from(combined));
+        }
+        if let Some(profile) = std::env::var_os("USERPROFILE").filter(|p| !p.is_empty()) {
+            return Some(PathBuf::from(profile));
+        }
+    }
+    None
 }
 
 /// True when Git would treat the config source as `CONFIG_ORIGIN_FILE` for includes.

--- a/grit-simple/src/commands/config.rs
+++ b/grit-simple/src/commands/config.rs
@@ -141,37 +141,26 @@ fn target_file(global: bool) -> Result<(ConfigScope, PathBuf)> {
     }
 }
 
-/// The global config file to write to, following Git's preference order: an
-/// explicit `$GIT_CONFIG_GLOBAL`, then an existing `~/.gitconfig`, then an
-/// existing XDG `git/config`, otherwise `~/.gitconfig`.
+/// The global config file to write to.
+///
+/// We derive this from grit-lib's own global-config search list
+/// ([`global_config_paths_pub`]) so a write always lands in a file the loader
+/// will read back — crucial on Windows, where the home directory may resolve via
+/// `%USERPROFILE%` rather than `$HOME`. Following Git's writer preference, we use
+/// an existing `~/.gitconfig`, then an existing XDG `git/config`, otherwise the
+/// conventional `~/.gitconfig`.
 fn global_config_path() -> Option<PathBuf> {
-    if let Some(p) = std::env::var_os("GIT_CONFIG_GLOBAL") {
-        return Some(PathBuf::from(p));
+    let paths = grit_lib::config::global_config_paths_pub();
+    // grit-lib returns `[XDG git/config, ~/.gitconfig]` (or a single
+    // `$GIT_CONFIG_GLOBAL`); the last entry is the conventional `~/.gitconfig`.
+    let dotgitconfig = paths.last().cloned();
+    if dotgitconfig.as_ref().is_some_and(|p| p.exists()) {
+        return dotgitconfig;
     }
-    let home = home_dir();
-    let home_config = home.as_ref().map(|h| h.join(".gitconfig"));
-    if let Some(p) = &home_config {
-        if p.exists() {
-            return home_config;
+    if let Some(xdg) = paths.first() {
+        if xdg.exists() {
+            return Some(xdg.clone());
         }
     }
-    let xdg = if let Some(x) = std::env::var_os("XDG_CONFIG_HOME") {
-        Some(PathBuf::from(x).join("git/config"))
-    } else {
-        home.as_ref().map(|h| h.join(".config/git/config"))
-    };
-    if let Some(p) = &xdg {
-        if p.exists() {
-            return xdg;
-        }
-    }
-    home_config
-}
-
-/// The user's home directory (`$HOME`, or `$USERPROFILE` on Windows).
-fn home_dir() -> Option<PathBuf> {
-    std::env::var_os("HOME")
-        .or_else(|| std::env::var_os("USERPROFILE"))
-        .map(PathBuf::from)
-        .filter(|p| !p.as_os_str().is_empty())
+    dotgitconfig
 }


### PR DESCRIPTION
grit-lib's home_dir() only consulted $HOME, which is typically unset on a
stock Windows shell (PowerShell/cmd without Git-for-Windows). As a result the
global config (~/.gitconfig) was invisible: `gs auth` wrote credential.helper
there but the loader never read it back, so `gs auth` re-set the helper every
run and never stored the token, and `gs clone`/fetch/push failed with
"credentials required but unavailable".

Resolve the home directory the way Git does on Windows: $HOME, then
%HOMEDRIVE%%HOMEPATH%, then %USERPROFILE%. Also make `gs config`'s global path
derive from grit-lib's own search list so a write always lands in a file the
loader reads back.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>