### PR TITLE
Fix typos in Readme and Agents files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ alwaysApply: true
 ---
 
 ---
-description: "Functionally complete Git reimplmentation in idiomatic, library focused Rust"
+description: "Functionally complete Git reimplementation in idiomatic, library-focused Rust"
 alwaysApply: true
 ---
 
@@ -57,9 +57,9 @@ you've fixed the underlying bug.
 
 The canonical Git source code we're targeting to replicate the functionality of is in the `git/` subdirectory.
 
-The tests we're trying to make pass with our new implementation is in the `git/t/` directory.
+The tests we're trying to make pass with our new implementation are in the `git/t/` directory.
 
-Manpage documentation is located in `git/Documentation` directory as `*.doc` files.
+Manpage documentation is located in the `git/Documentation` directory as `*.doc` files.
 
 ## Licensing Hard Rule — No Copied Expression in `grit-lib`
 

--- a/README.md
+++ b/README.md
@@ -42,11 +42,6 @@ To update your version of Grit, you can run `grit update` and it will re-run the
 
 ## The `grit` CLI
 
-test
-line two
-line three
-omg, more lines
-
 The `grit` binary (from the `grit-cli` crate) is what the install script ships. It is not a Git-identical CLI; it is a simpler interface for common developer workflows built on `grit-lib`, portable to Windows.
 
 `grit` treats status as the home screen and keeps the common path terse:
@@ -78,5 +73,3 @@ The Windows version also comes with `grit manager` which works as an interface t
 ## License
 
 The `grit-git` code is GPL-2.0; all other code and crates, including `grit-lib` are MIT licensed.
-
-testing

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Grit project is brought to you by the mad geniuses at [GitButler ⧓](https:
 
 ## Motivation
 
-Why rewrite Git functionality into Rust? It's not about replacing Git, it's about having a feature-complete linkable library. It's similar to Gitoxide or libgit2/git2-rs, but using LLMs to try to acheive total feature parity by targeting the Git testing suite.
+Why rewrite Git functionality into Rust? It's not about replacing Git, it's about having a feature-complete linkable library. It's similar to Gitoxide or libgit2/git2-rs, but using LLMs to try to achieve total feature parity by targeting the Git testing suite.
 
 ## Approach
 
@@ -22,7 +22,7 @@ The headline CLI shipped by the install script is `grit`, a simpler, opinionated
 
 ## Usability
 
-While the `grit-git` command emulates `git` functionality enough to successfully run over 42k of it's tests, it has been nearly entirely written by agents and has not been used for realsies. It's probably currently unusably slow or completely broken in ways that are not exercised in the test suite.
+While the `grit-git` command emulates `git` functionality enough to successfully run over 42k of its tests, it has been nearly entirely written by agents and has not been used for realsies. It's probably currently unusably slow or completely broken in ways that are not exercised in the test suite.
 
 Our current goal is to get all the tests to pass and then refactor to real usability (speed, API surface, etc) while being able to successfully test for regression easily. Try it out and either send a fix or report an issue for anything you find or ways you want to use it that it doesn't successfully do.
 
@@ -34,7 +34,7 @@ To install the `grit` CLI via Bash, you can run our install script:
 $ curl -fsSL https://grit-scm.com/install | sh
 ```
 
-There are builds for Mac and Linux, (aarch64 and x86_64 for both). Linux ships both glibc and statically-linked musl binaries, so the installer works on distros like Alpine too — it auto-detects which one your system needs. Windows installs the same `grit` CLI. The Git-compatible `grit-git` binary is not installed by the script — install it with `cargo install grit-git`.
+There are builds for Mac and Linux (aarch64 and x86_64 for both). Linux ships both glibc and statically-linked musl binaries, so the installer works on distros like Alpine too — it auto-detects which one your system needs. Windows installs the same `grit` CLI. The Git-compatible `grit-git` binary is not installed by the script — install it with `cargo install grit-git`.
 
 ## Updating
 
@@ -77,6 +77,6 @@ The Windows version also comes with `grit manager` which works as an interface t
 
 ## License
 
-The `grit-git` code is GPL-2.0, all other code and crates, including `grit-lib` are MIT licensed.
+The `grit-git` code is GPL-2.0; all other code and crates, including `grit-lib` are MIT licensed.
 
 testing


### PR DESCRIPTION
This PR fixes some typos observed in the README.md and AGENTS.md files.

It has also been observed two blocks of text that could be removed. I didn't update them in this PR as I was unsure of their original intention. They are

```md
test
line two
line three
omg, more lines
```

under ```## The `grit` CLI```,

and

```md
testing
```

under `## License`.

Please let me know if they can also be removed and, if so, I can update the PR accordingly.