### PR TITLE
gs: add global --filter for jq-like JSON output selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
+ "regex-automata",
  "serde",
 ]
 
@@ -331,6 +332,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "encoding_rs"
@@ -567,6 +574,9 @@ dependencies = [
  "anyhow",
  "clap",
  "grit-lib",
+ "jaq-core",
+ "jaq-json",
+ "jaq-std",
  "serde",
  "serde_json",
  "similar",
@@ -627,6 +637,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hifijson"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "242402749acf71e6f32f5857598b7002c4058a4e3c3b22b4c7d51cab9aea754e"
 
 [[package]]
 name = "http"
@@ -875,6 +891,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jaq-core"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7561783b20275a6c9cb576e39208b0c635f34ef14357f1f05a2927a774f3adec"
+dependencies = [
+ "dyn-clone",
+ "once_cell",
+ "typed-arena",
+]
+
+[[package]]
+name = "jaq-json"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ec9aaad7340e6990c6c1878ef3b46dbec624e535d7f786cc9ddcf94f773d33"
+dependencies = [
+ "bstr",
+ "bytes",
+ "foldhash",
+ "hifijson",
+ "indexmap",
+ "jaq-core",
+ "jaq-std",
+ "num-bigint",
+ "num-traits",
+ "ryu",
+ "self_cell",
+]
+
+[[package]]
+name = "jaq-std"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bdc5a74b0feeb5e6a1dc2dd08c34280a61e37668d10a6a3b27ad69d0fb9ce2e"
+dependencies = [
+ "aho-corasick",
+ "base64",
+ "bstr",
+ "jaq-core",
+ "jiff",
+ "libm",
+ "log",
+ "regex-bites",
+ "urlencoding",
+]
+
+[[package]]
+name = "jiff"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,6 +989,12 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -1009,6 +1119,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1094,6 +1214,21 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1192,6 +1327,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-bites"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6a15a2fa0bfda9361941c45550896ae87b15cc6c8c939ea350079670332e211"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1270,6 +1411,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
@@ -1631,6 +1778,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1700,6 +1853,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf16_iter"

--- a/grit-simple/Cargo.toml
+++ b/grit-simple/Cargo.toml
@@ -21,6 +21,9 @@ grit-lib = { version = "0.4", path = "../grit-lib", features = ["http-ureq"] }
 time.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+jaq-core = "3.1"
+jaq-json = "2.0"
+jaq-std = "3.0"
 terminal_size.workspace = true
 # `inline` enables word-level intra-line highlighting for `gs diff`.
 similar = { workspace = true, features = ["inline"] }

--- a/grit-simple/src/json_filter.rs
+++ b/grit-simple/src/json_filter.rs
@@ -1,0 +1,106 @@
+//! jq-like filtering for `--json` output.
+//!
+//! [`apply_json_filter`] evaluates a jq expression against a [`serde_json::Value`]
+//! using the [jaq](https://github.com/01mf02/jaq) engine. When a filter yields
+//! multiple values, they are wrapped in a JSON array so stdout still carries a
+//! single JSON value (matching the `--json` contract).
+
+use anyhow::{bail, Context, Result};
+use jaq_core::load::{Arena, File, Loader};
+use jaq_core::{data, unwrap_valr, Compiler, Ctx, Vars};
+use jaq_json::{read, Val};
+use serde_json::Value;
+
+/// Apply a jq-like `filter` expression to `input`.
+///
+/// # Parameters
+///
+/// * `input` — the JSON value to filter (typically a command outcome object).
+/// * `filter` — a jq expression, e.g. `.branch`, `.commits[].oid`, or `{branch, clean}`.
+///
+/// # Returns
+///
+/// The filtered JSON value. A filter that emits zero values yields `null`; one
+/// value is returned as-is; multiple values are returned as a JSON array.
+///
+/// # Errors
+///
+/// Returns an error when the expression fails to parse, compile, or execute.
+pub fn apply_json_filter(input: &Value, filter: &str) -> Result<Value> {
+    let filter = filter.trim();
+    if filter.is_empty() {
+        bail!("--filter expression must not be empty");
+    }
+
+    let input_bytes = serde_json::to_vec(input).context("serializing JSON for filter input")?;
+    let input_val = read::parse_single(&input_bytes).map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    let program = File {
+        code: filter,
+        path: (),
+    };
+    let defs = jaq_core::defs()
+        .chain(jaq_std::defs())
+        .chain(jaq_json::defs());
+    let funs = jaq_core::funs()
+        .chain(jaq_std::funs())
+        .chain(jaq_json::funs());
+    let loader = Loader::new(defs);
+    let arena = Arena::default();
+    let modules = loader
+        .load(&arena, program)
+        .map_err(|errs| anyhow::anyhow!("invalid filter {filter:?}: {errs:?}"))?;
+    let compiled = Compiler::default()
+        .with_funs(funs)
+        .compile(modules)
+        .map_err(|errs| anyhow::anyhow!("invalid filter {filter:?}: {errs:?}"))?;
+    let ctx = Ctx::<data::JustLut<Val>>::new(&compiled.lut, Vars::new([]));
+    let out = compiled.id.run((ctx, input_val)).map(unwrap_valr);
+
+    let mut results = Vec::new();
+    for item in out {
+        let val = item.map_err(|e| anyhow::anyhow!("filter {filter:?}: {e}"))?;
+        let json = serde_json::from_str(&val.to_string())
+            .context("converting filter output to JSON")?;
+        results.push(json);
+    }
+
+    match results.len() {
+        0 => Ok(Value::Null),
+        1 => Ok(results.into_iter().next().unwrap_or(Value::Null)),
+        _ => Ok(Value::Array(results)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::apply_json_filter;
+
+    #[test]
+    fn selects_scalar_field() {
+        let input = json!({"branch": "main", "clean": true});
+        let out = apply_json_filter(&input, ".branch").unwrap();
+        assert_eq!(out, json!("main"));
+    }
+
+    #[test]
+    fn selects_object_projection() {
+        let input = json!({"branch": "main", "clean": true, "head": null});
+        let out = apply_json_filter(&input, "{branch, clean}").unwrap();
+        assert_eq!(out, json!({"branch": "main", "clean": true}));
+    }
+
+    #[test]
+    fn maps_array_elements() {
+        let input = json!({
+            "commits": [
+                {"oid": "aaa", "subject": "one"},
+                {"oid": "bbb", "subject": "two"},
+            ]
+        });
+        let out = apply_json_filter(&input, ".commits[].oid").unwrap();
+        assert_eq!(out, json!(["aaa", "bbb"]));
+    }
+}

--- a/grit-simple/src/main.rs
+++ b/grit-simple/src/main.rs
@@ -7,6 +7,7 @@
 
 mod commands;
 mod context;
+mod json_filter;
 mod net;
 mod output;
 mod ui;
@@ -14,7 +15,7 @@ mod ui;
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 
-use output::{emit, OutputMode};
+use output::{emit, OutputMode, OutputOptions};
 
 /// A simplified alternative to the Git-compatible `grit` command line.
 #[derive(Debug, Parser)]
@@ -23,6 +24,11 @@ struct Cli {
     /// Emit machine-readable JSON instead of human-readable text.
     #[arg(long, global = true)]
     json: bool,
+    /// jq-like expression applied to JSON output (requires `--json`).
+    ///
+    /// Examples: `.branch`, `.commits[].oid`, `{branch, clean}`.
+    #[arg(long, global = true, value_name = "EXPR")]
+    filter: Option<String>,
     #[command(subcommand)]
     command: Option<Command>,
 }
@@ -192,52 +198,59 @@ enum Command {
 
 fn main() {
     let cli = Cli::parse();
-    let mode = if cli.json {
-        OutputMode::Json
-    } else {
-        OutputMode::Human
+    let opts = OutputOptions {
+        mode: if cli.json {
+            OutputMode::Json
+        } else {
+            OutputMode::Human
+        },
+        filter: cli.filter.clone(),
     };
-    if let Err(err) = dispatch(cli, mode) {
-        output::emit_error(&err, mode);
+    if let Err(err) = opts.validate() {
+        eprintln!("error: {err:#}");
+        std::process::exit(1);
+    }
+    if let Err(err) = dispatch(cli, &opts) {
+        output::emit_error(&err, &opts);
         std::process::exit(1);
     }
 }
 
-/// Run the selected subcommand and render its outcome in `mode`.
+/// Run the selected subcommand and render its outcome.
 ///
 /// Each command computes a typed, serializable outcome; [`emit`] renders it as
 /// human text or a single JSON object. The two exceptions are `manager` (a raw
 /// credential-helper protocol on stdin/stdout — no outcome) and `push` (which
 /// emits its per-ref outcome and then exits non-zero when a ref was rejected).
-fn dispatch(cli: Cli, mode: OutputMode) -> Result<()> {
+fn dispatch(cli: Cli, opts: &OutputOptions) -> Result<()> {
     match cli.command.unwrap_or(Command::Status) {
-        Command::Init { path, bare } => emit(&commands::init::run(path, bare)?, mode),
-        Command::Clone { url, dir } => emit(&commands::clone::run(&url, dir, mode)?, mode),
+        Command::Init { path, bare } => emit(&commands::init::run(path, bare)?, opts),
+        Command::Clone { url, dir } => emit(&commands::clone::run(&url, dir, opts.mode)?, opts),
         Command::Remote { action } => {
             let add = action.map(|RemoteAction::Add { name, url }| (name, url));
-            emit(&commands::remote::run(add)?, mode)
+            emit(&commands::remote::run(add)?, opts)
         }
-        Command::Log { before } => emit(&commands::log::run(before)?, mode),
-        Command::Diff { commit } => emit(&commands::diff::run(commit)?, mode),
-        Command::Show { object } => emit(&commands::show::run(object)?, mode),
-        Command::Status => emit(&commands::status::run()?, mode),
-        Command::Shortlog => emit(&commands::shortlog::run()?, mode),
-        Command::Add { paths } => emit(&commands::add::run(&paths)?, mode),
+        Command::Log { before } => emit(&commands::log::run(before)?, opts),
+        Command::Diff { commit } => emit(&commands::diff::run(commit)?, opts),
+        Command::Show { object } => emit(&commands::show::run(object)?, opts),
+        Command::Status => emit(&commands::status::run()?, opts),
+        Command::Shortlog => emit(&commands::shortlog::run()?, opts),
+        Command::Add { paths } => emit(&commands::add::run(&paths)?, opts),
         Command::Commit {
             message,
             message_flag,
             all: _,
-        } => emit(&commands::commit::run(message.or(message_flag))?, mode),
-        Command::Branch { name, delete } => emit(&commands::branch::run(name, delete)?, mode),
-        Command::Tag { name, delete } => emit(&commands::tag::run(name, delete)?, mode),
-        Command::Switch { name, create } => emit(&commands::switch::run(&name, create)?, mode),
-        Command::Merge { branch } => emit(&commands::merge::run(&branch)?, mode),
-        Command::Pick { commit } => emit(&commands::pick::run(&commit)?, mode),
-        Command::Fetch { remote } => emit(&commands::fetch::run(remote)?, mode),
-        Command::Pull => emit(&commands::pull::run()?, mode),
+        } => emit(&commands::commit::run(message.or(message_flag))?, opts),
+        Command::Branch { name, delete } => emit(&commands::branch::run(name, delete)?, opts),
+        Command::Tag { name, delete } => emit(&commands::tag::run(name, delete)?, opts),
+        Command::Switch { name, create } => emit(&commands::switch::run(&name, create)?, opts),
+        Command::Merge { branch } => emit(&commands::merge::run(&branch)?, opts),
+        Command::Pick { commit } => emit(&commands::pick::run(&commit)?, opts),
+        Command::Fetch { remote } => emit(&commands::fetch::run(remote)?, opts),
+        Command::Pull => emit(&commands::pull::run()?, opts),
         Command::Push { tags } => {
             let outcome = commands::push::run(tags)?;
-            emit(&outcome, mode)?;
+            emit(&outcome, opts)?;
             // The outcome (per-ref results) is reported in both modes; a rejected
             // push is still a failure, so mirror Git and exit non-zero.
             if outcome.rejected {
@@ -246,10 +259,10 @@ fn dispatch(cli: Cli, mode: OutputMode) -> Result<()> {
             Ok(())
         }
         Command::Auth { action } => match action {
-            None => emit(&commands::auth::run()?, mode),
-            Some(AuthAction::Logout) => emit(&commands::auth::logout()?, mode),
+            None => emit(&commands::auth::run()?, opts),
+            Some(AuthAction::Logout) => emit(&commands::auth::logout()?, opts),
         },
-        Command::Update => emit(&commands::update::run(mode)?, mode),
+        Command::Update => emit(&commands::update::run(opts.mode)?, opts),
         Command::Config {
             global,
             list,
@@ -258,7 +271,7 @@ fn dispatch(cli: Cli, mode: OutputMode) -> Result<()> {
             value,
         } => emit(
             &commands::config::run(global, list, unset, key, value)?,
-            mode,
+            opts,
         ),
         // `manager` speaks Git's credential protocol on stdout; it has no JSON form.
         Command::Manager { operation } => commands::manager::run(&operation),

--- a/grit-simple/src/output.rs
+++ b/grit-simple/src/output.rs
@@ -3,22 +3,23 @@
 //! Each command computes a typed, [`serde::Serialize`] *outcome* and returns it;
 //! the dispatcher in `main` then renders that outcome exactly once, either as the
 //! command's normal human-readable text or as a single JSON object on stdout
-//! (`--json`). This keeps the JSON schema centralized and stable, and leaves the
-//! human output unchanged.
+//! (`--json`). An optional global `--filter` applies a jq-like expression to that
+//! object so callers can select just the fields they need.
 //!
 //! ## Contract for `--json`
 //!
 //! * stdout carries exactly **one** JSON value: the command's outcome object on
-//!   success, or `{"error": "…"}` on failure.
+//!   success (optionally narrowed by `--filter`), or `{"error": "…"}` on failure.
 //! * the process still exits non-zero on failure, so consumers can branch on the
 //!   exit code *or* the presence of an `error` key.
 //! * progress / prompts / diagnostics go to **stderr** and never pollute stdout.
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use grit_lib::diff::{DiffEntry, DiffStatus};
 use serde::Serialize;
 
 use crate::context::CommitSummary;
+use crate::json_filter::apply_json_filter;
 use crate::ui::entry_path;
 
 /// How a command's outcome should be rendered.
@@ -28,6 +29,25 @@ pub enum OutputMode {
     Human,
     /// A single machine-readable JSON object on stdout.
     Json,
+}
+
+/// Rendering options for a command outcome.
+#[derive(Clone, Debug)]
+pub struct OutputOptions {
+    /// Human text or full/filtered JSON on stdout.
+    pub mode: OutputMode,
+    /// Optional jq-like expression applied to JSON output (requires [`OutputMode::Json`]).
+    pub filter: Option<String>,
+}
+
+impl OutputOptions {
+    /// Reject `--filter` without `--json`.
+    pub fn validate(&self) -> Result<()> {
+        if self.filter.is_some() && self.mode != OutputMode::Json {
+            bail!("--filter requires --json");
+        }
+        Ok(())
+    }
 }
 
 /// Render a value as the command's human-readable output.
@@ -42,28 +62,55 @@ pub trait HumanRender {
 ///
 /// Generic (rather than `Box<dyn …>`) because `serde::Serialize` is not
 /// object-safe; each dispatch arm calls this with its concrete outcome type.
-pub fn emit<T: Serialize + HumanRender>(value: &T, mode: OutputMode) -> Result<()> {
-    match mode {
+pub fn emit<T: Serialize + HumanRender>(value: &T, opts: &OutputOptions) -> Result<()> {
+    opts.validate()?;
+    match opts.mode {
         OutputMode::Human => value.render_human(),
-        OutputMode::Json => {
-            use std::io::Write as _;
-            let stdout = std::io::stdout();
-            let mut lock = stdout.lock();
-            serde_json::to_writer_pretty(&mut lock, value)
-                .map_err(|e| anyhow::anyhow!("serializing JSON output: {e}"))?;
-            let _ = writeln!(lock);
-        }
+        OutputMode::Json => write_json(value, opts.filter.as_deref())?,
     }
+    Ok(())
+}
+
+/// Serialize `value` to stdout, optionally applying a jq-like `filter`.
+fn write_json<T: Serialize>(value: &T, filter: Option<&str>) -> Result<()> {
+    use std::io::Write as _;
+    let stdout = std::io::stdout();
+    let mut lock = stdout.lock();
+    if let Some(expr) = filter {
+        let full = serde_json::to_value(value)
+            .map_err(|e| anyhow::anyhow!("serializing JSON output: {e}"))?;
+        let filtered = apply_json_filter(&full, expr)?;
+        serde_json::to_writer_pretty(&mut lock, &filtered)
+            .map_err(|e| anyhow::anyhow!("serializing filtered JSON output: {e}"))?;
+    } else {
+        serde_json::to_writer_pretty(&mut lock, value)
+            .map_err(|e| anyhow::anyhow!("serializing JSON output: {e}"))?;
+    }
+    let _ = writeln!(lock);
     Ok(())
 }
 
 /// Report a command failure: `{"error": "…"}` on stdout in JSON mode, or the
 /// usual `error: …` line on stderr in human mode. The caller still exits 1.
-pub fn emit_error(err: &anyhow::Error, mode: OutputMode) {
-    match mode {
+pub fn emit_error(err: &anyhow::Error, opts: &OutputOptions) {
+    if let Err(filter_err) = opts.validate() {
+        eprintln!("error: {filter_err:#}");
+        return;
+    }
+    match opts.mode {
         OutputMode::Human => eprintln!("error: {err:#}"),
         OutputMode::Json => {
-            let payload = serde_json::json!({ "error": format!("{err:#}") });
+            let payload = if let Some(expr) = opts.filter.as_deref() {
+                let full = serde_json::json!({ "error": format!("{err:#}") });
+                match apply_json_filter(&full, expr) {
+                    Ok(filtered) => filtered,
+                    Err(filter_err) => {
+                        serde_json::json!({ "error": format!("{filter_err:#}") })
+                    }
+                }
+            } else {
+                serde_json::json!({ "error": format!("{err:#}") })
+            };
             println!("{payload}");
         }
     }

--- a/grit-simple/tests/json_output.rs
+++ b/grit-simple/tests/json_output.rs
@@ -594,6 +594,61 @@ fn json_flag_works_before_or_after_subcommand() -> TestResult {
 /// renaming, or removing a field intentionally breaks this test — the guardrail
 /// for a stable schema.
 #[test]
+fn json_filter_selects_fields() -> TestResult {
+    let scratch = Scratch::new("filter")?;
+    let repo = scratch.child("repo");
+    fs::create_dir_all(&repo)?;
+    gs_ok(&repo, &["init", "."]);
+    write_file(&repo.join("a.txt"), "hi\n");
+    gs_ok(&repo, &["commit", "first"]);
+
+    let out = gs(&repo, ["--json", "--filter", ".branch", "status"]);
+    assert_eq!(out.status, Some(0), "{}", out.dump());
+    let v: Value = serde_json::from_str(&out.stdout).unwrap();
+    assert_eq!(v, Value::String("main".to_owned()));
+
+    let out = gs(&repo, ["status", "--json", "--filter", "{branch, clean}"]);
+    assert_eq!(out.status, Some(0), "{}", out.dump());
+    let v: Value = serde_json::from_str(&out.stdout).unwrap();
+    assert_eq!(v["branch"], "main");
+    assert_eq!(v["clean"], Value::Bool(true));
+    assert!(!v.as_object().unwrap().contains_key("staged"));
+
+    let out = gs(&repo, ["--filter", ".branch", "status"]);
+    assert_eq!(out.status, Some(1), "{}", out.dump());
+    assert!(
+        out.stderr.contains("--filter requires --json"),
+        "{}",
+        out.dump()
+    );
+    Ok(())
+}
+
+#[test]
+fn json_filter_maps_commit_subjects() -> TestResult {
+    let scratch = Scratch::new("filter-log")?;
+    let repo = scratch.child("repo");
+    fs::create_dir_all(&repo)?;
+    gs_ok(&repo, &["init", "."]);
+    for i in 0..3 {
+        write_file(&repo.join("a.txt"), &format!("v{i}\n"));
+        gs_ok(&repo, &["commit", &format!("commit {i}")]);
+    }
+
+    let out = gs(&repo, ["--json", "--filter", ".commits[].subject", "log"]);
+    assert_eq!(out.status, Some(0), "{}", out.dump());
+    let v: Value = serde_json::from_str(&out.stdout).unwrap();
+    let subjects: Vec<&str> = v
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|s| s.as_str().unwrap())
+        .collect();
+    assert_eq!(subjects, ["commit 2", "commit 1", "commit 0"]);
+    Ok(())
+}
+
+#[test]
 fn schema_top_level_keys_are_stable() -> TestResult {
     let scratch = Scratch::new("schema")?;
     let seed = scratch.child("seed");


### PR DESCRIPTION
Add a global --filter flag (requires --json) that applies a jq expression to every command's JSON outcome before printing. Filtering is centralized in output.rs via jaq, so all JSON-emitting commands get it automatically.

Examples:
  gs --json --filter .branch status
  gs --json --filter '.commits[].subject' log
  gs --json --filter '{branch, clean}' status