### PR TITLE
Speed and completeness pass for clone, commit, and push

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,6 +552,7 @@ name = "grit-lib"
 version = "0.5.0"
 dependencies = [
  "base64",
+ "crc32fast",
  "encoding_rs",
  "filetime",
  "flate2",

--- a/data/tests/t5/t5601-clone.toml
+++ b/data/tests/t5/t5601-clone.toml
@@ -1,7 +1,7 @@
 in_scope = "yes"
 tests_total = 115
-passed_last = 112
-failing = 3
-fully_passing = false
+passed_last = 115
+failing = 0
+fully_passing = true
 status = "ok"
 expect_failure = 0

--- a/grit-git/src/commands/commit.rs
+++ b/grit-git/src/commands/commit.rs
@@ -3036,24 +3036,47 @@ fn auto_stage_tracked(repo: &Repository, work_tree: &Path) -> Result<()> {
         Err(e) => return Err(e.into()),
     };
 
-    let path_keys: std::collections::HashSet<Vec<u8>> =
-        index.entries.iter().map(|e| e.path.clone()).collect();
+    // The index file's own mtime bounds racy-timestamp detection (Git `is_racy_timestamp`):
+    // an entry written in the same instant the index was saved cannot be trusted by stat alone.
+    let index_mtime = {
+        use std::os::unix::fs::MetadataExt;
+        fs::symlink_metadata(&index_path)
+            .ok()
+            .map(|m| (m.mtime() as u32, m.mtime_nsec() as u32))
+    };
+
+    // One pass over the (sorted) index instead of a linear scan per path: which paths have
+    // conflict stages, and a snapshot of each stage-0 entry for stat/oid comparisons below.
+    // Snapshots stay valid because the loop only mutates entries for the path it is visiting.
+    let mut path_keys: std::collections::HashSet<Vec<u8>> = std::collections::HashSet::new();
+    let mut unmerged_paths: std::collections::HashSet<Vec<u8>> = std::collections::HashSet::new();
+    let mut stage0: std::collections::HashMap<Vec<u8>, grit_lib::index::IndexEntry> =
+        std::collections::HashMap::new();
+    for e in &index.entries {
+        path_keys.insert(e.path.clone());
+        if e.stage() != 0 {
+            unmerged_paths.insert(e.path.clone());
+        } else {
+            stage0.insert(e.path.clone(), e.clone());
+        }
+    }
+
+    // Memoize per-directory symlink-parent answers so N files in one directory cost one
+    // ancestor walk, not N.
+    let mut symlink_parent_cache: std::collections::HashMap<PathBuf, bool> =
+        std::collections::HashMap::new();
 
     let mut changed = false;
     for raw_path in path_keys {
         let path_str = String::from_utf8_lossy(&raw_path).to_string();
         let abs_path = work_tree.join(&path_str);
-        if path_has_symlink_parent_for_commit(work_tree, &abs_path) {
+        if path_has_symlink_parent_cached(work_tree, &abs_path, &mut symlink_parent_cache) {
             index.remove(&raw_path);
             changed = true;
             continue;
         }
 
-        let unmerged = index
-            .entries
-            .iter()
-            .any(|e| e.path == raw_path && e.stage() != 0);
-        if unmerged {
+        if unmerged_paths.contains(&raw_path) {
             // Merge conflicts list multiple index rows per path. Refresh once from the
             // worktree and collapse to a single stage-0 entry (matches `git commit -a`).
             let idx_mode = index
@@ -3116,15 +3139,13 @@ fn auto_stage_tracked(repo: &Repository, work_tree: &Path) -> Result<()> {
             continue;
         }
 
-        let Some(idx_e) = index
-            .entries
-            .iter()
-            .find(|e| e.path == raw_path && e.stage() == 0)
-        else {
+        let Some(idx_e) = stage0.get(&raw_path) else {
             continue;
         };
         let idx_mode = idx_e.mode;
         let idx_skip_worktree = idx_e.skip_worktree();
+        let idx_intent_to_add = idx_e.intent_to_add();
+        let idx_oid = idx_e.oid;
 
         // Use `symlink_metadata`, not `exists()`: `Path::exists` follows symlinks, so
         // dangling symlinks look "missing" and would be dropped from the index (t1006).
@@ -3198,6 +3219,21 @@ fn auto_stage_tracked(repo: &Repository, work_tree: &Path) -> Result<()> {
                 }
                 continue;
             }
+            // Fast path (Git `ie_match_stat`): an unchanged stat tuple with an unchanged mode
+            // proves the blob is unchanged — unless the entry is racy — so skip both the
+            // re-hash and the object-database write for the common "file untouched" case.
+            let wt_mode = if meta.file_type().is_symlink() {
+                grit_lib::index::MODE_SYMLINK
+            } else {
+                grit_lib::index::normalize_mode(meta.mode())
+            };
+            if !idx_intent_to_add
+                && wt_mode == idx_mode
+                && grit_lib::diff::stat_matches(idx_e, &meta)
+                && !grit_lib::diff::entry_is_racy(idx_e, index_mtime)
+            {
+                continue;
+            }
             let data = if meta.file_type().is_symlink() {
                 let target = fs::read_link(&abs_path)?;
                 target.to_string_lossy().into_owned().into_bytes()
@@ -3205,17 +3241,9 @@ fn auto_stage_tracked(repo: &Repository, work_tree: &Path) -> Result<()> {
                 fs::read(&abs_path)?
             };
             let oid = repo.odb.write(ObjectKind::Blob, &data)?;
-            let has_unmerged_for_path = index
-                .entries
-                .iter()
-                .any(|e| e.path == raw_path && e.stage() != 0);
-            if !has_unmerged_for_path
-                && index
-                    .entries
-                    .iter()
-                    .find(|e| e.path == raw_path)
-                    .is_some_and(|e| !e.intent_to_add() && e.oid == oid)
-            {
+            // Unmerged paths were handled above, so the only index row for this path is the
+            // stage-0 snapshot taken before the loop.
+            if !idx_intent_to_add && idx_oid == oid {
                 continue;
             }
             let mode = grit_lib::index::normalize_mode(meta.mode());
@@ -3239,25 +3267,40 @@ fn auto_stage_tracked(repo: &Repository, work_tree: &Path) -> Result<()> {
     Ok(())
 }
 
-fn path_has_symlink_parent_for_commit(work_tree: &Path, abs_path: &Path) -> bool {
-    let Ok(rel) = abs_path.strip_prefix(work_tree) else {
+/// Whether any parent directory of `abs_path` (below `work_tree`) is a symlink, memoizing
+/// per-directory answers in `cache` so staging many files in one directory costs a single
+/// ancestor walk instead of one lstat per component per file.
+fn path_has_symlink_parent_cached(
+    work_tree: &Path,
+    abs_path: &Path,
+    cache: &mut std::collections::HashMap<PathBuf, bool>,
+) -> bool {
+    let Some(parent) = abs_path.parent() else {
         return false;
     };
-    let mut cur = work_tree.to_path_buf();
-    let mut comps = rel.components().peekable();
-    while let Some(component) = comps.next() {
-        if comps.peek().is_none() {
-            break;
-        }
-        cur.push(component.as_os_str());
-        if fs::symlink_metadata(&cur)
-            .map(|m| m.file_type().is_symlink())
-            .unwrap_or(false)
-        {
-            return true;
-        }
+    dir_or_ancestor_is_symlink(work_tree, parent, cache)
+}
+
+/// Whether `dir` itself or any of its ancestors below `work_tree` is a symlink (memoized).
+fn dir_or_ancestor_is_symlink(
+    work_tree: &Path,
+    dir: &Path,
+    cache: &mut std::collections::HashMap<PathBuf, bool>,
+) -> bool {
+    if dir == work_tree || !dir.starts_with(work_tree) {
+        return false;
     }
-    false
+    if let Some(&answer) = cache.get(dir) {
+        return answer;
+    }
+    let answer = match dir.parent() {
+        Some(parent) if dir_or_ancestor_is_symlink(work_tree, parent, cache) => true,
+        _ => fs::symlink_metadata(dir)
+            .map(|m| m.file_type().is_symlink())
+            .unwrap_or(false),
+    };
+    cache.insert(dir.to_path_buf(), answer);
+    answer
 }
 
 /// Result of building a commit message — may be UTF-8 or raw bytes.

--- a/grit-git/src/commands/pack_objects.rs
+++ b/grit-git/src/commands/pack_objects.rs
@@ -108,6 +108,10 @@ pub struct Args {
     #[arg(long = "no-reuse-delta")]
     pub no_reuse_delta: bool,
 
+    /// Do not copy already-compressed object data from existing packs (Git `--no-reuse-object`).
+    #[arg(long = "no-reuse-object")]
+    pub no_reuse_object: bool,
+
     /// Restrict cross-island deltas (Git `--delta-islands`; driven by `pack.island` config).
     #[arg(long = "delta-islands")]
     pub delta_islands: bool,
@@ -1010,6 +1014,27 @@ pub fn run(mut args: Args) -> Result<()> {
         }
     }
 
+    // Per-object data reuse (Git pack-objects without bitmaps): an object that stays full in the
+    // output pack and is already stored full in a local pack is copied verbatim — position-
+    // independent varint header plus zlib stream — skipping both inflate and deflate.
+    let mut slice_reused_objects = 0usize;
+    if !args.no_reuse_object {
+        let objects_dir = repo.odb.objects_dir();
+        for entry in &mut write_entries {
+            let PackWriteEntry::Full(pe) = entry else {
+                continue;
+            };
+            if let Ok(Some(raw)) = grit_lib::pack::packed_full_object_slice(objects_dir, &pe.oid) {
+                *entry = PackWriteEntry::ReusedSlice {
+                    oid: pe.oid,
+                    pack_id: std::mem::take(&mut pe.pack_id),
+                    raw,
+                };
+                slice_reused_objects += 1;
+            }
+        }
+    }
+
     if let Some(ref path) = std::env::var_os("GIT_TRACE2_EVENT") {
         if let Some(p) = path.to_str() {
             if let (Some(a), Some(b)) = (trace_pack_reused, trace_packs_reused) {
@@ -1062,7 +1087,9 @@ pub fn run(mut args: Args) -> Result<()> {
 
     if args.stdout {
         if !args.quiet {
-            let reused_pack = trace_pack_reused.unwrap_or(0);
+            // Like Git, "reused" counts every object whose packed data was copied instead of
+            // recompressed: bitmap/MIDX chunk reuse plus per-object slice reuse.
+            let reused_pack = trace_pack_reused.unwrap_or(0) as usize + slice_reused_objects;
             let total_delta = new_deltas + reused_deltas;
             let total: usize = chunks.iter().map(|c| c.len()).sum();
             eprintln!(
@@ -5273,8 +5300,10 @@ fn build_pack(
                 buf.extend_from_slice(&compressed);
                 oid_to_offset.insert(*oid, start);
             }
-            PackWriteEntry::ReusedSlice { raw, .. } => {
+            PackWriteEntry::ReusedSlice { oid, raw, .. } => {
                 buf.extend_from_slice(raw);
+                // Register the offset so later OFS_DELTA entries can reference a reused base.
+                oid_to_offset.insert(*oid, start);
             }
         }
     }

--- a/grit-git/src/commands/pack_objects.rs
+++ b/grit-git/src/commands/pack_objects.rs
@@ -5077,6 +5077,9 @@ fn apply_delta_depth_limit(map: &mut HashMap<ObjectId, ObjectId>, max_depth: usi
 
     let modulus = max_depth.saturating_add(1);
     let mut snip: std::collections::HashSet<ObjectId> = std::collections::HashSet::new();
+    // Only chains that actually exceed the limit are restructured; a chain already within
+    // `max_depth` keeps its natural delta topology (t5303 relies on the created structure).
+    let mut over_limit: std::collections::HashSet<ObjectId> = std::collections::HashSet::new();
 
     for tip in tips {
         let mut chain: Vec<ObjectId> = Vec::new();
@@ -5091,9 +5094,10 @@ fn apply_delta_depth_limit(map: &mut HashMap<ObjectId, ObjectId>, max_depth: usi
         }
 
         let n = chain.len();
-        if n < 2 {
+        if n < 2 || n - 1 <= max_depth {
             continue;
         }
+        over_limit.extend(chain.iter().copied());
 
         // Match `break_delta_chains`: after walking `DELTA` links from tip to base, `total_depth`
         // equals the number of edges (objects minus one).
@@ -5111,11 +5115,16 @@ fn apply_delta_depth_limit(map: &mut HashMap<ObjectId, ObjectId>, max_depth: usi
         map.remove(&oid);
     }
 
+    // Flatten the segments of the broken (over-limit) chains so no remaining edge chains through
+    // another delta; untouched chains keep their original bases.
     let mut changed = true;
     while changed {
         changed = false;
         let targets: Vec<ObjectId> = map.keys().copied().collect();
         for t in targets {
+            if !over_limit.contains(&t) {
+                continue;
+            }
             let Some(&b) = map.get(&t) else {
                 continue;
             };

--- a/grit-git/src/commands/pack_objects.rs
+++ b/grit-git/src/commands/pack_objects.rs
@@ -914,7 +914,7 @@ pub fn run(mut args: Args) -> Result<()> {
         order_all_commits_first_parent_chain(&repo, &mut entries)?;
     }
 
-    let max_delta_depth = pack_delta_depth_limit(&args);
+    let max_delta_depth = pack_delta_depth_limit(&args, &repo);
     let window_zero_cli = {
         let mut args = std::env::args();
         let mut z = false;
@@ -1756,7 +1756,7 @@ fn warn_pack_threads(args: &Args) {
     }
 }
 
-fn pack_delta_depth_limit(args: &Args) -> Option<usize> {
+fn pack_delta_depth_limit(args: &Args, repo: &Repository) -> Option<usize> {
     let _ = (
         args.path_walk,
         args.no_path_walk,
@@ -1775,7 +1775,19 @@ fn pack_delta_depth_limit(args: &Args) -> Option<usize> {
     };
     let d_opt = args.depth.or_else(from_extra);
     match d_opt {
-        None => None,
+        // Git's default chain cap is `pack.depth` (50 when unset); an uncapped
+        // writer produces arbitrarily deep chains that every later reader pays for.
+        None => {
+            let from_config = ConfigSet::load(Some(&repo.git_dir), true)
+                .ok()
+                .and_then(|cfg| cfg.get("pack.depth"))
+                .and_then(|v| v.trim().parse::<i64>().ok());
+            match from_config {
+                Some(d) if d <= 0 => Some(0),
+                Some(d) => Some(d as usize),
+                None => Some(50),
+            }
+        }
         Some(d) if d <= 0 => Some(0),
         Some(d) => Some(d as usize),
     }
@@ -4598,29 +4610,8 @@ fn read_object_from_repo(repo: &Repository, oid: &ObjectId) -> Result<grit_lib::
         return Odb::read_loose_verify_oid(&loose_path, oid).map_err(|e| anyhow::anyhow!("{e}"));
     }
 
-    // Try pack files.
-    let indexes = grit_lib::pack::read_local_pack_indexes(repo.odb.objects_dir())
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
-    for idx in &indexes {
-        if let Some(entry) = idx
-            .entries
-            .iter()
-            .find(|e| grit_lib::pack::pack_index_entry_matches_sha1_oid(e, oid))
-        {
-            let pack_bytes = std::fs::read(&idx.pack_path)?;
-            match read_object_from_pack(&pack_bytes, entry.offset, &indexes, idx.hash_bytes) {
-                Ok(obj) => return Ok(obj),
-                Err(_) if pack_index_is_v1(&idx.idx_path) => {
-                    return Ok(grit_lib::objects::Object::new(ObjectKind::Blob, Vec::new()));
-                }
-                Err(_) => {
-                    if let Ok(obj) = repo.odb.read(oid) {
-                        return Ok(obj);
-                    }
-                    continue;
-                }
-            }
-        }
+    if let Some(obj) = read_object_from_local_packs_cached(repo, oid)? {
+        return Ok(obj);
     }
 
     // The local loose store and local packs do not have the object. Before treating
@@ -4638,30 +4629,45 @@ fn read_object_from_repo(repo: &Repository, oid: &ObjectId) -> Result<grit_lib::
     if loose_path.is_file() {
         return Odb::read_loose_verify_oid(&loose_path, oid).map_err(|e| anyhow::anyhow!("{e}"));
     }
-    let indexes = grit_lib::pack::read_local_pack_indexes(repo.odb.objects_dir())
+    if let Some(obj) = read_object_from_local_packs_cached(repo, oid)? {
+        return Ok(obj);
+    }
+    bail!("object not found: {}", oid.to_hex())
+}
+
+/// Resolve `oid` from the repository's local packs via the process-wide pack cache
+/// (cached `.idx` parses, cached pack bytes, fanout binary search, delta-base cache).
+///
+/// Returns `Ok(None)` when no local pack holds the object. Preserves the historical
+/// fallbacks of the enumeration path: a pack copy that fails to decode from a v1
+/// (legacy) index yields an empty blob placeholder, and any other decode failure
+/// retries the full ODB read before moving on to the next pack.
+fn read_object_from_local_packs_cached(
+    repo: &Repository,
+    oid: &ObjectId,
+) -> Result<Option<grit_lib::objects::Object>> {
+    let indexes = grit_lib::pack::read_local_pack_indexes_cached(repo.odb.objects_dir())
         .map_err(|e| anyhow::anyhow!("{e}"))?;
     for idx in &indexes {
-        if let Some(entry) = idx
-            .entries
-            .iter()
-            .find(|e| grit_lib::pack::pack_index_entry_matches_sha1_oid(e, oid))
-        {
-            let pack_bytes = std::fs::read(&idx.pack_path)?;
-            match read_object_from_pack(&pack_bytes, entry.offset, &indexes, idx.hash_bytes) {
-                Ok(obj) => return Ok(obj),
-                Err(_) if pack_index_is_v1(&idx.idx_path) => {
-                    return Ok(grit_lib::objects::Object::new(ObjectKind::Blob, Vec::new()));
-                }
-                Err(_) => {
-                    if let Ok(obj) = repo.odb.read(oid) {
-                        return Ok(obj);
-                    }
-                    continue;
+        if idx.find_offset(oid).is_none() {
+            continue;
+        }
+        match grit_lib::pack::read_object_from_pack(idx, oid) {
+            Ok(obj) => return Ok(Some(obj)),
+            Err(_) if pack_index_is_v1(&idx.idx_path) => {
+                return Ok(Some(grit_lib::objects::Object::new(
+                    ObjectKind::Blob,
+                    Vec::new(),
+                )));
+            }
+            Err(_) => {
+                if let Ok(obj) = repo.odb.read(oid) {
+                    return Ok(Some(obj));
                 }
             }
         }
     }
-    bail!("object not found: {}", oid.to_hex())
+    Ok(None)
 }
 
 fn read_object_from_repo_no_lazy(

--- a/grit-lib/Cargo.toml
+++ b/grit-lib/Cargo.toml
@@ -47,6 +47,7 @@ shell-words.workspace = true
 # Optional: the default `ureq`-backed HTTP client (feature `http-ureq`).
 ureq = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
+crc32fast = "1.5.0"
 
 # `nix` (signals, poll, uid, uname, Unix sockets) is only used behind
 # `#[cfg(unix)]`, so it is not pulled in on Windows.

--- a/grit-lib/src/config.rs
+++ b/grit-lib/src/config.rs
@@ -1792,6 +1792,42 @@ impl ConfigSet {
         Ok(pack_level)
     }
 
+    /// Zlib deflate level for loose objects (Git's `zlib_compression_level`).
+    ///
+    /// `core.looseCompression` wins; otherwise `core.compression` applies; when neither is set
+    /// Git defaults loose objects to `Z_BEST_SPEED` (1), trading disk for write throughput.
+    /// `-1` means zlib default (level 6). Valid values are `-1` or `0..=9`; out-of-range or
+    /// non-numeric values fall back to the default rather than erroring (matching how the
+    /// object writer must not fail on odd config).
+    #[must_use]
+    pub fn loose_objects_zlib_level(&self) -> u32 {
+        const Z_BEST_SPEED: u32 = 1;
+        const Z_DEFAULT_COMPRESSION: u32 = 6;
+        let parse_level = |raw: &str| -> Option<u32> {
+            let v = parse_git_config_int_strict(raw.trim()).ok()?;
+            match v {
+                -1 => Some(Z_DEFAULT_COMPRESSION),
+                0..=9 => Some(v as u32),
+                _ => None,
+            }
+        };
+        if let Some(level) = self
+            .get("core.looseCompression")
+            .as_deref()
+            .and_then(parse_level)
+        {
+            return level;
+        }
+        if let Some(level) = self
+            .get("core.compression")
+            .as_deref()
+            .and_then(parse_level)
+        {
+            return level;
+        }
+        Z_BEST_SPEED
+    }
+
     /// Get all entries matching a key pattern (regex).
     ///
     /// Used by `git config --get-regexp`. Returns an error if the pattern

--- a/grit-lib/src/diff.rs
+++ b/grit-lib/src/diff.rs
@@ -2566,6 +2566,62 @@ pub fn refresh_index_stat_content_verified(
     changed
 }
 
+/// Smudge racily-clean index entries before an index write (Git `ce_smudge_racily_clean_entry`).
+///
+/// An entry written to the worktree in the same filesystem-timestamp tick as the index file
+/// cannot be proven unchanged by stat data alone. When such an entry's stat still matches the
+/// worktree but the content no longer matches the recorded OID, its cached size is zeroed so
+/// every future stat comparison fails and readers re-hash the file. Without this, rewriting the
+/// index (which advances the index mtime) would make the stale entry look trustworthy again.
+///
+/// # Parameters
+/// - `index` — the in-memory index about to be written.
+/// - `work_tree` — path to the working tree root.
+/// - `index_mtime` — `(mtime_sec, mtime_nsec)` of the index file that was read (racy reference
+///   point); pass `None` when the index file did not previously exist.
+///
+/// Returns `true` when at least one entry was smudged.
+pub fn smudge_racily_clean_entries(
+    index: &mut Index,
+    work_tree: &Path,
+    index_mtime: Option<(u32, u32)>,
+) -> bool {
+    use crate::index::{MODE_EXECUTABLE, MODE_REGULAR, MODE_SYMLINK};
+    if index_mtime.is_none() {
+        return false;
+    }
+    let mut changed = false;
+    for ie in &mut index.entries {
+        if ie.stage() != 0 || ie.skip_worktree() || ie.assume_unchanged() || ie.intent_to_add() {
+            continue;
+        }
+        if ie.mode != MODE_REGULAR && ie.mode != MODE_EXECUTABLE && ie.mode != MODE_SYMLINK {
+            continue;
+        }
+        // A zero-size entry cannot be smudged further; Git accepts that residual race.
+        if ie.size == 0 || !entry_is_racy(ie, index_mtime) {
+            continue;
+        }
+        let Ok(path) = std::str::from_utf8(&ie.path) else {
+            continue;
+        };
+        let abs = work_tree.join(path);
+        let Ok(meta) = fs::symlink_metadata(&abs) else {
+            continue;
+        };
+        // Only a stat-clean entry is dangerous: a stat-dirty entry already forces a re-hash.
+        if !stat_matches(ie, &meta) {
+            continue;
+        }
+        if worktree_content_matches_index_oid(ie, &abs, &meta) {
+            continue;
+        }
+        ie.size = 0;
+        changed = true;
+    }
+    changed
+}
+
 /// Symlink target as the byte string Git hashes for the blob OID.
 ///
 /// On Unix the raw `OsStr` bytes are used verbatim. On Windows `OsStr` is WTF-8

--- a/grit-lib/src/diff.rs
+++ b/grit-lib/src/diff.rs
@@ -2345,7 +2345,18 @@ impl SymlinkDirCache {
     }
 }
 
-fn entry_is_racy(ie: &IndexEntry, index_mtime: Option<(u32, u32)>) -> bool {
+/// Whether an index entry's cached mtime is "racy" relative to the index file's own mtime.
+///
+/// A racy entry was written to the worktree at (or after) the moment the index was saved, so a
+/// matching stat tuple cannot prove the content is unchanged — callers must re-hash. This is
+/// Git's `is_racy_timestamp` rule.
+///
+/// # Parameters
+/// - `ie` — the index entry to test.
+/// - `index_mtime` — the on-disk index file's `(mtime_sec, mtime_nsec)`; when `None` (or the
+///   seconds value is zero) racy detection is skipped and this returns `false`.
+#[must_use]
+pub fn entry_is_racy(ie: &IndexEntry, index_mtime: Option<(u32, u32)>) -> bool {
     let Some((index_mtime_sec, index_mtime_nsec)) = index_mtime else {
         return false;
     };

--- a/grit-lib/src/fetch.rs
+++ b/grit-lib/src/fetch.rs
@@ -1600,4 +1600,3 @@ fn peel_tag_target(odb: &crate::odb::Odb, oid: ObjectId) -> ObjectId {
     }
     current
 }
-

--- a/grit-lib/src/merge_base.rs
+++ b/grit-lib/src/merge_base.rs
@@ -591,8 +591,7 @@ impl<'r> CommitGraphCache<'r> {
 
         // Compare against commit OIDs (the form the walk yields), peeling tags.
         let ancestor = peel_to_commit_for_merge_base(self.repo, ancestor).unwrap_or(ancestor);
-        let descendant =
-            peel_to_commit_for_merge_base(self.repo, descendant).unwrap_or(descendant);
+        let descendant = peel_to_commit_for_merge_base(self.repo, descendant).unwrap_or(descendant);
         if ancestor == descendant {
             return Ok(true);
         }

--- a/grit-lib/src/midx.rs
+++ b/grit-lib/src/midx.rs
@@ -272,6 +272,11 @@ mod midx_cache {
     struct State {
         bytes: HashMap<PathBuf, (Stamp, Arc<Vec<u8>>)>,
         hash_version: HashMap<PathBuf, (Option<Stamp>, u8)>,
+        /// Tip-MIDX resolution per pack dir, held for the process lifetime and
+        /// evicted by in-process MIDX writers. Only the object-read hot path may
+        /// use this: a stale entry there degrades to the regular pack lookup,
+        /// which stays correct, whereas midx subcommands need the live state.
+        tip_path: HashMap<PathBuf, Option<PathBuf>>,
     }
 
     static CACHE: OnceLock<Mutex<State>> = OnceLock::new();
@@ -328,9 +333,25 @@ mod midx_cache {
         v
     }
 
-    /// Drop cached MIDX bytes under `pack_dir` (called by in-process writers).
+    /// Cached tip-MIDX resolution for `pack_dir`, computing it with `resolve` on
+    /// first use. Object-read hot path only (see [`State::tip_path`]): resolving
+    /// the tip costs two filesystem probes per call (root file + chain), which
+    /// history walks and pack building would otherwise pay per object.
+    pub fn tip_path(pack_dir: &Path, resolve: impl FnOnce() -> Option<PathBuf>) -> Option<PathBuf> {
+        if let Some(tip) = lock().tip_path.get(pack_dir) {
+            return tip.clone();
+        }
+        let tip = resolve();
+        lock().tip_path.insert(pack_dir.to_path_buf(), tip.clone());
+        tip
+    }
+
+    /// Drop cached MIDX bytes and tip resolutions under `pack_dir` (called by
+    /// in-process writers).
     pub fn evict_pack_dir(pack_dir: &Path) {
-        lock().bytes.retain(|p, _| !p.starts_with(pack_dir));
+        let mut g = lock();
+        g.bytes.retain(|p, _| !p.starts_with(pack_dir));
+        g.tip_path.retain(|p, _| !p.starts_with(pack_dir));
     }
 }
 
@@ -1782,10 +1803,17 @@ pub fn midx_lookup_pack_and_offset(objects_dir: &Path, oid: &ObjectId) -> Result
 /// [`None`] means there is no MIDX at the pack tip. [`Some`] is the lookup result when a MIDX exists.
 pub fn midx_oid_listed_in_tip(objects_dir: &Path, oid: &ObjectId) -> Result<Option<bool>> {
     let pack_dir = objects_dir.join("pack");
-    let Some(midx_path) = resolve_tip_midx_path(&pack_dir) else {
+    let Some(midx_path) = midx_cache::tip_path(&pack_dir, || resolve_tip_midx_path(&pack_dir))
+    else {
         return Ok(None);
     };
-    let data = midx_cache::get_bytes(&midx_path)?;
+    let data = match midx_cache::get_bytes(&midx_path) {
+        Ok(data) => data,
+        // A tip cached before another process removed the MIDX: fall back to
+        // the regular pack lookup instead of failing the read.
+        Err(Error::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err),
+    };
     let hash_len = midx_hash_len(&data);
     let MidxReadView {
         oidf_off,
@@ -2087,10 +2115,17 @@ pub fn try_read_object_via_midx(
     oid: &ObjectId,
 ) -> Result<Option<crate::objects::Object>> {
     let pack_dir = objects_dir.join("pack");
-    let Some(midx_path) = resolve_tip_midx_path(&pack_dir) else {
+    let Some(midx_path) = midx_cache::tip_path(&pack_dir, || resolve_tip_midx_path(&pack_dir))
+    else {
         return Ok(None);
     };
-    let data = midx_cache::get_bytes(&midx_path)?;
+    let data = match midx_cache::get_bytes(&midx_path) {
+        Ok(data) => data,
+        // A tip cached before another process removed the MIDX: fall back to
+        // the regular pack lookup instead of failing the read.
+        Err(Error::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err),
+    };
 
     // Load-time validation, mirroring `load_multi_pack_index` in git/midx.c.
     // Fatal corruptions `die()` (print error + fatal, exit 128); recoverable
@@ -2242,6 +2277,7 @@ pub fn clear_pack_midx_state(pack_dir: &Path) -> Result<()> {
     if midx_d.exists() {
         let _ = fs::remove_dir_all(&midx_d);
     }
+    midx_cache::evict_pack_dir(pack_dir);
     Ok(())
 }
 

--- a/grit-lib/src/odb.rs
+++ b/grit-lib/src/odb.rs
@@ -106,6 +106,9 @@ pub struct Odb {
     /// detected lazily from the config and cached. Determines the hash used
     /// when writing objects. Defaults to SHA-1 when no config is available.
     hash_algo_cache: Arc<OnceLock<HashAlgo>>,
+    /// Zlib level for loose-object writes (`core.looseCompression` falling back to
+    /// `core.compression`, Git default `Z_BEST_SPEED`), resolved lazily and cached.
+    loose_zlib_cache: Arc<OnceLock<Compression>>,
 }
 
 impl std::fmt::Debug for Odb {
@@ -134,6 +137,7 @@ impl Odb {
             core_multi_pack_index_cache: Arc::new(OnceLock::new()),
             mem_overlay: Arc::new(Mutex::new(None)),
             hash_algo_cache: Arc::new(OnceLock::new()),
+            loose_zlib_cache: Arc::new(OnceLock::new()),
         }
     }
 
@@ -148,6 +152,7 @@ impl Odb {
             core_multi_pack_index_cache: Arc::new(OnceLock::new()),
             mem_overlay: Arc::new(Mutex::new(None)),
             hash_algo_cache: Arc::new(OnceLock::new()),
+            loose_zlib_cache: Arc::new(OnceLock::new()),
         }
     }
 
@@ -256,6 +261,25 @@ impl Odb {
             cfg.get("extensions.objectformat")
                 .and_then(|v| HashAlgo::from_name(&v))
                 .unwrap_or(HashAlgo::Sha1)
+        })
+    }
+
+    /// Zlib compression used for loose-object writes, resolved from
+    /// `core.looseCompression` / `core.compression` (Git `zlib_compression_level`, default
+    /// `Z_BEST_SPEED`) and cached for the lifetime of this `Odb`.
+    fn loose_compression(&self) -> Compression {
+        *self.loose_zlib_cache.get_or_init(|| {
+            let git_dir = self
+                .config_git_dir
+                .clone()
+                .or_else(|| self.objects_dir.parent().map(Path::to_path_buf));
+            let level = match git_dir {
+                Some(git_dir) => ConfigSet::load(Some(&git_dir), true)
+                    .unwrap_or_default()
+                    .loose_objects_zlib_level(),
+                None => 1,
+            };
+            Compression::new(level)
         })
     }
 
@@ -625,7 +649,7 @@ impl Odb {
         let tmp_path = prefix_dir.join(format!("tmp_{}", oid.loose_suffix()));
         {
             let tmp_file = fs::File::create(&tmp_path)?;
-            let mut encoder = ZlibEncoder::new(tmp_file, Compression::default());
+            let mut encoder = ZlibEncoder::new(tmp_file, self.loose_compression());
             encoder
                 .write_all(&store_bytes)
                 .map_err(|e| Error::Zlib(e.to_string()))?;
@@ -678,7 +702,7 @@ impl Odb {
         let tmp_path = prefix_dir.join(format!("tmp_{}", oid.loose_suffix()));
         {
             let tmp_file = fs::File::create(&tmp_path)?;
-            let mut encoder = ZlibEncoder::new(tmp_file, Compression::default());
+            let mut encoder = ZlibEncoder::new(tmp_file, self.loose_compression());
             encoder
                 .write_all(&store_bytes)
                 .map_err(|e| Error::Zlib(e.to_string()))?;
@@ -717,7 +741,7 @@ impl Odb {
         let tmp_path = prefix_dir.join(format!("tmp_{}", oid.loose_suffix()));
         {
             let tmp_file = fs::File::create(&tmp_path)?;
-            let mut encoder = ZlibEncoder::new(tmp_file, Compression::default());
+            let mut encoder = ZlibEncoder::new(tmp_file, self.loose_compression());
             encoder
                 .write_all(&store_bytes)
                 .map_err(|e| Error::Zlib(e.to_string()))?;
@@ -765,7 +789,7 @@ impl Odb {
         let tmp_path = prefix_dir.join(format!("tmp_{}", oid.loose_suffix()));
         {
             let tmp_file = fs::File::create(&tmp_path)?;
-            let mut encoder = ZlibEncoder::new(tmp_file, Compression::default());
+            let mut encoder = ZlibEncoder::new(tmp_file, self.loose_compression());
             encoder
                 .write_all(store_bytes)
                 .map_err(|e| Error::Zlib(e.to_string()))?;
@@ -810,7 +834,7 @@ impl Odb {
         let tmp_path = prefix_dir.join(format!("tmp_{}", oid.loose_suffix()));
         {
             let tmp_file = fs::File::create(&tmp_path)?;
-            let mut encoder = ZlibEncoder::new(tmp_file, Compression::default());
+            let mut encoder = ZlibEncoder::new(tmp_file, self.loose_compression());
             encoder
                 .write_all(store_bytes)
                 .map_err(|e| Error::Zlib(e.to_string()))?;

--- a/grit-lib/src/odb.rs
+++ b/grit-lib/src/odb.rs
@@ -173,6 +173,11 @@ impl Odb {
         }
     }
 
+    /// Whether the in-memory write overlay is currently enabled.
+    fn overlay_active(&self) -> bool {
+        self.mem_overlay.lock().is_ok_and(|g| g.is_some())
+    }
+
     /// If the in-memory overlay is active, store `(kind, data)` under `oid` there and return
     /// `true`; otherwise return `false` so the caller falls through to the on-disk path.
     fn overlay_store(&self, oid: ObjectId, kind: ObjectKind, data: &[u8]) -> bool {
@@ -624,17 +629,20 @@ impl Odb {
         let store_bytes = build_store_bytes(kind, data);
         let oid = hash_bytes_with(self.hash_algo(), &store_bytes);
 
-        // When the in-memory overlay is active, keep the object in memory only (unless it is
-        // already present on disk, in which case nothing new needs to be written anyway).
-        if !self.exists(&oid) && self.overlay_store(oid, kind, data) {
-            return Ok(oid);
-        }
-
+        // Cheapest check first: a loose copy in this store answers every case below with a
+        // single stat, avoiding the full pack/alternates/MIDX existence scan per write.
         let path = self.object_path(&oid);
         if path.exists() {
             let _ = self.freshen_object(&oid);
             return Ok(oid);
         }
+
+        // When the in-memory overlay is active, keep the object in memory only (unless it is
+        // already present on disk, in which case nothing new needs to be written anyway).
+        if self.overlay_active() && !self.exists(&oid) && self.overlay_store(oid, kind, data) {
+            return Ok(oid);
+        }
+
         if self.exists(&oid) {
             let _ = self.freshen_object(&oid);
             return Ok(oid);

--- a/grit-lib/src/pack.rs
+++ b/grit-lib/src/pack.rs
@@ -1395,6 +1395,12 @@ fn read_pack_base_cached(
     Ok((kind, data))
 }
 
+/// Deepest delta chain a read will follow before treating the pack as corrupt.
+///
+/// This is a safety valve against cyclic ref-delta chains and unbounded recursion,
+/// not a format limit: Git itself reads chains of any depth.
+const MAX_DELTA_CHAIN_READ_DEPTH: usize = 4096;
+
 fn read_pack_object_at(
     pack_bytes: &[u8],
     offset: u64,
@@ -1402,10 +1408,15 @@ fn read_pack_object_at(
     objects_dir: Option<&Path>,
     depth: usize,
 ) -> Result<(ObjectKind, Vec<u8>)> {
-    if depth > 50 {
-        return Err(Error::CorruptObject(
-            "delta chain too deep (>50)".to_owned(),
-        ));
+    // Git imposes no read-side delta-chain limit (`pack.depth` caps only what the
+    // writer produces, default 50). Reads must therefore handle chains far deeper
+    // than 50 — both packs written with an explicit `--depth`, and historical grit
+    // packs written before the writer capped chains. The bound below exists only
+    // to terminate corrupt cyclic ref-delta chains and bound recursion stack use.
+    if depth > MAX_DELTA_CHAIN_READ_DEPTH {
+        return Err(Error::CorruptObject(format!(
+            "delta chain too deep (>{MAX_DELTA_CHAIN_READ_DEPTH})"
+        )));
     }
     let mut pos = offset as usize;
     let (packed_type, size) = parse_pack_object_header(pack_bytes, &mut pos)?;

--- a/grit-lib/src/pack.rs
+++ b/grit-lib/src/pack.rs
@@ -478,7 +478,26 @@ mod pack_cache {
 
     /// Get the raw bytes of a pack file from cache, re-reading from disk when the
     /// file's mtime/size changes.
+    /// Whether `path` names a final, content-addressed pack file (`pack-<hash>.pack`).
+    /// For such paths the name pins the content, so a cached copy cannot silently
+    /// go stale; temporary packs (`tmp_pack_*`) keep the stat-stamp revalidation.
+    fn is_content_addressed_pack(path: &Path) -> bool {
+        path.file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.starts_with("pack-") && n.ends_with(".pack"))
+    }
+
     pub fn get_pack_bytes(pack_path: &Path) -> Result<Arc<Vec<u8>>> {
+        // Content-addressed packs are immutable in practice: in-process rewrites go
+        // through `repack`/`gc`, which clear this cache, and cross-process mutation
+        // cannot outlive the process boundary. Serving the cached copy without a
+        // stat removes one syscall per packed-object read on hot walks.
+        if is_content_addressed_pack(pack_path) {
+            let g = lock();
+            if let Some(c) = g.by_pack.get(pack_path) {
+                return Ok(Arc::clone(&c.bytes));
+            }
+        }
         let sig = file_signature(pack_path);
         if let Some((mtime, size)) = sig {
             {

--- a/grit-lib/src/pack.rs
+++ b/grit-lib/src/pack.rs
@@ -1682,22 +1682,18 @@ pub fn packed_ref_delta_reuse_slice(
     oid: &ObjectId,
     packed_set: &HashSet<ObjectId>,
 ) -> Result<Option<(ObjectId, Vec<u8>)>> {
-    let mut indexes = read_local_pack_indexes(objects_dir)?;
+    let mut indexes = read_local_pack_indexes_cached(objects_dir)?;
     sort_pack_indexes_oldest_first(&mut indexes);
     for idx in indexes {
-        let Some(entry) = idx
-            .entries
-            .iter()
-            .find(|e| e.oid.len() == 20 && e.oid.as_slice() == oid.as_bytes())
-        else {
-            continue;
-        };
         let hb = idx.hash_bytes;
         if hb != 20 {
             continue;
         }
-        let pack_bytes = fs::read(&idx.pack_path).map_err(Error::Io)?;
-        let mut p = entry.offset as usize;
+        let Some(entry_offset) = idx.find_offset(oid) else {
+            continue;
+        };
+        let pack_bytes = read_pack_bytes_cached(&idx.pack_path)?;
+        let mut p = entry_offset as usize;
         let (packed_type, _size) = parse_pack_object_header(&pack_bytes, &mut p)?;
         let base = match packed_type {
             PackedType::RefDelta => {
@@ -1711,7 +1707,7 @@ pub fn packed_ref_delta_reuse_slice(
                 bo
             }
             PackedType::OfsDelta => {
-                let base_off = parse_ofs_delta_base(&pack_bytes, &mut p, entry.offset)?;
+                let base_off = parse_ofs_delta_base(&pack_bytes, &mut p, entry_offset)?;
                 let Some(base_entry) = idx.entries.iter().find(|e| e.offset == base_off) else {
                     continue;
                 };
@@ -1731,7 +1727,7 @@ pub fn packed_ref_delta_reuse_slice(
         }
         let zlib_start = p;
         let mut end_pos = zlib_start;
-        if skip_one_pack_object(&pack_bytes, &mut end_pos, entry.offset, hb).is_err() {
+        if skip_one_pack_object(&pack_bytes, &mut end_pos, entry_offset, hb).is_err() {
             continue;
         }
         let compressed = &pack_bytes[zlib_start..end_pos];
@@ -1747,7 +1743,7 @@ pub fn packed_ref_delta_reuse_slice(
 
 /// Prefer older packs when the same OID exists as a full object in a fresh repack and as a delta
 /// in an earlier thin pack (t5316).
-fn sort_pack_indexes_oldest_first(indexes: &mut [PackIndex]) {
+fn sort_pack_indexes_oldest_first(indexes: &mut [Arc<PackIndex>]) {
     indexes.sort_by(|a, b| {
         let ta = fs::metadata(&a.pack_path)
             .and_then(|m| m.modified())
@@ -1759,7 +1755,7 @@ fn sort_pack_indexes_oldest_first(indexes: &mut [PackIndex]) {
     });
 }
 
-fn sort_pack_indexes_newest_first(indexes: &mut [PackIndex]) {
+fn sort_pack_indexes_newest_first(indexes: &mut [Arc<PackIndex>]) {
     indexes.sort_by(|a, b| {
         let ta = fs::metadata(&a.pack_path)
             .and_then(|m| m.modified())
@@ -1772,21 +1768,17 @@ fn sort_pack_indexes_newest_first(indexes: &mut [PackIndex]) {
 }
 
 pub fn packed_delta_base_oid(objects_dir: &Path, oid: &ObjectId) -> Result<Option<ObjectId>> {
-    let mut indexes = read_local_pack_indexes(objects_dir)?;
+    let mut indexes = read_local_pack_indexes_cached(objects_dir)?;
     sort_pack_indexes_newest_first(&mut indexes);
     for idx in &indexes {
         if idx.hash_bytes != 20 {
             continue;
         }
-        let Some(entry) = idx
-            .entries
-            .iter()
-            .find(|e| e.oid.len() == 20 && e.oid.as_slice() == oid.as_bytes())
-        else {
+        let Some(entry_offset) = idx.find_offset(oid) else {
             continue;
         };
-        let pack_bytes = fs::read(&idx.pack_path).map_err(Error::Io)?;
-        let mut p = entry.offset as usize;
+        let pack_bytes = read_pack_bytes_cached(&idx.pack_path)?;
+        let mut p = entry_offset as usize;
         let (packed_type, _) = parse_pack_object_header(&pack_bytes, &mut p)?;
         match packed_type {
             PackedType::RefDelta => {
@@ -1797,7 +1789,7 @@ pub fn packed_delta_base_oid(objects_dir: &Path, oid: &ObjectId) -> Result<Optio
                 return Ok(Some(ObjectId::from_bytes(&pack_bytes[p..p + hb])?));
             }
             PackedType::OfsDelta => {
-                let base_off = parse_ofs_delta_base(&pack_bytes, &mut p, entry.offset)?;
+                let base_off = parse_ofs_delta_base(&pack_bytes, &mut p, entry_offset)?;
                 return Ok(idx
                     .entries
                     .iter()

--- a/grit-lib/src/pack.rs
+++ b/grit-lib/src/pack.rs
@@ -23,6 +23,9 @@ pub struct PackIndexEntry {
     pub oid: Vec<u8>,
     /// Byte offset of the object in the corresponding `.pack`.
     pub offset: u64,
+    /// CRC32 of the raw packed entry bytes (header + payload), from the v2 index CRC table.
+    /// `None` for version-1 indexes, which do not record CRCs.
+    pub crc32: Option<u32>,
 }
 
 /// Parsed data from a `.idx` file (version 2).
@@ -749,7 +752,11 @@ fn read_pack_index_v1(idx_path: &Path, bytes: &[u8], verify: bool) -> Result<Pac
                 idx_path.display()
             )));
         }
-        entries.push(PackIndexEntry { oid, offset });
+        entries.push(PackIndexEntry {
+            oid,
+            offset,
+            crc32: None,
+        });
     }
 
     if verify {
@@ -833,7 +840,10 @@ fn read_pack_index_v2(idx_path: &Path, bytes: &[u8], verify: bool) -> Result<Pac
         oids.push(slice.to_vec());
     }
 
-    pos += object_count * 4;
+    let mut crcs = Vec::with_capacity(object_count);
+    for _ in 0..object_count {
+        crcs.push(read_u32_be(bytes, &mut pos)?);
+    }
 
     let mut offsets32 = Vec::with_capacity(object_count);
     let mut large_count = 0usize;
@@ -869,7 +879,11 @@ fn read_pack_index_v2(idx_path: &Path, bytes: &[u8], verify: bool) -> Result<Pac
             next_large += 1;
             off
         };
-        entries.push(PackIndexEntry { oid, offset });
+        entries.push(PackIndexEntry {
+            oid,
+            offset,
+            crc32: Some(crcs[i]),
+        });
     }
 
     let mut pack_path = idx_path.to_path_buf();
@@ -1798,6 +1812,75 @@ pub fn packed_delta_base_oid(objects_dir: &Path, oid: &ObjectId) -> Result<Optio
             }
             _ => continue,
         }
+    }
+    Ok(None)
+}
+
+/// When `oid` is stored as a full (non-delta) object in a local pack, return its verbatim packed
+/// bytes: the varint type+size header followed by the zlib stream.
+///
+/// The header of a non-delta pack entry is position-independent, so the returned slice can be
+/// copied into a new pack unchanged — skipping both inflate and deflate. This is Git
+/// pack-objects' object reuse for objects that stay full in the output pack.
+///
+/// # Parameters
+/// - `objects_dir` — the repository's `objects/` directory.
+/// - `oid` — the object to look up.
+///
+/// Returns `None` when the object is loose only, stored as a delta, or the repository uses a
+/// hash width other than SHA-1.
+///
+/// # Errors
+///
+/// Returns [`Error::Io`] when pack files cannot be read; a malformed candidate entry is skipped
+/// rather than reported so another pack (or the recompression path) can serve the object.
+pub fn packed_full_object_slice(objects_dir: &Path, oid: &ObjectId) -> Result<Option<Vec<u8>>> {
+    let mut indexes = read_local_pack_indexes_cached(objects_dir)?;
+    sort_pack_indexes_newest_first(&mut indexes);
+    for idx in &indexes {
+        if idx.hash_bytes != 20 {
+            continue;
+        }
+        let Some(entry_offset) = idx.find_offset(oid) else {
+            continue;
+        };
+        let pack_bytes = read_pack_bytes_cached(&idx.pack_path)?;
+        let start = entry_offset as usize;
+        let mut p = start;
+        let Ok((packed_type, _size)) = parse_pack_object_header(&pack_bytes, &mut p) else {
+            continue;
+        };
+        if matches!(packed_type, PackedType::OfsDelta | PackedType::RefDelta) {
+            // The same OID may be a full object in another pack; keep scanning.
+            continue;
+        }
+        let mut end = start;
+        if skip_one_pack_object(&pack_bytes, &mut end, entry_offset, idx.hash_bytes).is_err() {
+            continue;
+        }
+        let slice = &pack_bytes[start..end];
+        // Git `check_pack_crc`: verbatim reuse copies bytes unparsed, so guard with the pack
+        // index's CRC32. A corrupt copy is skipped, letting a redundant pack or the normal
+        // (validating) read path serve the object instead (t5303).
+        let recorded_crc = idx
+            .entries
+            .iter()
+            .find(|e| e.offset == entry_offset)
+            .and_then(|e| e.crc32);
+        match recorded_crc {
+            Some(crc) if crc32fast::hash(slice) != crc => continue,
+            // v1 indexes carry no CRC; verify by inflating and re-hashing the content.
+            None => {
+                if read_object_from_pack(idx, oid)
+                    .map(|obj| crate::odb::Odb::hash_object_data(obj.kind, &obj.data) != *oid)
+                    .unwrap_or(true)
+                {
+                    continue;
+                }
+            }
+            _ => {}
+        }
+        return Ok(Some(slice.to_vec()));
     }
     Ok(None)
 }

--- a/grit-lib/src/pack.rs
+++ b/grit-lib/src/pack.rs
@@ -1319,13 +1319,16 @@ fn read_alternates_inner(
     if depth > MAX_ALTERNATE_DEPTH {
         return Ok(());
     }
-    let canonical = canonical_or_self(objects_dir);
-    let alt_file = canonical.join("info").join("alternates");
+    // Read the alternates file before canonicalizing: the canonical form is only needed to
+    // resolve relative entries and deduplicate, and canonicalize walks every path component
+    // (a readlink per ancestor) — pure waste in the overwhelmingly common no-alternates case.
+    let alt_file = objects_dir.join("info").join("alternates");
     let text = match fs::read_to_string(&alt_file) {
         Ok(text) => text,
         Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(()),
         Err(err) => return Err(Error::Io(err)),
     };
+    let canonical = canonical_or_self(objects_dir);
 
     for raw in text.lines() {
         let line = raw.trim();

--- a/grit-lib/src/pathspec.rs
+++ b/grit-lib/src/pathspec.rs
@@ -1632,7 +1632,20 @@ pub fn resolve_pathspec(pathspec: &str, work_tree: &Path, prefix: Option<&str>) 
         Some(p) if !p.is_empty() => {
             normalize_relative_path_str(&PathBuf::from(p).join(pathspec).to_string_lossy())
         }
-        _ => pathspec.to_owned(),
+        _ => {
+            // Git's `prefix_path` normalizes away leading `./` segments, so index and tree
+            // paths never contain a `.` component (`git add ./-` stages `-`, not `./-`,
+            // which would otherwise write an invalid `.` tree entry).
+            let mut spec = pathspec;
+            while let Some(rest) = spec.strip_prefix("./") {
+                spec = rest.trim_start_matches('/');
+            }
+            if spec.is_empty() {
+                ".".to_owned()
+            } else {
+                spec.to_owned()
+            }
+        }
     }
 }
 

--- a/grit-lib/src/repo.rs
+++ b/grit-lib/src/repo.rs
@@ -622,6 +622,19 @@ impl Repository {
         // index written through the repository is consistent, regardless of how
         // the in-memory `Index` was constructed (e.g. a fresh `Index::new`).
         index.hash_algo = self.odb.hash_algo();
+        // Racy-git protection (Git `ce_smudge_racily_clean_entry`): before overwriting the index,
+        // zero the cached size of entries whose worktree file changed in the same timestamp tick
+        // as the previous index write, so the rewritten (newer-mtime) index cannot make them look
+        // clean. The pre-overwrite mtime of `path` is the racy reference point.
+        if let Some(work_tree) = self.work_tree.as_deref() {
+            let prev_index_mtime = {
+                use std::os::unix::fs::MetadataExt;
+                std::fs::symlink_metadata(path)
+                    .ok()
+                    .map(|m| (m.mtime() as u32, m.mtime_nsec() as u32))
+            };
+            crate::diff::smudge_racily_clean_entries(index, work_tree, prev_index_mtime);
+        }
         self.finalize_sparse_index_if_needed(index)?;
         let cfg = ConfigSet::load(Some(&self.git_dir), true).unwrap_or_default();
         let skip_hash = crate::index::index_skip_hash_for_write(Some(&cfg));

--- a/scripts/bench-ccp.sh
+++ b/scripts/bench-ccp.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+# Benchmark grit's clone / commit / push workflows against fixed fixtures.
+#
+# Usage:
+#   scripts/bench-ccp.sh fixtures            # build fixture repos (one-time)
+#   scripts/bench-ccp.sh run [BIN] [N]       # run all scenarios, median of N (default 5)
+#   scripts/bench-ccp.sh run-one NAME [BIN] [N]
+#
+# BIN defaults to target/release/grit-git. Pass /usr/bin/git to get a
+# reference baseline. All work happens under $BENCH_ROOT (default
+# /tmp/grit-bench); the source tree is never touched.
+set -u
+BENCH_ROOT=${BENCH_ROOT:-/tmp/grit-bench}
+FIX=$BENCH_ROOT/fixtures
+WORK=$BENCH_ROOT/work
+DEFAULT_BIN=$(cd "$(dirname "$0")/.." && pwd)/target/release/grit-git
+export GIT_AUTHOR_NAME=bench GIT_AUTHOR_EMAIL=bench@example.com
+export GIT_COMMITTER_NAME=bench GIT_COMMITTER_EMAIL=bench@example.com
+export GIT_CONFIG_NOSYSTEM=1 HOME=$BENCH_ROOT/home
+
+now_ms() { date +%s%3N; }
+
+build_fixtures() {
+  local g=${1:-$DEFAULT_BIN}
+  rm -rf "$FIX" "$BENCH_ROOT/home"
+  mkdir -p "$FIX" "$BENCH_ROOT/home"
+
+  # many: 10k small files over 100 dirs, 5 commits, packed.
+  local d=$FIX/many
+  "$g" init -q "$d"
+  (
+    cd "$d"
+    for batch in 0 1 2 3 4; do
+      for dir in $(seq 0 19); do
+        mkdir -p "d$((batch * 20 + dir))"
+        for f in $(seq 0 99); do
+          printf 'content %s %s %s\n' "$batch" "$dir" "$f" > "d$((batch * 20 + dir))/f$f.txt"
+        done
+      done
+      "$g" add . && "$g" commit -q -m "batch $batch"
+    done
+    "$g" repack -adq 2>/dev/null || "$g" repack -ad
+  )
+
+  # many-loose: same tree shape, single commit, objects left loose.
+  d=$FIX/many-loose
+  "$g" init -q "$d"
+  (
+    cd "$d"
+    for dir in $(seq 0 99); do
+      mkdir -p "d$dir"
+      for f in $(seq 0 99); do
+        printf 'loose %s %s\n' "$dir" "$f" > "d$dir/f$f.txt"
+      done
+    done
+    "$g" add . && "$g" commit -q -m loose
+  )
+
+  # hist: 2000 commits appending to a rotating set of 10 files, packed.
+  d=$FIX/hist
+  "$g" init -q "$d"
+  (
+    cd "$d"
+    for i in $(seq 1 2000); do
+      echo "line $i" >> "file$((i % 10)).txt"
+      "$g" add "file$((i % 10)).txt"
+      "$g" commit -q -m "c$i"
+    done
+    "$g" repack -adq 2>/dev/null || "$g" repack -ad
+  )
+
+  # large: three ~40MB blobs (base64 of urandom: incompressible-ish), packed.
+  d=$FIX/large
+  "$g" init -q "$d"
+  (
+    cd "$d"
+    for i in 1 2 3; do
+      head -c 30000000 /dev/urandom | base64 > "big$i.bin"
+    done
+    "$g" add . && "$g" commit -q -m large
+    "$g" repack -adq 2>/dev/null || "$g" repack -ad
+  )
+
+  # plain-10k: bare directory tree (no repo) used to seed add/commit runs.
+  d=$FIX/plain-10k
+  mkdir -p "$d"
+  (
+    cd "$d"
+    for dir in $(seq 0 99); do
+      mkdir -p "d$dir"
+      for f in $(seq 0 99); do
+        printf 'plain %s %s\n' "$dir" "$f" > "d$dir/f$f.txt"
+      done
+    done
+  )
+  echo "fixtures built under $FIX"
+}
+
+# Each scenario defines: prep (untimed), cmd (timed), post (untimed check).
+prep() {
+  rm -rf "$WORK"
+  mkdir -p "$WORK"
+  cd "$WORK"
+  case $1 in
+    clone-many|clone-hist|clone-large|clone-file-many|clone-bare-many|clone-many-loose) : ;;
+    commit-touch-many)
+      "$G" clone -q "$FIX/many" w
+      cd w && echo tweak >> d0/f0.txt ;;
+    add-10k)
+      "$G" init -q w
+      cp -r "$FIX/plain-10k/." w/
+      cd w ;;
+    commit-10k)
+      "$G" init -q w
+      cp -r "$FIX/plain-10k/." w/
+      cd w && "$G" add -A ;;
+    push-hist)
+      "$G" clone -q "$FIX/hist" w
+      "$G" init -q --bare r.git
+      cd w && "$G" remote add dst ../r.git ;;
+    push-incr)
+      "$G" clone -q "$FIX/hist" w
+      "$G" clone -q --bare "$FIX/hist" r.git
+      cd w && "$G" remote add dst ../r.git
+      echo extra >> file0.txt && "$G" commit -q -am extra ;;
+    push-large)
+      "$G" clone -q "$FIX/large" w
+      "$G" init -q --bare r.git
+      cd w && "$G" remote add dst ../r.git ;;
+    *) echo "unknown scenario $1" >&2; return 1 ;;
+  esac
+}
+
+run_cmd() {
+  case $1 in
+    clone-many)       "$G" clone -q "$FIX/many" c ;;
+    clone-many-loose) "$G" clone -q "$FIX/many-loose" c ;;
+    clone-hist)       "$G" clone -q "$FIX/hist" c ;;
+    clone-large)      "$G" clone -q "$FIX/large" c ;;
+    clone-file-many)  "$G" clone -q "file://$FIX/many" c ;;
+    clone-bare-many)  "$G" clone -q --bare "$FIX/many" c.git ;;
+    commit-touch-many) "$G" commit -q -am tweak ;;
+    add-10k)          "$G" add -A ;;
+    commit-10k)       "$G" commit -q -m init ;;
+    push-hist)        "$G" push -q dst master ;;
+    push-incr)        "$G" push -q dst master ;;
+    push-large)       "$G" push -q dst master ;;
+  esac
+}
+
+SCENARIOS="clone-many clone-many-loose clone-hist clone-large clone-file-many clone-bare-many commit-touch-many add-10k commit-10k push-hist push-incr push-large"
+
+run_one() {
+  local name=$1 n=${2:-5} times=() t0 t1 rc
+  for _ in $(seq 1 "$n"); do
+    prep "$name" > /dev/null 2>&1 || { echo "$name PREP-FAIL"; return 1; }
+    t0=$(now_ms)
+    run_cmd "$name" > /dev/null 2>&1
+    rc=$?
+    t1=$(now_ms)
+    [ $rc -ne 0 ] && { echo "$name FAIL rc=$rc"; return 1; }
+    times+=($((t1 - t0)))
+  done
+  local sorted median
+  sorted=$(printf '%s\n' "${times[@]}" | sort -n)
+  median=$(printf '%s\n' "$sorted" | awk "NR==$(((n + 1) / 2))")
+  printf '%s\t%s\t[%s]\n' "$name" "$median" "$(printf '%s\n' "$sorted" | paste -sd,)"
+}
+
+case ${1:-run} in
+  fixtures) build_fixtures "${2:-$DEFAULT_BIN}" ;;
+  run)
+    G=${2:-$DEFAULT_BIN}; n=${3:-5}
+    echo -e "scenario\tmedian_ms\truns"
+    for s in $SCENARIOS; do run_one "$s" "$n"; done ;;
+  run-one)
+    G=${3:-$DEFAULT_BIN}
+    run_one "$2" "${4:-5}" ;;
+  *) echo "usage: $0 fixtures|run [BIN] [N]|run-one NAME [BIN] [N]" >&2; exit 1 ;;
+esac


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

End-to-end speed and completeness pass over the clone / commit / push workflows. A frozen benchmark harness (`scripts/bench-ccp.sh`) covering 12 scenarios drove an iterative measure–fix–re-measure loop until remaining gaps were architectural rather than incremental.

## Completeness fixes

- **Push failed on repos grit itself repacked.** Pack reading capped delta chains at 50, but grit's `repack` produces chains ~110 deep, so `push` failed with "unable to read <oid>". The read cap is now 4096 and the pack writer honors `pack.depth` (default 50) like Git.
- **`add ./-` corrupted the tree.** Pathspecs without a prefix skipped normalization, so `./-` was stored literally and produced an invalid `.` tree entry (t7501.76). Leading `./` segments are now normalized in `grit-lib::pathspec`.
- **Racy-timestamp smudge was missing.** Index writes lacked Git's racily-clean-entry smudge, so `diff-files` intermittently missed same-mtime-tick modifications (t0010 flaked at 5–9/10). Implemented and wired into the index write path; t0010 now passes 10/10 consistently.

## Speed optimizations (median of 5 runs, ms)

| Scenario | Before | After | System git 2.43 |
|---|---|---|---|
| push-incr (1 commit) | 82,413 | 103 | 11 |
| push-hist (2000 commits) | 88,599 | 280 | n/a* |
| clone-file-many (file://, 10k files) | 14,121 | 1,375 | n/a* |
| push-large (3×40MB) | 9,097 | 2,912 | 3,998 |
| commit -a over 10k files | 855 | 168 | n/a* |
| add-10k | 1,170 | 995 | 691 |
| commit-10k | 133 | 115 | 65 |
| clone-many (local path) | 891 | 803 | n/a* |

\* git 2.43 cannot read the multi-pack-index v2 that grit writes, so it could not clone those fixtures for reference.

Key changes, one commit each:

- Cached pack index/byte reads replacing per-object whole-pack `fs::read` and linear index scans (the ~800x push win)
- Cached lookups in the delta-reuse helpers (10x on `file://` clones)
- `commit -a` trusts clean stat data instead of re-hashing every tracked file (5x)
- Verbatim reuse of already-packed full objects with a CRC32 guard, plus loose-object compression at Git's default level 1 (3x on large pushes)
- Fewer per-write syscalls in `Odb::write` and deferred alternates canonicalization
- Cached MIDX tip resolution and content-addressed pack bytes (per-push syscalls ~37k → ~17k)

Remaining gaps are architectural: `add-10k` vs git is an O(N²) index-insert pattern needing an index redesign, and the `push-incr` residual is process-spawn overhead with per-process caches.

## Tests

- `cargo test -p grit-lib --lib`: 346 passed; 2 pre-existing `ignore.rs` glob failures that also fail on `main`.
- Integration, all at or above committed baselines: t0010 10/10, t1006 291/291, t1060 16/16, t3700 58/58, t5300 63/63, t5303 36/36, t5316 5/5, t5319 94/98 (equals main), t5516 124/124, **t5601 115/115 (up from 112)**, t5604 34/34, t5605 23/23, t5606 21/21, t7500 57/57, t7501 77/77, t7502 82/82.
- `cargo fmt` clean; no new `check`/`clippy` warnings.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00a15-ebde-765c-ad3a-ebcca729814c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00a15-ebde-765c-ad3a-ebcca729814c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

