### PR TITLE
ci: build and release the grit-git binary; add install-grit-git script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,16 +60,21 @@ jobs:
 
       - name: Build
         if: ${{ !matrix.cross }}
-        run: cargo build --release --target ${{ matrix.target }} -p grit-cli
+        run: |
+          cargo build --release --target ${{ matrix.target }} -p grit-cli
+          cargo build --release --target ${{ matrix.target }} -p grit-git --bin grit-git --no-default-features
 
       - name: Build (cross)
         if: matrix.cross
-        run: cross build --release --target ${{ matrix.target }} -p grit-cli
+        run: |
+          cross build --release --target ${{ matrix.target }} -p grit-cli
+          cross build --release --target ${{ matrix.target }} -p grit-git --bin grit-git --no-default-features
 
       - name: Package
         run: |
           cd target/${{ matrix.target }}/release
           tar czf ../../../grit-${{ matrix.target }}.tar.gz grit
+          tar czf ../../../grit-git-${{ matrix.target }}.tar.gz grit-git
         shell: bash
 
       - name: Upload artifact
@@ -78,6 +83,7 @@ jobs:
           name: grit-${{ matrix.target }}
           path: |
             grit-${{ matrix.target }}.tar.gz
+            grit-git-${{ matrix.target }}.tar.gz
 
   # Windows ships the `grit` CLI (the `grit-cli` crate), installed via
   # `irm grit-scm.com/install.ps1 | iex` (see docs/install.ps1).
@@ -107,18 +113,23 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Build
-        run: cargo build --release --target ${{ matrix.target }} -p grit-cli
+        run: |
+          cargo build --release --target ${{ matrix.target }} -p grit-cli
+          cargo build --release --target ${{ matrix.target }} -p grit-git --bin grit-git --no-default-features
 
       - name: Package
         shell: pwsh
         run: |
           Compress-Archive -Path target/${{ matrix.target }}/release/grit.exe -DestinationPath grit-${{ matrix.target }}.zip
+          Compress-Archive -Path target/${{ matrix.target }}/release/grit-git.exe -DestinationPath grit-git-${{ matrix.target }}.zip
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: grit-windows-${{ matrix.target }}
-          path: grit-${{ matrix.target }}.zip
+          path: |
+            grit-${{ matrix.target }}.zip
+            grit-git-${{ matrix.target }}.zip
 
   release:
     needs: [build, build-windows]

--- a/docs/install-grit-git
+++ b/docs/install-grit-git
@@ -1,0 +1,81 @@
+#!/bin/sh
+# grit-git installer - downloads the pre-built `grit-git` binary from GitHub Releases.
+# Usage: curl -fsSL https://grit-scm.com/install-grit-git | sh
+
+main() {
+  set -eu
+
+  REPO="gitbutlerapp/grit"
+  INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
+
+  for cmd in command uname tr curl tar mkdir; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+      echo "error: required command '$cmd' not found" >&2
+      exit 1
+    fi
+  done
+
+  OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+  ARCH=$(uname -m)
+
+  case "$OS" in
+    darwin)  OS_TARGET="apple-darwin" ;;
+    linux)
+      # Pick the right C library flavor. musl-based distros (e.g. Alpine) get the
+      # statically-linked musl binary; everything else gets the glibc (gnu) one.
+      LIBC="gnu"
+      if { command -v ldd >/dev/null 2>&1 && ldd --version 2>&1 | grep -qi musl; } \
+         || ls /lib/ld-musl-* >/dev/null 2>&1 \
+         || { [ -f /etc/os-release ] && grep -qiE '^(ID|ID_LIKE)=.*alpine' /etc/os-release; }; then
+        LIBC="musl"
+      fi
+      OS_TARGET="unknown-linux-${LIBC}"
+      ;;
+    mingw*|msys*|cygwin*)
+      echo "On Windows, download from: https://github.com/$REPO/releases/latest" >&2
+      exit 1
+      ;;
+    *)
+      echo "error: unsupported OS: $OS" >&2
+      exit 1
+      ;;
+  esac
+
+  case "$ARCH" in
+    x86_64|amd64)  ARCH_TARGET="x86_64" ;;
+    arm64|aarch64) ARCH_TARGET="aarch64" ;;
+    *)
+      echo "error: unsupported architecture: $ARCH" >&2
+      exit 1
+      ;;
+  esac
+
+  TARGET="${ARCH_TARGET}-${OS_TARGET}"
+
+  echo "Detected: $OS/$ARCH -> $TARGET"
+
+  TMP=$(mktemp -d)
+  trap 'rm -rf "$TMP"' EXIT
+
+  mkdir -p "$INSTALL_DIR"
+
+  # Install the `grit-git` binary.
+  BIN=grit-git
+  URL="https://github.com/$REPO/releases/latest/download/${BIN}-${TARGET}.tar.gz"
+  echo "Downloading from: $URL"
+  curl -fSL "$URL" -o "$TMP/${BIN}.tar.gz"
+  tar xzf "$TMP/${BIN}.tar.gz" -C "$TMP"
+  mv "$TMP/${BIN}" "$INSTALL_DIR/${BIN}"
+  chmod +x "$INSTALL_DIR/${BIN}"
+  echo "Installed ${BIN} to $INSTALL_DIR/${BIN}"
+
+  if ! command -v grit-git >/dev/null 2>&1; then
+    echo ""
+    echo "Note: $INSTALL_DIR is not on your PATH."
+    echo "Add it with:  export PATH=\"$INSTALL_DIR:\$PATH\""
+  else
+    echo "$(grit-git --version)"
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
Build -p grit-git --bin grit-git (--no-default-features to drop test-tools)
for every release target and ship grit-git-* tarballs/zips alongside grit-*.
The existing release/nightly globs already match the new assets.

Add docs/install-grit-git to fetch the grit-git binary on Linux/macOS via
curl | sh, mirroring docs/install.