### PR TITLE
test: port --full-name regression test from shell to Rust

### DIFF
--- a/grit/tests/common/mod.rs
+++ b/grit/tests/common/mod.rs
@@ -1,0 +1,210 @@
+//! Shared test helpers: composable command builder, cross-check assertions,
+//! and a unified-diff macro.
+
+use similar::TextDiff;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+const GRIT_BIN: &str = env!("CARGO_BIN_EXE_grit");
+
+// ---------------------------------------------------------------------------
+// Command result
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+pub struct Output {
+    pub status: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+impl Output {
+    pub fn ok(&self) -> bool {
+        self.status == Some(0)
+    }
+
+    pub fn dump(&self, label: &str) -> String {
+        format!(
+            "{label}: exit={:?}\n--- stdout ---\n{}\n--- stderr ---\n{}",
+            self.status, self.stdout, self.stderr
+        )
+    }
+}
+
+impl fmt::Debug for Output {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Output {{ status: {:?}, .. }}", self.status)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Diff assertion
+// ---------------------------------------------------------------------------
+
+/// Assert `left == right`, printing a unified diff on failure.
+#[macro_export]
+macro_rules! assert_eq_nice {
+    ($left:expr, $right:expr $(,)?) => {
+        assert_eq_nice!($left, $right,)
+    };
+    ($left:expr, $right:expr, $($arg:tt)+) => {{
+        use std::borrow::Borrow;
+        let left: &str = $left.borrow();
+        let right: &str = $right.borrow();
+        if left != right {
+            let diff: TextDiff<'_, '_, '_, str> = TextDiff::from_lines(right, left);
+            let diff = diff
+                .unified_diff()
+                .context_radius(3)
+                .to_string();
+            panic!(
+                "assertion failed: left != right\n\
+                 --- right (expected)\n\
+                 +++ left (actual)\n\
+                 {diff}\n\
+                 {}",
+                format_args!($($arg)+),
+            );
+        }
+    }};
+}
+
+// ---------------------------------------------------------------------------
+// Temp directory
+// ---------------------------------------------------------------------------
+
+pub fn unique_tmp(prefix: &str, tag: &str) -> PathBuf {
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let mut p = std::env::temp_dir();
+    p.push(format!("grit-{prefix}-{tag}-{}-{n}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&p);
+    std::fs::create_dir_all(&p).expect("create temp dir");
+    p
+}
+
+// ---------------------------------------------------------------------------
+// File helpers
+// ---------------------------------------------------------------------------
+
+pub fn write_file(dir: &Path, name: &str, contents: &str) {
+    std::fs::write(dir.join(name), contents).unwrap_or_else(|e| panic!("write {name}: {e}"));
+}
+
+// ---------------------------------------------------------------------------
+// Low-level runner
+// ---------------------------------------------------------------------------
+
+fn run(bin: &str, args: &[String], dir: &Path) -> Output {
+    let out = Command::new(bin)
+        .args(args)
+        .current_dir(dir)
+        .env("GIT_AUTHOR_NAME", "Test")
+        .env("GIT_AUTHOR_EMAIL", "test@example.com")
+        .env("GIT_COMMITTER_NAME", "Test")
+        .env("GIT_COMMITTER_EMAIL", "test@example.com")
+        .env("GIT_AUTHOR_DATE", "1700000000 +0000")
+        .env("GIT_COMMITTER_DATE", "1700000000 +0000")
+        .output()
+        .unwrap_or_else(|e| panic!("spawn {bin} {args:?}: {e}"));
+    Output {
+        status: out.status.code(),
+        stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Command builder
+// ---------------------------------------------------------------------------
+
+pub struct Cmd {
+    bin: String,
+    args: Vec<String>,
+    dir: Option<PathBuf>,
+}
+
+impl Cmd {
+    pub fn in_dir(mut self, dir: &Path) -> Self {
+        self.dir = Some(dir.to_path_buf());
+        self
+    }
+
+    fn exec(&self) -> Output {
+        let dir = self.dir.as_deref().expect("Cmd: call .in_dir() first");
+        let args: Vec<String> = self.args.clone();
+        run(&self.bin, &args, dir)
+    }
+
+    /// Assert exit code is 0 and return `Output`.
+    pub fn suc(&self) -> Output {
+        let out = self.exec();
+        assert!(out.ok(), "{}\n{}", self.bin, out.dump(&self.bin));
+        out
+    }
+
+    /// Cross-check: run the same args against both grit and system `git`,
+    /// asserting identical exit code, stdout, and stderr.
+    pub fn check(&self) {
+        let dir = self.dir.as_deref().expect("Cmd: call .in_dir() first");
+
+        let g = run(GRIT_BIN, &self.args, dir);
+        let r = run("git", &self.args, dir);
+
+        let g_ok = g.status == Some(0);
+        let r_ok = r.status == Some(0);
+
+        assert_eq!(
+            g.status, r.status,
+            "exit status mismatch: grit={:?} git={:?}\n\
+             args: {:?}  dir: {:?}\n\n\
+             --- grit stdout ---\n{}\n\
+             --- git  stdout ---\n{}\n",
+            g.status, r.status, self.args, dir, g.stdout, r.stdout,
+        );
+
+        if g_ok && r_ok {
+            assert_eq_nice!(
+                g.stdout, r.stdout,
+                "stdout mismatch (both exited 0)\n\
+                 args: {:?}  dir: {:?}",
+                self.args, dir,
+            );
+            if !g.stderr.is_empty() && !r.stderr.is_empty() {
+                assert_eq_nice!(
+                    g.stderr, r.stderr,
+                    "stderr mismatch (both exited 0)\n\
+                     args: {:?}  dir: {:?}",
+                    self.args, dir,
+                );
+            }
+        }
+
+        if !g_ok && !r_ok {
+            assert_eq_nice!(
+                g.stderr, r.stderr,
+                "stderr mismatch (both failed)\n\
+                 args: {:?}  dir: {:?}",
+                self.args, dir,
+            );
+        }
+    }
+}
+
+pub fn grit_cmd(args: &[&str]) -> Cmd {
+    Cmd {
+        bin: GRIT_BIN.to_string(),
+        args: args.iter().map(|s| s.to_string()).collect(),
+        dir: None,
+    }
+}
+
+pub fn git_cmd(args: &[&str]) -> Cmd {
+    Cmd {
+        bin: "git".to_string(),
+        args: args.iter().map(|s| s.to_string()).collect(),
+        dir: None,
+    }
+}

--- a/grit/tests/full_name_scope.rs
+++ b/grit/tests/full_name_scope.rs
@@ -1,0 +1,104 @@
+//! Regression tests: `--full-name` does not affect scope in `ls-files` / `ls-tree`.
+//!
+//! Both commands shared the same bug class: `--full-name` (a display-only flag
+//! that controls whether paths are printed repo-relative or cwd-relative) was
+//! treated as a scope-widening flag so running from a subdirectory listed the
+//! entire repository instead of only files under the cwd.
+//!
+//! | # | Issue | Fix  | Scope                                            |
+//! |---|-------|------|--------------------------------------------------|
+//! | 1 | #835  | —    | kevmoo reports `ls-files --full-name` scope leak |
+//! | 2 | #856  | #857 | ls-files: drop `!args.full_name`                 |
+//! | 3 | #856  | #858 | ls-tree: split scope + display flags             |
+//!
+//! Each test cross-checks grit output against system `git`.
+
+mod common;
+
+use crate::common::*;
+use std::path::{Path, PathBuf};
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+/// Build a repo with files at root level and inside `sub/`:
+///
+/// ```text
+/// <root>/
+///   root         (file created in first commit)
+///   sub/a        (created in second commit)
+///   sub/b
+/// ```
+fn build_test_repo(tag: &str) -> PathBuf {
+    let dir = unique_tmp("full-name", tag);
+
+    git_cmd(&["init", "-q", "-b", "main", "."]).in_dir(&dir).suc();
+    write_file(&dir, "root", "root content\n");
+    git_cmd(&["add", "root"]).in_dir(&dir).suc();
+    git_cmd(&["commit", "-q", "-m", "root"]).in_dir(&dir).suc();
+
+    let sub = dir.join("sub");
+    std::fs::create_dir_all(&sub)
+        .unwrap_or_else(|e| panic!("fixture: mkdir sub: {e}"));
+
+    write_file(&sub, "a", "a content\n");
+    write_file(&sub, "b", "b content\n");
+    git_cmd(&["add", "sub/a", "sub/b"]).in_dir(&dir).suc();
+    git_cmd(&["commit", "-q", "-m", "sub"]).in_dir(&dir).suc();
+
+    dir
+}
+
+fn sub(dir: &Path) -> PathBuf {
+    dir.join("sub")
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ls_files_full_name_from_subdir_no_pathspec() {
+    let dir = build_test_repo("lsf-np");
+    grit_cmd(&["ls-files", "--full-name"]).in_dir(&sub(&dir)).check();
+}
+
+#[test]
+fn ls_files_full_name_from_subdir_with_pathspec() {
+    let dir = build_test_repo("lsf-ps");
+    grit_cmd(&["ls-files", "--full-name", "--", "sub"])
+        .in_dir(&sub(&dir)).check();
+}
+
+#[test]
+fn ls_tree_full_name_from_subdir_no_pathspec() {
+    let dir = build_test_repo("lst-np");
+    grit_cmd(&["ls-tree", "--full-name", "HEAD"])
+        .in_dir(&sub(&dir)).check();
+}
+
+#[test]
+fn ls_tree_full_name_from_subdir_with_pathspec() {
+    let dir = build_test_repo("lst-ps");
+    grit_cmd(&["ls-tree", "--full-name", "HEAD", "--", "sub"])
+        .in_dir(&sub(&dir)).check();
+}
+
+#[test]
+fn ls_tree_full_name_is_not_full_tree() {
+    // --full-tree (scope) and --full-name (display) must NOT produce
+    // the same output from a subdirectory.
+    let dir = build_test_repo("lst-nt");
+    let s = sub(&dir);
+
+    let name = grit_cmd(&["ls-tree", "--full-name", "HEAD"]).in_dir(&s).suc();
+    let tree = grit_cmd(&["ls-tree", "--full-tree", "HEAD"]).in_dir(&s).suc();
+
+    assert_ne!(
+        name.stdout, tree.stdout,
+        "--full-name and --full-tree produced identical output\n\
+         --full-name:\n{}\n--full-tree:\n{}",
+        name.stdout, tree.stdout,
+    );
+}


### PR DESCRIPTION
Replaces the shell-based regression test (#859) with a Rust integration test cross-checking grit output against system `git`.

Covers:
- `ls-files --full-name` from subdir (no pathspec / with pathspec)
- `ls-tree --full-name HEAD` from subdir (no pathspec / with pathspec)
- `--full-name` vs `--full-tree` produce different output